### PR TITLE
Disable HCC_OPT_FLUSH

### DIFF
--- a/src/hip_db.cpp
+++ b/src/hip_db.cpp
@@ -1,5 +1,5 @@
 
-#include "hcc/hc_am.hpp"
+#include <hc_am.hpp>
 
 
 

--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -96,7 +96,7 @@ int HIP_SYNC_NULL_STREAM = 1;
 
 // HIP needs to change some behavior based on HCC_OPT_FLUSH :
 // TODO - set this to 1
-int HCC_OPT_FLUSH = 1;
+int HCC_OPT_FLUSH = 0;
 
 
 


### PR DESCRIPTION
It is observed several HIP-based applications are having issue when `HCC_OPT_FLUSH` is set to `1`. Before a proper fix is devised, turn off this optimization in this PR.