### PR TITLE
[HIPIFY] Finally finished syncing with CUDA 8.0.61 Driver and Runtime…

### DIFF
--- a/docs/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -2,859 +2,859 @@
 
 ## **1. Data types used by CUDA driver**
 
-| **type**     |   **CUDA**                                                    |   **HIP**                                                  | **CUDA description**                                                                                                           |
-|-------------:|---------------------------------------------------------------|------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| struct       | `CUDA_ARRAY3D_DESCRIPTOR`                                     |                                                            |                                                                                                                                |
-| struct       | `CUDA_ARRAY_DESCRIPTOR`                                       |                                                            |                                                                                                                                |
-| struct       | `CUDA_MEMCPY2D`                                               |                                                            |                                                                                                                                |
-| struct       | `CUDA_MEMCPY3D`                                               |                                                            |                                                                                                                                |
-| struct       | `CUDA_MEMCPY3D_PEER`                                          |                                                            |                                                                                                                                |
-| struct       | `CUDA_POINTER_ATTRIBUTE_P2P_TOKENS`                           |                                                            |                                                                                                                                |
-| struct       | `CUDA_RESOURCE_DESC`                                          |                                                            |                                                                                                                                |
-| struct       | `CUDA_RESOURCE_VIEW_DESC`                                     |                                                            |                                                                                                                                |
-| struct       | `CUdevprop`                                                   | `hipDeviceProp_t`                                          |                                                                                                                                |
-| struct       | `CUipcEventHandle`                                            |                                                            |                                                                                                                                |
-| struct       | `CUipcMemHandle`                                              |                                                            |                                                                                                                                |
-| enum         |***`CUaddress_mode`***                                         |                                                            | Texture reference addressing modes                                                                                             |
-|            0 |*`CU_TR_ADDRESS_MODE_WRAP`*                                    |                                                            | Wrapping address mode                                                                                                          |
-|            1 |*`CU_TR_ADDRESS_MODE_CLAMP`*                                   |                                                            | Clamp to edge address mode                                                                                                     |
-|            2 |*`CU_TR_ADDRESS_MODE_MIRROR`*                                  |                                                            | Mirror address mode                                                                                                            |
-|            3 |*`CU_TR_ADDRESS_MODE_BORDER`*                                  |                                                            | Border address mode                                                                                                            |
-| enum         |***`CUarray_cubemap_face`***                                   |                                                            | Array indices for cube faces                                                                                                   |
-|         0x00 |*`CU_CUBEMAP_FACE_POSITIVE_X`*                                 |                                                            | Positive X face of cubemap                                                                                                     |
-|         0x01 |*`CU_CUBEMAP_FACE_NEGATIVE_X`*                                 |                                                            | Negative X face of cubemap                                                                                                     |
-|         0x02 |*`CU_CUBEMAP_FACE_POSITIVE_Y`*                                 |                                                            | Positive Y face of cubemap                                                                                                     |
-|         0x03 |*`CU_CUBEMAP_FACE_NEGATIVE_Y`*                                 |                                                            | Negative Y face of cubemap                                                                                                     |
-|         0x04 |*`CU_CUBEMAP_FACE_POSITIVE_Z`*                                 |                                                            | Positive Z face of cubemap                                                                                                     |
-|         0x05 |*`CU_CUBEMAP_FACE_NEGATIVE_Z`*                                 |                                                            | Negative Z face of cubemap                                                                                                     |
-| enum         |***`CUarray_format`***                                         |                                                            | Array formats                                                                                                                  |
-|         0x01 |*`CU_AD_FORMAT_UNSIGNED_INT8`*                                 |                                                            | Unsigned 8-bit integers                                                                                                        |
-|         0x02 |*`CU_AD_FORMAT_UNSIGNED_INT16`*                                |                                                            | Unsigned 16-bit integers                                                                                                       |
-|         0x03 |*`CU_AD_FORMAT_UNSIGNED_INT32`*                                |                                                            | Unsigned 32-bit integers                                                                                                       |
-|         0x08 |*`CU_AD_FORMAT_SIGNED_INT8`*                                   |                                                            | Signed 8-bit integers                                                                                                          |
-|         0x09 |*`CU_AD_FORMAT_SIGNED_INT16`*                                  |                                                            | Signed 16-bit integers                                                                                                         |
-|         0x0a |*`CU_AD_FORMAT_SIGNED_INT32`*                                  |                                                            | Signed 32-bit integers                                                                                                         |
-|         0x10 |*`CU_AD_FORMAT_HALF`*                                          |                                                            | 16-bit floating point                                                                                                          |
-|         0x20 |*`CU_AD_FORMAT_FLOAT`*                                         |                                                            | 32-bit floating point                                                                                                          |
-| enum         |***`CUctx_flags`***                                            |                                                            | Context creation flags                                                                                                         |
-|         0x00 |*`CU_CTX_SCHED_AUTO`*                                          |                                                            | Automatic scheduling                                                                                                           |
-|         0x01 |*`CU_CTX_SCHED_SPIN`*                                          |                                                            | Set spin as default scheduling                                                                                                 |
-|         0x02 |*`CU_CTX_SCHED_YIELD`*                                         |                                                            | Set yield as default scheduling                                                                                                |
-|         0x04 |*`CU_CTX_SCHED_BLOCKING_SYNC`*                                 |                                                            | Set blocking synchronization as default scheduling                                                                             |
-|         0x04 |*`CU_CTX_BLOCKING_SYNC`*                                       |                                                            | Set blocking synchronization as default scheduling Deprecated. This flag was deprecated as of CUDA 4.0 and was replaced with CU_CTX_SCHED_BLOCKING_SYNC.|
-|         0x07 |*`CU_CTX_SCHED_MASK`*                                          |                                                            |                                                                                                                                |
-|         0x08 |*`CU_CTX_MAP_HOST`*                                            |                                                            | Support mapped pinned allocations                                                                                              |
-|         0x10 |*`CU_CTX_LMEM_RESIZE_TO_MAX`*                                  |                                                            | Keep local memory allocation after launch                                                                                      |
-|         0x1f |*`CU_CTX_FLAGS_MASK`*                                          |                                                            |                                                                                                                                |
-| enum         |***`CUdevice_attribute`***                                     |                                                            | Device properties                                                                                                              |
-|            1 |*`CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK`*                  |*`hipDeviceAttributeMaxThreadsPerBlock`*                    | Maximum number of threads per block                                                                                            |
-|            2 |*`CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X`*                        |*`hipDeviceAttributeMaxBlockDimX`*                          | Maximum block dimension X                                                                                                      |
-|            3 |*`CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y`*                        |*`hipDeviceAttributeMaxBlockDimY`*                          | Maximum block dimension Y                                                                                                      |
-|            4 |*`CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z`*                        |*`hipDeviceAttributeMaxBlockDimZ`*                          | Maximum block dimension Z                                                                                                      |
-|            5 |*`CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X`*                         |*`hipDeviceAttributeMaxGridDimX`*                           | Maximum grid dimension X                                                                                                       |
-|            6 |*`CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y`*                         |*`hipDeviceAttributeMaxGridDimY`*                           | Maximum grid dimension Y                                                                                                       |
-|            7 |*`CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z`*                         |*`hipDeviceAttributeMaxGridDimZ`*                           | Maximum grid dimension Y                                                                                                       |
-|            8 |*`CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK`*            |*`hipDeviceAttributeMaxSharedMemoryPerBlock`*               | Maximum shared memory available per block in bytes                                                                             |
-|            8 |*`CU_DEVICE_ATTRIBUTE_SHARED_MEMORY_PER_BLOCK`*                |*`hipDeviceAttributeMaxSharedMemoryPerBlock`*               | Deprecated, use CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK                                                                |
-|            9 |*`CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY`*                  |*`hipDeviceAttributeTotalConstantMemory`*                   | Memory available on device for __constant__ variables in a CUDA C kernel in bytes                                              |
-|           10 |*`CU_DEVICE_ATTRIBUTE_WARP_SIZE`*                              |*`hipDeviceAttributeWarpSize`*                              | Warp size in threads                                                                                                           |
-|           11 |*`CU_DEVICE_ATTRIBUTE_MAX_PITCH`*                              |                                                            | Maximum pitch in bytes allowed by memory copies                                                                                |
-|           12 |*`CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK`*                |*`hipDeviceAttributeMaxRegistersPerBlock`*                  | Maximum number of 32-bit registers available per block                                                                         |
-|           12 |*`CU_DEVICE_ATTRIBUTE_REGISTERS_PER_BLOCK`*                    |*`hipDeviceAttributeMaxRegistersPerBlock`*                  | Deprecated, use CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK                                                                    |
-|           13 |*`CU_DEVICE_ATTRIBUTE_CLOCK_RATE`*                             |*`hipDeviceAttributeClockRate`*                             | Typical clock frequency in kilohertz                                                                                           |
-|           14 |*`CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT`*                      |                                                            | Alignment requirement for textures                                                                                             |
-|           15 |*`CU_DEVICE_ATTRIBUTE_GPU_OVERLAP`*                            |                                                            | Device can possibly copy memory and execute a kernel concurrently. Deprecated. Use instead CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT|
-|           16 |*`CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT`*                   |*`hipDeviceAttributeMultiprocessorCount`*                   | Number of multiprocessors on device                                                                                            |
-|           17 |*`CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT`*                    |                                                            | Specifies whether there is a run time limit on kernels                                                                         |
-|           18 |*`CU_DEVICE_ATTRIBUTE_INTEGRATED`*                             |                                                            | Device is integrated with host memory                                                                                          |
-|           19 |*`CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY`*                    |                                                            | Device can map host memory into CUDA address space                                                                             |
-|           20 |*`CU_DEVICE_ATTRIBUTE_COMPUTE_MODE`*                           |*`hipDeviceAttributeComputeMode`*                           | Compute mode (See CUcomputemode for details)                                                                                   |
-|           21 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH`*                |                                                            | Maximum 1D texture width                                                                                                       |
-|           22 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH`*                |                                                            | Maximum 2D texture width                                                                                                       |
-|           23 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT`*               |                                                            | Maximum 2D texture height                                                                                                      |
-|           24 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH`*                |                                                            | Maximum 3D texture width                                                                                                       |
-|           25 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT`*               |                                                            | Maximum 3D texture height                                                                                                      |
-|           26 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH`*                |                                                            | Maximum 3D texture depth                                                                                                       |
-|           27 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH`*        |                                                            | Maximum 2D layered texture width                                                                                               |
-|           28 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT`*       |                                                            | Maximum 2D layered texture height                                                                                              |
-|           29 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS`*       |                                                            | Maximum layers in a 2D layered texture                                                                                         |
-|           27 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_WIDTH`*          |                                                            | Deprecated, use CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH                                                            |
-|           28 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_HEIGHT`*         |                                                            | Deprecated, use CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT                                                           |
-|           29 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_NUMSLICES`*      |                                                            | Deprecated, use CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS                                                           |
-|           30 |*`CU_DEVICE_ATTRIBUTE_SURFACE_ALIGNMENT`*                      |                                                            | Alignment requirement for surfaces                                                                                             |
-|           31 |*`CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS`*                     |*`hipDeviceAttributeConcurrentKernels`*                     | Device can possibly execute multiple kernels concurrently                                                                      |
-|           32 |*`CU_DEVICE_ATTRIBUTE_ECC_ENABLED`*                            |                                                            | Device has ECC support enabled                                                                                                 |
-|           33 |*`CU_DEVICE_ATTRIBUTE_PCI_BUS_ID`*                             |*`hipDeviceAttributePciBusId`*                              | PCI bus ID of the device                                                                                                       |
-|           34 |*`CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID`*                          |*`hipDeviceAttributePciDeviceId`*                           | PCI device ID of the device                                                                                                    |
-|           35 |*`CU_DEVICE_ATTRIBUTE_TCC_DRIVER`*                             |                                                            | Device is using TCC driver model                                                                                               |
-|           36 |*`CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE`*                      |*`hipDeviceAttributeMemoryClockRate`*                       | Peak memory clock frequency in kilohertz                                                                                       |
-|           37 |*`CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH`*                |*`hipDeviceAttributeMemoryBusWidth`*                        | Global memory bus width in bits                                                                                                |
-|           38 |*`CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE`*                          |*`hipDeviceAttributeL2CacheSize`*                           | Size of L2 cache in bytes                                                                                                      |
-|           39 |*`CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR`*         |*`hipDeviceAttributeMaxThreadsPerMultiProcessor`*           | Maximum resident threads per multiprocessor                                                                                    |
-|           40 |*`CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT`*                     |                                                            | Number of asynchronous engines                                                                                                 |
-|           41 |*`CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING`*                     |                                                            | Device shares a unified address space with the host                                                                            |
-|           42 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_WIDTH`*        |                                                            | Maximum 1D layered texture width                                                                                               |
-|           43 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_LAYERS`*       |                                                            | Maximum layers in a 1D layered texture                                                                                         |
-|           44 |*`CU_DEVICE_ATTRIBUTE_CAN_TEX2D_GATHER`*                       |                                                            | Deprecated, do not use                                                                                                         |
-|           45 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_WIDTH`*         |                                                            | Maximum 2D texture width if CUDA_ARRAY3D_TEXTURE_GATHER is set                                                                 |
-|           46 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_HEIGHT`*        |                                                            | Maximum 2D texture height if CUDA_ARRAY3D_TEXTURE_GATHER is set                                                                |
-|           47 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH_ALTERNATE`*      |                                                            | Alternate maximum 3D texture width                                                                                             |
-|           48 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT_ALTERNATE`*     |                                                            | Alternate maximum 3D texture height                                                                                            |
-|           49 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH_ALTERNATE`*      |                                                            | Alternate maximum 3D texture depth                                                                                             |
-|           50 |*`CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID`*                          |                                                            | PCI domain ID of the device                                                                                                    |
-|           51 |*`CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT`*                |                                                            | Pitch alignment requirement for textures                                                                                       |
-|           52 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_WIDTH`*           |                                                            | Maximum cubemap texture width/height                                                                                           |
-|           53 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_WIDTH`*   |                                                            | Maximum cubemap layered texture width/height                                                                                   |
-|           54 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_LAYERS`*  |                                                            | Maximum layers in a cubemap layered texture                                                                                    |
-|           55 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH`*                |                                                            | Maximum 1D surface width                                                                                                       |
-|           56 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH`*                |                                                            | Maximum 2D surface width                                                                                                       |
-|           57 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT`*               |                                                            | Maximum 2D surface height                                                                                                      |
-|           58 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH`*                |                                                            | Maximum 3D surface width                                                                                                       |
-|           59 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT`*               |                                                            | Maximum 3D surface height                                                                                                      |
-|           60 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH`*                |                                                            | Maximum 3D surface depth                                                                                                       |
-|           61 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_WIDTH`*        |                                                            | Maximum 1D layered surface width                                                                                               |
-|           62 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_LAYERS`*       |                                                            | Maximum layers in a 1D layered surface                                                                                         |
-|           63 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_WIDTH`*        |                                                            | Maximum 2D layered surface width                                                                                               |
-|           64 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_HEIGHT`*       |                                                            | Maximum 2D layered surface height                                                                                              |
-|           65 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_LAYERS`*       |                                                            | Maximum layers in a 2D layered surface                                                                                         |
-|           66 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_WIDTH`*           |                                                            | Maximum cubemap surface width                                                                                                  |
-|           67 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_WIDTH`*   |                                                            | Maximum cubemap layered surface width                                                                                          |
-|           68 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_LAYERS`*  |                                                            | Maximum layers in a cubemap layered surface                                                                                    |
-|           69 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LINEAR_WIDTH`*         |                                                            | Maximum 1D linear texture width                                                                                                |
-|           70 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH`*         |                                                            | Maximum 2D linear texture width                                                                                                |
-|           71 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT`*        |                                                            | Maximum 2D linear texture height                                                                                               |
-|           72 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH`*         |                                                            | Maximum 2D linear texture pitch in bytes                                                                                       |
-|           73 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_WIDTH`*      |                                                            | Maximum mipmapped 2D texture width                                                                                             |
-|           74 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_HEIGHT`*     |                                                            | Maximum mipmapped 2D texture height                                                                                            |
-|           75 |*`CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR`*               |*`hipDeviceAttributeComputeCapabilityMajor`*                | Major compute capability version number                                                                                        |
-|           76 |*`CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR`*               |*`hipDeviceAttributeComputeCapabilityMinor`*                | Minor compute capability version number                                                                                        |
-|           77 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_MIPMAPPED_WIDTH`*      |                                                            | Maximum mipmapped 1D texture width                                                                                             |
-|           78 |*`CU_DEVICE_ATTRIBUTE_STREAM_PRIORITIES_SUPPORTED`*            |                                                            | Device supports stream priorities                                                                                              |
-|           79 |*`CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED`*              |                                                            | Device supports caching globals in L1                                                                                          |
-|           80 |*`CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED`*               |                                                            | Device supports caching locals in L1                                                                                           |
-|           81 |*`CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR`*   |*`hipDeviceAttributeMaxSharedMemoryPerMultiprocessor`*      | Maximum shared memory available per multiprocessor in bytes                                                                    |
-|           82 |*`CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR`*       |                                                            | Maximum number of 32-bit registers available per multiprocessor                                                                |
-|           83 |*`CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY`*                         |*`hipDeviceAttributeManagedMemory`*                         | Device can allocate managed memory on this system                                                                              |
-|           84 |*`CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD`*                        |                                                            | Device is on a multi-GPU board                                                                                                 |
-|           85 |*`CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID`*               |                                                            | Unique id for a group of devices on the same multi-GPU board                                                                   |
-|           86 |*`CU_DEVICE_ATTRIBUTE_MAX`*                                    |                                                            |                                                                                                                                |
-| enum         |***`CUevent_flags`***                                          |                                                            | Event creation flags                                                                                                           |
-|         0x00 |*`CU_EVENT_DEFAULT`*                                           |*`hipEventDefault`*                                         | Default event flag                                                                                                             |
-|         0x01 |*`CU_EVENT_BLOCKING_SYNC`*                                     |*`hipEventBlockingSync`*                                    | Event uses blocking synchronization                                                                                            |
-|         0x02 |*`CU_EVENT_DISABLE_TIMING`*                                    |*`hipEventDisableTiming`*                                   | Event will not record timing data                                                                                              |
-|         0x04 |*`CU_EVENT_INTERPROCESS`*                                      |*`hipEventInterprocess`*                                    | Event is suitable for interprocess use. CU_EVENT_DISABLE_TIMING must be set                                                    |
-| enum         |***`CUfilter_mode`***                                          |***`hipTextureFilterMode`***                                | Texture reference filtering modes                                                                                              |
-|            0 |*`CU_TR_FILTER_MODE_POINT`*                                    |*`hipFilterModePoint`*                                      | Point filter mode                                                                                                              |
-|            1 |*`CU_TR_FILTER_MODE_LINEAR`*                                   |*`hipFilterModeLinear`*                                     | Linear filter mode                                                                                                             |
-| enum         |***`CUfunc_cache`***                                           |***`hipFuncCache`***                                        | Function cache configurations                                                                                                  |
-|         0x00 |*`CU_FUNC_CACHE_PREFER_NONE`*                                  |*`hipFuncCachePreferNone`*                                  | no preference for shared memory or L1 (default)                                                                                |
-|         0x01 |*`CU_FUNC_CACHE_PREFER_SHARED`*                                |*`hipFuncCachePreferShared`*                                | prefer larger shared memory and smaller L1 cache                                                                               |
-|         0x02 |*`CU_FUNC_CACHE_PREFER_L1`*                                    |*`hipFuncCachePreferL1`*                                    | prefer larger L1 cache and smaller shared memory                                                                               |
-|         0x03 |*`CU_FUNC_CACHE_PREFER_EQUAL`*                                 |*`hipFuncCachePreferEqual`*                                 | prefer equal sized L1 cache and shared memory                                                                                  |
-| enum         |***`CUfunction_attribute`***                                   |                                                            | Function properties                                                                                                            |
-|            0 |*`CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK`*                    |                                                            | The maximum number of threads per block, beyond which a launch of the function would fail. This number depends on both the function and the device on which the function is currently loaded. |
-|            1 |*`CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES`*                        |                                                            | The size in bytes of statically-allocated shared memory required by this function. This does not include dynamically-allocated shared memory requested by the user at runtime. |
-|            2 |*`CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES`*                         |                                                            | The size in bytes of user-allocated constant memory required by this function.                                                 |
-|            3 |*`CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES`*                         |                                                            | The size in bytes of local memory used by each thread of this function.                                                        |
-|            4 |*`CU_FUNC_ATTRIBUTE_NUM_REGS`*                                 |                                                            | The number of registers used by each thread of this function.                                                                  |
-|            5 |*`CU_FUNC_ATTRIBUTE_PTX_VERSION`*                              |                                                            | The PTX virtual architecture version for which the function was compiled. This value is the major PTX version * 10 + the minor PTX version, so a PTX version 1.3 function would return the value 13. Note that this may return the undefined value of 0 for cubins compiled prior to CUDA 3.0. |
-|            6 |*`CU_FUNC_ATTRIBUTE_BINARY_VERSION`*                           |                                                            | The binary architecture version for which the function was compiled. This value is the major binary version * 10 + the minor binary version, so a binary version 1.3 function would return the value 13. Note that this will return a value of 10 for legacy cubins that do not have a properly-encoded binary architecture version. |
-|            7 |*`CU_FUNC_ATTRIBUTE_CACHE_MODE_CA`*                            |                                                            | The attribute to indicate whether the function has been compiled with user specified option "-Xptxas --dlcm=ca" set.           |
-|            8 |*`CU_FUNC_ATTRIBUTE_MAX`*                                      |                                                            |                                                                                                                                |
-| enum         |***`CUgraphicsMapResourceFlags`***                             |                                                            | Flags for mapping and unmapping interop resources                                                                              |
-|         0x00 |*`CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE`*                        |                                                            |                                                                                                                                |
-|         0x01 |*`CU_GRAPHICS_MAP_RESOURCE_FLAGS_READ_ONLY`*                   |                                                            |                                                                                                                                |
-|         0x02 |*`CU_GRAPHICS_MAP_RESOURCE_FLAGS_WRITE_DISCARD`*               |                                                            |                                                                                                                                |
-| enum         |***`CUgraphicsRegisterFlags`***                                |                                                            | Flags to register a graphics resource                                                                                          |
-|         0x00 |*`CU_GRAPHICS_REGISTER_FLAGS_NONE`*                            |                                                            |                                                                                                                                |
-|         0x01 |*`CU_GRAPHICS_REGISTER_FLAGS_READ_ONLY`*                       |                                                            |                                                                                                                                |
-|         0x02 |*`CU_GRAPHICS_REGISTER_FLAGS_WRITE_DISCARD`*                   |                                                            |                                                                                                                                |
-|         0x04 |*`CU_GRAPHICS_REGISTER_FLAGS_SURFACE_LDST`*                    |                                                            |                                                                                                                                |
-|         0x08 |*`CU_GRAPHICS_REGISTER_FLAGS_TEXTURE_GATHER`*                  |                                                            |                                                                                                                                |
-| enum         |***`CUipcMem_flags`***                                         |                                                            | CUDA Ipc Mem Flags                                                                                                             |
-|          0x1 |*`CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS`*                         |*`hipIpcMemLazyEnablePeerAccess`*                           | Automatically enable peer access between remote devices as needed                                                              |
-| enum         |***`CUjit_cacheMode`***                                        |                                                            | Caching modes for dlcm                                                                                                         |
-|            0 |*`CU_JIT_CACHE_OPTION_NONE`*                                   |                                                            | Compile with no -dlcm flag specified                                                                                           |
-|              |*`CU_JIT_CACHE_OPTION_CG`*                                     |                                                            | Compile with L1 cache disabled                                                                                                 |
-|              |*`CU_JIT_CACHE_OPTION_CA`*                                     |                                                            | Compile with L1 cache enabled                                                                                                  |
-| enum         |***`CUjit_fallback`***                                         |                                                            | Cubin matching fallback strategies                                                                                             |
-|            0 |*`CU_PREFER_PTX`*                                              |                                                            | Prefer to compile ptx if exact binary match not found                                                                          |
-|              |*`CU_PREFER_BINARY`*                                           |                                                            | Prefer to fall back to compatible binary code if exact match not found                                                         |
-| enum         |***`CUjit_option`***                                           |                                                            | Online compiler and linker options                                                                                             |
-|            0 |*`CU_JIT_MAX_REGISTERS`*                                       |                                                            | Max number of registers that a thread may use. Option type: unsigned int Applies to: compiler only.                            |
-|              |*`CU_JIT_THREADS_PER_BLOCK`*                                   |                                                            | IN: Specifies minimum number of threads per block to target compilation for OUT: Returns the number of threads the compiler actually targeted. This restricts the resource utilization fo the compiler (e.g. max registers) such that a block with the given number of threads should be able to launch based on register limitations. Note, this option does not currently take into account any other resource limitations, such as shared memory utilization. Cannot be combined with CU_JIT_TARGET. Option type: unsigned int Applies to: compiler only. |
-|              |*`CU_JIT_WALL_TIME`*                                           |                                                            | Overwrites the option value with the total wall clock time, in milliseconds, spent in the compiler and linker Option type: float Applies to: compiler and linker. |
-|              |*`CU_JIT_INFO_LOG_BUFFER`*                                     |                                                            | Pointer to a buffer in which to print any log messages that are informational in nature (the buffer size is specified via option CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES) Option type: char * Applies to: compiler and linker. |
-|              |*`CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES`*                          |                                                            | IN: Log buffer size in bytes. Log messages will be capped at this size (including null terminator) OUT: Amount of log buffer filled with messages Option type: unsigned int Applies to: compiler and linker. |
-|              |*`CU_JIT_OPTIMIZATION_LEVEL`*                                  |                                                            | Level of optimizations to apply to generated code (0 - 4), with 4 being the default and highest level of optimizations. Option type: unsigned int Applies to: compiler only. |
-|              |*`CU_JIT_TARGET_FROM_CUCONTEXT`*                               |                                                            | No option value required. Determines the target based on the current attached context (default) Option type: No option value needed Applies to: compiler and linker. |
-|              |*`CU_JIT_TARGET`*                                              |                                                            | Target is chosen based on supplied CUjit_target. Cannot be combined with CU_JIT_THREADS_PER_BLOCK. Option type: unsigned int for enumerated type CUjit_target Applies to: compiler and linker. |
-|              |*`CU_JIT_FALLBACK_STRATEGY`*                                   |                                                            | Specifies choice of fallback strategy if matching cubin is not found. Choice is based on supplied CUjit_fallback. This option cannot be used with cuLink* APIs as the linker requires exact matches. Option type: unsigned int for enumerated type CUjit_fallback Applies to: compiler only. |
-|              |*`CU_JIT_GENERATE_DEBUG_INFO`*                                 |                                                            | Specifies whether to create debug information in output (-g) (0: false, default) Option type: int Applies to: compiler and linker. |
-|              |*`CU_JIT_LOG_VERBOSE`*                                         |                                                            | Generate verbose log messages (0: false, default) Option type: int Applies to: compiler and linker.                            |
-|              |*`CU_JIT_GENERATE_LINE_INFO`*                                  |                                                            | Generate line number information (-lineinfo) (0: false, default) Option type: int Applies to: compiler only.                   |
-|              |*`CU_JIT_CACHE_MODE`*                                          |                                                            | Specifies whether to enable caching explicitly (-dlcm) Choice is based on supplied CUjit_cacheMode_enum. Option type: unsigned int for enumerated type CUjit_cacheMode_enum Applies to: compiler only. |
-|              |*`CU_JIT_NUM_OPTIONS`*                                         |                                                            |                                                                                                                                |
-| enum         |***`CUjit_target`***                                           |                                                            | Online compilation targets                                                                                                     |
-|           10 |*`CU_TARGET_COMPUTE_10`*                                       |                                                            | Compute device class 1.0.                                                                                                      |
-|           11 |*`CU_TARGET_COMPUTE_11`*                                       |                                                            | Compute device class 1.1.                                                                                                      |
-|           12 |*`CU_TARGET_COMPUTE_12`*                                       |                                                            | Compute device class 1.2.                                                                                                      |
-|           13 |*`CU_TARGET_COMPUTE_13`*                                       |                                                            | Compute device class 1.3.                                                                                                      |
-|           20 |*`CU_TARGET_COMPUTE_20`*                                       |                                                            | Compute device class 2.0.                                                                                                      |
-|           21 |*`CU_TARGET_COMPUTE_21`*                                       |                                                            | Compute device class 2.1.                                                                                                      |
-|           30 |*`CU_TARGET_COMPUTE_30`*                                       |                                                            | Compute device class 3.0.                                                                                                      |
-|           32 |*`CU_TARGET_COMPUTE_32`*                                       |                                                            | Compute device class 3.2.                                                                                                      |
-|           35 |*`CU_TARGET_COMPUTE_35`*                                       |                                                            | Compute device class 3.5.                                                                                                      |
-|           37 |*`CU_TARGET_COMPUTE_37`*                                       |                                                            | Compute device class 3.7.                                                                                                      |
-|           50 |*`CU_TARGET_COMPUTE_50`*                                       |                                                            | Compute device class 5.0.                                                                                                      |
-|           52 |*`CU_TARGET_COMPUTE_52`*                                       |                                                            | Compute device class 5.2.                                                                                                      |
-| enum         |***`CUjitInputType`***                                         |                                                            | Device code formats                                                                                                            |
-|            0 |*`CU_JIT_INPUT_CUBIN`*                                         |                                                            | Compiled device-class-specific device code Applicable options: none.                                                           |
-|              |*`CU_JIT_INPUT_PTX`*                                           |                                                            | PTX source code Applicable options: PTX compiler options.                                                                      |
-|              |*`CU_JIT_INPUT_FATBINARY`*                                     |                                                            | Bundle of multiple cubins and/or PTX of some device code Applicable options: PTX compiler options, CU_JIT_FALLBACK_STRATEGY.   |
-|              |*`CU_JIT_INPUT_OBJECT`*                                        |                                                            | Host object with embedded device code Applicable options: PTX compiler options, CU_JIT_FALLBACK_STRATEGY.                      |
-|              |*`CU_JIT_INPUT_LIBRARY`*                                       |                                                            | Archive of host objects with embedded device code Applicable options: PTX compiler options, CU_JIT_FALLBACK_STRATEGY.          |
-|              |*`CU_JIT_NUM_INPUT_TYPES`*                                     |                                                            |                                                                                                                                |
-| enum         |***`CUlimit`***                                                |***`hipLimit_t`***                                          | Limits                                                                                                                         |
-|         0x00 |*`CU_LIMIT_STACK_SIZE`*                                        |                                                            | GPU thread stack size.                                                                                                         |
-|         0x01 |*`CU_LIMIT_PRINTF_FIFO_SIZE`*                                  |                                                            | GPU printf FIFO size.                                                                                                          |
-|         0x02 |*`CU_LIMIT_MALLOC_HEAP_SIZE`*                                  |*`hipLimitMallocHeapSize`*                                  | GPU malloc heap size.                                                                                                          |
-|         0x03 |*`CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH`*                            |                                                            | GPU device runtime launch synchronize depth.                                                                                   |
-|         0x04 |*`CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT`*                  |                                                            | GPU device runtime pending launch count.                                                                                       |
-|              |*`CU_LIMIT_MAX`*                                               |                                                            |                                                                                                                                |
-| enum         |***`CUmemAttach_flags`***                                      |                                                            | CUDA Mem Attach Flags                                                                                                          |
-|          0x1 |*`CU_MEM_ATTACH_GLOBAL`*                                       |                                                            | Memory can be accessed by any stream on any device.                                                                            |
-|          0x2 |*`CU_MEM_ATTACH_HOST`*                                         |                                                            | Memory cannot be accessed by any stream on any device.                                                                         |
-|          0x4 |*`CU_MEM_ATTACH_SINGLE`*                                       |                                                            | Memory can only be accessed by a single stream on the associated device.                                                       |
-| enum         |***`CUmemorytype`***                                           |                                                            | Memory types                                                                                                                   |
-|         0x01 |*`CU_MEMORYTYPE_HOST`*                                         |                                                            | Host memory                                                                                                                    |
-|         0x02 |*`CU_MEMORYTYPE_DEVICE`*                                       |                                                            | Device memory                                                                                                                  |
-|         0x03 |*`CU_MEMORYTYPE_ARRAY`*                                        |                                                            | Array memory                                                                                                                   |
-|         0x04 |*`CU_MEMORYTYPE_UNIFIED`*                                      |                                                            | Unified device or host memory                                                                                                  |
-| enum         |***`CUoccupancy_flags`***                                      |                                                            | Occupancy calculator flag                                                                                                      |
-|         0x00 |*`CU_OCCUPANCY_DEFAULT`*                                       |                                                            | Default behavior                                                                                                               |
-|         0x01 |*`CU_OCCUPANCY_DISABLE_CACHING_OVERRIDE`*                      |                                                            | Assume global caching is enabled and cannot be automatically turned off                                                        |
-| enum         |***`CUpointer_attribute`***                                    |                                                            | Pointer information                                                                                                            |
-|            1 |*`CU_POINTER_ATTRIBUTE_CONTEXT`*                               |                                                            | The CUcontext on which a pointer was allocated or registered                                                                   |
-|            2 |*`CU_POINTER_ATTRIBUTE_MEMORY_TYPE`*                           |                                                            | The CUmemorytype describing the physical location of a pointer                                                                 |
-|            3 |*`CU_POINTER_ATTRIBUTE_DEVICE_POINTER`*                        |                                                            | The address at which a pointer's memory may be accessed on the device                                                          |
-|            4 |*`CU_POINTER_ATTRIBUTE_HOST_POINTER`*                          |                                                            | The address at which a pointer's memory may be accessed on the host                                                            |
-|            5 |*`CU_POINTER_ATTRIBUTE_P2P_TOKENS`*                            |                                                            | A pair of tokens for use with the nv-p2p.h Linux kernel interface                                                              |
-|            6 |*`CU_POINTER_ATTRIBUTE_SYNC_MEMOPS`*                           |                                                            | Synchronize every synchronous memory operation initiated on this region                                                        |
-|            7 |*`CU_POINTER_ATTRIBUTE_BUFFER_ID`*                             |                                                            | A process-wide unique ID for an allocated memory region                                                                        |
-|            8 |*`CU_POINTER_ATTRIBUTE_IS_MANAGED`*                            |                                                            | Indicates if the pointer points to managed memory                                                                              |
-| enum         |***`CUmemorytype`***                                           |                                                            | Resource types                                                                                                                 |
-|         0x00 |*`CU_RESOURCE_TYPE_ARRAY`*                                     |                                                            | Array resoure                                                                                                                  |
-|         0x01 |*`CU_RESOURCE_TYPE_MIPMAPPED_ARRAY`*                           |                                                            | Mipmapped array resource                                                                                                       |
-|         0x02 |*`CU_RESOURCE_TYPE_LINEAR`*                                    |                                                            | Linear resource                                                                                                                |
-|         0x03 |*`CU_RESOURCE_TYPE_PITCH2D`*                                   |                                                            | Pitch 2D resource                                                                                                              |
-| enum         |***`CUresourceViewFormat`***                                   |                                                            | Resource view format                                                                                                           |
-|         0x00 |*`CU_RES_VIEW_FORMAT_NONE`*                                    |                                                            | No resource view format (use underlying resource format)                                                                       |
-|         0x01 |*`CU_RES_VIEW_FORMAT_UINT_1X8`*                                |                                                            | 1 channel unsigned 8-bit integers                                                                                              |
-|         0x02 |*`CU_RES_VIEW_FORMAT_UINT_2X8`*                                |                                                            | 2 channel unsigned 8-bit integers                                                                                              |
-|         0x03 |*`CU_RES_VIEW_FORMAT_UINT_4X8`*                                |                                                            | 4 channel unsigned 8-bit integers                                                                                              |
-|         0x04 |*`CU_RES_VIEW_FORMAT_SINT_1X8`*                                |                                                            | 1 channel signed 8-bit integers                                                                                                |
-|         0x05 |*`CU_RES_VIEW_FORMAT_SINT_2X8`*                                |                                                            | 2 channel signed 8-bit integers                                                                                                |
-|         0x06 |*`CU_RES_VIEW_FORMAT_SINT_4X8`*                                |                                                            | 4 channel signed 8-bit integers                                                                                                |
-|         0x07 |*`CU_RES_VIEW_FORMAT_UINT_1X16`*                               |                                                            | 1 channel unsigned 16-bit integers                                                                                             |
-|         0x08 |*`CU_RES_VIEW_FORMAT_UINT_2X16`*                               |                                                            | 2 channel unsigned 16-bit integers                                                                                             |
-|         0x09 |*`CU_RES_VIEW_FORMAT_UINT_4X16`*                               |                                                            | 4 channel unsigned 16-bit integers                                                                                             |
-|         0x0a |*`CU_RES_VIEW_FORMAT_SINT_1X16`*                               |                                                            | 1 channel signed 16-bit integers                                                                                               |
-|         0x0b |*`CU_RES_VIEW_FORMAT_SINT_2X16`*                               |                                                            | 2 channel signed 16-bit integers                                                                                               |
-|         0x0c |*`CU_RES_VIEW_FORMAT_SINT_4X16`*                               |                                                            | 4 channel signed 16-bit integers                                                                                               |
-|         0x0d |*`CU_RES_VIEW_FORMAT_UINT_1X32`*                               |                                                            | 1 channel unsigned 32-bit integers                                                                                             |
-|         0x0e |*`CU_RES_VIEW_FORMAT_UINT_2X32`*                               |                                                            | 2 channel unsigned 32-bit integers                                                                                             |
-|         0x0f |*`CU_RES_VIEW_FORMAT_UINT_4X32`*                               |                                                            | 4 channel unsigned 32-bit integers                                                                                             |
-|         0x10 |*`CU_RES_VIEW_FORMAT_SINT_1X32`*                               |                                                            | 1 channel signed 32-bit integers                                                                                               |
-|         0x11 |*`CU_RES_VIEW_FORMAT_SINT_2X32`*                               |                                                            | 2 channel signed 32-bit integers                                                                                               |
-|         0x12 |*`CU_RES_VIEW_FORMAT_SINT_4X32`*                               |                                                            | 4 channel signed 32-bit integers                                                                                               |
-|         0x13 |*`CU_RES_VIEW_FORMAT_FLOAT_1X16`*                              |                                                            | 1 channel 16-bit floating point                                                                                                |
-|         0x14 |*`CU_RES_VIEW_FORMAT_FLOAT_2X16`*                              |                                                            | 2 channel 16-bit floating point                                                                                                |
-|         0x15 |*`CU_RES_VIEW_FORMAT_FLOAT_4X16`*                              |                                                            | 4 channel 16-bit floating point                                                                                                |
-|         0x16 |*`CU_RES_VIEW_FORMAT_FLOAT_1X32`*                              |                                                            | 1 channel 32-bit floating point                                                                                                |
-|         0x17 |*`CU_RES_VIEW_FORMAT_FLOAT_2X32`*                              |                                                            | 2 channel 32-bit floating point                                                                                                |
-|         0x18 |*`CU_RES_VIEW_FORMAT_FLOAT_4X32`*                              |                                                            | 4 channel 32-bit floating point                                                                                                |
-|         0x19 |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC1`*                            |                                                            | Block compressed 1                                                                                                             |
-|         0x1a |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC3`*                            |                                                            | Block compressed 2                                                                                                             |
-|         0x1b |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC3`*                            |                                                            | Block compressed 3                                                                                                             |
-|         0x1c |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC4`*                            |                                                            | Block compressed 4 unsigned                                                                                                    |
-|         0x1d |*`CU_RES_VIEW_FORMAT_SIGNED_BC4`*                              |                                                            | Block compressed 4 signed                                                                                                      |
-|         0x1e |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC5`*                            |                                                            | Block compressed 5 unsigned                                                                                                    |
-|         0x1f |*`CU_RES_VIEW_FORMAT_SIGNED_BC5`*                              |                                                            | Block compressed 5 signed                                                                                                      |
-|         0x20 |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC6H`*                           |                                                            | Block compressed 6 unsigned half-float                                                                                         |
-|         0x21 |*`CU_RES_VIEW_FORMAT_SIGNED_BC6H`*                             |                                                            | Block compressed 6 signed half-float                                                                                           |
-|         0x22 |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC7`*                            |                                                            | Block compressed 7                                                                                                             |
-| enum         |***`CUresult`***                                               |***`hipError_t`***                                          | Error codes                                                                                                                    |
-|            0 |*`CUDA_SUCCESS`*                                               |*`hipSuccess`*                                              | The API call returned with no errors. In the case of query calls, this can also mean that the operation being queried is complete (see cuEventQuery() and cuStreamQuery()). |
-|            1 |*`CUDA_ERROR_INVALID_VALUE`*                                   |*`hipErrorInvalidValue`*                                    | This indicates that one or more of the parameters passed to the API call is not within an acceptable range of values.          |
-|            2 |*`CUDA_ERROR_OUT_OF_MEMORY`*                                   |*`hipErrorMemoryAllocation`*                                | The API call failed because it was unable to allocate enough memory to perform the requested operation.                        |
-|            3 |*`CUDA_ERROR_NOT_INITIALIZED`*                                 |*`hipErrorNotInitialized`*                                  | This indicates that the CUDA driver has not been initialized with cuInit() or that initialization has failed.                  |
-|            4 |*`CUDA_ERROR_DEINITIALIZED`*                                   |*`hipErrorDeinitialized`*                                   | This indicates that the CUDA driver is in the process of shutting down.                                                        |
-|            5 |*`CUDA_ERROR_PROFILER_DISABLED`*                               |*`hipErrorProfilerDisabled`*                                | This indicates profiler is not initialized for this run. This can happen when the application is running with external profiling tools like visual profiler. |
-|            6 |*`CUDA_ERROR_PROFILER_NOT_INITIALIZED`*                        |*`hipErrorProfilerNotInitialized`*                          | Deprecated This error return is deprecated as of CUDA 5.0. It is no longer an error to attempt to enable/disable the profiling via cuProfilerStart or cuProfilerStop without initialization. |
-|            7 |*`CUDA_ERROR_PROFILER_ALREADY_STARTED`*                        |*`hipErrorProfilerAlreadyStarted`*                          | Deprecated This error return is deprecated as of CUDA 5.0. It is no longer an error to call cuProfilerStart() when profiling is already enabled. |
-|            8 |*`CUDA_ERROR_PROFILER_ALREADY_STOPPED`*                        |*`hipErrorProfilerAlreadyStopped`*                          | Deprecated This error return is deprecated as of CUDA 5.0. It is no longer an error to call cuProfilerStop() when profiling is already disabled. |
-|          100 |*`CUDA_ERROR_NO_DEVICE`*                                       |*`hipErrorNoDevice`*                                        | This indicates that no CUDA-capable devices were detected by the installed CUDA driver.                                        |
-|          101 |*`CUDA_ERROR_INVALID_DEVICE`*                                  |*`hipErrorInvalidDevice`*                                   | This indicates that the device ordinal supplied by the user does not correspond to a valid CUDA device.                        |
-|          200 |*`CUDA_ERROR_INVALID_IMAGE`*                                   |*`hipErrorInvalidImage`*                                    | This indicates that the device kernel image is invalid. This can also indicate an invalid CUDA module.                         |
-|          201 |*`CUDA_ERROR_INVALID_CONTEXT`*                                 |*`hipErrorInvalidContext`*                                  | This most frequently indicates that there is no context bound to the current thread. This can also be returned if the context passed to an API call is not a valid handle (such as a context that has had cuCtxDestroy() invoked on it). This can also be returned if a user mixes different API versions (i.e. 3010 context with 3020 API calls). See cuCtxGetApiVersion() for more details. |
-|          202 |*`CUDA_ERROR_CONTEXT_ALREADY_CURRENT`*                         |*`hipErrorContextAlreadyCurrent`*                           | This indicated that the context being supplied as a parameter to the API call was already the active context. Deprecated This error return is deprecated as of CUDA 3.2. It is no longer an error to attempt to push the active context via cuCtxPushCurrent(). |
-|          205 |*`CUDA_ERROR_MAP_FAILED`*                                      |*`hipErrorMapFailed`*                                       | This indicates that a map or register operation has failed.                                                                    |
-|          206 |*`CUDA_ERROR_UNMAP_FAILED`*                                    |*`hipErrorUnmapFailed`*                                     | This indicates that an unmap or unregister operation has failed.                                                               |
-|          207 |*`CUDA_ERROR_ARRAY_IS_MAPPED`*                                 |*`hipErrorArrayIsMapped`*                                   | This indicates that the specified array is currently mapped and thus cannot be destroyed.                                      |
-|          208 |*`CUDA_ERROR_ALREADY_MAPPED`*                                  |*`hipErrorAlreadyMapped`*                                   | This indicates that the resource is already mapped.                                                                            |
-|          209 |*`CUDA_ERROR_NO_BINARY_FOR_GPU`*                               |*`hipErrorNoBinaryForGpu*                                   | This indicates that there is no kernel image available that is suitable for the device. This can occur when a user specifies code generation options for a particular CUDA source file that do not include the corresponding device configuration. |
-|          210 |*`CUDA_ERROR_ALREADY_ACQUIRED`*                                |*`hipErrorAlreadyAcquired*                                  | This indicates that a resource has already been acquired.                                                                      |
-|          211 |*`CUDA_ERROR_NOT_MAPPED`*                                      |*`hipErrorNotMapped`*                                       | This indicates that a resource is not mapped.                                                                                  |
-|          212 |*`CUDA_ERROR_NOT_MAPPED_AS_ARRAY`*                             |*`hipErrorNotMappedAsArray`*                                | This indicates that a mapped resource is not available for access as an array.                                                 |
-|          213 |*`CUDA_ERROR_NOT_MAPPED_AS_POINTER`*                           |*`hipErrorNotMappedAsPointer`*                              | This indicates that a mapped resource is not available for access as a pointer.                                                |
-|          214 |*`CUDA_ERROR_ECC_UNCORRECTABLE`*                               |*`hipErrorECCNotCorrectable`*                               | This indicates that an uncorrectable ECC error was detected during execution.                                                  |
-|          215 |*`CUDA_ERROR_UNSUPPORTED_LIMIT`*                               |*`hipErrorUnsupportedLimit`*                                | This indicates that the CUlimit passed to the API call is not supported by the active device.                                  |
-|          216 |*`CUDA_ERROR_CONTEXT_ALREADY_IN_USE`*                          |*`hipErrorContextAlreadyInUse`*                             | This indicates that the CUcontext passed to the API call can only be bound to a single CPU thread at a time but is already bound to a CPU thread. |
-|          217 |*`CUDA_ERROR_PEER_ACCESS_UNSUPPORTED`*                         |*`hipErrorPeerAccessUnsupported`*                           | This indicates that peer access is not supported across the given devices.                                                     |
-|          218 |*`CUDA_ERROR_INVALID_PTX`*                                     |*`hipErrorInvalidKernelFile`*                               | This indicates that a PTX JIT compilation failed.                                                                              |
-|          219 |*`CUDA_ERROR_INVALID_GRAPHICS_CONTEXT`*                        |*`hipErrorInvalidGraphicsContext`*                          | This indicates an error with OpenGL or DirectX context.                                                                        |
-|          300 |*`CUDA_ERROR_INVALID_SOURCE`*                                  |*`hipErrorInvalidSource`*                                   | This indicates that the device kernel source is invalid.                                                                       |
-|          301 |*`CUDA_ERROR_FILE_NOT_FOUND`*                                  |*`hipErrorFileNotFound`*                                    | This indicates that the file specified was not found.                                                                          |
-|          302 |*`CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND`*                  |*`hipErrorSharedObjectSymbolNotFound`*                      | This indicates that a link to a shared object failed to resolve.                                                               |
-|          303 |*`CUDA_ERROR_SHARED_OBJECT_INIT_FAILED`*                       |*`hipErrorSharedObjectInitFailed`*                          | This indicates that initialization of a shared object failed.                                                                  |
-|          304 |*`CUDA_ERROR_OPERATING_SYSTEM`*                                |*`hipErrorOperatingSystem`*                                 | This indicates that an OS call failed.                                                                                         |
-|          400 |*`CUDA_ERROR_INVALID_HANDLE`*                                  |*`hipErrorInvalidResourceHandle`*                           | This indicates that a resource handle passed to the API call was not valid. Resource handles are opaque types like CUstream and CUevent. |
-|          500 |*`CUDA_ERROR_NOT_FOUND`*                                       |*`hipErrorNotFound`*                                        | This indicates that a named symbol was not found. Examples of symbols are global/constant variable names, texture names, and surface names. |
-|          600 |*`CUDA_ERROR_NOT_READY`*                                       |*`hipErrorNotReady`*                                        | This indicates that asynchronous operations issued previously have not completed yet. This result is not actually an error, but must be indicated differently than CUDA_SUCCESS (which indicates completion). Calls that may return this value include cuEventQuery() and cuStreamQuery(). |
-|          700 |*`CUDA_ERROR_ILLEGAL_ADDRESS`*                                 |*`hipErrorIllegalAddress`*                                  | While executing a kernel, the device encountered a load or store instruction on an invalid memory address. The context cannot be used, so it must be destroyed (and a new one should be created). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA. |
-|          701 |*`CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES`*                         |*`hipErrorLaunchOutOfResources`*                            | This indicates that a launch did not occur because it did not have appropriate resources. This error usually indicates that the user has attempted to pass too many arguments to the device kernel, or the kernel launch specifies too many threads for the kernel's register count. Passing arguments of the wrong size (i.e. a 64-bit pointer when a 32-bit int is expected) is equivalent to passing too many arguments and can also result in this error. |
-|          702 |*`CUDA_ERROR_LAUNCH_TIMEOUT`*                                  |*`hipErrorLaunchTimeOut`*                                   | This indicates that the device kernel took too long to execute. This can only occur if timeouts are enabled - see the device attribute CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT for more information. The context cannot be used (and must be destroyed similar to CUDA_ERROR_LAUNCH_FAILED). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA. |
-|          703 |*`CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING`*                   |                                                            | This error indicates a kernel launch that uses an incompatible texturing mode.                                                 |
-|          704 |*`CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED`*                     |*`hipErrorPeerAccessAlreadyEnabled`*                        | This error indicates that a call to cuCtxEnablePeerAccess() is trying to re-enable peer access to a context which has already had peer access to it enabled. |
-|          705 |*`CUDA_ERROR_PEER_ACCESS_NOT_ENABLED`*                         |*`hipErrorPeerAccessNotEnabled`*                            | This error indicates that cuCtxDisablePeerAccess() is trying to disable peer access which has not been enabled yet via cuCtxEnablePeerAccess(). |
-|          708 |*`CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE`*                          |                                                            | This error indicates that cuCtxDisablePeerAccess() is trying to disable peer access which has not been enabled yet via cuCtxEnablePeerAccess(). |
-|          709 |*`CUDA_ERROR_CONTEXT_IS_DESTROYED`*                            |                                                            | This error indicates that the context current to the calling thread has been destroyed using cuCtxDestroy, or is a primary context which has not yet been initialized. |
-|          710 |*`CUDA_ERROR_ASSERT`*                                          |                                                            | A device-side assert triggered during kernel execution. The context cannot be used anymore, and must be destroyed. All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA. |
-|          711 |*`CUDA_ERROR_TOO_MANY_PEERS`*                                  |                                                            | This error indicates that the hardware resources required to enable peer access have been exhausted for one or more of the devices passed to cuCtxEnablePeerAccess(). |
-|          712 |*`CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED`*                  |*`hipErrorHostMemoryAlreadyRegistered`*                     | This error indicates that the memory range passed to cuMemHostRegister() has already been registered.                          |
-|          713 |*`CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED`*                      |*`hipErrorHostMemoryNotRegistered`*                         | This error indicates that the pointer passed to cuMemHostUnregister() does not correspond to any currently registered memory region. |
-|          714 |*`CUDA_ERROR_HARDWARE_STACK_ERROR`*                            |                                                            | While executing a kernel, the device encountered a stack error. This can be due to stack corruption or exceeding the stack size limit. The context cannot be used, so it must be destroyed (and a new one should be created). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA. |
-|          715 |*`CUDA_ERROR_ILLEGAL_INSTRUCTION`*                             |                                                            | While executing a kernel, the device encountered an illegal instruction. The context cannot be used, so it must be destroyed (and a new one should be created). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA. |
-|          716 |*`CUDA_ERROR_MISALIGNED_ADDRESS`*                              |                                                            | While executing a kernel, the device encountered a load or store instruction on a memory address which is not aligned. The context cannot be used, so it must be destroyed (and a new one should be created). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA. |
-|          717 |*`CUDA_ERROR_INVALID_ADDRESS_SPACE`*                           |                                                            | While executing a kernel, the device encountered an instruction which can only operate on memory locations in certain address spaces (global, shared, or local), but was supplied a memory address not belonging to an allowed address space. The context cannot be used, so it must be destroyed (and a new one should be created). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA. |
-|          718 |*`CUDA_ERROR_INVALID_PC`*                                      |                                                            | While executing a kernel, the device program counter wrapped its address space. The context cannot be used, so it must be destroyed (and a new one should be created). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA. |
-|          719 |*`CUDA_ERROR_LAUNCH_FAILED`*                                   |                                                            | An exception occurred on the device while executing a kernel. Common causes include dereferencing an invalid device pointer and accessing out of bounds shared memory. The context cannot be used, so it must be destroyed (and a new one should be created). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA. |
-|          800 |*`CUDA_ERROR_NOT_PERMITTED`*                                   |                                                            | This error indicates that the attempted operation is not permitted.                                                            |
-|          801 |*`CUDA_ERROR_NOT_SUPPORTED`*                                   |                                                            | This error indicates that the attempted operation is not supported on the current system or device.                            |
-|          999 |*`CUDA_ERROR_UNKNOWN`*                                         |                                                            | This indicates that an unknown internal error has occurred.                                                                    |
-| enum         |***`CUstream_flags`***                                         |***`hipStreamFlags`***                                      | Stream creation flags                                                                                                          |
-|          0x0 |*`CU_STREAM_DEFAULT`*                                          |*`hipStreamDefault`*                                        | Default stream flag                                                                                                            |
-|          0x1 |*`CU_STREAM_NON_BLOCKING`*                                     |*`hipStreamNonBlocking`*                                    | Stream does not synchronize with stream 0 (the NULL stream)                                                                    |
-| enum         |***`CUGLDeviceList`***                                         |                                                            | CUDA devices corresponding to an OpenGL device                                                                                 |
-|         0x01 |*`CU_GL_DEVICE_LIST_ALL`*                                      |                                                            | The CUDA devices for all GPUs used by the current OpenGL context                                                               |
-|         0x02 |*`CU_GL_DEVICE_LIST_CURRENT_FRAME`*                            |                                                            | The CUDA devices for the GPUs used by the current OpenGL context in its currently rendering frame                              |
-|         0x03 |*`CU_GL_DEVICE_LIST_NEXT_FRAME`*                               |                                                            | The CUDA devices for the GPUs to be used by the current OpenGL context in the next frame                                       |
-| enum         |***`CUGLmap_flags`***                                          |                                                            | CUDA GL Map Flags                                                                                                              |
-|         0x00 |*`CU_GL_MAP_RESOURCE_FLAGS_NONE`*                              |                                                            | Default; Assume resource can be read/written                                                                                   |
-|         0x01 |*`CU_GL_MAP_RESOURCE_FLAGS_READ_ONLY`*                         |                                                            | CUDA kernels will not write to this resource                                                                                   |
-|         0x02 |*`CU_GL_MAP_RESOURCE_FLAGS_WRITE_DISCARD`*                     |                                                            | CUDA kernels will only write to and will not read from this resource                                                           |
-| enum         |***`CUd3d9DeviceList`***                                       |                                                            | CUDA devices corresponding to a D3D9 device                                                                                    |
-|         0x01 |*`CU_D3D9_DEVICE_LIST_ALL`*                                    |                                                            | The CUDA devices for all GPUs used by a D3D9 device                                                                            |
-|         0x02 |*`CU_D3D9_DEVICE_LIST_CURRENT_FRAME`*                          |                                                            | The CUDA devices for the GPUs used by a D3D9 device in its currently rendering frame                                           |
-|         0x03 |*`CU_D3D9_DEVICE_LIST_NEXT_FRAME`*                             |                                                            | The CUDA devices for the GPUs to be used by a D3D9 device in the next frame                                                    |
-| enum         |***`CUd3d9map_flags`***                                        |                                                            | Flags to map or unmap a resource                                                                                               |
-|         0x00 |*`CU_D3D9_MAPRESOURCE_FLAGS_NONE`*                             |                                                            | Default; Assume resource can be read/written                                                                                   |
-|         0x01 |*`CU_D3D9_MAPRESOURCE_FLAGS_READONLY`*                         |                                                            | CUDA kernels will not write to this resource                                                                                   |
-|         0x02 |*`CU_D3D9_MAPRESOURCE_FLAGS_WRITEDISCARD`*                     |                                                            | CUDA kernels will only write to and will not read from this resource                                                           |
-| enum         |***`CUd3d9register_flags`***                                   |                                                            | CUDA D3D9 Register Flags                                                                                                       |
-|         0x00 |*`CU_D3D9_REGISTER_FLAGS_NONE`*                                |                                                            | Default; Resource can be accessed througa void*                                                                                |
-|         0x01 |*`CU_D3D9_REGISTER_FLAGS_ARRAY`*                               |                                                            | Resource can be accessed through a CUarray*                                                                                    |
-| enum         |***`CUd3d10DeviceList`***                                      |                                                            | CUDA devices corresponding to a D3D10 device                                                                                   |
-|         0x01 |*`CU_D3D10_DEVICE_LIST_ALL`*                                   |                                                            | The CUDA devices for all GPUs used by a D3D10 device                                                                           |
-|         0x02 |*`CU_D3D10_DEVICE_LIST_CURRENT_FRAME`*                         |                                                            | The CUDA devices for the GPUs used by a D3D10 device in its currently rendering frame                                          |
-|         0x03 |*`CU_D3D10_DEVICE_LIST_NEXT_FRAME`*                            |                                                            | The CUDA devices for the GPUs to be used by a D3D10 device in the next frame                                                   |
-| enum         |***`CUd3d10map_flags`***                                       |                                                            | Flags to map or unmap a resource                                                                                               |
-|         0x00 |*`CU_D3D10_MAPRESOURCE_FLAGS_NONE`*                            |                                                            | Default; Assume resource can be read/written                                                                                   |
-|         0x01 |*`CU_D3D10_MAPRESOURCE_FLAGS_READONLY`*                        |                                                            | CUDA kernels will not write to this resource                                                                                   |
-|         0x02 |*`CU_D3D10_MAPRESOURCE_FLAGS_WRITEDISCARD`*                    |                                                            | CUDA kernels will only write to and will not read from this resource                                                           |
-| enum         |***`CUd3d10register_flags`***                                  |                                                            | CUDA D3D10 Register Flags                                                                                                      |
-|         0x00 |*`CU_D3D10_REGISTER_FLAGS_NONE`*                               |                                                            | Default; Resource can be accessed througa void*                                                                                |
-|         0x01 |*`CU_D3D10_REGISTER_FLAGS_ARRAY`*                              |                                                            | Resource can be accessed through a CUarray*                                                                                    |
-| enum         |***`CUd3d11DeviceList`***                                      |                                                            | CUDA devices corresponding to a D3D11 device                                                                                   |
-|         0x01 |*`CU_D3D11_DEVICE_LIST_ALL`*                                   |                                                            | The CUDA devices for all GPUs used by a D3D11 device                                                                           |
-|         0x02 |*`CU_D3D11_DEVICE_LIST_CURRENT_FRAME`*                         |                                                            | The CUDA devices for the GPUs used by a D3D11 device in its currently rendering frame                                          |
-|         0x03 |*`CU_D3D11_DEVICE_LIST_NEXT_FRAME`*                            |                                                            | The CUDA devices for the GPUs to be used by a D3D11 device in the next frame                                                   |
-| typedef      | `CUarray`                                                     | `hipArray *`                                               | CUDA array                                                                                                                     |
-| struct       | `CUarray_st`                                                  | `hipArray`                                                 | CUDA array                                                                                                                     |
-| typedef      | `CUcontext`                                                   | `hipCtx_t`                                                 | CUDA context                                                                                                                   |
-| typedef      | `CUdevice`                                                    | `hipDevice_t`                                              | CUDA device                                                                                                                    |
-| typedef      | `CUdeviceptr`                                                 | `hipDeviceptr_t`                                           | CUDA device pointer CUdeviceptr is defined as an unsigned integer type whose size matches the size of a pointer on the target platform. |
-| typedef      | `CUevent`                                                     | `hipEvent_t`                                               | CUDA event                                                                                                                     |
-| typedef      | `CUfunction`                                                  | `hipFunction_t`                                            | CUDA function                                                                                                                  |
-| typedef      | `CUgraphicsResource`                                          |                                                            | CUDA graphics interop resource                                                                                                 |
-| typedef      | `CUmipmappedArray`                                            |                                                            | CUDA mipmapped array                                                                                                           |
-| typedef      | `CUmodule`                                                    | `hipModule_t`                                              | CUDA module                                                                                                                    |
-| typedef      | `CUstream`                                                    | `hipStream_t`                                              | CUDA module                                                                                                                    |
-| typedef      | `CUstreamCallback`                                            | `hipStreamCallback_t`                                      | CUDA stream callback                                                                                                           |
-| typedef      | `CUsurfObject`                                                |                                                            | An opaque value that represents a CUDA surface object                                                                          |
-| typedef      | `CUsurfref`                                                   |                                                            | CUDA surface reference                                                                                                         |
-| typedef      | `CUtexObject`                                                 |                                                            | An opaque value that represents a CUDA texture object                                                                          |
-| typedef      | `CUtexref`                                                    |                                                            | CUDA texture reference                                                                                                         |
-| define       |`CU_IPC_HANDLE_SIZE`                                           |                                                            | CUDA IPC handle size.                                                                                                          |
-| define       |`CU_LAUNCH_PARAM_BUFFER_POINTER`                               | `HIP_LAUNCH_PARAM_BUFFER_POINTER`                          | Indicator that the next value in the extra parameter to cuLaunchKernel will be a pointer to a buffer containing all kernel parameters used for launching kernel f. This buffer needs to honor all alignment/padding requirements of the individual parameters. If CU_LAUNCH_PARAM_BUFFER_SIZE is not also specified in the extra array, then CU_LAUNCH_PARAM_BUFFER_POINTER will have no effect. |
-| define       |`CU_LAUNCH_PARAM_BUFFER_SIZE`                                  | `HIP_LAUNCH_PARAM_BUFFER_SIZE`                             | Indicator that the next value in the extra parameter to cuLaunchKernel will be a pointer to a size_t which contains the size of the buffer specified with CU_LAUNCH_PARAM_BUFFER_POINTER. It is required that CU_LAUNCH_PARAM_BUFFER_POINTER also be specified in the extra array if the value associated with CU_LAUNCH_PARAM_BUFFER_SIZE is not zero. |
-| define       |`CU_LAUNCH_PARAM_END`                                          | `HIP_LAUNCH_PARAM_END`                                     | End of array terminator for the extra parameter to cuLaunchKernel.                                                             |
-| define       |`CU_MEMHOSTALLOC_DEVICEMAP`                                    |                                                            | If set, host memory is mapped into CUDA address space and cuMemHostGetDevicePointer() may be called on the host pointer. Flag for cuMemHostAlloc(). |
-| define       |`CU_MEMHOSTALLOC_PORTABLE`                                     |                                                            | If set, host memory is portable between CUDA contexts. Flag for cuMemHostAlloc().                                              |
-| define       |`CU_MEMHOSTALLOC_WRITECOMBINED`                                |                                                            | If set, host memory is allocated as write-combined - fast to write, faster to DMA, slow to read except via SSE4 streaming load instruction (MOVNTDQA). Flag for cuMemHostAlloc(). |
-| define       |`CU_MEMHOSTREGISTER_DEVICEMAP`                                 |                                                            | If set, host memory is mapped into CUDA address space and cuMemHostGetDevicePointer() may be called on the host pointer. Flag for cuMemHostRegister(). |
-| define       |`CU_MEMHOSTREGISTER_IOMEMORY`                                  |                                                            | If set, the passed memory pointer is treated as pointing to some memory-mapped I/O space, e.g. belonging to a third-party PCIe device. On Windows the flag is a no-op. On Linux that memory is marked as non cache-coherent for the GPU and is expected to be physically contiguous. It may return CUDA_ERROR_NOT_PERMITTED if run as an unprivileged user, CUDA_ERROR_NOT_SUPPORTED on older Linux kernel versions. On all other platforms, it is not supported and CUDA_ERROR_NOT_SUPPORTED is returned. Flag for cuMemHostRegister(). |
-| define       |`CU_MEMHOSTREGISTER_PORTABLE`                                  |                                                            | If set, host memory is portable between CUDA contexts. Flag for cuMemHostRegister().                                           |
-| define       |`CU_PARAM_TR_DEFAULT`                                          |                                                            | For texture references loaded into the module, use default texunit from texture reference.                                     |
-| define       |`CU_STREAM_LEGACY`                                             |                                                            | Legacy stream handle. Stream handle that can be passed as a CUstream to use an implicit stream with legacy synchronization behavior. See details of the synchronization behavior. |
-| define       |`CU_STREAM_PER_THREAD`                                         |                                                            | Per-thread stream handle. Stream handle that can be passed as a CUstream to use an implicit stream with perthread synchronization behavior. See details of the synchronization behavior. |
-| define       |`CU_TRSA_OVERRIDE_FORMAT`                                      |                                                            | Override the texref format with a format inferred from the array. Flag for cuTexRefSetArray().                                 |
-| define       |`CU_TRSF_NORMALIZED_COORDINATES`                               |                                                            | Use normalized texture coordinates in the range [0,1) instead of [0,dim). Flag for cuTexRefSetFlags().                         |
-| define       |`CU_TRSF_SRGB`                                                 |                                                            | Perform sRGB->linear conversion during texture read. Flag for cuTexRefSetFlags().                                              |
-| define       |`CUDA_ARRAY3D_2DARRAY`                                         |                                                            | Deprecated, use CUDA_ARRAY3D_LAYERED.                                                                                          |
-| define       |`CUDA_ARRAY3D_CUBEMAP`                                         |                                                            | If set, the CUDA array is a collection of six 2D arrays, representing faces of a cube. The width of such a CUDA array must be equal to its height, and Depth must be six. If CUDA_ARRAY3D_LAYERED flag is also set, then the CUDA array is a collection of cubemaps and Depth must be a multiple of six. |
-| define       |`CUDA_ARRAY3D_DEPTH_TEXTURE`                                   |                                                            | This flag if set indicates that the CUDA array is a DEPTH_TEXTURE.                                                             |
-| define       |`CUDA_ARRAY3D_LAYERED`                                         |                                                            | If set, the CUDA array is a collection of layers, where each layer is either a 1D or a 2D array and the Depth member of CUDA_ARRAY3D_DESCRIPTOR specifies the number of layers, not the depth of a 3D array. |
-| define       |`CUDA_ARRAY3D_SURFACE_LDST`                                    |                                                            | This flag must be set in order to bind a surface reference to the CUDA array.                                                  |
-| define       |`CUDA_ARRAY3D_TEXTURE_GATHER`                                  |                                                            | This flag must be set in order to perform texture gather operations on a CUDA array.                                           |
-| define       |`CUDA_VERSION`                                                 |                                                            | CUDA API version number.                                                                                                       |
+| **type**     |   **CUDA**                                                    |   **HIP**                                                  |
+|-------------:|---------------------------------------------------------------|------------------------------------------------------------|
+| struct       | `CUDA_ARRAY3D_DESCRIPTOR`                                     |                                                            |
+| struct       | `CUDA_ARRAY_DESCRIPTOR`                                       |                                                            |
+| struct       | `CUDA_MEMCPY2D`                                               |                                                            |
+| struct       | `CUDA_MEMCPY3D`                                               |                                                            |
+| struct       | `CUDA_MEMCPY3D_PEER`                                          |                                                            |
+| struct       | `CUDA_POINTER_ATTRIBUTE_P2P_TOKENS`                           |                                                            |
+| struct       | `CUDA_RESOURCE_DESC`                                          |                                                            |
+| struct       | `CUDA_RESOURCE_VIEW_DESC`                                     |                                                            |
+| struct       | `CUdevprop`                                                   | `hipDeviceProp_t`                                          |
+| struct       | `CUipcEventHandle`                                            |                                                            |
+| struct       | `CUipcMemHandle`                                              |                                                            |
+| enum         |***`CUaddress_mode`***                                         |                                                            |
+|            0 |*`CU_TR_ADDRESS_MODE_WRAP`*                                    |                                                            |
+|            1 |*`CU_TR_ADDRESS_MODE_CLAMP`*                                   |                                                            |
+|            2 |*`CU_TR_ADDRESS_MODE_MIRROR`*                                  |                                                            |
+|            3 |*`CU_TR_ADDRESS_MODE_BORDER`*                                  |                                                            |
+| enum         |***`CUarray_cubemap_face`***                                   |                                                            |
+|         0x00 |*`CU_CUBEMAP_FACE_POSITIVE_X`*                                 |                                                            |
+|         0x01 |*`CU_CUBEMAP_FACE_NEGATIVE_X`*                                 |                                                            |
+|         0x02 |*`CU_CUBEMAP_FACE_POSITIVE_Y`*                                 |                                                            |
+|         0x03 |*`CU_CUBEMAP_FACE_NEGATIVE_Y`*                                 |                                                            |
+|         0x04 |*`CU_CUBEMAP_FACE_POSITIVE_Z`*                                 |                                                            |
+|         0x05 |*`CU_CUBEMAP_FACE_NEGATIVE_Z`*                                 |                                                            |
+| enum         |***`CUarray_format`***                                         |                                                            |
+|         0x01 |*`CU_AD_FORMAT_UNSIGNED_INT8`*                                 |                                                            |
+|         0x02 |*`CU_AD_FORMAT_UNSIGNED_INT16`*                                |                                                            |
+|         0x03 |*`CU_AD_FORMAT_UNSIGNED_INT32`*                                |                                                            |
+|         0x08 |*`CU_AD_FORMAT_SIGNED_INT8`*                                   |                                                            |
+|         0x09 |*`CU_AD_FORMAT_SIGNED_INT16`*                                  |                                                            |
+|         0x0a |*`CU_AD_FORMAT_SIGNED_INT32`*                                  |                                                            |
+|         0x10 |*`CU_AD_FORMAT_HALF`*                                          |                                                            |
+|         0x20 |*`CU_AD_FORMAT_FLOAT`*                                         |                                                            |
+| enum         |***`CUctx_flags`***                                            |                                                            |
+|         0x00 |*`CU_CTX_SCHED_AUTO`*                                          |                                                            |
+|         0x01 |*`CU_CTX_SCHED_SPIN`*                                          |                                                            |
+|         0x02 |*`CU_CTX_SCHED_YIELD`*                                         |                                                            |
+|         0x04 |*`CU_CTX_SCHED_BLOCKING_SYNC`*                                 |                                                            |
+|         0x04 |*`CU_CTX_BLOCKING_SYNC`*                                       |                                                            |
+|         0x07 |*`CU_CTX_SCHED_MASK`*                                          |                                                            |
+|         0x08 |*`CU_CTX_MAP_HOST`*                                            |                                                            |
+|         0x10 |*`CU_CTX_LMEM_RESIZE_TO_MAX`*                                  |                                                            |
+|         0x1f |*`CU_CTX_FLAGS_MASK`*                                          |                                                            |
+| enum         |***`CUdevice_attribute`***                                     |                                                            |
+|            1 |*`CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK`*                  |*`hipDeviceAttributeMaxThreadsPerBlock`*                    |
+|            2 |*`CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X`*                        |*`hipDeviceAttributeMaxBlockDimX`*                          |
+|            3 |*`CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y`*                        |*`hipDeviceAttributeMaxBlockDimY`*                          |
+|            4 |*`CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z`*                        |*`hipDeviceAttributeMaxBlockDimZ`*                          |
+|            5 |*`CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X`*                         |*`hipDeviceAttributeMaxGridDimX`*                           |
+|            6 |*`CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y`*                         |*`hipDeviceAttributeMaxGridDimY`*                           |
+|            7 |*`CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z`*                         |*`hipDeviceAttributeMaxGridDimZ`*                           |
+|            8 |*`CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK`*            |*`hipDeviceAttributeMaxSharedMemoryPerBlock`*               |
+|            8 |*`CU_DEVICE_ATTRIBUTE_SHARED_MEMORY_PER_BLOCK`*                |*`hipDeviceAttributeMaxSharedMemoryPerBlock`*               |
+|            9 |*`CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY`*                  |*`hipDeviceAttributeTotalConstantMemory`*                   |
+|           10 |*`CU_DEVICE_ATTRIBUTE_WARP_SIZE`*                              |*`hipDeviceAttributeWarpSize`*                              |
+|           11 |*`CU_DEVICE_ATTRIBUTE_MAX_PITCH`*                              |                                                            |
+|           12 |*`CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK`*                |*`hipDeviceAttributeMaxRegistersPerBlock`*                  |
+|           12 |*`CU_DEVICE_ATTRIBUTE_REGISTERS_PER_BLOCK`*                    |*`hipDeviceAttributeMaxRegistersPerBlock`*                  |
+|           13 |*`CU_DEVICE_ATTRIBUTE_CLOCK_RATE`*                             |*`hipDeviceAttributeClockRate`*                             |
+|           14 |*`CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT`*                      |                                                            |
+|           15 |*`CU_DEVICE_ATTRIBUTE_GPU_OVERLAP`*                            |                                                            |
+|           16 |*`CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT`*                   |*`hipDeviceAttributeMultiprocessorCount`*                   |
+|           17 |*`CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT`*                    |                                                            |
+|           18 |*`CU_DEVICE_ATTRIBUTE_INTEGRATED`*                             |                                                            |
+|           19 |*`CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY`*                    |                                                            |
+|           20 |*`CU_DEVICE_ATTRIBUTE_COMPUTE_MODE`*                           |*`hipDeviceAttributeComputeMode`*                           |
+|           21 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH`*                |                                                            |
+|           22 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH`*                |                                                            |
+|           23 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT`*               |                                                            |
+|           24 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH`*                |                                                            |
+|           25 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT`*               |                                                            |
+|           26 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH`*                |                                                            |
+|           27 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH`*        |                                                            |
+|           28 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT`*       |                                                            |
+|           29 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS`*       |                                                            |
+|           27 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_WIDTH`*          |                                                            |
+|           28 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_HEIGHT`*         |                                                            |
+|           29 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_NUMSLICES`*      |                                                            |
+|           30 |*`CU_DEVICE_ATTRIBUTE_SURFACE_ALIGNMENT`*                      |                                                            |
+|           31 |*`CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS`*                     |*`hipDeviceAttributeConcurrentKernels`*                     |
+|           32 |*`CU_DEVICE_ATTRIBUTE_ECC_ENABLED`*                            |                                                            |
+|           33 |*`CU_DEVICE_ATTRIBUTE_PCI_BUS_ID`*                             |*`hipDeviceAttributePciBusId`*                              |
+|           34 |*`CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID`*                          |*`hipDeviceAttributePciDeviceId`*                           |
+|           35 |*`CU_DEVICE_ATTRIBUTE_TCC_DRIVER`*                             |                                                            |
+|           36 |*`CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE`*                      |*`hipDeviceAttributeMemoryClockRate`*                       |
+|           37 |*`CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH`*                |*`hipDeviceAttributeMemoryBusWidth`*                        |
+|           38 |*`CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE`*                          |*`hipDeviceAttributeL2CacheSize`*                           |
+|           39 |*`CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR`*         |*`hipDeviceAttributeMaxThreadsPerMultiProcessor`*           |
+|           40 |*`CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT`*                     |                                                            |
+|           41 |*`CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING`*                     |                                                            |
+|           42 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_WIDTH`*        |                                                            |
+|           43 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_LAYERS`*       |                                                            |
+|           44 |*`CU_DEVICE_ATTRIBUTE_CAN_TEX2D_GATHER`*                       |                                                            |
+|           45 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_WIDTH`*         |                                                            |
+|           46 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_HEIGHT`*        |                                                            |
+|           47 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH_ALTERNATE`*      |                                                            |
+|           48 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT_ALTERNATE`*     |                                                            |
+|           49 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH_ALTERNATE`*      |                                                            |
+|           50 |*`CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID`*                          |                                                            |
+|           51 |*`CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT`*                |                                                            |
+|           52 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_WIDTH`*           |                                                            |
+|           53 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_WIDTH`*   |                                                            |
+|           54 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_LAYERS`*  |                                                            |
+|           55 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH`*                |                                                            |
+|           56 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH`*                |                                                            |
+|           57 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT`*               |                                                            |
+|           58 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH`*                |                                                            |
+|           59 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT`*               |                                                            |
+|           60 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH`*                |                                                            |
+|           61 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_WIDTH`*        |                                                            |
+|           62 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_LAYERS`*       |                                                            |
+|           63 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_WIDTH`*        |                                                            |
+|           64 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_HEIGHT`*       |                                                            |
+|           65 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_LAYERS`*       |                                                            |
+|           66 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_WIDTH`*           |                                                            |
+|           67 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_WIDTH`*   |                                                            |
+|           68 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_LAYERS`*  |                                                            |
+|           69 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LINEAR_WIDTH`*         |                                                            |
+|           70 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH`*         |                                                            |
+|           71 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT`*        |                                                            |
+|           72 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH`*         |                                                            |
+|           73 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_WIDTH`*      |                                                            |
+|           74 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_HEIGHT`*     |                                                            |
+|           75 |*`CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR`*               |*`hipDeviceAttributeComputeCapabilityMajor`*                |
+|           76 |*`CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR`*               |*`hipDeviceAttributeComputeCapabilityMinor`*                |
+|           77 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_MIPMAPPED_WIDTH`*      |                                                            |
+|           78 |*`CU_DEVICE_ATTRIBUTE_STREAM_PRIORITIES_SUPPORTED`*            |                                                            |
+|           79 |*`CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED`*              |                                                            |
+|           80 |*`CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED`*               |                                                            |
+|           81 |*`CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR`*   |*`hipDeviceAttributeMaxSharedMemoryPerMultiprocessor`*      |
+|           82 |*`CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR`*       |                                                            |
+|           83 |*`CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY`*                         |*`hipDeviceAttributeManagedMemory`*                         |
+|           84 |*`CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD`*                        |                                                            |
+|           85 |*`CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID`*               |                                                            |
+|           86 |*`CU_DEVICE_ATTRIBUTE_MAX`*                                    |                                                            |
+| enum         |***`CUevent_flags`***                                          |                                                            |
+|         0x00 |*`CU_EVENT_DEFAULT`*                                           |*`hipEventDefault`*                                         |
+|         0x01 |*`CU_EVENT_BLOCKING_SYNC`*                                     |*`hipEventBlockingSync`*                                    |
+|         0x02 |*`CU_EVENT_DISABLE_TIMING`*                                    |*`hipEventDisableTiming`*                                   |
+|         0x04 |*`CU_EVENT_INTERPROCESS`*                                      |*`hipEventInterprocess`*                                    |
+| enum         |***`CUfilter_mode`***                                          |***`hipTextureFilterMode`***                                |
+|            0 |*`CU_TR_FILTER_MODE_POINT`*                                    |*`hipFilterModePoint`*                                      |
+|            1 |*`CU_TR_FILTER_MODE_LINEAR`*                                   |*`hipFilterModeLinear`*                                     |
+| enum         |***`CUfunc_cache`***                                           |***`hipFuncCache`***                                        |
+|         0x00 |*`CU_FUNC_CACHE_PREFER_NONE`*                                  |*`hipFuncCachePreferNone`*                                  |
+|         0x01 |*`CU_FUNC_CACHE_PREFER_SHARED`*                                |*`hipFuncCachePreferShared`*                                |
+|         0x02 |*`CU_FUNC_CACHE_PREFER_L1`*                                    |*`hipFuncCachePreferL1`*                                    |
+|         0x03 |*`CU_FUNC_CACHE_PREFER_EQUAL`*                                 |*`hipFuncCachePreferEqual`*                                 |
+| enum         |***`CUfunction_attribute`***                                   |                                                            |
+|            0 |*`CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK`*                    |                                                            |
+|            1 |*`CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES`*                        |                                                            |
+|            2 |*`CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES`*                         |                                                            |
+|            3 |*`CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES`*                         |                                                            |
+|            4 |*`CU_FUNC_ATTRIBUTE_NUM_REGS`*                                 |                                                            |
+|            5 |*`CU_FUNC_ATTRIBUTE_PTX_VERSION`*                              |                                                            |
+|            6 |*`CU_FUNC_ATTRIBUTE_BINARY_VERSION`*                           |                                                            |
+|            7 |*`CU_FUNC_ATTRIBUTE_CACHE_MODE_CA`*                            |                                                            |
+|            8 |*`CU_FUNC_ATTRIBUTE_MAX`*                                      |                                                            |
+| enum         |***`CUgraphicsMapResourceFlags`***                             |                                                            |
+|         0x00 |*`CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE`*                        |                                                            |
+|         0x01 |*`CU_GRAPHICS_MAP_RESOURCE_FLAGS_READ_ONLY`*                   |                                                            |
+|         0x02 |*`CU_GRAPHICS_MAP_RESOURCE_FLAGS_WRITE_DISCARD`*               |                                                            |
+| enum         |***`CUgraphicsRegisterFlags`***                                |                                                            |
+|         0x00 |*`CU_GRAPHICS_REGISTER_FLAGS_NONE`*                            |                                                            |
+|         0x01 |*`CU_GRAPHICS_REGISTER_FLAGS_READ_ONLY`*                       |                                                            |
+|         0x02 |*`CU_GRAPHICS_REGISTER_FLAGS_WRITE_DISCARD`*                   |                                                            |
+|         0x04 |*`CU_GRAPHICS_REGISTER_FLAGS_SURFACE_LDST`*                    |                                                            |
+|         0x08 |*`CU_GRAPHICS_REGISTER_FLAGS_TEXTURE_GATHER`*                  |                                                            |
+| enum         |***`CUipcMem_flags`***                                         |                                                            |
+|          0x1 |*`CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS`*                         |*`hipIpcMemLazyEnablePeerAccess`*                           |
+| enum         |***`CUjit_cacheMode`***                                        |                                                            |
+|            0 |*`CU_JIT_CACHE_OPTION_NONE`*                                   |                                                            |
+|              |*`CU_JIT_CACHE_OPTION_CG`*                                     |                                                            |
+|              |*`CU_JIT_CACHE_OPTION_CA`*                                     |                                                            |
+| enum         |***`CUjit_fallback`***                                         |                                                            |
+|            0 |*`CU_PREFER_PTX`*                                              |                                                            |
+|              |*`CU_PREFER_BINARY`*                                           |                                                            |
+| enum         |***`CUjit_option`***                                           |                                                            |
+|            0 |*`CU_JIT_MAX_REGISTERS`*                                       |                                                            |
+|              |*`CU_JIT_THREADS_PER_BLOCK`*                                   |                                                            |
+|              |*`CU_JIT_WALL_TIME`*                                           |                                                            |
+|              |*`CU_JIT_INFO_LOG_BUFFER`*                                     |                                                            |
+|              |*`CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES`*                          |                                                            |
+|              |*`CU_JIT_OPTIMIZATION_LEVEL`*                                  |                                                            |
+|              |*`CU_JIT_TARGET_FROM_CUCONTEXT`*                               |                                                            |
+|              |*`CU_JIT_TARGET`*                                              |                                                            |
+|              |*`CU_JIT_FALLBACK_STRATEGY`*                                   |                                                            |
+|              |*`CU_JIT_GENERATE_DEBUG_INFO`*                                 |                                                            |
+|              |*`CU_JIT_LOG_VERBOSE`*                                         |                                                            |
+|              |*`CU_JIT_GENERATE_LINE_INFO`*                                  |                                                            |
+|              |*`CU_JIT_CACHE_MODE`*                                          |                                                            |
+|              |*`CU_JIT_NUM_OPTIONS`*                                         |                                                            |
+| enum         |***`CUjit_target`***                                           |                                                            |
+|           10 |*`CU_TARGET_COMPUTE_10`*                                       |                                                            |
+|           11 |*`CU_TARGET_COMPUTE_11`*                                       |                                                            |
+|           12 |*`CU_TARGET_COMPUTE_12`*                                       |                                                            |
+|           13 |*`CU_TARGET_COMPUTE_13`*                                       |                                                            |
+|           20 |*`CU_TARGET_COMPUTE_20`*                                       |                                                            |
+|           21 |*`CU_TARGET_COMPUTE_21`*                                       |                                                            |
+|           30 |*`CU_TARGET_COMPUTE_30`*                                       |                                                            |
+|           32 |*`CU_TARGET_COMPUTE_32`*                                       |                                                            |
+|           35 |*`CU_TARGET_COMPUTE_35`*                                       |                                                            |
+|           37 |*`CU_TARGET_COMPUTE_37`*                                       |                                                            |
+|           50 |*`CU_TARGET_COMPUTE_50`*                                       |                                                            |
+|           52 |*`CU_TARGET_COMPUTE_52`*                                       |                                                            |
+| enum         |***`CUjitInputType`***                                         |                                                            |
+|            0 |*`CU_JIT_INPUT_CUBIN`*                                         |                                                            |
+|              |*`CU_JIT_INPUT_PTX`*                                           |                                                            |
+|              |*`CU_JIT_INPUT_FATBINARY`*                                     |                                                            |
+|              |*`CU_JIT_INPUT_OBJECT`*                                        |                                                            |
+|              |*`CU_JIT_INPUT_LIBRARY`*                                       |                                                            |
+|              |*`CU_JIT_NUM_INPUT_TYPES`*                                     |                                                            |
+| enum         |***`CUlimit`***                                                |***`hipLimit_t`***                                          |
+|         0x00 |*`CU_LIMIT_STACK_SIZE`*                                        |                                                            |
+|         0x01 |*`CU_LIMIT_PRINTF_FIFO_SIZE`*                                  |                                                            |
+|         0x02 |*`CU_LIMIT_MALLOC_HEAP_SIZE`*                                  |*`hipLimitMallocHeapSize`*                                  |
+|         0x03 |*`CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH`*                            |                                                            |
+|         0x04 |*`CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT`*                  |                                                            |
+|              |*`CU_LIMIT_MAX`*                                               |                                                            |
+| enum         |***`CUmemAttach_flags`***                                      |                                                            |
+|          0x1 |*`CU_MEM_ATTACH_GLOBAL`*                                       |                                                            |
+|          0x2 |*`CU_MEM_ATTACH_HOST`*                                         |                                                            |
+|          0x4 |*`CU_MEM_ATTACH_SINGLE`*                                       |                                                            |
+| enum         |***`CUmemorytype`***                                           |                                                            |
+|         0x01 |*`CU_MEMORYTYPE_HOST`*                                         |                                                            |
+|         0x02 |*`CU_MEMORYTYPE_DEVICE`*                                       |                                                            |
+|         0x03 |*`CU_MEMORYTYPE_ARRAY`*                                        |                                                            |
+|         0x04 |*`CU_MEMORYTYPE_UNIFIED`*                                      |                                                            |
+| enum         |***`CUoccupancy_flags`***                                      |                                                            |
+|         0x00 |*`CU_OCCUPANCY_DEFAULT`*                                       |                                                            |
+|         0x01 |*`CU_OCCUPANCY_DISABLE_CACHING_OVERRIDE`*                      |                                                            |
+| enum         |***`CUpointer_attribute`***                                    |                                                            |
+|            1 |*`CU_POINTER_ATTRIBUTE_CONTEXT`*                               |                                                            |
+|            2 |*`CU_POINTER_ATTRIBUTE_MEMORY_TYPE`*                           |                                                            |
+|            3 |*`CU_POINTER_ATTRIBUTE_DEVICE_POINTER`*                        |                                                            |
+|            4 |*`CU_POINTER_ATTRIBUTE_HOST_POINTER`*                          |                                                            |
+|            5 |*`CU_POINTER_ATTRIBUTE_P2P_TOKENS`*                            |                                                            |
+|            6 |*`CU_POINTER_ATTRIBUTE_SYNC_MEMOPS`*                           |                                                            |
+|            7 |*`CU_POINTER_ATTRIBUTE_BUFFER_ID`*                             |                                                            |
+|            8 |*`CU_POINTER_ATTRIBUTE_IS_MANAGED`*                            |                                                            |
+| enum         |***`CUmemorytype`***                                           |                                                            |
+|         0x00 |*`CU_RESOURCE_TYPE_ARRAY`*                                     |                                                            |
+|         0x01 |*`CU_RESOURCE_TYPE_MIPMAPPED_ARRAY`*                           |                                                            |
+|         0x02 |*`CU_RESOURCE_TYPE_LINEAR`*                                    |                                                            |
+|         0x03 |*`CU_RESOURCE_TYPE_PITCH2D`*                                   |                                                            |
+| enum         |***`CUresourceViewFormat`***                                   |                                                            |
+|         0x00 |*`CU_RES_VIEW_FORMAT_NONE`*                                    |                                                            |
+|         0x01 |*`CU_RES_VIEW_FORMAT_UINT_1X8`*                                |                                                            |
+|         0x02 |*`CU_RES_VIEW_FORMAT_UINT_2X8`*                                |                                                            |
+|         0x03 |*`CU_RES_VIEW_FORMAT_UINT_4X8`*                                |                                                            |
+|         0x04 |*`CU_RES_VIEW_FORMAT_SINT_1X8`*                                |                                                            |
+|         0x05 |*`CU_RES_VIEW_FORMAT_SINT_2X8`*                                |                                                            |
+|         0x06 |*`CU_RES_VIEW_FORMAT_SINT_4X8`*                                |                                                            |
+|         0x07 |*`CU_RES_VIEW_FORMAT_UINT_1X16`*                               |                                                            |
+|         0x08 |*`CU_RES_VIEW_FORMAT_UINT_2X16`*                               |                                                            |
+|         0x09 |*`CU_RES_VIEW_FORMAT_UINT_4X16`*                               |                                                            |
+|         0x0a |*`CU_RES_VIEW_FORMAT_SINT_1X16`*                               |                                                            |
+|         0x0b |*`CU_RES_VIEW_FORMAT_SINT_2X16`*                               |                                                            |
+|         0x0c |*`CU_RES_VIEW_FORMAT_SINT_4X16`*                               |                                                            |
+|         0x0d |*`CU_RES_VIEW_FORMAT_UINT_1X32`*                               |                                                            |
+|         0x0e |*`CU_RES_VIEW_FORMAT_UINT_2X32`*                               |                                                            |
+|         0x0f |*`CU_RES_VIEW_FORMAT_UINT_4X32`*                               |                                                            |
+|         0x10 |*`CU_RES_VIEW_FORMAT_SINT_1X32`*                               |                                                            |
+|         0x11 |*`CU_RES_VIEW_FORMAT_SINT_2X32`*                               |                                                            |
+|         0x12 |*`CU_RES_VIEW_FORMAT_SINT_4X32`*                               |                                                            |
+|         0x13 |*`CU_RES_VIEW_FORMAT_FLOAT_1X16`*                              |                                                            |
+|         0x14 |*`CU_RES_VIEW_FORMAT_FLOAT_2X16`*                              |                                                            |
+|         0x15 |*`CU_RES_VIEW_FORMAT_FLOAT_4X16`*                              |                                                            |
+|         0x16 |*`CU_RES_VIEW_FORMAT_FLOAT_1X32`*                              |                                                            |
+|         0x17 |*`CU_RES_VIEW_FORMAT_FLOAT_2X32`*                              |                                                            |
+|         0x18 |*`CU_RES_VIEW_FORMAT_FLOAT_4X32`*                              |                                                            |
+|         0x19 |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC1`*                            |                                                            |
+|         0x1a |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC3`*                            |                                                            |
+|         0x1b |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC3`*                            |                                                            |
+|         0x1c |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC4`*                            |                                                            |
+|         0x1d |*`CU_RES_VIEW_FORMAT_SIGNED_BC4`*                              |                                                            |
+|         0x1e |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC5`*                            |                                                            |
+|         0x1f |*`CU_RES_VIEW_FORMAT_SIGNED_BC5`*                              |                                                            |
+|         0x20 |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC6H`*                           |                                                            |
+|         0x21 |*`CU_RES_VIEW_FORMAT_SIGNED_BC6H`*                             |                                                            |
+|         0x22 |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC7`*                            |                                                            |
+| enum         |***`CUresult`***                                               |***`hipError_t`***                                          |
+|            0 |*`CUDA_SUCCESS`*                                               |*`hipSuccess`*                                              |
+|            1 |*`CUDA_ERROR_INVALID_VALUE`*                                   |*`hipErrorInvalidValue`*                                    |
+|            2 |*`CUDA_ERROR_OUT_OF_MEMORY`*                                   |*`hipErrorMemoryAllocation`*                                |
+|            3 |*`CUDA_ERROR_NOT_INITIALIZED`*                                 |*`hipErrorNotInitialized`*                                  |
+|            4 |*`CUDA_ERROR_DEINITIALIZED`*                                   |*`hipErrorDeinitialized`*                                   |
+|            5 |*`CUDA_ERROR_PROFILER_DISABLED`*                               |*`hipErrorProfilerDisabled`*                                |
+|            6 |*`CUDA_ERROR_PROFILER_NOT_INITIALIZED`*                        |*`hipErrorProfilerNotInitialized`*                          |
+|            7 |*`CUDA_ERROR_PROFILER_ALREADY_STARTED`*                        |*`hipErrorProfilerAlreadyStarted`*                          |
+|            8 |*`CUDA_ERROR_PROFILER_ALREADY_STOPPED`*                        |*`hipErrorProfilerAlreadyStopped`*                          |
+|          100 |*`CUDA_ERROR_NO_DEVICE`*                                       |*`hipErrorNoDevice`*                                        |
+|          101 |*`CUDA_ERROR_INVALID_DEVICE`*                                  |*`hipErrorInvalidDevice`*                                   |
+|          200 |*`CUDA_ERROR_INVALID_IMAGE`*                                   |*`hipErrorInvalidImage`*                                    |
+|          201 |*`CUDA_ERROR_INVALID_CONTEXT`*                                 |*`hipErrorInvalidContext`*                                  |
+|          202 |*`CUDA_ERROR_CONTEXT_ALREADY_CURRENT`*                         |*`hipErrorContextAlreadyCurrent`*                           |
+|          205 |*`CUDA_ERROR_MAP_FAILED`*                                      |*`hipErrorMapFailed`*                                       |
+|          206 |*`CUDA_ERROR_UNMAP_FAILED`*                                    |*`hipErrorUnmapFailed`*                                     |
+|          207 |*`CUDA_ERROR_ARRAY_IS_MAPPED`*                                 |*`hipErrorArrayIsMapped`*                                   |
+|          208 |*`CUDA_ERROR_ALREADY_MAPPED`*                                  |*`hipErrorAlreadyMapped`*                                   |
+|          209 |*`CUDA_ERROR_NO_BINARY_FOR_GPU`*                               |*`hipErrorNoBinaryForGpu*                                   |
+|          210 |*`CUDA_ERROR_ALREADY_ACQUIRED`*                                |*`hipErrorAlreadyAcquired*                                  |
+|          211 |*`CUDA_ERROR_NOT_MAPPED`*                                      |*`hipErrorNotMapped`*                                       |
+|          212 |*`CUDA_ERROR_NOT_MAPPED_AS_ARRAY`*                             |*`hipErrorNotMappedAsArray`*                                |
+|          213 |*`CUDA_ERROR_NOT_MAPPED_AS_POINTER`*                           |*`hipErrorNotMappedAsPointer`*                              |
+|          214 |*`CUDA_ERROR_ECC_UNCORRECTABLE`*                               |*`hipErrorECCNotCorrectable`*                               |
+|          215 |*`CUDA_ERROR_UNSUPPORTED_LIMIT`*                               |*`hipErrorUnsupportedLimit`*                                |
+|          216 |*`CUDA_ERROR_CONTEXT_ALREADY_IN_USE`*                          |*`hipErrorContextAlreadyInUse`*                             |
+|          217 |*`CUDA_ERROR_PEER_ACCESS_UNSUPPORTED`*                         |*`hipErrorPeerAccessUnsupported`*                           |
+|          218 |*`CUDA_ERROR_INVALID_PTX`*                                     |*`hipErrorInvalidKernelFile`*                               |
+|          219 |*`CUDA_ERROR_INVALID_GRAPHICS_CONTEXT`*                        |*`hipErrorInvalidGraphicsContext`*                          |
+|          300 |*`CUDA_ERROR_INVALID_SOURCE`*                                  |*`hipErrorInvalidSource`*                                   |
+|          301 |*`CUDA_ERROR_FILE_NOT_FOUND`*                                  |*`hipErrorFileNotFound`*                                    |
+|          302 |*`CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND`*                  |*`hipErrorSharedObjectSymbolNotFound`*                      |
+|          303 |*`CUDA_ERROR_SHARED_OBJECT_INIT_FAILED`*                       |*`hipErrorSharedObjectInitFailed`*                          |
+|          304 |*`CUDA_ERROR_OPERATING_SYSTEM`*                                |*`hipErrorOperatingSystem`*                                 |
+|          400 |*`CUDA_ERROR_INVALID_HANDLE`*                                  |*`hipErrorInvalidResourceHandle`*                           |
+|          500 |*`CUDA_ERROR_NOT_FOUND`*                                       |*`hipErrorNotFound`*                                        |
+|          600 |*`CUDA_ERROR_NOT_READY`*                                       |*`hipErrorNotReady`*                                        |
+|          700 |*`CUDA_ERROR_ILLEGAL_ADDRESS`*                                 |*`hipErrorIllegalAddress`*                                  |
+|          701 |*`CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES`*                         |*`hipErrorLaunchOutOfResources`*                            |
+|          702 |*`CUDA_ERROR_LAUNCH_TIMEOUT`*                                  |*`hipErrorLaunchTimeOut`*                                   |
+|          703 |*`CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING`*                   |                                                            |
+|          704 |*`CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED`*                     |*`hipErrorPeerAccessAlreadyEnabled`*                        |
+|          705 |*`CUDA_ERROR_PEER_ACCESS_NOT_ENABLED`*                         |*`hipErrorPeerAccessNotEnabled`*                            |
+|          708 |*`CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE`*                          |                                                            |
+|          709 |*`CUDA_ERROR_CONTEXT_IS_DESTROYED`*                            |                                                            |
+|          710 |*`CUDA_ERROR_ASSERT`*                                          |                                                            |
+|          711 |*`CUDA_ERROR_TOO_MANY_PEERS`*                                  |                                                            |
+|          712 |*`CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED`*                  |*`hipErrorHostMemoryAlreadyRegistered`*                     |
+|          713 |*`CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED`*                      |*`hipErrorHostMemoryNotRegistered`*                         |
+|          714 |*`CUDA_ERROR_HARDWARE_STACK_ERROR`*                            |                                                            |
+|          715 |*`CUDA_ERROR_ILLEGAL_INSTRUCTION`*                             |                                                            |
+|          716 |*`CUDA_ERROR_MISALIGNED_ADDRESS`*                              |                                                            |
+|          717 |*`CUDA_ERROR_INVALID_ADDRESS_SPACE`*                           |                                                            |
+|          718 |*`CUDA_ERROR_INVALID_PC`*                                      |                                                            |
+|          719 |*`CUDA_ERROR_LAUNCH_FAILED`*                                   |                                                            |
+|          800 |*`CUDA_ERROR_NOT_PERMITTED`*                                   |                                                            |
+|          801 |*`CUDA_ERROR_NOT_SUPPORTED`*                                   |                                                            |
+|          999 |*`CUDA_ERROR_UNKNOWN`*                                         |                                                            |
+| enum         |***`CUstream_flags`***                                         |***`hipStreamFlags`***                                      |
+|          0x0 |*`CU_STREAM_DEFAULT`*                                          |*`hipStreamDefault`*                                        |
+|          0x1 |*`CU_STREAM_NON_BLOCKING`*                                     |*`hipStreamNonBlocking`*                                    |
+| enum         |***`CUGLDeviceList`***                                         |                                                            |
+|         0x01 |*`CU_GL_DEVICE_LIST_ALL`*                                      |                                                            |
+|         0x02 |*`CU_GL_DEVICE_LIST_CURRENT_FRAME`*                            |                                                            |
+|         0x03 |*`CU_GL_DEVICE_LIST_NEXT_FRAME`*                               |                                                            |
+| enum         |***`CUGLmap_flags`***                                          |                                                            |
+|         0x00 |*`CU_GL_MAP_RESOURCE_FLAGS_NONE`*                              |                                                            |
+|         0x01 |*`CU_GL_MAP_RESOURCE_FLAGS_READ_ONLY`*                         |                                                            |
+|         0x02 |*`CU_GL_MAP_RESOURCE_FLAGS_WRITE_DISCARD`*                     |                                                            |
+| enum         |***`CUd3d9DeviceList`***                                       |                                                            |
+|         0x01 |*`CU_D3D9_DEVICE_LIST_ALL`*                                    |                                                            |
+|         0x02 |*`CU_D3D9_DEVICE_LIST_CURRENT_FRAME`*                          |                                                            |
+|         0x03 |*`CU_D3D9_DEVICE_LIST_NEXT_FRAME`*                             |                                                            |
+| enum         |***`CUd3d9map_flags`***                                        |                                                            |
+|         0x00 |*`CU_D3D9_MAPRESOURCE_FLAGS_NONE`*                             |                                                            |
+|         0x01 |*`CU_D3D9_MAPRESOURCE_FLAGS_READONLY`*                         |                                                            |
+|         0x02 |*`CU_D3D9_MAPRESOURCE_FLAGS_WRITEDISCARD`*                     |                                                            |
+| enum         |***`CUd3d9register_flags`***                                   |                                                            |
+|         0x00 |*`CU_D3D9_REGISTER_FLAGS_NONE`*                                |                                                            |
+|         0x01 |*`CU_D3D9_REGISTER_FLAGS_ARRAY`*                               |                                                            |
+| enum         |***`CUd3d10DeviceList`***                                      |                                                            |
+|         0x01 |*`CU_D3D10_DEVICE_LIST_ALL`*                                   |                                                            |
+|         0x02 |*`CU_D3D10_DEVICE_LIST_CURRENT_FRAME`*                         |                                                            |
+|         0x03 |*`CU_D3D10_DEVICE_LIST_NEXT_FRAME`*                            |                                                            |
+| enum         |***`CUd3d10map_flags`***                                       |                                                            |
+|         0x00 |*`CU_D3D10_MAPRESOURCE_FLAGS_NONE`*                            |                                                            |
+|         0x01 |*`CU_D3D10_MAPRESOURCE_FLAGS_READONLY`*                        |                                                            |
+|         0x02 |*`CU_D3D10_MAPRESOURCE_FLAGS_WRITEDISCARD`*                    |                                                            |
+| enum         |***`CUd3d10register_flags`***                                  |                                                            |
+|         0x00 |*`CU_D3D10_REGISTER_FLAGS_NONE`*                               |                                                            |
+|         0x01 |*`CU_D3D10_REGISTER_FLAGS_ARRAY`*                              |                                                            |
+| enum         |***`CUd3d11DeviceList`***                                      |                                                            |
+|         0x01 |*`CU_D3D11_DEVICE_LIST_ALL`*                                   |                                                            |
+|         0x02 |*`CU_D3D11_DEVICE_LIST_CURRENT_FRAME`*                         |                                                            |
+|         0x03 |*`CU_D3D11_DEVICE_LIST_NEXT_FRAME`*                            |                                                            |
+| typedef      | `CUarray`                                                     | `hipArray *`                                               |
+| struct       | `CUarray_st`                                                  | `hipArray`                                                 |
+| typedef      | `CUcontext`                                                   | `hipCtx_t`                                                 |
+| typedef      | `CUdevice`                                                    | `hipDevice_t`                                              |
+| typedef      | `CUdeviceptr`                                                 | `hipDeviceptr_t`                                           |
+| typedef      | `CUevent`                                                     | `hipEvent_t`                                               |
+| typedef      | `CUfunction`                                                  | `hipFunction_t`                                            |
+| typedef      | `CUgraphicsResource`                                          |                                                            |
+| typedef      | `CUmipmappedArray`                                            |                                                            |
+| typedef      | `CUmodule`                                                    | `hipModule_t`                                              |
+| typedef      | `CUstream`                                                    | `hipStream_t`                                              |
+| typedef      | `CUstreamCallback`                                            | `hipStreamCallback_t`                                      |
+| typedef      | `CUsurfObject`                                                |                                                            |
+| typedef      | `CUsurfref`                                                   |                                                            |
+| typedef      | `CUtexObject`                                                 |                                                            |
+| typedef      | `CUtexref`                                                    |                                                            |
+| define       |`CU_IPC_HANDLE_SIZE`                                           |                                                            |
+| define       |`CU_LAUNCH_PARAM_BUFFER_POINTER`                               | `HIP_LAUNCH_PARAM_BUFFER_POINTER`                          |
+| define       |`CU_LAUNCH_PARAM_BUFFER_SIZE`                                  | `HIP_LAUNCH_PARAM_BUFFER_SIZE`                             |
+| define       |`CU_LAUNCH_PARAM_END`                                          | `HIP_LAUNCH_PARAM_END`                                     |
+| define       |`CU_MEMHOSTALLOC_DEVICEMAP`                                    |                                                            |
+| define       |`CU_MEMHOSTALLOC_PORTABLE`                                     |                                                            |
+| define       |`CU_MEMHOSTALLOC_WRITECOMBINED`                                |                                                            |
+| define       |`CU_MEMHOSTREGISTER_DEVICEMAP`                                 |                                                            |
+| define       |`CU_MEMHOSTREGISTER_IOMEMORY`                                  |                                                            |
+| define       |`CU_MEMHOSTREGISTER_PORTABLE`                                  |                                                            |
+| define       |`CU_PARAM_TR_DEFAULT`                                          |                                                            |
+| define       |`CU_STREAM_LEGACY`                                             |                                                            |
+| define       |`CU_STREAM_PER_THREAD`                                         |                                                            |
+| define       |`CU_TRSA_OVERRIDE_FORMAT`                                      |                                                            |
+| define       |`CU_TRSF_NORMALIZED_COORDINATES`                               |                                                            |
+| define       |`CU_TRSF_SRGB`                                                 |                                                            |
+| define       |`CUDA_ARRAY3D_2DARRAY`                                         |                                                            |
+| define       |`CUDA_ARRAY3D_CUBEMAP`                                         |                                                            |
+| define       |`CUDA_ARRAY3D_DEPTH_TEXTURE`                                   |                                                            |
+| define       |`CUDA_ARRAY3D_LAYERED`                                         |                                                            |
+| define       |`CUDA_ARRAY3D_SURFACE_LDST`                                    |                                                            |
+| define       |`CUDA_ARRAY3D_TEXTURE_GATHER`                                  |                                                            |
+| define       |`CUDA_VERSION`                                                 |                                                            |
 
 ## **2. Error Handling**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuGetErrorName`                                          |                               | Gets the string representation of an error code enum name.                                                                     |
-| `cuGetErrorString`                                        |                               | Gets the string description of an error code.                                                                                  |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuGetErrorName`                                          |                               |
+| `cuGetErrorString`                                        |                               |
 
 ## **3. Initialization**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuInit`                                                  | `hipInit`                     | Initialize the CUDA driver API.                                                                                                |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuInit`                                                  | `hipInit`                     |
 
 ## **4. Version Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuDriverGetVersion`                                      | `hipDriverGetVersion`         | Returns the CUDA driver version.                                                                                               |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuDriverGetVersion`                                      | `hipDriverGetVersion`         |
 
 ## **5. Device Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuDriverGetVersion`                                      | `hipGetDevice`                | Returns a handle to a compute device.                                                                                          |
-| `cuDeviceGetAttribute`                                    | `hipDeviceGetAttribute`       | Returns information about the device.                                                                                          |
-| `cuDeviceGetCount`                                        | `hipGetDeviceCount`           | Returns the number of compute-capable devices.                                                                                 |
-| `cuDeviceGetName`                                         | `hipDeviceGetName`            | Returns an identifer string for the device.                                                                                    |
-| `cuDeviceTotalMem`                                        | `hipDeviceTotalMem`           | Returns the total amount of memory on the device.                                                                              |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuDriverGetVersion`                                      | `hipGetDevice`                |
+| `cuDeviceGetAttribute`                                    | `hipDeviceGetAttribute`       |
+| `cuDeviceGetCount`                                        | `hipGetDeviceCount`           |
+| `cuDeviceGetName`                                         | `hipDeviceGetName`            |
+| `cuDeviceTotalMem`                                        | `hipDeviceTotalMem`           |
 
 ## **6. Device Management [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuDeviceComputeCapability`                               | `hipDeviceComputeCapability`  | Returns the compute capability of the device.                                                                                  |
-| `cuDeviceGetProperties`                                   | `hipGetDeviceProperties`      | Returns properties for a selected device.                                                                                      |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuDeviceComputeCapability`                               | `hipDeviceComputeCapability`  |
+| `cuDeviceGetProperties`                                   | `hipGetDeviceProperties`      |
 
 ## **7. Primary Context Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuDevicePrimaryCtxGetState`                              | `hipDevicePrimaryCtxGetState` | Get the state of the primary context.                                                                                          |
-| `cuDevicePrimaryCtxRelease`                               | `hipDevicePrimaryCtxRelease`  | Release the primary context on the GPU.                                                                                        |
-| `cuDevicePrimaryCtxReset`                                 | `hipDevicePrimaryCtxReset`    | Destroy all allocations and reset all state on the primary context.                                                            |
-| `cuDevicePrimaryCtxRetain`                                | `hipDevicePrimaryCtxRetain`   | Retain the primary context on the GPU.                                                                                         |
-| `cuDevicePrimaryCtxSetFlags`                              | `hipDevicePrimaryCtxSetFlags` | Set flags for the primary context.                                                                                             |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuDevicePrimaryCtxGetState`                              | `hipDevicePrimaryCtxGetState` |
+| `cuDevicePrimaryCtxRelease`                               | `hipDevicePrimaryCtxRelease`  |
+| `cuDevicePrimaryCtxReset`                                 | `hipDevicePrimaryCtxReset`    |
+| `cuDevicePrimaryCtxRetain`                                | `hipDevicePrimaryCtxRetain`   |
+| `cuDevicePrimaryCtxSetFlags`                              | `hipDevicePrimaryCtxSetFlags` |
 
 ## **8. Context Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuCtxCreate`                                             | `hipCtxCreate`                | Create a CUDA context.                                                                                                         |
-| `cuCtxDestroy`                                            | `hipCtxDestroy`               | Destroy a CUDA context.                                                                                                        |
-| `cuCtxGetApiVersion`                                      | `hipCtxGetApiVersion`         | Gets the context's API version.                                                                                                |
-| `cuCtxGetCacheConfig`                                     | `hipCtxGetCacheConfig`        | Returns the preferred cache configuration for the current context.                                                             |
-| `cuCtxGetCurrent`                                         | `hipCtxGetCurrent`            | Returns the CUDA context bound to the calling CPU thread.                                                                      |
-| `cuCtxGetDevice`                                          | `hipCtxGetDevice`             | Returns the device ID for the current context.                                                                                 |
-| `cuCtxGetFlags`                                           | `hipCtxGetFlags`              | Returns the flags for the current context.                                                                                     |
-| `cuCtxGetLimit`                                           |                               | Returns resource limits.                                                                                                       |
-| `cuCtxGetSharedMemConfig`                                 | `hipCtxGetSharedMemConfig`    | Returns the current shared memory configuration for the current context.                                                       |
-| `cuCtxGetStreamPriorityRange`                             |                               | Returns numerical values that correspond to the least and greatest stream priorities.                                          |
-| `cuCtxPopCurrent`                                         | `hipCtxPopCurrent`            | Pops the current CUDA context from the current CPU thread.                                                                     |
-| `cuCtxPushCurrent`                                        | `hipCtxPushCurrent`           | Pushes a context on the current CPU thread.                                                                                    |
-| `cuCtxSetCacheConfig`                                     | `hipCtxSetCacheConfig`        | Sets the preferred cache configuration for the current context.                                                                |
-| `cuCtxSetCurrent`                                         | `hipCtxSetCurrent`            | Binds the specified CUDA context to the calling CPU thread.                                                                    |
-| `cuCtxSetLimit`                                           |                               | Set resource limits.                                                                                                           |
-| `cuCtxSetSharedMemConfig`                                 | `hipCtxSetSharedMemConfig`    | Sets the shared memory configuration for the current context.                                                                  |
-| `cuCtxSynchronize`                                        | `hipCtxSynchronize`           | Block for a context's tasks to complete.                                                                                       |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuCtxCreate`                                             | `hipCtxCreate`                |
+| `cuCtxDestroy`                                            | `hipCtxDestroy`               |
+| `cuCtxGetApiVersion`                                      | `hipCtxGetApiVersion`         |
+| `cuCtxGetCacheConfig`                                     | `hipCtxGetCacheConfig`        |
+| `cuCtxGetCurrent`                                         | `hipCtxGetCurrent`            |
+| `cuCtxGetDevice`                                          | `hipCtxGetDevice`             |
+| `cuCtxGetFlags`                                           | `hipCtxGetFlags`              |
+| `cuCtxGetLimit`                                           |                               |
+| `cuCtxGetSharedMemConfig`                                 | `hipCtxGetSharedMemConfig`    |
+| `cuCtxGetStreamPriorityRange`                             |                               |
+| `cuCtxPopCurrent`                                         | `hipCtxPopCurrent`            |
+| `cuCtxPushCurrent`                                        | `hipCtxPushCurrent`           |
+| `cuCtxSetCacheConfig`                                     | `hipCtxSetCacheConfig`        |
+| `cuCtxSetCurrent`                                         | `hipCtxSetCurrent`            |
+| `cuCtxSetLimit`                                           |                               |
+| `cuCtxSetSharedMemConfig`                                 | `hipCtxSetSharedMemConfig`    |
+| `cuCtxSynchronize`                                        | `hipCtxSynchronize`           |
 
 ## **9. Context Management [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuCtxAttach`                                             |                               | Increment a context's usage-count.                                                                                             |
-| `cuCtxDetach`                                             |                               | Decrement a context's usage-count.                                                                                             |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuCtxAttach`                                             |                               |
+| `cuCtxDetach`                                             |                               |
 
 ## **10. Module Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuLinkAddData`                                           |                               | Add an input to a pending linker invocation.                                                                                   |
-| `cuLinkAddFile`                                           |                               | Add a file input to a pending linker invocation.                                                                               |
-| `cuLinkComplete`                                          |                               | Complete a pending linker invocation.                                                                                          |
-| `cuLinkCreate`                                            |                               | Creates a pending JIT linker invocation.                                                                                       |
-| `cuLinkDestroy`                                           |                               | Destroys state for a JIT linker invocation.                                                                                    |
-| `cuModuleGetFunction`                                     | `hipModuleGetFunction`        | Returns a function handle.                                                                                                     |
-| `cuModuleGetGlobal`                                       | `hipModuleGetGlobal`          | Returns a global pointer from a module.                                                                                        |
-| `cuModuleGetSurfRef`                                      |                               | Returns a handle to a surface reference.                                                                                       |
-| `cuModuleGetTexRef`                                       |                               | Returns a handle to a texture reference.                                                                                       |
-| `cuModuleLoad`                                            | `hipModuleLoad`               | Loads a compute module.                                                                                                        |
-| `cuModuleLoadData`                                        | `hipModuleLoadData`           | Load a module's data.                                                                                                          |
-| `cuModuleLoadDataEx`                                      | `hipModuleLoadDataEx`         | Load a module's data with options.                                                                                             |
-| `cuModuleLoadFatBinary`                                   |                               | Load a module's data.                                                                                                          |
-| `cuModuleUnload`                                          | `hipModuleUnload`             | Unloads a module.                                                                                                              |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuLinkAddData`                                           |                               |
+| `cuLinkAddFile`                                           |                               |
+| `cuLinkComplete`                                          |                               |
+| `cuLinkCreate`                                            |                               |
+| `cuLinkDestroy`                                           |                               |
+| `cuModuleGetFunction`                                     | `hipModuleGetFunction`        |
+| `cuModuleGetGlobal`                                       | `hipModuleGetGlobal`          |
+| `cuModuleGetSurfRef`                                      |                               |
+| `cuModuleGetTexRef`                                       |                               |
+| `cuModuleLoad`                                            | `hipModuleLoad`               |
+| `cuModuleLoadData`                                        | `hipModuleLoadData`           |
+| `cuModuleLoadDataEx`                                      | `hipModuleLoadDataEx`         |
+| `cuModuleLoadFatBinary`                                   |                               |
+| `cuModuleUnload`                                          | `hipModuleUnload`             |
 
 ## **11. Memory Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuArray3DCreate`                                         |                               | Creates a 3D CUDA array.                                                                                                       |
-| `cuArray3DGetDescriptor`                                  |                               | Get a 3D CUDA array descriptor.                                                                                                |
-| `cuArrayCreate`                                           |                               | Creates a 1D or 2D CUDA array.                                                                                                 |
-| `cuArrayDestroy`                                          |                               | Destroys a CUDA array.                                                                                                         |
-| `cuArrayGetDescriptor`                                    |                               | Get a 1D or 2D CUDA array descriptor.                                                                                          |
-| `cuDeviceGetByPCIBusId`                                   | `hipDeviceGetByPCIBusId`      | Returns a handle to a compute device.                                                                                          |
-| `cuDeviceGetPCIBusId`                                     | `hipDeviceGetPCIBusId`        | Returns a PCI Bus Id string for the device.                                                                                    |
-| `cuIpcCloseMemHandle`                                     |                               | Close memory mapped with cuIpcOpenMemHandle.                                                                                   |
-| `cuIpcGetEventHandle`                                     |                               | Gets an interprocess handle for a previously allocated event.                                                                  |
-| `cuIpcGetMemHandle`                                       |                               | Gets an interprocess memory handle for an existing device memory allocation.                                                   |
-| `cuIpcOpenEventHandle`                                    |                               | Opens an interprocess event handle for use in the current process.                                                             |
-| `cuIpcOpenMemHandle`                                      |                               | Opens an interprocess memory handle exported from another process and returns a device pointer usable in the local process.    |
-| `cuMemAlloc`                                              | `hipMalloc`                   | Allocates device memory.                                                                                                       |
-| `cuMemAllocHost`                                          |                               | Allocates page-locked host memory.                                                                                             |
-| `cuMemAllocManaged`                                       |                               | Allocates memory that will be automatically managed by the Unified Memory system.                                              |
-| `cuMemAllocPitch`                                         |                               | Allocates pitched device memory.                                                                                               |
-| `cuMemcpy`                                                |                               | Copies memory.                                                                                                                 |
-| `cuMemcpy2D`                                              |                               | Copies memory for 2D arrays.                                                                                                   |
-| `cuMemcpy2DAsync`                                         |                               | Copies memory for 2D arrays.                                                                                                   |
-| `cuMemcpy2DUnaligned`                                     |                               | Copies memory for 2D arrays.                                                                                                   |
-| `cuMemcpy3D`                                              |                               | Copies memory for 3D arrays.                                                                                                   |
-| `cuMemcpy3DAsync`                                         |                               | Copies memory for 3D arrays.                                                                                                   |
-| `cuMemcpy3DPeer`                                          |                               | Copies memory between contexts.                                                                                                |
-| `cuMemcpy3DPeerAsync`                                     |                               | Copies memory between contexts asynchronously.                                                                                 |
-| `cuMemcpyAsync`                                           |                               | Copies memory asynchronously.                                                                                                  |
-| `cuMemcpyAtoA`                                            |                               | Copies memory from Array to Array.                                                                                             |
-| `cuMemcpyAtoD`                                            |                               | Copies memory from Array to Device.                                                                                            |
-| `cuMemcpyAtoH`                                            |                               | Copies memory from Array to Host.                                                                                              |
-| `cuMemcpyAtoHAsync`                                       |                               | Copies memory from Array to Host.                                                                                              |
-| `cuMemcpyDtoA`                                            |                               | Copies memory from Device to Array.                                                                                            |
-| `cuMemcpyDtoD`                                            | `hipMemcpyDtoD`               | Copies memory from Device to Device.                                                                                           |
-| `cuMemcpyDtoDAsync`                                       | `hipMemcpyDtoDAsync`          | Copies memory from Device to Device.                                                                                           |
-| `cuMemcpyDtoH`                                            | `hipMemcpyDtoH`               | Copies memory from Device to Host.                                                                                             |
-| `cuMemcpyDtoHAsync`                                       | `hipMemcpyDtoHAsync`          | Copies memory from Device to Host.                                                                                             |
-| `cuMemcpyHtoA`                                            |                               | Copies memory from Host to Array.                                                                                              |
-| `cuMemcpyHtoAAsync`                                       |                               | Copies memory from Host to Array.                                                                                              |
-| `cuMemcpyHtoD`                                            | `hipMemcpyHtoD`               | Copies memory from Host to Device.                                                                                             |
-| `cuMemcpyHtoDAsync`                                       | `hipMemcpyHtoDAsync`          | Copies memory from Host to Device.                                                                                             |
-| `cuMemcpyPeer`                                            |                               | Copies device memory between two contexts.                                                                                     |
-| `cuMemcpyPeerAsync`                                       |                               | Copies device memory between two contexts asynchronously.                                                                      |
-| `cuMemFree`                                               | `hipFree`                     | Frees device memory.                                                                                                           |
-| `cuMemFreeHost`                                           | `hipFreeHost`                 | Frees page-locked host memory.                                                                                                 |
-| `cuMemGetAddressRange`                                    |                               | Get information on memory allocations.                                                                                         |
-| `cuMemGetInfo`                                            | `hipMemGetInfo`               | Gets free and total memory.                                                                                                    |
-| `cuMemHostAlloc`                                          | `hipHostMalloc`               | Allocates page-locked host memory.                                                                                             |
-| `cuMemHostGetDevicePointer`                               |                               | Passes back device pointer of mapped pinned memory.                                                                            |
-| `cuMemHostGetFlags`                                       |                               | Passes back flags that were used for a pinned allocation.                                                                      |
-| `cuMemHostRegister`                                       | `hipHostRegister`             | Registers an existing host memory range for use by CUDA.                                                                       |
-| `cuMemHostUnregister`                                     | `hipHostUnregister`           | Unregisters a memory range that was registered with cuMemHostRegister.                                                         |
-| `cuMemsetD16`                                             |                               | Initializes device memory.                                                                                                     |
-| `cuMemsetD16Async`                                        |                               | Sets device memory.                                                                                                            |
-| `cuMemsetD2D16`                                           |                               | Initializes device memory.                                                                                                     |
-| `cuMemsetD2D16Async`                                      |                               | Sets device memory.                                                                                                            |
-| `cuMemsetD2D32`                                           |                               | Initializes device memory.                                                                                                     |
-| `cuMemsetD2D32Async`                                      |                               | Sets device memory.                                                                                                            |
-| `cuMemsetD2D8`                                            |                               | Initializes device memory.                                                                                                     |
-| `cuMemsetD2D8Async`                                       |                               | Sets device memory.                                                                                                            |
-| `cuMemsetD32`                                             | `hipMemset`                   | Initializes device memory.                                                                                                     |
-| `cuMemsetD32Async`                                        | `hipMemsetAsync`              | Sets device memory.                                                                                                            |
-| `cuMemsetD2D8`                                            |                               | Initializes device memory.                                                                                                     |
-| `cuMemsetD2D8Async`                                       |                               | Sets device memory.                                                                                                            |
-| `cuMipmappedArrayCreate`                                  |                               | Creates a CUDA mipmapped array.                                                                                                |
-| `cuMipmappedArrayDestroy`                                 |                               | Destroys a CUDA mipmapped array.                                                                                               |
-| `cuMipmappedArrayGetLevel`                                |                               | Gets a mipmap level of a CUDA mipmapped array.                                                                                 |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuArray3DCreate`                                         |                               |
+| `cuArray3DGetDescriptor`                                  |                               |
+| `cuArrayCreate`                                           |                               |
+| `cuArrayDestroy`                                          |                               |
+| `cuArrayGetDescriptor`                                    |                               |
+| `cuDeviceGetByPCIBusId`                                   | `hipDeviceGetByPCIBusId`      |
+| `cuDeviceGetPCIBusId`                                     | `hipDeviceGetPCIBusId`        |
+| `cuIpcCloseMemHandle`                                     |                               |
+| `cuIpcGetEventHandle`                                     |                               |
+| `cuIpcGetMemHandle`                                       |                               |
+| `cuIpcOpenEventHandle`                                    |                               |
+| `cuIpcOpenMemHandle`                                      |                               |
+| `cuMemAlloc`                                              | `hipMalloc`                   |
+| `cuMemAllocHost`                                          |                               |
+| `cuMemAllocManaged`                                       |                               |
+| `cuMemAllocPitch`                                         |                               |
+| `cuMemcpy`                                                |                               |
+| `cuMemcpy2D`                                              |                               |
+| `cuMemcpy2DAsync`                                         |                               |
+| `cuMemcpy2DUnaligned`                                     |                               |
+| `cuMemcpy3D`                                              |                               |
+| `cuMemcpy3DAsync`                                         |                               |
+| `cuMemcpy3DPeer`                                          |                               |
+| `cuMemcpy3DPeerAsync`                                     |                               |
+| `cuMemcpyAsync`                                           |                               |
+| `cuMemcpyAtoA`                                            |                               |
+| `cuMemcpyAtoD`                                            |                               |
+| `cuMemcpyAtoH`                                            |                               |
+| `cuMemcpyAtoHAsync`                                       |                               |
+| `cuMemcpyDtoA`                                            |                               |
+| `cuMemcpyDtoD`                                            | `hipMemcpyDtoD`               |
+| `cuMemcpyDtoDAsync`                                       | `hipMemcpyDtoDAsync`          |
+| `cuMemcpyDtoH`                                            | `hipMemcpyDtoH`               |
+| `cuMemcpyDtoHAsync`                                       | `hipMemcpyDtoHAsync`          |
+| `cuMemcpyHtoA`                                            |                               |
+| `cuMemcpyHtoAAsync`                                       |                               |
+| `cuMemcpyHtoD`                                            | `hipMemcpyHtoD`               |
+| `cuMemcpyHtoDAsync`                                       | `hipMemcpyHtoDAsync`          |
+| `cuMemcpyPeer`                                            |                               |
+| `cuMemcpyPeerAsync`                                       |                               |
+| `cuMemFree`                                               | `hipFree`                     |
+| `cuMemFreeHost`                                           | `hipFreeHost`                 |
+| `cuMemGetAddressRange`                                    |                               |
+| `cuMemGetInfo`                                            | `hipMemGetInfo`               |
+| `cuMemHostAlloc`                                          | `hipHostMalloc`               |
+| `cuMemHostGetDevicePointer`                               |                               |
+| `cuMemHostGetFlags`                                       |                               |
+| `cuMemHostRegister`                                       | `hipHostRegister`             |
+| `cuMemHostUnregister`                                     | `hipHostUnregister`           |
+| `cuMemsetD16`                                             |                               |
+| `cuMemsetD16Async`                                        |                               |
+| `cuMemsetD2D16`                                           |                               |
+| `cuMemsetD2D16Async`                                      |                               |
+| `cuMemsetD2D32`                                           |                               |
+| `cuMemsetD2D32Async`                                      |                               |
+| `cuMemsetD2D8`                                            |                               |
+| `cuMemsetD2D8Async`                                       |                               |
+| `cuMemsetD32`                                             | `hipMemset`                   |
+| `cuMemsetD32Async`                                        | `hipMemsetAsync`              |
+| `cuMemsetD2D8`                                            |                               |
+| `cuMemsetD2D8Async`                                       |                               |
+| `cuMipmappedArrayCreate`                                  |                               |
+| `cuMipmappedArrayDestroy`                                 |                               |
+| `cuMipmappedArrayGetLevel`                                |                               |
 
 ## **12. Unified Addressing**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuMemAdvise`                                             |                               | Advise about the usage of a given memory range.                                                                                |
-| `cuMemPrefetchAsync`                                      |                               | Prefetches memory to the specified destination device.                                                                         |
-| `cuMemRangeGetAttribute`                                  |                               | Query an attribute of a given memory range.                                                                                    |
-| `cuMemRangeGetAttributes`                                 |                               | Query attributes of a given memory range.                                                                                      |
-| `cuPointerGetAttribute`                                   |                               | Returns information about a pointer.                                                                                           |
-| `cuPointerGetAttributes`                                  |                               | Returns information about a pointer.                                                                                           |
-| `cuPointerSetAttribute`                                   |                               | Set attributes on a previously allocated memory region.                                                                        |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuMemAdvise`                                             |                               |
+| `cuMemPrefetchAsync`                                      |                               |
+| `cuMemRangeGetAttribute`                                  |                               |
+| `cuMemRangeGetAttributes`                                 |                               |
+| `cuPointerGetAttribute`                                   |                               |
+| `cuPointerGetAttributes`                                  |                               |
+| `cuPointerSetAttribute`                                   |                               |
 
 ## **13. Stream Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuStreamAddCallback`                                     |                               | Add a callback to a compute stream.                                                                                            |
-| `cuStreamAttachMemAsync`                                  |                               | Attach memory to a stream asynchronously.                                                                                      |
-| `cuStreamCreate`                                          |                               | Create a stream.                                                                                                               |
-| `cuStreamCreateWithPriority`                              |                               | Create a stream with the given priority.                                                                                       |
-| `cuStreamDestroy`                                         | `hipStreamDestroy`            | Destroys a stream.                                                                                                             |
-| `cuStreamGetFlags`                                        | `hipStreamGetFlags`           | Query the flags of a given stream.                                                                                             |
-| `cuStreamGetPriority`                                     | `hipStreamGetPriority`        | Query the priority of a given stream.                                                                                          |
-| `cuStreamQuery`                                           | `hipStreamQuery`              | Determine status of a compute stream.                                                                                          |
-| `cuStreamSynchronize`                                     | `hipStreamSynchronize`        | Wait until a stream's tasks are completed.                                                                                     |
-| `cuStreamWaitEvent`                                       | `hipStreamWaitEvent`          | Make a compute stream wait on an event.                                                                                        |
-| `cuStreamBatchMemOp`                                      |                               | Batch operations to synchronize the stream via memory operations.                                                              |
-| `cuStreamWaitValue32`                                     |                               | Wait on a memory location.                                                                                                     |
-| `cuStreamWriteValue32`                                    |                               | Write a value to memory.                                                                                                       |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuStreamAddCallback`                                     |                               |
+| `cuStreamAttachMemAsync`                                  |                               |
+| `cuStreamCreate`                                          |                               |
+| `cuStreamCreateWithPriority`                              |                               |
+| `cuStreamDestroy`                                         | `hipStreamDestroy`            |
+| `cuStreamGetFlags`                                        | `hipStreamGetFlags`           |
+| `cuStreamGetPriority`                                     | `hipStreamGetPriority`        |
+| `cuStreamQuery`                                           | `hipStreamQuery`              |
+| `cuStreamSynchronize`                                     | `hipStreamSynchronize`        |
+| `cuStreamWaitEvent`                                       | `hipStreamWaitEvent`          |
+| `cuStreamBatchMemOp`                                      |                               |
+| `cuStreamWaitValue32`                                     |                               |
+| `cuStreamWriteValue32`                                    |                               |
 
 ## **14. Event Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuEventCreate`                                           | `hipEventCreate`              | Creates an event.                                                                                                              |
-| `cuEventDestroy`                                          | `hipEventDestroy`             | Destroys an event.                                                                                                             |
-| `cuEventElapsedTime`                                      | `hipEventElapsedTime`         | Computes the elapsed time between two events.                                                                                  |
-| `cuEventQuery`                                            | `hipEventQuery`               | Queries an event's status.                                                                                                     |
-| `cuEventRecord`                                           | `hipEventRecord`              | Records an event.                                                                                                              |
-| `cuEventSynchronize`                                      | `hipEventSynchronize`         | Waits for an event to complete.                                                                                                |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuEventCreate`                                           | `hipEventCreate`              |
+| `cuEventDestroy`                                          | `hipEventDestroy`             |
+| `cuEventElapsedTime`                                      | `hipEventElapsedTime`         |
+| `cuEventQuery`                                            | `hipEventQuery`               |
+| `cuEventRecord`                                           | `hipEventRecord`              |
+| `cuEventSynchronize`                                      | `hipEventSynchronize`         |
 
 ## **15. Execution Control**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuFuncGetAttribute`                                      |                               | Returns information about a function.                                                                                          |
-| `cuFuncSetCacheConfig`                                    | `hipFuncSetCacheConfig`       | Sets the preferred cache configuration for a device function.                                                                  |
-| `cuFuncSetSharedMemConfig`                                |                               | Sets the shared memory configuration for a device function.                                                                    |
-| `cuLaunchKernel`                                          | `hipModuleLaunchKernel`       | Launches a CUDA function.                                                                                                      |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuFuncGetAttribute`                                      |                               |
+| `cuFuncSetCacheConfig`                                    | `hipFuncSetCacheConfig`       |
+| `cuFuncSetSharedMemConfig`                                |                               |
+| `cuLaunchKernel`                                          | `hipModuleLaunchKernel`       |
 
 ## **16. Execution Control [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuFuncSetBlockShape`                                     |                               | Sets the block-dimensions for the function.                                                                                    |
-| `cuFuncSetSharedSize`                                     |                               | Sets the dynamic shared-memory size for the function.                                                                          |
-| `cuLaunch`                                                |                               | Launches a CUDA function.                                                                                                      |
-| `cuLaunchGrid`                                            |                               | Launches a CUDA function.                                                                                                      |
-| `cuLaunchGridAsync`                                       |                               | Launches a CUDA function.                                                                                                      |
-| `cuParamSetf`                                             |                               | Adds a floating-point parameter to the function's argument list.                                                               |
-| `cuParamSeti`                                             |                               | Adds an integer parameter to the function's argument list.                                                                     |
-| `cuParamSetTexRef`                                        |                               | Adds a texture-reference to the function's argument list.                                                                      |
-| `cuParamSetv`                                             |                               | Adds arbitrary data to the function's argument list.                                                                           |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuFuncSetBlockShape`                                     |                               |
+| `cuFuncSetSharedSize`                                     |                               |
+| `cuLaunch`                                                |                               |
+| `cuLaunchGrid`                                            |                               |
+| `cuLaunchGridAsync`                                       |                               |
+| `cuParamSetf`                                             |                               |
+| `cuParamSeti`                                             |                               |
+| `cuParamSetTexRef`                                        |                               |
+| `cuParamSetv`                                             |                               |
 
 ## **17. Occupancy**
 
-|   **CUDA**                                                |   **HIP**                                               | **CUDA description**                                                                                 |
-|-----------------------------------------------------------|---------------------------------------------------------|------------------------------------------------------------------------------------------------------|
-| `cuOccupancyMaxActiveBlocksPerMultiprocessor`             | `hipOccupancyMaxActiveBlocksPerMultiprocessor`          | Returns occupancy of a function.                                                                     |
-| `cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`    |                                                         | Returns occupancy of a function.                                                                     |
-| `cuOccupancyMaxPotentialBlockSize`                        | `hipOccupancyMaxPotentialBlockSize`                     | Suggest a launch configuration with reasonable occupancy.                                            |
-| `cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`    |                                                         | Suggest a launch configuration with reasonable occupancy.                                            |
+|   **CUDA**                                                |   **HIP**                                               |
+|-----------------------------------------------------------|---------------------------------------------------------|
+| `cuOccupancyMaxActiveBlocksPerMultiprocessor`             | `hipOccupancyMaxActiveBlocksPerMultiprocessor`          |
+| `cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`    |                                                         |
+| `cuOccupancyMaxPotentialBlockSize`                        | `hipOccupancyMaxPotentialBlockSize`                     |
+| `cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`    |                                                         |
 
 ## **18. Texture Reference Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuTexRefGetAddress`                                      |                               | Gets the address associated with a texture reference.                                                                          |
-| `cuTexRefGetAddressMode`                                  |                               | Gets the addressing mode used by a texture reference.                                                                          |
-| `cuTexRefGetArray`                                        |                               | Gets the array bound to a texture reference.                                                                                   |
-| `cuTexRefGetBorderColor`                                  |                               | Gets the border color used by a texture reference.                                                                             |
-| `cuTexRefGetFilterMode`                                   |                               | Gets the filter-mode used by a texture reference.                                                                              |
-| `cuTexRefGetFlags`                                        |                               | Gets the flags used by a texture reference.                                                                                    |
-| `cuTexRefGetFormat`                                       |                               | Gets the format used by a texture reference.                                                                                   |
-| `cuTexRefGetMaxAnisotropy`                                |                               | Gets the maximum anisotropy for a texture reference.                                                                           |
-| `cuTexRefGetMipmapFilterMode`                             |                               | Gets the mipmap filtering mode for a texture reference.                                                                        |
-| `cuTexRefGetMipmapLevelBias`                              |                               | Gets the mipmap level bias for a texture reference.                                                                            |
-| `cuTexRefGetMipmapLevelClamp`                             |                               | Gets the min/max mipmap level clamps for a texture reference.                                                                  |
-| `cuTexRefGetMipmappedArray`                               |                               | Gets the mipmapped array bound to a texture reference.                                                                         |
-| `cuTexRefSetAddress`                                      |                               | Binds an address as a texture reference.                                                                                       |
-| `cuTexRefSetAddress2D`                                    |                               | Binds an address as a 2D texture reference.                                                                                    |
-| `cuTexRefSetAddressMode`                                  |                               | Sets the addressing mode for a texture reference.                                                                              |
-| `cuTexRefSetArray`                                        |                               | Binds an array as a texture reference.                                                                                         |
-| `cuTexRefSetBorderColor`                                  |                               | Sets the border color for a texture reference.                                                                                 |
-| `cuTexRefSetFilterMode`                                   |                               | Sets the filtering mode for a texture reference.                                                                               |
-| `cuTexRefSetFlags`                                        |                               | Sets the flags for a texture reference.                                                                                        |
-| `cuTexRefSetFormat`                                       |                               | Sets the format for a texture reference.                                                                                       |
-| `cuTexRefSetMaxAnisotropy`                                |                               | Sets the maximum anisotropy for a texture reference.                                                                           |
-| `cuTexRefSetMipmapFilterMode`                             |                               | Sets the mipmap filtering mode for a texture reference.                                                                        |
-| `cuTexRefSetMipmapLevelBias`                              |                               | Sets the mipmap level bias for a texture reference.                                                                            |
-| `cuTexRefSetMipmapLevelClamp`                             |                               | Sets the mipmap min/max mipmap level clamps for a texture reference.                                                           |
-| `cuTexRefSetMipmappedArray`                               |                               | Binds a mipmapped array to a texture reference.                                                                                |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuTexRefGetAddress`                                      |                               |
+| `cuTexRefGetAddressMode`                                  |                               |
+| `cuTexRefGetArray`                                        |                               |
+| `cuTexRefGetBorderColor`                                  |                               |
+| `cuTexRefGetFilterMode`                                   |                               |
+| `cuTexRefGetFlags`                                        |                               |
+| `cuTexRefGetFormat`                                       |                               |
+| `cuTexRefGetMaxAnisotropy`                                |                               |
+| `cuTexRefGetMipmapFilterMode`                             |                               |
+| `cuTexRefGetMipmapLevelBias`                              |                               |
+| `cuTexRefGetMipmapLevelClamp`                             |                               |
+| `cuTexRefGetMipmappedArray`                               |                               |
+| `cuTexRefSetAddress`                                      |                               |
+| `cuTexRefSetAddress2D`                                    |                               |
+| `cuTexRefSetAddressMode`                                  |                               |
+| `cuTexRefSetArray`                                        |                               |
+| `cuTexRefSetBorderColor`                                  |                               |
+| `cuTexRefSetFilterMode`                                   |                               |
+| `cuTexRefSetFlags`                                        |                               |
+| `cuTexRefSetFormat`                                       |                               |
+| `cuTexRefSetMaxAnisotropy`                                |                               |
+| `cuTexRefSetMipmapFilterMode`                             |                               |
+| `cuTexRefSetMipmapLevelBias`                              |                               |
+| `cuTexRefSetMipmapLevelClamp`                             |                               |
+| `cuTexRefSetMipmappedArray`                               |                               |
 
 ## **19. Texture Reference Management [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuTexRefCreate`                                          |                               | Creates a texture reference.                                                                                                   |
-| `cuTexRefDestroy`                                         |                               | Destroys a texture reference.                                                                                                  |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuTexRefCreate`                                          |                               |
+| `cuTexRefDestroy`                                         |                               |
 
 ## **20. Surface Reference Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuSurfRefGetArray`                                       |                               | Passes back the CUDA array bound to a surface reference.                                                                       |
-| `cuSurfRefSetArray`                                       |                               | Sets the CUDA array for a surface reference.                                                                                   |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuSurfRefGetArray`                                       |                               |
+| `cuSurfRefSetArray`                                       |                               |
 
 ## **21. Texture Object Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuTexObjectCreate`                                       |                               | Creates a texture object.                                                                                                      |
-| `cuTexObjectDestroy`                                      |                               | Destroys a texture object.                                                                                                     |
-| `cuTexObjectGetResourceDesc`                              |                               | Returns a texture object's resource descriptor.                                                                                |
-| `cuTexObjectGetResourceViewDesc`                          |                               | Returns a texture object's resource view descriptor.                                                                           |
-| `cuTexObjectGetTextureDesc`                               |                               | Returns a texture object's texture descriptor.                                                                                 |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuTexObjectCreate`                                       |                               |
+| `cuTexObjectDestroy`                                      |                               |
+| `cuTexObjectGetResourceDesc`                              |                               |
+| `cuTexObjectGetResourceViewDesc`                          |                               |
+| `cuTexObjectGetTextureDesc`                               |                               |
 
 ## **22. Surface Object Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuSurfObjectCreate`                                      |                               | Creates a surface object.                                                                                                      |
-| `cuSurfObjectDestroy`                                     |                               | Destroys a surface object.                                                                                                     |
-| `cuSurfObjectGetResourceDesc`                             |                               | Returns a surface object's resource descriptor.                                                                                |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuSurfObjectCreate`                                      |                               |
+| `cuSurfObjectDestroy`                                     |                               |
+| `cuSurfObjectGetResourceDesc`                             |                               |
 
 ## **23. Peer Context Memory Access**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuCtxEnablePeerAccess`                                   | `hipCtxEnablePeerAccess`      | Enables direct access to memory allocations in a peer context.                                                                 |
-| `cuCtxDisablePeerAccess`                                  | `hipCtxDisablePeerAccess`     | Disables direct access to memory allocations in a peer context and unregisters any registered allocations.                     |
-| `cuDeviceCanAccessPeer`                                   | `hipDeviceCanAccessPeer`      | Queries if a device may directly access a peer device's memory.                                                                |
-| `cuDeviceGetP2PAttribute`                                 |                               | Queries attributes of the link between two devices.                                                                            |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuCtxEnablePeerAccess`                                   | `hipCtxEnablePeerAccess`      |
+| `cuCtxDisablePeerAccess`                                  | `hipCtxDisablePeerAccess`     |
+| `cuDeviceCanAccessPeer`                                   | `hipDeviceCanAccessPeer`      |
+| `cuDeviceGetP2PAttribute`                                 |                               |
 
 ## **24. Graphics Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuGraphicsMapResources`                                  |                               | Map graphics resources for access by CUDA.                                                                                     |
-| `cuGraphicsResourceGetMappedMipmappedArray`               |                               | Get a mipmapped array through which to access a mapped graphics resource.                                                      |
-| `cuGraphicsResourceGetMappedPointer`                      |                               | Get a device pointer through which to access a mapped graphics resource.                                                       |
-| `cuGraphicsResourceSetMapFlags`                           |                               | Set usage flags for mapping a graphics resource.                                                                               |
-| `cuGraphicsSubResourceGetMappedArray`                     |                               | Get an array through which to access a subresource of a mapped graphics resource.                                              |
-| `cuGraphicsUnmapResources`                                |                               | Unmap graphics resources.                                                                                                      |
-| `cuGraphicsUnregisterResource`                            |                               | Unregisters a graphics resource for access by CUDA.                                                                            |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuGraphicsMapResources`                                  |                               |
+| `cuGraphicsResourceGetMappedMipmappedArray`               |                               |
+| `cuGraphicsResourceGetMappedPointer`                      |                               |
+| `cuGraphicsResourceSetMapFlags`                           |                               |
+| `cuGraphicsSubResourceGetMappedArray`                     |                               |
+| `cuGraphicsUnmapResources`                                |                               |
+| `cuGraphicsUnregisterResource`                            |                               |
 
 ## **25. Profiler Control**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuProfilerInitialize`                                    |                               | Initialize the profiling.                                                                                                      |
-| `cuProfilerStart`                                         | `hipProfilerStart`            | Enable profiling.                                                                                                              |
-| `cuProfilerStop`                                          | `hipProfilerStop`             | Disable profiling.                                                                                                             |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuProfilerInitialize`                                    |                               |
+| `cuProfilerStart`                                         | `hipProfilerStart`            |
+| `cuProfilerStop`                                          | `hipProfilerStop`             |
 
 ## **26. OpenGL Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuGLGetDevices`                                          |                               | Gets the CUDA devices associated with the current OpenGL context.                                                              |
-| `cuGraphicsGLRegisterBuffer`                              |                               | Registers an OpenGL buffer object.                                                                                             |
-| `cuGraphicsGLRegisterImage`                               |                               | Register an OpenGL texture or renderbuffer object.                                                                             |
-| `cuWGLGetDevice`                                          |                               | Gets the CUDA device associated with hGpu.                                                                                     |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuGLGetDevices`                                          |                               |
+| `cuGraphicsGLRegisterBuffer`                              |                               |
+| `cuGraphicsGLRegisterImage`                               |                               |
+| `cuWGLGetDevice`                                          |                               |
 
 ## **26.1. OpenGL Interoperability [DEPRECATED]**
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuGLCtxCreate`                                           |                               | Create a CUDA context for interoperability with OpenGL.                                                                        |
-| `cuGLInit`                                                |                               | Initializes OpenGL interoperability.                                                                                           |
-| `cuGLMapBufferObject`                                     |                               | Maps an OpenGL buffer object.                                                                                                  |
-| `cuGLMapBufferObjectAsync`                                |                               | Maps an OpenGL buffer object.                                                                                                  |
-| `cuGLRegisterBufferObject`                                |                               | Registers an OpenGL buffer object.                                                                                             |
-| `cuGLSetBufferObjectMapFlags`                             |                               | Set the map flags for an OpenGL buffer object.                                                                                 |
-| `cuGLUnmapBufferObject`                                   |                               | Unmaps an OpenGL buffer object.                                                                                                |
-| `cuGLUnmapBufferObjectAsync`                              |                               | Unmaps an OpenGL buffer object.                                                                                                |
-| `cuGLUnregisterBufferObject`                              |                               | Unregister an OpenGL buffer object.                                                                                            |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuGLCtxCreate`                                           |                               |
+| `cuGLInit`                                                |                               |
+| `cuGLMapBufferObject`                                     |                               |
+| `cuGLMapBufferObjectAsync`                                |                               |
+| `cuGLRegisterBufferObject`                                |                               |
+| `cuGLSetBufferObjectMapFlags`                             |                               |
+| `cuGLUnmapBufferObject`                                   |                               |
+| `cuGLUnmapBufferObjectAsync`                              |                               |
+| `cuGLUnregisterBufferObject`                              |                               |
 
 ## **27. Direct3D 9 Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuD3D9CtxCreate`                                         |                               | Create a CUDA context for interoperability with Direct3D 9.                                                                    |
-| `cuD3D9CtxCreateOnDevice`                                 |                               | Create a CUDA context for interoperability with Direct3D 9.                                                                    |
-| `cuD3D9GetDevice`                                         |                               | Gets the CUDA device corresponding to a display adapter.                                                                       |
-| `cuD3D9GetDevices`                                        |                               | Gets the CUDA devices corresponding to a Direct3D 9 device.                                                                    |
-| `cuD3D9GetDirect3DDevice`                                 |                               | Get the Direct3D 9 device against which the current CUDA context was created.                                                  |
-| `cuGraphicsD3D9RegisterResource`                          |                               | Register a Direct3D 9 resource for access by CUDA.                                                                             |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuD3D9CtxCreate`                                         |                               |
+| `cuD3D9CtxCreateOnDevice`                                 |                               |
+| `cuD3D9GetDevice`                                         |                               |
+| `cuD3D9GetDevices`                                        |                               |
+| `cuD3D9GetDirect3DDevice`                                 |                               |
+| `cuGraphicsD3D9RegisterResource`                          |                               |
 
 ## **27.1. Direct3D 9 Interoperability [DEPRECATED]**
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuD3D9MapResources`                                      |                               | Map Direct3D resources for access by CUDA.                                                                                     |
-| `cuD3D9RegisterResource`                                  |                               | Register a Direct3D resource for access by CUDA.                                                                               |
-| `cuD3D9ResourceGetMappedArray`                            |                               | Get an array through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.            |
-| `cuD3D9ResourceGetMappedPitch`                            |                               | Get the pitch of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                |
-| `cuD3D9ResourceGetMappedPointer`                          |                               | Get the pointer through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.         |
-| `cuD3D9ResourceGetMappedSize`                             |                               | Get the size of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                 |
-| `cuD3D9ResourceGetSurfaceDimensions`                      |                               | Get the dimensions of a registered surface.                                                                                    |
-| `cuD3D9ResourceSetMapFlags`                               |                               | Set usage flags for mapping a Direct3D resource.                                                                               |
-| `cuD3D9UnmapResources`                                    |                               | Unmaps Direct3D resources.                                                                                                     |
-| `cuD3D9UnregisterResource`                                |                               | Unregister a Direct3D resource.                                                                                                |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuD3D9MapResources`                                      |                               |
+| `cuD3D9RegisterResource`                                  |                               |
+| `cuD3D9ResourceGetMappedArray`                            |                               |
+| `cuD3D9ResourceGetMappedPitch`                            |                               |
+| `cuD3D9ResourceGetMappedPointer`                          |                               |
+| `cuD3D9ResourceGetMappedSize`                             |                               |
+| `cuD3D9ResourceGetSurfaceDimensions`                      |                               |
+| `cuD3D9ResourceSetMapFlags`                               |                               |
+| `cuD3D9UnmapResources`                                    |                               |
+| `cuD3D9UnregisterResource`                                |                               |
 
 ## **28. Direct3D 10 Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuD3D10GetDevice`                                        |                               | Gets the CUDA device corresponding to a display adapter.                                                                       |
-| `cuD3D10GetDevices`                                       |                               | Gets the CUDA devices corresponding to a Direct3D 10 device.                                                                   |
-| `cuGraphicsD3D10RegisterResource`                         |                               | Register a Direct3D 10 resource for access by CUDA.                                                                            |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuD3D10GetDevice`                                        |                               |
+| `cuD3D10GetDevices`                                       |                               |
+| `cuGraphicsD3D10RegisterResource`                         |                               |
 
 ## **28.1. Direct3D 10 Interoperability [DEPRECATED]**
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuD3D10CtxCreate`                                        |                               | Create a CUDA context for interoperability with Direct3D 10.                                                                   |
-| `cuD3D10CtxCreateOnDevice`                                |                               | Create a CUDA context for interoperability with Direct3D 10.                                                                   |
-| `cuD3D10GetDirect3DDevice`                                |                               | Get the Direct3D 10 device against which the current CUDA context was created.                                                 |
-| `cuD3D10MapResources`                                     |                               | Map Direct3D resources for access by CUDA.                                                                                     |
-| `cuD3D10RegisterResource`                                 |                               | Register a Direct3D resource for access by CUDA.                                                                               |
-| `cuD3D10ResourceGetMappedArray`                           |                               | Get an array through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.            |
-| `cuD3D10ResourceGetMappedPitch`                           |                               | Get the pitch of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                |
-| `cuD3D10ResourceGetMappedPointer`                         |                               | Get the pointer through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.         |
-| `cuD3D10ResourceGetMappedSize`                            |                               | Get the size of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                 |
-| `cuD3D10ResourceGetSurfaceDimensions`                     |                               | Get the dimensions of a registered surface.                                                                                    |
-| `cuD3D10ResourceSetMapFlags`                              |                               | Set usage flags for mapping a Direct3D resource.                                                                               |
-| `cuD3D10UnmapResources`                                   |                               | Unmaps Direct3D resources.                                                                                                     |
-| `cuD3D10UnregisterResource`                               |                               | Unregister a Direct3D resource.                                                                                                |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuD3D10CtxCreate`                                        |                               |
+| `cuD3D10CtxCreateOnDevice`                                |                               |
+| `cuD3D10GetDirect3DDevice`                                |                               |
+| `cuD3D10MapResources`                                     |                               |
+| `cuD3D10RegisterResource`                                 |                               |
+| `cuD3D10ResourceGetMappedArray`                           |                               |
+| `cuD3D10ResourceGetMappedPitch`                           |                               |
+| `cuD3D10ResourceGetMappedPointer`                         |                               |
+| `cuD3D10ResourceGetMappedSize`                            |                               |
+| `cuD3D10ResourceGetSurfaceDimensions`                     |                               |
+| `cuD3D10ResourceSetMapFlags`                              |                               |
+| `cuD3D10UnmapResources`                                   |                               |
+| `cuD3D10UnregisterResource`                               |                               |
 
 ## **29. Direct3D 11 Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuD3D11GetDevice`                                        |                               | Gets the CUDA device corresponding to a display adapter.                                                                       |
-| `cuD3D11GetDevices`                                       |                               | Gets the CUDA devices corresponding to a Direct3D 11 device.                                                                   |
-| `cuGraphicsD3D11RegisterResource`                         |                               | Register a Direct3D 11 resource for access by CUDA.                                                                            |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuD3D11GetDevice`                                        |                               |
+| `cuD3D11GetDevices`                                       |                               |
+| `cuGraphicsD3D11RegisterResource`                         |                               |
 
 ## **29.1. Direct3D 11 Interoperability [DEPRECATED]**
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuD3D11CtxCreate`                                        |                               | Create a CUDA context for interoperability with Direct3D 11.                                                                   |
-| `cuD3D11CtxCreateOnDevice`                                |                               | Create a CUDA context for interoperability with Direct3D 11.                                                                   |
-| `cuD3D11GetDirect3DDevice`                                |                               | Get the Direct3D 11 device against which the current CUDA context was created.                                                 |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuD3D11CtxCreate`                                        |                               |
+| `cuD3D11CtxCreateOnDevice`                                |                               |
+| `cuD3D11GetDirect3DDevice`                                |                               |
 
 ## **30. VDPAU Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuGraphicsVDPAURegisterOutputSurface`                    |                               | Registers a VDPAU VdpOutputSurface object.                                                                                     |
-| `cuGraphicsVDPAURegisterVideoSurface`                     |                               | Registers a VDPAU VdpVideoSurface object.                                                                                      |
-| `cuVDPAUCtxCreate`                                        |                               | Create a CUDA context for interoperability with VDPAU.                                                                         |
-| `cuVDPAUGetDevice`                                        |                               | Gets the CUDA device associated with a VDPAU device.                                                                           |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuGraphicsVDPAURegisterOutputSurface`                    |                               |
+| `cuGraphicsVDPAURegisterVideoSurface`                     |                               |
+| `cuVDPAUCtxCreate`                                        |                               |
+| `cuVDPAUGetDevice`                                        |                               |
 
 ## **31. EGL Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cuEGLStreamConsumerAcquireFrame`                         |                               | Acquire an image frame from the EGLStream with CUDA as a consumer.                                                             |
-| `cuEGLStreamConsumerConnect`                              |                               | Connect CUDA to EGLStream as a consumer.                                                                                       |
-| `cuEGLStreamConsumerConnectWithFlags`                     |                               | Connect CUDA to EGLStream as a consumer with given flags.                                                                      |
-| `cuEGLStreamConsumerDisconnect`                           |                               | Disconnect CUDA as a consumer to EGLStream.                                                                                    |
-| `cuEGLStreamConsumerReleaseFrame`                         |                               | Releases the last frame acquired from the EGLStream.                                                                           |
-| `cuEGLStreamProducerConnect`                              |                               | Connect CUDA to EGLStream as a producer.                                                                                       |
-| `cuEGLStreamProducerDisconnect`                           |                               | Disconnect CUDA as a producer to EGLStream .                                                                                   |
-| `cuEGLStreamProducerPresentFrame`                         |                               | Present a CUDA eglFrame to the EGLStream with CUDA as a producer.                                                              |
-| `cuEGLStreamProducerReturnFrame`                          |                               | Return the CUDA eglFrame to the EGLStream released by the consumer.                                                            |
-| `cuGraphicsEGLRegisterImage`                              |                               | Registers an EGL image.                                                                                                        |
-| `cuGraphicsResourceGetMappedEglFrame`                     |                               | Get an eglFrame through which to access a registered EGL graphics resource.                                                    |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cuEGLStreamConsumerAcquireFrame`                         |                               |
+| `cuEGLStreamConsumerConnect`                              |                               |
+| `cuEGLStreamConsumerConnectWithFlags`                     |                               |
+| `cuEGLStreamConsumerDisconnect`                           |                               |
+| `cuEGLStreamConsumerReleaseFrame`                         |                               |
+| `cuEGLStreamProducerConnect`                              |                               |
+| `cuEGLStreamProducerDisconnect`                           |                               |
+| `cuEGLStreamProducerPresentFrame`                         |                               |
+| `cuEGLStreamProducerReturnFrame`                          |                               |
+| `cuGraphicsEGLRegisterImage`                              |                               |
+| `cuGraphicsResourceGetMappedEglFrame`                     |                               |

--- a/docs/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -346,6 +346,40 @@
 | enum         |***`CUstream_flags`***                                         |***`hipStreamFlags`***                                      | Stream creation flags                                                                                                          |
 |          0x0 |*`CU_STREAM_DEFAULT`*                                          |*`hipStreamDefault`*                                        | Default stream flag                                                                                                            |
 |          0x1 |*`CU_STREAM_NON_BLOCKING`*                                     |*`hipStreamNonBlocking`*                                    | Stream does not synchronize with stream 0 (the NULL stream)                                                                    |
+| enum         |***`CUGLDeviceList`***                                         |                                                            | CUDA devices corresponding to an OpenGL device                                                                                 |
+|         0x01 |*`CU_GL_DEVICE_LIST_ALL`*                                      |                                                            | The CUDA devices for all GPUs used by the current OpenGL context                                                               |
+|         0x02 |*`CU_GL_DEVICE_LIST_CURRENT_FRAME`*                            |                                                            | The CUDA devices for the GPUs used by the current OpenGL context in its currently rendering frame                              |
+|         0x03 |*`CU_GL_DEVICE_LIST_NEXT_FRAME`*                               |                                                            | The CUDA devices for the GPUs to be used by the current OpenGL context in the next frame                                       |
+| enum         |***`CUGLmap_flags`***                                          |                                                            | CUDA GL Map Flags                                                                                                              |
+|         0x00 |*`CU_GL_MAP_RESOURCE_FLAGS_NONE`*                              |                                                            | Default; Assume resource can be read/written                                                                                   |
+|         0x01 |*`CU_GL_MAP_RESOURCE_FLAGS_READ_ONLY`*                         |                                                            | CUDA kernels will not write to this resource                                                                                   |
+|         0x02 |*`CU_GL_MAP_RESOURCE_FLAGS_WRITE_DISCARD`*                     |                                                            | CUDA kernels will only write to and will not read from this resource                                                           |
+| enum         |***`CUd3d9DeviceList`***                                       |                                                            | CUDA devices corresponding to a D3D9 device                                                                                    |
+|         0x01 |*`CU_D3D9_DEVICE_LIST_ALL`*                                    |                                                            | The CUDA devices for all GPUs used by a D3D9 device                                                                            |
+|         0x02 |*`CU_D3D9_DEVICE_LIST_CURRENT_FRAME`*                          |                                                            | The CUDA devices for the GPUs used by a D3D9 device in its currently rendering frame                                           |
+|         0x03 |*`CU_D3D9_DEVICE_LIST_NEXT_FRAME`*                             |                                                            | The CUDA devices for the GPUs to be used by a D3D9 device in the next frame                                                    |
+| enum         |***`CUd3d9map_flags`***                                        |                                                            | Flags to map or unmap a resource                                                                                               |
+|         0x00 |*`CU_D3D9_MAPRESOURCE_FLAGS_NONE`*                             |                                                            | Default; Assume resource can be read/written                                                                                   |
+|         0x01 |*`CU_D3D9_MAPRESOURCE_FLAGS_READONLY`*                         |                                                            | CUDA kernels will not write to this resource                                                                                   |
+|         0x02 |*`CU_D3D9_MAPRESOURCE_FLAGS_WRITEDISCARD`*                     |                                                            | CUDA kernels will only write to and will not read from this resource                                                           |
+| enum         |***`CUd3d9register_flags`***                                   |                                                            | CUDA D3D9 Register Flags                                                                                                       |
+|         0x00 |*`CU_D3D9_REGISTER_FLAGS_NONE`*                                |                                                            | Default; Resource can be accessed througa void*                                                                                |
+|         0x01 |*`CU_D3D9_REGISTER_FLAGS_ARRAY`*                               |                                                            | Resource can be accessed through a CUarray*                                                                                    |
+| enum         |***`CUd3d10DeviceList`***                                      |                                                            | CUDA devices corresponding to a D3D10 device                                                                                   |
+|         0x01 |*`CU_D3D10_DEVICE_LIST_ALL`*                                   |                                                            | The CUDA devices for all GPUs used by a D3D10 device                                                                           |
+|         0x02 |*`CU_D3D10_DEVICE_LIST_CURRENT_FRAME`*                         |                                                            | The CUDA devices for the GPUs used by a D3D10 device in its currently rendering frame                                          |
+|         0x03 |*`CU_D3D10_DEVICE_LIST_NEXT_FRAME`*                            |                                                            | The CUDA devices for the GPUs to be used by a D3D10 device in the next frame                                                   |
+| enum         |***`CUd3d10map_flags`***                                       |                                                            | Flags to map or unmap a resource                                                                                               |
+|         0x00 |*`CU_D3D10_MAPRESOURCE_FLAGS_NONE`*                            |                                                            | Default; Assume resource can be read/written                                                                                   |
+|         0x01 |*`CU_D3D10_MAPRESOURCE_FLAGS_READONLY`*                        |                                                            | CUDA kernels will not write to this resource                                                                                   |
+|         0x02 |*`CU_D3D10_MAPRESOURCE_FLAGS_WRITEDISCARD`*                    |                                                            | CUDA kernels will only write to and will not read from this resource                                                           |
+| enum         |***`CUd3d10register_flags`***                                  |                                                            | CUDA D3D10 Register Flags                                                                                                      |
+|         0x00 |*`CU_D3D10_REGISTER_FLAGS_NONE`*                               |                                                            | Default; Resource can be accessed througa void*                                                                                |
+|         0x01 |*`CU_D3D10_REGISTER_FLAGS_ARRAY`*                              |                                                            | Resource can be accessed through a CUarray*                                                                                    |
+| enum         |***`CUd3d11DeviceList`***                                      |                                                            | CUDA devices corresponding to a D3D11 device                                                                                   |
+|         0x01 |*`CU_D3D11_DEVICE_LIST_ALL`*                                   |                                                            | The CUDA devices for all GPUs used by a D3D11 device                                                                           |
+|         0x02 |*`CU_D3D11_DEVICE_LIST_CURRENT_FRAME`*                         |                                                            | The CUDA devices for the GPUs used by a D3D11 device in its currently rendering frame                                          |
+|         0x03 |*`CU_D3D11_DEVICE_LIST_NEXT_FRAME`*                            |                                                            | The CUDA devices for the GPUs to be used by a D3D11 device in the next frame                                                   |
 | typedef      | `CUarray`                                                     | `hipArray *`                                               | CUDA array                                                                                                                     |
 | struct       | `CUarray_st`                                                  | `hipArray`                                                 | CUDA array                                                                                                                     |
 | typedef      | `CUcontext`                                                   | `hipCtx_t`                                                 | CUDA context                                                                                                                   |
@@ -599,93 +633,228 @@
 | `cuFuncSetSharedMemConfig`                                |                               | Sets the shared memory configuration for a device function.                                                                    |
 | `cuLaunchKernel`                                          | `hipModuleLaunchKernel`       | Launches a CUDA function.                                                                                                      |
 
-
 ## **16. Execution Control [DEPRECATED]**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-
+| `cuFuncSetBlockShape`                                     |                               | Sets the block-dimensions for the function.                                                                                    |
+| `cuFuncSetSharedSize`                                     |                               | Sets the dynamic shared-memory size for the function.                                                                          |
+| `cuLaunch`                                                |                               | Launches a CUDA function.                                                                                                      |
+| `cuLaunchGrid`                                            |                               | Launches a CUDA function.                                                                                                      |
+| `cuLaunchGridAsync`                                       |                               | Launches a CUDA function.                                                                                                      |
+| `cuParamSetf`                                             |                               | Adds a floating-point parameter to the function's argument list.                                                               |
+| `cuParamSeti`                                             |                               | Adds an integer parameter to the function's argument list.                                                                     |
+| `cuParamSetTexRef`                                        |                               | Adds a texture-reference to the function's argument list.                                                                      |
+| `cuParamSetv`                                             |                               | Adds arbitrary data to the function's argument list.                                                                           |
 
 ## **17. Occupancy**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-
+|   **CUDA**                                                |   **HIP**                                               | **CUDA description**                                                                                 |
+|-----------------------------------------------------------|---------------------------------------------------------|------------------------------------------------------------------------------------------------------|
+| `cuOccupancyMaxActiveBlocksPerMultiprocessor`             | `hipOccupancyMaxActiveBlocksPerMultiprocessor`          | Returns occupancy of a function.                                                                     |
+| `cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`    |                                                         | Returns occupancy of a function.                                                                     |
+| `cuOccupancyMaxPotentialBlockSize`                        | `hipOccupancyMaxPotentialBlockSize`                     | Suggest a launch configuration with reasonable occupancy.                                            |
+| `cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`    |                                                         | Suggest a launch configuration with reasonable occupancy.                                            |
 
 ## **18. Texture Reference Management**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-
+| `cuTexRefGetAddress`                                      |                               | Gets the address associated with a texture reference.                                                                          |
+| `cuTexRefGetAddressMode`                                  |                               | Gets the addressing mode used by a texture reference.                                                                          |
+| `cuTexRefGetArray`                                        |                               | Gets the array bound to a texture reference.                                                                                   |
+| `cuTexRefGetBorderColor`                                  |                               | Gets the border color used by a texture reference.                                                                             |
+| `cuTexRefGetFilterMode`                                   |                               | Gets the filter-mode used by a texture reference.                                                                              |
+| `cuTexRefGetFlags`                                        |                               | Gets the flags used by a texture reference.                                                                                    |
+| `cuTexRefGetFormat`                                       |                               | Gets the format used by a texture reference.                                                                                   |
+| `cuTexRefGetMaxAnisotropy`                                |                               | Gets the maximum anisotropy for a texture reference.                                                                           |
+| `cuTexRefGetMipmapFilterMode`                             |                               | Gets the mipmap filtering mode for a texture reference.                                                                        |
+| `cuTexRefGetMipmapLevelBias`                              |                               | Gets the mipmap level bias for a texture reference.                                                                            |
+| `cuTexRefGetMipmapLevelClamp`                             |                               | Gets the min/max mipmap level clamps for a texture reference.                                                                  |
+| `cuTexRefGetMipmappedArray`                               |                               | Gets the mipmapped array bound to a texture reference.                                                                         |
+| `cuTexRefSetAddress`                                      |                               | Binds an address as a texture reference.                                                                                       |
+| `cuTexRefSetAddress2D`                                    |                               | Binds an address as a 2D texture reference.                                                                                    |
+| `cuTexRefSetAddressMode`                                  |                               | Sets the addressing mode for a texture reference.                                                                              |
+| `cuTexRefSetArray`                                        |                               | Binds an array as a texture reference.                                                                                         |
+| `cuTexRefSetBorderColor`                                  |                               | Sets the border color for a texture reference.                                                                                 |
+| `cuTexRefSetFilterMode`                                   |                               | Sets the filtering mode for a texture reference.                                                                               |
+| `cuTexRefSetFlags`                                        |                               | Sets the flags for a texture reference.                                                                                        |
+| `cuTexRefSetFormat`                                       |                               | Sets the format for a texture reference.                                                                                       |
+| `cuTexRefSetMaxAnisotropy`                                |                               | Sets the maximum anisotropy for a texture reference.                                                                           |
+| `cuTexRefSetMipmapFilterMode`                             |                               | Sets the mipmap filtering mode for a texture reference.                                                                        |
+| `cuTexRefSetMipmapLevelBias`                              |                               | Sets the mipmap level bias for a texture reference.                                                                            |
+| `cuTexRefSetMipmapLevelClamp`                             |                               | Sets the mipmap min/max mipmap level clamps for a texture reference.                                                           |
+| `cuTexRefSetMipmappedArray`                               |                               | Binds a mipmapped array to a texture reference.                                                                                |
 
 ## **19. Texture Reference Management [DEPRECATED]**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-
+| `cuTexRefCreate`                                          |                               | Creates a texture reference.                                                                                                   |
+| `cuTexRefDestroy`                                         |                               | Destroys a texture reference.                                                                                                  |
 
 ## **20. Surface Reference Management**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-
+| `cuSurfRefGetArray`                                       |                               | Passes back the CUDA array bound to a surface reference.                                                                       |
+| `cuSurfRefSetArray`                                       |                               | Sets the CUDA array for a surface reference.                                                                                   |
 
 ## **21. Texture Object Management**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-
+| `cuTexObjectCreate`                                       |                               | Creates a texture object.                                                                                                      |
+| `cuTexObjectDestroy`                                      |                               | Destroys a texture object.                                                                                                     |
+| `cuTexObjectGetResourceDesc`                              |                               | Returns a texture object's resource descriptor.                                                                                |
+| `cuTexObjectGetResourceViewDesc`                          |                               | Returns a texture object's resource view descriptor.                                                                           |
+| `cuTexObjectGetTextureDesc`                               |                               | Returns a texture object's texture descriptor.                                                                                 |
 
 ## **22. Surface Object Management**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-
+| `cuSurfObjectCreate`                                      |                               | Creates a surface object.                                                                                                      |
+| `cuSurfObjectDestroy`                                     |                               | Destroys a surface object.                                                                                                     |
+| `cuSurfObjectGetResourceDesc`                             |                               | Returns a surface object's resource descriptor.                                                                                |
 
 ## **23. Peer Context Memory Access**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-
+| `cuCtxEnablePeerAccess`                                   | `hipCtxEnablePeerAccess`      | Enables direct access to memory allocations in a peer context.                                                                 |
+| `cuCtxDisablePeerAccess`                                  | `hipCtxDisablePeerAccess`     | Disables direct access to memory allocations in a peer context and unregisters any registered allocations.                     |
+| `cuDeviceCanAccessPeer`                                   | `hipDeviceCanAccessPeer`      | Queries if a device may directly access a peer device's memory.                                                                |
+| `cuDeviceGetP2PAttribute`                                 |                               | Queries attributes of the link between two devices.                                                                            |
 
 ## **24. Graphics Interoperability**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-
+| `cuGraphicsMapResources`                                  |                               | Map graphics resources for access by CUDA.                                                                                     |
+| `cuGraphicsResourceGetMappedMipmappedArray`               |                               | Get a mipmapped array through which to access a mapped graphics resource.                                                      |
+| `cuGraphicsResourceGetMappedPointer`                      |                               | Get a device pointer through which to access a mapped graphics resource.                                                       |
+| `cuGraphicsResourceSetMapFlags`                           |                               | Set usage flags for mapping a graphics resource.                                                                               |
+| `cuGraphicsSubResourceGetMappedArray`                     |                               | Get an array through which to access a subresource of a mapped graphics resource.                                              |
+| `cuGraphicsUnmapResources`                                |                               | Unmap graphics resources.                                                                                                      |
+| `cuGraphicsUnregisterResource`                            |                               | Unregisters a graphics resource for access by CUDA.                                                                            |
 
 ## **25. Profiler Control**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-
+| `cuProfilerInitialize`                                    |                               | Initialize the profiling.                                                                                                      |
+| `cuProfilerStart`                                         | `hipProfilerStart`            | Enable profiling.                                                                                                              |
+| `cuProfilerStop`                                          | `hipProfilerStop`             | Disable profiling.                                                                                                             |
 
 ## **26. OpenGL Interoperability**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cuGLGetDevices`                                          |                               | Gets the CUDA devices associated with the current OpenGL context.                                                              |
+| `cuGraphicsGLRegisterBuffer`                              |                               | Registers an OpenGL buffer object.                                                                                             |
+| `cuGraphicsGLRegisterImage`                               |                               | Register an OpenGL texture or renderbuffer object.                                                                             |
+| `cuWGLGetDevice`                                          |                               | Gets the CUDA device associated with hGpu.                                                                                     |
 
+## **26.1. OpenGL Interoperability [DEPRECATED]**
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cuGLCtxCreate`                                           |                               | Create a CUDA context for interoperability with OpenGL.                                                                        |
+| `cuGLInit`                                                |                               | Initializes OpenGL interoperability.                                                                                           |
+| `cuGLMapBufferObject`                                     |                               | Maps an OpenGL buffer object.                                                                                                  |
+| `cuGLMapBufferObjectAsync`                                |                               | Maps an OpenGL buffer object.                                                                                                  |
+| `cuGLRegisterBufferObject`                                |                               | Registers an OpenGL buffer object.                                                                                             |
+| `cuGLSetBufferObjectMapFlags`                             |                               | Set the map flags for an OpenGL buffer object.                                                                                 |
+| `cuGLUnmapBufferObject`                                   |                               | Unmaps an OpenGL buffer object.                                                                                                |
+| `cuGLUnmapBufferObjectAsync`                              |                               | Unmaps an OpenGL buffer object.                                                                                                |
+| `cuGLUnregisterBufferObject`                              |                               | Unregister an OpenGL buffer object.                                                                                            |
 
 ## **27. Direct3D 9 Interoperability**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cuD3D9CtxCreate`                                         |                               | Create a CUDA context for interoperability with Direct3D 9.                                                                    |
+| `cuD3D9CtxCreateOnDevice`                                 |                               | Create a CUDA context for interoperability with Direct3D 9.                                                                    |
+| `cuD3D9GetDevice`                                         |                               | Gets the CUDA device corresponding to a display adapter.                                                                       |
+| `cuD3D9GetDevices`                                        |                               | Gets the CUDA devices corresponding to a Direct3D 9 device.                                                                    |
+| `cuD3D9GetDirect3DDevice`                                 |                               | Get the Direct3D 9 device against which the current CUDA context was created.                                                  |
+| `cuGraphicsD3D9RegisterResource`                          |                               | Register a Direct3D 9 resource for access by CUDA.                                                                             |
 
+## **27.1. Direct3D 9 Interoperability [DEPRECATED]**
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cuD3D9MapResources`                                      |                               | Map Direct3D resources for access by CUDA.                                                                                     |
+| `cuD3D9RegisterResource`                                  |                               | Register a Direct3D resource for access by CUDA.                                                                               |
+| `cuD3D9ResourceGetMappedArray`                            |                               | Get an array through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.            |
+| `cuD3D9ResourceGetMappedPitch`                            |                               | Get the pitch of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                |
+| `cuD3D9ResourceGetMappedPointer`                          |                               | Get the pointer through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.         |
+| `cuD3D9ResourceGetMappedSize`                             |                               | Get the size of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                 |
+| `cuD3D9ResourceGetSurfaceDimensions`                      |                               | Get the dimensions of a registered surface.                                                                                    |
+| `cuD3D9ResourceSetMapFlags`                               |                               | Set usage flags for mapping a Direct3D resource.                                                                               |
+| `cuD3D9UnmapResources`                                    |                               | Unmaps Direct3D resources.                                                                                                     |
+| `cuD3D9UnregisterResource`                                |                               | Unregister a Direct3D resource.                                                                                                |
 
 ## **28. Direct3D 10 Interoperability**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cuD3D10GetDevice`                                        |                               | Gets the CUDA device corresponding to a display adapter.                                                                       |
+| `cuD3D10GetDevices`                                       |                               | Gets the CUDA devices corresponding to a Direct3D 10 device.                                                                   |
+| `cuGraphicsD3D10RegisterResource`                         |                               | Register a Direct3D 10 resource for access by CUDA.                                                                            |
 
+## **28.1. Direct3D 10 Interoperability [DEPRECATED]**
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cuD3D10CtxCreate`                                        |                               | Create a CUDA context for interoperability with Direct3D 10.                                                                   |
+| `cuD3D10CtxCreateOnDevice`                                |                               | Create a CUDA context for interoperability with Direct3D 10.                                                                   |
+| `cuD3D10GetDirect3DDevice`                                |                               | Get the Direct3D 10 device against which the current CUDA context was created.                                                 |
+| `cuD3D10MapResources`                                     |                               | Map Direct3D resources for access by CUDA.                                                                                     |
+| `cuD3D10RegisterResource`                                 |                               | Register a Direct3D resource for access by CUDA.                                                                               |
+| `cuD3D10ResourceGetMappedArray`                           |                               | Get an array through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.            |
+| `cuD3D10ResourceGetMappedPitch`                           |                               | Get the pitch of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                |
+| `cuD3D10ResourceGetMappedPointer`                         |                               | Get the pointer through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.         |
+| `cuD3D10ResourceGetMappedSize`                            |                               | Get the size of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                 |
+| `cuD3D10ResourceGetSurfaceDimensions`                     |                               | Get the dimensions of a registered surface.                                                                                    |
+| `cuD3D10ResourceSetMapFlags`                              |                               | Set usage flags for mapping a Direct3D resource.                                                                               |
+| `cuD3D10UnmapResources`                                   |                               | Unmaps Direct3D resources.                                                                                                     |
+| `cuD3D10UnregisterResource`                               |                               | Unregister a Direct3D resource.                                                                                                |
 
 ## **29. Direct3D 11 Interoperability**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cuD3D11GetDevice`                                        |                               | Gets the CUDA device corresponding to a display adapter.                                                                       |
+| `cuD3D11GetDevices`                                       |                               | Gets the CUDA devices corresponding to a Direct3D 11 device.                                                                   |
+| `cuGraphicsD3D11RegisterResource`                         |                               | Register a Direct3D 11 resource for access by CUDA.                                                                            |
 
+## **29.1. Direct3D 11 Interoperability [DEPRECATED]**
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cuD3D11CtxCreate`                                        |                               | Create a CUDA context for interoperability with Direct3D 11.                                                                   |
+| `cuD3D11CtxCreateOnDevice`                                |                               | Create a CUDA context for interoperability with Direct3D 11.                                                                   |
+| `cuD3D11GetDirect3DDevice`                                |                               | Get the Direct3D 11 device against which the current CUDA context was created.                                                 |
 
 ## **30. VDPAU Interoperability**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cuGraphicsVDPAURegisterOutputSurface`                    |                               | Registers a VDPAU VdpOutputSurface object.                                                                                     |
+| `cuGraphicsVDPAURegisterVideoSurface`                     |                               | Registers a VDPAU VdpVideoSurface object.                                                                                      |
+| `cuVDPAUCtxCreate`                                        |                               | Create a CUDA context for interoperability with VDPAU.                                                                         |
+| `cuVDPAUGetDevice`                                        |                               | Gets the CUDA device associated with a VDPAU device.                                                                           |
 
+## **31. EGL Interoperability**
+
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cuEGLStreamConsumerAcquireFrame`                         |                               | Acquire an image frame from the EGLStream with CUDA as a consumer.                                                             |
+| `cuEGLStreamConsumerConnect`                              |                               | Connect CUDA to EGLStream as a consumer.                                                                                       |
+| `cuEGLStreamConsumerConnectWithFlags`                     |                               | Connect CUDA to EGLStream as a consumer with given flags.                                                                      |
+| `cuEGLStreamConsumerDisconnect`                           |                               | Disconnect CUDA as a consumer to EGLStream.                                                                                    |
+| `cuEGLStreamConsumerReleaseFrame`                         |                               | Releases the last frame acquired from the EGLStream.                                                                           |
+| `cuEGLStreamProducerConnect`                              |                               | Connect CUDA to EGLStream as a producer.                                                                                       |
+| `cuEGLStreamProducerDisconnect`                           |                               | Disconnect CUDA as a producer to EGLStream .                                                                                   |
+| `cuEGLStreamProducerPresentFrame`                         |                               | Present a CUDA eglFrame to the EGLStream with CUDA as a producer.                                                              |
+| `cuEGLStreamProducerReturnFrame`                          |                               | Return the CUDA eglFrame to the EGLStream released by the consumer.                                                            |
+| `cuGraphicsEGLRegisterImage`                              |                               | Registers an EGL image.                                                                                                        |
+| `cuGraphicsResourceGetMappedEglFrame`                     |                               | Get an eglFrame through which to access a registered EGL graphics resource.                                                    |

--- a/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -2,783 +2,783 @@
 
 ## **1. Device Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaChooseDevice`                                        | `hipChooseDevice`             | Select compute-device which best matches criteria.                                                                             |
-| `cudaDeviceGetAttribute`                                  | `hipDeviceGetAttribute`       | Returns information about the device.                                                                                          |
-| `cudaDeviceGetByPCIBusId`                                 | `hipDeviceGetByPCIBusId`      | Returns a handle to a compute device.                                                                                          |
-| `cudaDeviceGetCacheConfig`                                | `hipDeviceGetCacheConfig`     | Returns the preferred cache configuration for the current device.                                                              |
-| `cudaDeviceGetLimit`                                      | `hipDeviceGetLimit`           | Returns resource limits.                                                                                                       |
-| `cudaDeviceGetPCIBusId`                                   | `hipDeviceGetPCIBusId`        | Returns a PCI Bus Id string for the device.                                                                                    |
-| `cudaDeviceGetSharedMemConfig`                            | `hipDeviceGetSharedMemConfig` | Returns the shared memory configuration for the current device.                                                                |
-| `cudaDeviceGetStreamPriorityRange`                        |                               | Returns numerical values that correspond to the least and greatest stream priorities.                                          |
-| `cudaDeviceReset`                                         | `hipDeviceReset`              | Destroy all allocations and reset all state on the current device in the current process.                                      |
-| `cudaDeviceSetCacheConfig`                                | `hipDeviceSetCacheConfig`     | Sets the preferred cache configuration for the current device.                                                                 |
-| `cudaDeviceSetLimit`                                      | `hipDeviceSetLimit`           | Set resource limits.                                                                                                           |
-| `cudaDeviceSetSharedMemConfig`                            | `hipDeviceSetSharedMemConfig` | Sets the shared memory configuration for the current device.                                                                   |
-| `cudaDeviceSynchronize`                                   | `hipDeviceSynchronize`        | Wait for compute device to finish.                                                                                             |
-| `cudaGetDevice`                                           | `hipGetDevice`                | Returns which device is currently being used.                                                                                  |
-| `cudaGetDeviceCount`                                      | `hipGetDeviceCount`           | Returns the number of compute-capable devices.                                                                                 |
-| `cudaGetDeviceFlags`                                      |                               | Gets the flags for the current device.                                                                                         |
-| `cudaGetDeviceProperties`                                 | `hipGetDeviceProperties`      | Returns information about the compute-device.                                                                                  |
-| `cudaIpcCloseMemHandle`                                   | `hipIpcCloseMemHandle`        | Close memory mapped with cudaIpcOpenMemHandle.                                                                                 |
-| `cudaIpcGetEventHandle`                                   | `hipIpcGetEventHandle`        | Gets an interprocess handle for a previously allocated event.                                                                  |
-| `cudaIpcGetMemHandle`                                     | `hipIpcGetMemHandle`          | Gets an interprocess memory handle for an existing device memory allocation.                                                   |
-| `cudaIpcOpenEventHandle`                                  | `hipIpcOpenEventHandle`       | Opens an interprocess event handle for use in the current process.                                                             |
-| `cudaIpcOpenMemHandle`                                    | `hipIpcOpenMemHandle`         | Opens an interprocess memory handle exported from another process and returns a device pointer usable in the local process.    |
-| `cudaSetDevice`                                           | `hipSetDevice`                | Set device to be used for GPU executions.                                                                                      |
-| `cudaSetDeviceFlags`                                      | `hipSetDeviceFlags`           | Sets flags to be used for device executions.                                                                                   |
-| `cudaSetValidDevices`                                     |                               | Set a list of devices that can be used for CUDA.                                                                               |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaChooseDevice`                                        | `hipChooseDevice`             |
+| `cudaDeviceGetAttribute`                                  | `hipDeviceGetAttribute`       |
+| `cudaDeviceGetByPCIBusId`                                 | `hipDeviceGetByPCIBusId`      |
+| `cudaDeviceGetCacheConfig`                                | `hipDeviceGetCacheConfig`     |
+| `cudaDeviceGetLimit`                                      | `hipDeviceGetLimit`           |
+| `cudaDeviceGetPCIBusId`                                   | `hipDeviceGetPCIBusId`        |
+| `cudaDeviceGetSharedMemConfig`                            | `hipDeviceGetSharedMemConfig` |
+| `cudaDeviceGetStreamPriorityRange`                        |                               |
+| `cudaDeviceReset`                                         | `hipDeviceReset`              |
+| `cudaDeviceSetCacheConfig`                                | `hipDeviceSetCacheConfig`     |
+| `cudaDeviceSetLimit`                                      | `hipDeviceSetLimit`           |
+| `cudaDeviceSetSharedMemConfig`                            | `hipDeviceSetSharedMemConfig` |
+| `cudaDeviceSynchronize`                                   | `hipDeviceSynchronize`        |
+| `cudaGetDevice`                                           | `hipGetDevice`                |
+| `cudaGetDeviceCount`                                      | `hipGetDeviceCount`           |
+| `cudaGetDeviceFlags`                                      |                               |
+| `cudaGetDeviceProperties`                                 | `hipGetDeviceProperties`      |
+| `cudaIpcCloseMemHandle`                                   | `hipIpcCloseMemHandle`        |
+| `cudaIpcGetEventHandle`                                   | `hipIpcGetEventHandle`        |
+| `cudaIpcGetMemHandle`                                     | `hipIpcGetMemHandle`          |
+| `cudaIpcOpenEventHandle`                                  | `hipIpcOpenEventHandle`       |
+| `cudaIpcOpenMemHandle`                                    | `hipIpcOpenMemHandle`         |
+| `cudaSetDevice`                                           | `hipSetDevice`                |
+| `cudaSetDeviceFlags`                                      | `hipSetDeviceFlags`           |
+| `cudaSetValidDevices`                                     |                               |
 
 ## **2. Thread Management [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaThreadExit`                                          | `hipDeviceReset`              | Exit and clean up from CUDA launches.                                                                                          |
-| `cudaThreadGetCacheConfig`                                | `hipDeviceGetCacheConfig`     | Returns the preferred cache configuration for the current device.                                                              |
-| `cudaThreadGetLimit`                                      |                               | Returns resource limits.                                                                                                       |
-| `cudaThreadSetCacheConfig`                                | `hipDeviceSetCacheConfig`     | Sets the preferred cache configuration for the current device.                                                                 |
-| `cudaThreadSetLimit`                                      |                               | Set resource limits.                                                                                                           |
-| `cudaThreadSynchronize`                                   | `hipDeviceSynchronize`        | Wait for compute device to finish.                                                                                             |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaThreadExit`                                          | `hipDeviceReset`              |
+| `cudaThreadGetCacheConfig`                                | `hipDeviceGetCacheConfig`     |
+| `cudaThreadGetLimit`                                      |                               |
+| `cudaThreadSetCacheConfig`                                | `hipDeviceSetCacheConfig`     |
+| `cudaThreadSetLimit`                                      |                               |
+| `cudaThreadSynchronize`                                   | `hipDeviceSynchronize`        |
 
 ## **3. Error Handling**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaGetErrorName`                                        | `hipGetErrorName`             | Returns the string representation of an error code enum name.                                                                  |
-| `cudaGetErrorString`                                      | `hipGetErrorString`           | Returns the description string for an error code.                                                                              |
-| `cudaGetLastError`                                        | `hipGetLastError`             | Returns the last error from a runtime call.                                                                                    |
-| `cudaPeekAtLastError`                                     | `hipPeekAtLastError`          | Returns the last error from a runtime call.                                                                                    |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaGetErrorName`                                        | `hipGetErrorName`             |
+| `cudaGetErrorString`                                      | `hipGetErrorString`           |
+| `cudaGetLastError`                                        | `hipGetLastError`             |
+| `cudaPeekAtLastError`                                     | `hipPeekAtLastError`          |
 
 ## **4. Stream Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaStreamAddCallback`                                   | `hipStreamAddCallback`        | Add a callback to a compute stream.                                                                                            |
-| `cudaStreamAttachMemAsync`                                |                               | Attach managed memory to a stream asynchronously.                                                                              |
-| `cudaStreamCreate`                                        | `hipStreamCreate`             | Create an asynchronous stream.                                                                                                 |
-| `cudaStreamCreateWithFlags`                               | `hipStreamCreateWithFlags`    | Create an asynchronous stream.                                                                                                 |
-| `cudaStreamCreateWithPriority`                            |                               | Create an asynchronous stream with the specified priority.                                                                     |
-| `cudaStreamDestroy`                                       | `hipStreamDestroy`            | Destroys and cleans up an asynchronous stream.                                                                                 |
-| `cudaStreamGetFlags`                                      | `hipStreamGetFlags`           | Query the flags of a stream.                                                                                                   |
-| `cudaStreamGetPriority`                                   |                               | Query the priority of a stream.                                                                                                |
-| `cudaStreamQuery`                                         | `hipStreamQuery`              | Queries an asynchronous stream for completion status.                                                                          |
-| `cudaStreamSynchronize`                                   | `hipStreamSynchronize`        | Waits for stream tasks to complete.                                                                                            |
-| `cudaStreamWaitEvent`                                     | `hipStreamWaitEvent`          | Make a compute stream wait on an event.                                                                                        |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaStreamAddCallback`                                   | `hipStreamAddCallback`        |
+| `cudaStreamAttachMemAsync`                                |                               |
+| `cudaStreamCreate`                                        | `hipStreamCreate`             |
+| `cudaStreamCreateWithFlags`                               | `hipStreamCreateWithFlags`    |
+| `cudaStreamCreateWithPriority`                            |                               |
+| `cudaStreamDestroy`                                       | `hipStreamDestroy`            |
+| `cudaStreamGetFlags`                                      | `hipStreamGetFlags`           |
+| `cudaStreamGetPriority`                                   |                               |
+| `cudaStreamQuery`                                         | `hipStreamQuery`              |
+| `cudaStreamSynchronize`                                   | `hipStreamSynchronize`        |
+| `cudaStreamWaitEvent`                                     | `hipStreamWaitEvent`          |
 
 ## **5. Event Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaEventCreate`                                         | `hipEventCreate`              | Creates an event object.                                                                                                       |
-| `cudaEventCreateWithFlags`                                | `hipEventCreateWithFlags`     | Creates an event object with the specified flags.                                                                              |
-| `cudaEventDestroy`                                        | `hipEventDestroy`             | Destroys an event object.                                                                                                      |
-| `cudaEventElapsedTime`                                    | `hipEventElapsedTime`         | Computes the elapsed time between events.                                                                                      |
-| `cudaEventQuery`                                          | `hipEventQuery`               | Queries an event's status.                                                                                                     |
-| `cudaEventRecord`                                         | `hipEventRecord`              | Records an event.                                                                                                              |
-| `cudaEventSynchronize`                                    | `hipEventSynchronize`         | Waits for an event to complete.                                                                                                |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaEventCreate`                                         | `hipEventCreate`              |
+| `cudaEventCreateWithFlags`                                | `hipEventCreateWithFlags`     |
+| `cudaEventDestroy`                                        | `hipEventDestroy`             |
+| `cudaEventElapsedTime`                                    | `hipEventElapsedTime`         |
+| `cudaEventQuery`                                          | `hipEventQuery`               |
+| `cudaEventRecord`                                         | `hipEventRecord`              |
+| `cudaEventSynchronize`                                    | `hipEventSynchronize`         |
 
 ## **6. Execution Control**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaFuncGetAttributes`                                   |                               | Find out attributes for a given function.                                                                                      |
-| `cudaFuncSetCacheConfig`                                  | `hipFuncSetCacheConfig`       | Sets the preferred cache configuration for a device function.                                                                  |
-| `cudaFuncSetSharedMemConfig`                              |                               | Sets the shared memory configuration for a device function.                                                                    |
-| `cudaGetParameterBuffer`                                  |                               | Obtains a parameter buffer.                                                                                                    |
-| `cudaGetParameterBufferV2`                                |                               | Launches a specified kernel.                                                                                                   |
-| `cudaLaunchKernel`                                        | `hipLaunchKernel`             | Launches a device function.                                                                                                    |
-| `cudaSetDoubleForDevice`                                  |                               | Converts a double argument to be executed on a device.                                                                         |
-| `cudaSetDoubleForHost`                                    |                               | Converts a double argument after execution on a device.                                                                        |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaFuncGetAttributes`                                   |                               |
+| `cudaFuncSetCacheConfig`                                  | `hipFuncSetCacheConfig`       |
+| `cudaFuncSetSharedMemConfig`                              |                               |
+| `cudaGetParameterBuffer`                                  |                               |
+| `cudaGetParameterBufferV2`                                |                               |
+| `cudaLaunchKernel`                                        | `hipLaunchKernel`             |
+| `cudaSetDoubleForDevice`                                  |                               |
+| `cudaSetDoubleForHost`                                    |                               |
 
 ## **7. Occupancy**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaOccupancyMaxActiveBlocksPerMultiprocessor`           | `hipOccupancyMaxActiveBlocksPerMultiprocessor`| Returns occupancy for a device function.                                                                       |
-| `cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`  |                               | Returns occupancy for a device function with the specified flags.                                                              |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaOccupancyMaxActiveBlocksPerMultiprocessor`           | `hipOccupancyMaxActiveBlocksPerMultiprocessor`|
+| `cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`  |                               |
 
 ## **8. Execution Control [deprecated since 7.0]**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaConfigureCall`                                       |                               | Configure a device-launch.                                                                                                     |
-| `cudaLaunch`                                              |                               | Launches a device function.                                                                                                    |
-| `cudaSetupArgument`                                       |                               | Configure a device launch.                                                                                                     |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaConfigureCall`                                       |                               |
+| `cudaLaunch`                                              |                               |
+| `cudaSetupArgument`                                       |                               |
 
 ## **9. Memory Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaArrayGetInfo`                                        |                               | Gets info about the specified cudaArray.                                                                                       |
-| `cudaFree`                                                | `hipFree`                     | Frees memory on the device.                                                                                                    |
-| `cudaFreeArray`                                           | `hipFreeArray`                | Frees an array on the device.                                                                                                  |
-| `cudaFreeHost`                                            | `hipHostFree`                 | Frees page-locked memory.                                                                                                      |
-| `cudaFreeMipmappedArray`                                  |                               | Frees a mipmapped array on the device.                                                                                         |
-| `cudaGetMipmappedArrayLevel`                              |                               | Gets a mipmap level of a CUDA mipmapped array.                                                                                 |
-| `cudaGetSymbolAddress`                                    |                               | Finds the address associated with a CUDA symbol.                                                                               |
-| `cudaGetSymbolSize`                                       |                               | Finds the size of the object associated with a CUDA symbol.                                                                    |
-| `cudaHostAlloc`                                           | `hipHostMalloc`               | Allocates page-locked memory on the host.                                                                                      |
-| `cudaHostGetDevicePointer`                                | `hipHostGetDevicePointer`     | Passes back device pointer of mapped host memory allocated by cudaHostAlloc or registered by cudaHostRegister.                 |
-| `cudaHostGetFlags`                                        | `hipHostGetFlags`             | Passes back flags used to allocate pinned host memory allocated by cudaHostAlloc.                                              |
-| `cudaHostRegister`                                        | `hipHostRegister`             | Registers an existing host memory range for use by CUDA.                                                                       |
-| `cudaHostUnregister`                                      | `hipHostUnregister`           | Unregisters a memory range that was registered with cudaHostRegister.                                                          |
-| `cudaMalloc`                                              | `hipMalloc`                   | Allocate memory on the device.                                                                                                 |
-| `cudaMalloc3D`                                            |                               | Allocates logical 1D, 2D, or 3D memory objects on the device.                                                                  |
-| `cudaMalloc3DArray`                                       |                               | Allocate an array on the device.                                                                                               |
-| `cudaMallocArray`                                         | `hipMallocArray`              | Allocate an array on the device.                                                                                               |
-| `cudaMallocHost`                                          | `hipHostMalloc`               | Allocates page-locked memory on the host.                                                                                      |
-| `cudaMallocManaged`                                       |                               | Allocates memory that will be automatically managed by the Unified Memory system.                                              |
-| `cudaMallocMipmappedArray`                                |                               | Allocate a mipmapped array on the device.                                                                                      |
-| `cudaMallocPitch`                                         |                               | Allocates pitched memory on the device.                                                                                        |
-| `cudaMemGetInfo`                                          | `hipMemGetInfo`               | Gets free and total device memory.                                                                                             |
-| `cudaMemcpy`                                              | `hipMemcpy`                   | Copies data between host and device.                                                                                           |
-| `cudaMemcpy2D`                                            | `hipMemcpy2D`                 | Copies data between host and device.                                                                                           |
-| `cudaMemcpy2DArrayToArray`                                |                               | Copies data between host and device.                                                                                           |
-| `cudaMemcpy2DAsync`                                       |                               | Copies data between host and device.                                                                                           |
-| `cudaMemcpy2DFromArray`                                   |                               | Copies data between host and device.                                                                                           |
-| `cudaMemcpy2DFromArrayAsync`                              |                               | Copies data between host and device.                                                                                           |
-| `cudaMemcpy2DToArray`                                     | `hipMemcpy2DToArray`          | Copies data between host and device.                                                                                           |
-| `cudaMemcpy2DToArrayAsync`                                |                               | Copies data between host and device.                                                                                           |
-| `cudaMemcpy3D`                                            |                               | Copies data between 3D objects.                                                                                                |
-| `cudaMemcpy3DAsync`                                       |                               | Copies data between 3D objects.                                                                                                |
-| `cudaMemcpy3DPeer`                                        |                               | Copies memory between devices.                                                                                                 |
-| `cudaMemcpy3DPeerAsync`                                   |                               | Copies memory between devices asynchronously.                                                                                  |
-| `cudaMemcpyArrayToArray`                                  |                               | Copies data between host and device.                                                                                           |
-| `cudaMemcpyAsync`                                         | `hipMemcpyAsync`              | Copies data between host and device.                                                                                           |
-| `cudaMemcpyFromArray`                                     | `MemcpyFromArray`             | Copies data between host and device.                                                                                           |
-| `cudaMemcpyFromArrayAsync`                                |                               | Copies data between host and device.                                                                                           |
-| `cudaMemcpyFromSymbol`                                    | `hipMemcpyFromSymbol`         | Copies data from the given symbol on the device.                                                                               |
-| `cudaMemcpyFromSymbolAsync`                               |                               | Copies data from the given symbol on the device.                                                                               |
-| `cudaMemcpyPeer`                                          | `hipMemcpyPeer`               | Copies memory between two devices.                                                                                             |
-| `cudaMemcpyPeerAsync`                                     | `hipMemcpyPeerAsync`          | Copies memory between two devices asynchronously.                                                                              |
-| `cudaMemcpyToArray`                                       | `hipMemcpyToArray`            | Copies data between host and device.                                                                                           |
-| `cudaMemcpyToArrayAsync`                                  |                               | Copies data between host and device.                                                                                           |
-| `cudaMemcpyToSymbol`                                      | `hipMemcpyToSymbol`           | Copies data to the given symbol on the device.                                                                                 |
-| `cudaMemcpyToSymbolAsync`                                 | `hipMemcpyToSymbolAsync`      | Copies data to the given symbol on the device.                                                                                 |
-| `cudaMemset`                                              | `hipMemset`                   | Initializes or sets device memory to a value.                                                                                  |
-| `cudaMemset2D`                                            |                               | Initializes or sets device memory to a value.                                                                                  |
-| `cudaMemset2DAsync`                                       |                               | Initializes or sets device memory to a value.                                                                                  |
-| `cudaMemset3D`                                            |                               | Initializes or sets device memory to a value.                                                                                  |
-| `cudaMemset3DAsync`                                       |                               | Initializes or sets device memory to a value.                                                                                  |
-| `cudaMemsetAsync`                                         | `hipMemsetAsync`              | Initializes or sets device memory to a value.                                                                                  |
-| `make_cudaExtent`                                         |                               | Returns a cudaExtent based on input parameters.                                                                                |
-| `make_cudaPitchedPtr`                                     |                               | Returns a cudaPitchedPtr based on input parameters.                                                                            |
-| `make_cudaPos`                                            |                               | Returns a cudaPos based on input parameters.                                                                                   |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaArrayGetInfo`                                        |                               |
+| `cudaFree`                                                | `hipFree`                     |
+| `cudaFreeArray`                                           | `hipFreeArray`                |
+| `cudaFreeHost`                                            | `hipHostFree`                 |
+| `cudaFreeMipmappedArray`                                  |                               |
+| `cudaGetMipmappedArrayLevel`                              |                               |
+| `cudaGetSymbolAddress`                                    |                               |
+| `cudaGetSymbolSize`                                       |                               |
+| `cudaHostAlloc`                                           | `hipHostMalloc`               |
+| `cudaHostGetDevicePointer`                                | `hipHostGetDevicePointer`     |
+| `cudaHostGetFlags`                                        | `hipHostGetFlags`             |
+| `cudaHostRegister`                                        | `hipHostRegister`             |
+| `cudaHostUnregister`                                      | `hipHostUnregister`           |
+| `cudaMalloc`                                              | `hipMalloc`                   |
+| `cudaMalloc3D`                                            |                               |
+| `cudaMalloc3DArray`                                       |                               |
+| `cudaMallocArray`                                         | `hipMallocArray`              |
+| `cudaMallocHost`                                          | `hipHostMalloc`               |
+| `cudaMallocManaged`                                       |                               |
+| `cudaMallocMipmappedArray`                                |                               |
+| `cudaMallocPitch`                                         |                               |
+| `cudaMemGetInfo`                                          | `hipMemGetInfo`               |
+| `cudaMemcpy`                                              | `hipMemcpy`                   |
+| `cudaMemcpy2D`                                            | `hipMemcpy2D`                 |
+| `cudaMemcpy2DArrayToArray`                                |                               |
+| `cudaMemcpy2DAsync`                                       |                               |
+| `cudaMemcpy2DFromArray`                                   |                               |
+| `cudaMemcpy2DFromArrayAsync`                              |                               |
+| `cudaMemcpy2DToArray`                                     | `hipMemcpy2DToArray`          |
+| `cudaMemcpy2DToArrayAsync`                                |                               |
+| `cudaMemcpy3D`                                            |                               |
+| `cudaMemcpy3DAsync`                                       |                               |
+| `cudaMemcpy3DPeer`                                        |                               |
+| `cudaMemcpy3DPeerAsync`                                   |                               |
+| `cudaMemcpyArrayToArray`                                  |                               |
+| `cudaMemcpyAsync`                                         | `hipMemcpyAsync`              |
+| `cudaMemcpyFromArray`                                     | `MemcpyFromArray`             |
+| `cudaMemcpyFromArrayAsync`                                |                               |
+| `cudaMemcpyFromSymbol`                                    | `hipMemcpyFromSymbol`         |
+| `cudaMemcpyFromSymbolAsync`                               |                               |
+| `cudaMemcpyPeer`                                          | `hipMemcpyPeer`               |
+| `cudaMemcpyPeerAsync`                                     | `hipMemcpyPeerAsync`          |
+| `cudaMemcpyToArray`                                       | `hipMemcpyToArray`            |
+| `cudaMemcpyToArrayAsync`                                  |                               |
+| `cudaMemcpyToSymbol`                                      | `hipMemcpyToSymbol`           |
+| `cudaMemcpyToSymbolAsync`                                 | `hipMemcpyToSymbolAsync`      |
+| `cudaMemset`                                              | `hipMemset`                   |
+| `cudaMemset2D`                                            |                               |
+| `cudaMemset2DAsync`                                       |                               |
+| `cudaMemset3D`                                            |                               |
+| `cudaMemset3DAsync`                                       |                               |
+| `cudaMemsetAsync`                                         | `hipMemsetAsync`              |
+| `make_cudaExtent`                                         |                               |
+| `make_cudaPitchedPtr`                                     |                               |
+| `make_cudaPos`                                            |                               |
 
 ## **10. Unified Addressing**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaPointerGetAttributes`                                | `hipPointerGetAttributes`     | Returns attributes about a specified pointer.                                                                                  |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaPointerGetAttributes`                                | `hipPointerGetAttributes`     |
 
 ## **11. Peer Device Memory Access**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaDeviceCanAccessPeer`                                 | `hipDeviceCanAccessPeer`      | Queries if a device may directly access a peer device's memory.                                                                |
-| `cudaDeviceDisablePeerAccess`                             | `hipDeviceDisablePeerAccess`  | Disables direct access to memory allocations on a peer device.                                                                 |
-| `cudaDeviceEnablePeerAccess`                              | `hipDeviceEnablePeerAccess`   | Enables direct access to memory allocations on a peer device.                                                                  |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaDeviceCanAccessPeer`                                 | `hipDeviceCanAccessPeer`      |
+| `cudaDeviceDisablePeerAccess`                             | `hipDeviceDisablePeerAccess`  |
+| `cudaDeviceEnablePeerAccess`                              | `hipDeviceEnablePeerAccess`   |
 
 ## **12. OpenGL Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaGLGetDevices`                                        |                               | Gets the CUDA devices associated with the current OpenGL context.                                                              |
-| `cudaGraphicsGLRegisterBuffer`                            |                               | Registers an OpenGL buffer object.                                                                                             |
-| `cudaGraphicsGLRegisterImage`                             |                               | Register an OpenGL texture or renderbuffer object.                                                                             |
-| `cudaWGLGetDevice`                                        |                               | Gets the CUDA device associated with hGpu.                                                                                     |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaGLGetDevices`                                        |                               |
+| `cudaGraphicsGLRegisterBuffer`                            |                               |
+| `cudaGraphicsGLRegisterImage`                             |                               |
+| `cudaWGLGetDevice`                                        |                               |
 
 ## **13. OpenGL Interoperability [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaGLMapBufferObject`                                   |                               | Maps a buffer object for access by CUDA.                                                                                       |
-| `cudaGLMapBufferObjectAsync`                              |                               | Maps a buffer object for access by CUDA.                                                                                       |
-| `cudaGLRegisterBufferObject`                              |                               | Registers a buffer object for access by CUDA.                                                                                  |
-| `cudaGLSetBufferObjectMapFlags`                           |                               | Set usage flags for mapping an OpenGL buffer.                                                                                  |
-| `cudaGLSetGLDevice`                                       |                               | Sets a CUDA device to use OpenGL interoperability.                                                                             |
-| `cudaGLUnmapBufferObject`                                 |                               | Unmaps a buffer object for access by CUDA.                                                                                     |
-| `cudaGLUnmapBufferObjectAsync`                            |                               | Unmaps a buffer object for access by CUDA.                                                                                     |
-| `cudaGLUnregisterBufferObject`                            |                               | Unregisters a buffer object for access by CUDA.                                                                                |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaGLMapBufferObject`                                   |                               |
+| `cudaGLMapBufferObjectAsync`                              |                               |
+| `cudaGLRegisterBufferObject`                              |                               |
+| `cudaGLSetBufferObjectMapFlags`                           |                               |
+| `cudaGLSetGLDevice`                                       |                               |
+| `cudaGLUnmapBufferObject`                                 |                               |
+| `cudaGLUnmapBufferObjectAsync`                            |                               |
+| `cudaGLUnregisterBufferObject`                            |                               |
 
 ## **14. Direct3D 9 Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaD3D9GetDevice`                                       |                               | Gets the device number for an adapter.                                                                                         |
-| `cudaD3D9GetDevices`                                      |                               | Gets the CUDA devices corresponding to a Direct3D 9 device.                                                                    |
-| `cudaD3D9GetDirect3DDevice`                               |                               | Gets the Direct3D device against which the current CUDA context was created.                                                   |
-| `cudaD3D9SetDirect3DDevice`                               |                               | Sets the Direct3D 9 device to use for interoperability with a CUDA device.                                                     |
-| `cudaGraphicsD3D9RegisterResource`                        |                               | Register a Direct3D 9 resource for access by CUDA.                                                                             |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaD3D9GetDevice`                                       |                               |
+| `cudaD3D9GetDevices`                                      |                               |
+| `cudaD3D9GetDirect3DDevice`                               |                               |
+| `cudaD3D9SetDirect3DDevice`                               |                               |
+| `cudaGraphicsD3D9RegisterResource`                        |                               |
 
 ## **15. Direct3D 9 Interoperability [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaD3D9MapResources`                                    |                               | Map Direct3D resources for access by CUDA.                                                                                     |
-| `cudaD3D9RegisterResource`                                |                               | Register a Direct3D resource for access by CUDA.                                                                               |
-| `cudaD3D9ResourceGetMappedArray`                          |                               | Get an array through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.            |
-| `cudaD3D9ResourceGetMappedPitch`                          |                               | Get the pitch of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                |
-| `cudaD3D9ResourceGetMappedPointer`                        |                               | Get the pointer through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.         |
-| `cudaD3D9ResourceGetMappedSize`                           |                               | Get the size of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                 |
-| `cudaD3D9ResourceGetSurfaceDimensions`                    |                               | Get the dimensions of a registered surface.                                                                                    |
-| `cudaD3D9ResourceSetMapFlags`                             |                               | Set usage flags for mapping a Direct3D resource.                                                                               |
-| `cudaD3D9UnmapResources`                                  |                               | Unmaps Direct3D resources.                                                                                                     |
-| `cudaD3D9UnregisterResource`                              |                               | Unregister a Direct3D resource.                                                                                                |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaD3D9MapResources`                                    |                               |
+| `cudaD3D9RegisterResource`                                |                               |
+| `cudaD3D9ResourceGetMappedArray`                          |                               |
+| `cudaD3D9ResourceGetMappedPitch`                          |                               |
+| `cudaD3D9ResourceGetMappedPointer`                        |                               |
+| `cudaD3D9ResourceGetMappedSize`                           |                               |
+| `cudaD3D9ResourceGetSurfaceDimensions`                    |                               |
+| `cudaD3D9ResourceSetMapFlags`                             |                               |
+| `cudaD3D9UnmapResources`                                  |                               |
+| `cudaD3D9UnregisterResource`                              |                               |
 
 ## **16. Direct3D 10 Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaD3D10GetDevice`                                      |                               | Gets the device number for an adapter.                                                                                         |
-| `cudaD3D10GetDevices`                                     |                               | Gets the CUDA devices corresponding to a Direct3D 10 device.                                                                   |
-| `cudaGraphicsD3D10RegisterResource`                       |                               | Register a Direct3D 10 resource for access by CUDA.                                                                            |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaD3D10GetDevice`                                      |                               |
+| `cudaD3D10GetDevices`                                     |                               |
+| `cudaGraphicsD3D10RegisterResource`                       |                               |
 
 ## **17. Direct3D 10 Interoperability [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaD3D10GetDirect3DDevice`                              |                               | Gets the Direct3D device against which the current CUDA context was created.                                                   |
-| `cudaD3D10MapResources`                                   |                               | Map Direct3D resources for access by CUDA.                                                                                     |
-| `cudaD3D10RegisterResource`                               |                               | Register a Direct3D resource for access by CUDA.                                                                               |
-| `cudaD3D10ResourceGetMappedArray`                         |                               | Get an array through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.            |
-| `cudaD3D10ResourceGetMappedPitch`                         |                               | Get the pitch of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                |
-| `cudaD3D10ResourceGetMappedPointer`                       |                               | Get the pointer through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.         |
-| `cudaD3D10ResourceGetMappedSize`                          |                               | Get the size of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                 |
-| `cudaD3D10ResourceGetSurfaceDimensions`                   |                               | Get the dimensions of a registered surface.                                                                                    |
-| `cudaD3D10ResourceSetMapFlags`                            |                               | Set usage flags for mapping a Direct3D resource.                                                                               |
-| `cudaD3D10SetDirect3DDevice`                              |                               | Sets the Direct3D 10 device to use for interoperability with a CUDA device.                                                    |
-| `cudaD3D10UnmapResources`                                 |                               | Unmaps Direct3D resources.                                                                                                     |
-| `cudaD3D10UnregisterResource`                             |                               | Unregister a Direct3D resource.                                                                                                |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaD3D10GetDirect3DDevice`                              |                               |
+| `cudaD3D10MapResources`                                   |                               |
+| `cudaD3D10RegisterResource`                               |                               |
+| `cudaD3D10ResourceGetMappedArray`                         |                               |
+| `cudaD3D10ResourceGetMappedPitch`                         |                               |
+| `cudaD3D10ResourceGetMappedPointer`                       |                               |
+| `cudaD3D10ResourceGetMappedSize`                          |                               |
+| `cudaD3D10ResourceGetSurfaceDimensions`                   |                               |
+| `cudaD3D10ResourceSetMapFlags`                            |                               |
+| `cudaD3D10SetDirect3DDevice`                              |                               |
+| `cudaD3D10UnmapResources`                                 |                               |
+| `cudaD3D10UnregisterResource`                             |                               |
 
 ## **18. Direct3D 11 Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaD3D11GetDevice`                                      |                               | Gets the device number for an adapter.                                                                                         |
-| `cudaD3D11GetDevices`                                     |                               | Gets the CUDA devices corresponding to a Direct3D 11 device.                                                                   |
-| `cudaGraphicsD3D11RegisterResource`                       |                               | Register a Direct3D 11 resource for access by CUDA.                                                                            |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaD3D11GetDevice`                                      |                               |
+| `cudaD3D11GetDevices`                                     |                               |
+| `cudaGraphicsD3D11RegisterResource`                       |                               |
 
 ## **19. Direct3D 11 Interoperability [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaD3D11GetDirect3DDevice`                              |                               | Gets the Direct3D device against which the current CUDA context was created.                                                   |
-| `cudaD3D11SetDirect3DDevice`                              |                               | Sets the Direct3D 11 device to use for interoperability with a CUDA device.                                                    |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaD3D11GetDirect3DDevice`                              |                               |
+| `cudaD3D11SetDirect3DDevice`                              |                               |
 
 ## **20. VDPAU Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaGraphicsVDPAURegisterOutputSurface`                  |                               | Registers a VDPAU VdpOutputSurface object.                                                                                     |
-| `cudaGraphicsVDPAURegisterVideoSurface`                   |                               | Registers a VDPAU VdpVideoSurface object.                                                                                      |
-| `cudaVDPAUGetDevice`                                      |                               | Gets the CUDA device associated with a VDPAU device.                                                                           |
-| `cudaVDPAUSetVDPAUDevice`                                 |                               | Sets a CUDA device to use VDPAU interoperability.                                                                              |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaGraphicsVDPAURegisterOutputSurface`                  |                               |
+| `cudaGraphicsVDPAURegisterVideoSurface`                   |                               |
+| `cudaVDPAUGetDevice`                                      |                               |
+| `cudaVDPAUSetVDPAUDevice`                                 |                               |
 
 ## **21. EGL Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaEGLStreamConsumerAcquireFrame`                       |                               | Acquire an image frame from the EGLStream with CUDA as a consumer.                                                             |
-| `cudaEGLStreamConsumerConnect`                            |                               | Connect CUDA to EGLStream as a consumer.                                                                                       |
-| `cudaEGLStreamConsumerConnectWithFlags`                   |                               | Connect CUDA to EGLStream as a consumer with given flags.                                                                      |
-| `cudaEGLStreamConsumerReleaseFrame`                       |                               | Releases the last frame acquired from the EGLStream.                                                                           |
-| `cudaEGLStreamProducerConnect`                            |                               | Connect CUDA to EGLStream as a producer.                                                                                       |
-| `cudaEGLStreamProducerDisconnect`                         |                               | Disconnect CUDA as a producer to EGLStream .                                                                                   |
-| `cudaEGLStreamProducerPresentFrame`                       |                               | Present a CUDA eglFrame to the EGLStream with CUDA as a producer.                                                              |
-| `cudaEGLStreamProducerReturnFrame`                        |                               | Return the CUDA eglFrame to the EGLStream last released by the consumer.                                                       |
-| `cudaGraphicsEGLRegisterImage`                            |                               | Registers an EGL image.                                                                                                        |
-| `cudaGraphicsResourceGetMappedEglFrame`                   |                               | Get an eglFrame through which to access a registered EGL graphics resource.                                                    |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaEGLStreamConsumerAcquireFrame`                       |                               |
+| `cudaEGLStreamConsumerConnect`                            |                               |
+| `cudaEGLStreamConsumerConnectWithFlags`                   |                               |
+| `cudaEGLStreamConsumerReleaseFrame`                       |                               |
+| `cudaEGLStreamProducerConnect`                            |                               |
+| `cudaEGLStreamProducerDisconnect`                         |                               |
+| `cudaEGLStreamProducerPresentFrame`                       |                               |
+| `cudaEGLStreamProducerReturnFrame`                        |                               |
+| `cudaGraphicsEGLRegisterImage`                            |                               |
+| `cudaGraphicsResourceGetMappedEglFrame`                   |                               |
 
 ## **22. Graphics Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaGraphicsMapResources`                                |                               | Map graphics resources for access by CUDA.                                                                                     |
-| `cudaGraphicsResourceGetMappedMipmappedArray`             |                               | Get a mipmapped array through which to access a mapped graphics resource.                                                      |
-| `cudaGraphicsResourceGetMappedPointer`                    |                               | Get a device pointer through which to access a mapped graphics resource.                                                       |
-| `cudaGraphicsResourceSetMapFlags`                         |                               | Set usage flags for mapping a graphics resource.                                                                               |
-| `cudaGraphicsSubResourceGetMappedArray`                   |                               | Get an array through which to access a subresource of a mapped graphics resource.                                              |
-| `cudaGraphicsUnmapResources`                              |                               | Unmap graphics resources.                                                                                                      |
-| `cudaGraphicsUnregisterResource`                          |                               | Unregisters a graphics resource for access by CUDA.                                                                            |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaGraphicsMapResources`                                |                               |
+| `cudaGraphicsResourceGetMappedMipmappedArray`             |                               |
+| `cudaGraphicsResourceGetMappedPointer`                    |                               |
+| `cudaGraphicsResourceSetMapFlags`                         |                               |
+| `cudaGraphicsSubResourceGetMappedArray`                   |                               |
+| `cudaGraphicsUnmapResources`                              |                               |
+| `cudaGraphicsUnregisterResource`                          |                               |
 
 ## **23. Texture Reference Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaBindTexture`                                         |                               | Binds a memory area to a texture.                                                                                              |
-| `cudaBindTexture2D`                                       |                               | Binds a 2D memory area to a texture.                                                                                           |
-| `cudaBindTextureToArray`                                  |                               | Binds an array to a texture.                                                                                                   |
-| `cudaBindTextureToMipmappedArray`                         |                               | Binds a mipmapped array to a texture.                                                                                          |
-| `cudaCreateChannelDesc`                                   |                               | Returns a channel descriptor using the specified format.                                                                       |
-| `cudaGetChannelDesc`                                      |                               | Get the channel descriptor of an array.                                                                                        |
-| `cudaGetTextureAlignmentOffset`                           |                               | Get the alignment offset of a texture.                                                                                         |
-| `cudaGetTextureReference`                                 |                               | Get the texture reference associated with a symbol.                                                                            |
-| `cudaUnbindTexture`                                       |                               | Unbinds a texture.                                                                                                             |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaBindTexture`                                         |                               |
+| `cudaBindTexture2D`                                       |                               |
+| `cudaBindTextureToArray`                                  |                               |
+| `cudaBindTextureToMipmappedArray`                         |                               |
+| `cudaCreateChannelDesc`                                   |                               |
+| `cudaGetChannelDesc`                                      |                               |
+| `cudaGetTextureAlignmentOffset`                           |                               |
+| `cudaGetTextureReference`                                 |                               |
+| `cudaUnbindTexture`                                       |                               |
 
 ## **24. Surface Reference Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaBindSurfaceToArray`                                  |                               | Binds an array to a surface.                                                                                                   |
-| `cudaGetSurfaceReference`                                 |                               | Get the surface reference associated with a symbol.                                                                            |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaBindSurfaceToArray`                                  |                               |
+| `cudaGetSurfaceReference`                                 |                               |
 
 ## **25. Texture Object Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaCreateTextureObject`                                 |                               | Creates a texture object.                                                                                                      |
-| `cudaDestroyTextureObject`                                |                               | Destroys a texture object.                                                                                                     |
-| `cudaGetTextureObjectResourceDesc`                        |                               | Returns a texture object's resource descriptor.                                                                                |
-| `cudaGetTextureObjectResourceViewDesc`                    |                               | Returns a texture object's resource view descriptor.                                                                           |
-| `cudaGetTextureObjectTextureDesc`                         |                               | Returns a texture object's texture descriptor.                                                                                 |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaCreateTextureObject`                                 |                               |
+| `cudaDestroyTextureObject`                                |                               |
+| `cudaGetTextureObjectResourceDesc`                        |                               |
+| `cudaGetTextureObjectResourceViewDesc`                    |                               |
+| `cudaGetTextureObjectTextureDesc`                         |                               |
 
 ## **26. Surface Object Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaCreateSurfaceObject`                                 |                               | Creates a surface object.                                                                                                      |
-| `cudaDestroySurfaceObject`                                |                               | Destroys a surface object.                                                                                                     |
-| `cudaGetSurfaceObjectResourceDesc`                        |                               | Returns a surface object's resource descriptor Returns the resource descriptor for the surface object specified by surfObject. |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaCreateSurfaceObject`                                 |                               |
+| `cudaDestroySurfaceObject`                                |                               |
+| `cudaGetSurfaceObjectResourceDesc`                        |                               |
 
 ## **27. Version Management**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaDriverGetVersion`                                    | `hipDriverGetVersion`         | Returns the CUDA driver version.                                                                                               |
-| `cudaRuntimeGetVersion`                                   | `hipRuntimeGetVersion`        | Returns the CUDA Runtime version.                                                                                              |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaDriverGetVersion`                                    | `hipDriverGetVersion`         |
+| `cudaRuntimeGetVersion`                                   | `hipRuntimeGetVersion`        |
 
 ## **28. C++ API Routines**
 *(7.0 contains, 7.5 doesn’t)*
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaBindSurfaceToArray`                                  |                               | Binds an array to a surface.                                                                                                   |
-| `cudaBindTexture`                                         | `hipBindTexture`              | Binds a memory area to a texture.                                                                                              |
-| `cudaBindTexture2D`                                       |                               | Binds a 2D memory area to a texture.                                                                                           |
-| `cudaBindTextureToArray`                                  |                               | Binds an array to a texture.                                                                                                   |
-| `cudaBindTextureToMipmappedArray`                         |                               | Binds a mipmapped array to a texture.                                                                                          |
-| `cudaCreateChannelDesc`                                   | `hipCreateChannelDesc`        | Returns a channel descriptor using the specified format.                                                                       |
-| `cudaFuncGetAttributes`                                   |                               | Find out attributes for a given function.                                                                                      |
-| `cudaFuncSetCacheConfig`                                  |                               | Sets the preferred cache configuration for a device function.                                                                  |
-| `cudaGetSymbolAddress`                                    |                               | Finds the address associated with a CUDA symbol                                                                                |
-| `cudaGetSymbolSize`                                       |                               | Finds the size of the object associated with a CUDA symbol.                                                                    |
-| `cudaGetTextureAlignmentOffset`                           |                               | Get the alignment offset of a texture.                                                                                         |
-| `cudaLaunch`                                              |                               | Launches a device function.                                                                                                    |
-| `cudaLaunchKernel`                                        |                               | Launches a device function.                                                                                                    |
-| `cudaMallocHost`                                          |                               | Allocates page-locked memory on the host                                                                                       |
-| `cudaMallocManaged`                                       |                               | Allocates memory that will be automatically managed by the Unified Memory system.                                              |
-| `cudaMemcpyFromSymbol`                                    |                               | Copies data from the given symbol on the device.                                                                               |
-| `cudaMemcpyFromSymbolAsync`                               |                               | Copies data from the given symbol on the device.                                                                               |
-| `cudaMemcpyToSymbol`                                      |                               | Copies data to the given symbol on the device.                                                                                 |
-| `cudaMemcpyToSymbolAsync`                                 |                               | Async copies data to the given symbol on the device.                                                                           |
-| `cudaOccupancyMaxActiveBlocksPerMultiprocessor`           | `hipOccupancyMaxActiveBlocksPerMultiprocessor` | Returns occupancy for a device function.                                                                      |
-| `cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`  |                               | Returns occupancy for a device function with the specified flags.                                                              |
-| `cudaOccupancyMaxPotentialBlockSize`                      | `hipOccupancyMaxPotentialBlockSize` | Returns grid and block size that achieves maximum potential occupancy for a device function.                             |
-| `cudaOccupancyMaxPotentialBlockSizeVariableSMem`          |                               | Returns grid and block size that achieves maximum potential occupancy for a device function.                                   |
-| `cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags` |                               | Returns grid and block size that achieves maximum potential occupancy for a device function.                                   |
-| `cudaOccupancyMaxPotentialBlockSizeWithFlags`             |                               | Returns grid and block size that achived maximum potential occupancy for a device function with the specified flags.           |
-| `cudaSetupArgument`                                       |                               | Configure a device launch.                                                                                                     |
-| `cudaStreamAttachMemAsync`                                |                               | Attach memory to a stream asynchronously.                                                                                      |
-| `cudaUnbindTexture`                                       | `hipUnbindTexture`            | Unbinds a texture.                                                                                                             |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaBindSurfaceToArray`                                  |                               |
+| `cudaBindTexture`                                         | `hipBindTexture`              |
+| `cudaBindTexture2D`                                       |                               |
+| `cudaBindTextureToArray`                                  |                               |
+| `cudaBindTextureToMipmappedArray`                         |                               |
+| `cudaCreateChannelDesc`                                   | `hipCreateChannelDesc`        |
+| `cudaFuncGetAttributes`                                   |                               |
+| `cudaFuncSetCacheConfig`                                  |                               |
+| `cudaGetSymbolAddress`                                    |                               |
+| `cudaGetSymbolSize`                                       |                               |
+| `cudaGetTextureAlignmentOffset`                           |                               |
+| `cudaLaunch`                                              |                               |
+| `cudaLaunchKernel`                                        |                               |
+| `cudaMallocHost`                                          |                               |
+| `cudaMallocManaged`                                       |                               |
+| `cudaMemcpyFromSymbol`                                    |                               |
+| `cudaMemcpyFromSymbolAsync`                               |                               |
+| `cudaMemcpyToSymbol`                                      |                               |
+| `cudaMemcpyToSymbolAsync`                                 |                               |
+| `cudaOccupancyMaxActiveBlocksPerMultiprocessor`           | `hipOccupancyMaxActiveBlocksPerMultiprocessor` |
+| `cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`  |                               |
+| `cudaOccupancyMaxPotentialBlockSize`                      | `hipOccupancyMaxPotentialBlockSize` |
+| `cudaOccupancyMaxPotentialBlockSizeVariableSMem`          |                               |
+| `cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags` |                               |
+| `cudaOccupancyMaxPotentialBlockSizeWithFlags`             |                               |
+| `cudaSetupArgument`                                       |                               |
+| `cudaStreamAttachMemAsync`                                |                               |
+| `cudaUnbindTexture`                                       | `hipUnbindTexture`            |
 
 ## **30. Profiler Control**
 
-|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
-|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `cudaProfilerInitialize`                                  |                               | Initialize the CUDA profiler.                                                                                                  |
-| `cudaProfilerStart`                                       | `hipProfilerStart`            | Enable profiling.                                                                                                              |
-| `cudaProfilerStop`                                        | `hipProfilerStop`             | Disable profiling.                                                                                                             |
+|   **CUDA**                                                |   **HIP**                     |
+|-----------------------------------------------------------|-------------------------------|
+| `cudaProfilerInitialize`                                  |                               |
+| `cudaProfilerStart`                                       | `hipProfilerStart`            |
+| `cudaProfilerStop`                                        | `hipProfilerStop`             |
 
 # Data types used by CUDA Runtime API and supported by HIP
 
 ## **31. Data types**
 
-| **type**     |   **CUDA**                                    |   **HIP**                                            | **CUDA description**                                                                                                           |
-|-------------:|-----------------------------------------------|------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| struct       | `cudaChannelFormatDesc`                       | `hipChannelFormatDesc`                               | CUDA Channel format descriptor.                                                                                                |
-| struct       | `cudaDeviceProp`                              | `hipDeviceProp_t`                                    | CUDA device properties.                                                                                                        |
-| struct       | `cudaExtent`                                  |                                                      | CUDA extent (width, height, depth).                                                                                            |
-| struct       | `cudaFuncAttributes`                          |                                                      | CUDA function attributes.                                                                                                      |
-| struct       | `cudaIpcEventHandle_t`                        | `hipIpcEventHandle_t`                                | CUDA IPC event handle.                                                                                                         |
-| struct       | `cudaIpcMemHandle_t`                          | `hipIpcMemHandle_t`                                  | CUDA IPC memory handle.                                                                                                        |
-| struct       | `cudaMemcpy3DParms`                           |                                                      | CUDA 3D memory copying parameters.                                                                                             |
-| struct       | `cudaMemcpy3DPeerParms`                       |                                                      | CUDA 3D cross-device memory copying parameters.                                                                                |
-| struct       | `cudaPitchedPtr`                              |                                                      | CUDA Pitched memory pointer.                                                                                                   |
-| struct       | `cudaPointerAttributes`                       | `hipPointerAttribute_t`                              | CUDA pointer attributes.                                                                                                       |
-| struct       | `cudaPos`                                     |                                                      | CUDA 3D position.                                                                                                              |
-| struct       | `cudaResourceDesc`                            |                                                      | CUDA resource descriptor.                                                                                                      |
-| struct       | `cudaResourceViewDesc`                        |                                                      | CUDA resource view descriptor.                                                                                                 |
-| struct       | `cudaTextureDesc`                             |                                                      | CUDA texture descriptor.                                                                                                       |
-| struct       | `surfaceReference`                            |                                                      | CUDA Surface reference.                                                                                                        |
-| struct       | `textureReference`                            | `textureReference`                                   | CUDA texture reference.                                                                                                        |
-| enum         |***`cudaChannelFormatKind`***                  |***`hipChannelFormatKind`***                          | Channel format kind.                                                                                                           |
-|            0 |*`cudaChannelFormatKindSigned`*                |*`hipChannelFormatKindSigned`*                        | Signed channel format.                                                                                                         |
-|            1 |*`cudaChannelFormatKindUnsigned`*              |*`hipChannelFormatKindUnsigned`*                      | Unsigned channel format.                                                                                                       |
-|            2 |*`cudaChannelFormatKindFloat`*                 |*`hipChannelFormatKindFloat`*                         | Float channel format.                                                                                                          |
-|            3 |*`cudaChannelFormatKindNone`*                  |*`hipChannelFormatKindNone`*                          | No channel format.                                                                                                             |
-| enum         |***`cudaComputeMode`***                        |                                                      | CUDA device compute modes.                                                                                                     |
-|            0 |*`cudaComputeModeDefault`*                     |                                                      | Default compute mode (Multiple threads can use ::cudaSetDevice() with this device).                                            |
-|            1 |*`cudaComputeModeExclusive`*                   |                                                      | Compute-exclusive-thread mode (Only one thread in one process will be able to use ::cudaSetDevice() with this device).         |
-|            2 |*`cudaComputeModeProhibited`*                  |                                                      | Compute-prohibited mode (No threads can use ::cudaSetDevice() with this device).                                               |
-|            3 |*`cudaComputeModeExclusiveProcess`*            |                                                      | Compute-exclusive-process mode (Many threads in one process will be able to use ::cudaSetDevice() with this device).           |
-| enum         |***`cudaDeviceAttr`***                         |***`hipDeviceAttribute_t`***                          | CUDA device attributes.                                                                                                        |
-|            1 |*`cudaDevAttrMaxThreadsPerBlock`*              |*`hipDeviceAttributeMaxThreadsPerBlock`*              | Maximum number of threads per block.                                                                                           |
-|            2 |*`cudaDevAttrMaxBlockDimX`*                    |*`hipDeviceAttributeMaxBlockDimX`*                    | Maximum block dimension X.                                                                                                     |
-|            3 |*`cudaDevAttrMaxBlockDimY`*                    |*`hipDeviceAttributeMaxBlockDimY`*                    | Maximum block dimension Y.                                                                                                     |
-|            4 |*`cudaDevAttrMaxBlockDimZ`*                    |*`hipDeviceAttributeMaxBlockDimZ`*                    | Maximum block dimension Y.                                                                                                     |
-|            5 |*`cudaDevAttrMaxGridDimX`*                     |*`hipDeviceAttributeMaxGridDimX`*                     | Maximum grid dimension X.                                                                                                      |
-|            6 |*`cudaDevAttrMaxGridDimY`*                     |*`hipDeviceAttributeMaxGridDimY`*                     | Maximum grid dimension Y.                                                                                                      |
-|            7 |*`cudaDevAttrMaxGridDimZ`*                     |*`hipDeviceAttributeMaxGridDimZ`*                     | Maximum grid dimension Y.                                                                                                      |
-|            8 |*`cudaDevAttrMaxSharedMemoryPerBlock`*         |*`hipDeviceAttributeMaxSharedMemoryPerBlock`*         | Maximum shared memory available per block in bytes.                                                                            |
-|            9 |*`cudaDevAttrTotalConstantMemory`*             |*`hipDeviceAttributeTotalConstantMemory`*             | Memory available on device for \__constant__ variables in a CUDA C kernel in bytes.                                            |
-|           10 |*`cudaDevAttrWarpSize`*                        |*`hipDeviceAttributeWarpSize`*                        | Warp size in threads.                                                                                                          |
-|           11 |*`cudaDevAttrMaxPitch`*                        |                                                      | Maximum pitch in bytes allowed by memory copies.                                                                               |
-|           12 |*`cudaDevAttrMaxRegistersPerBlock`*            |*`hipDeviceAttributeMaxRegistersPerBlock`*            | Maximum number of 32-bit registers available per block.                                                                        |
-|           13 |*`cudaDevAttrClockRate`*                       |*`hipDeviceAttributeClockRate`*                       | Peak clock frequency in kilohertz.                                                                                             |
-|           14 |*`cudaDevAttrTextureAlignment`*                |                                                      | Alignment requirement for textures.                                                                                            |
-|           15 |*`cudaDevAttrGpuOverlap`*                      |                                                      | Device can possibly copy memory and execute a kernel concurrently.                                                             |
-|           16 |*`cudaDevAttrMultiProcessorCount`*             |*`hipDeviceAttributeMultiprocessorCount`*             | Number of multiprocessors on device.                                                                                           |
-|           17 |*`cudaDevAttrKernelExecTimeout`*               |                                                      | Specifies whether there is a run time limit on kernels.                                                                        |
-|           18 |*`cudaDevAttrIntegrated`*                      |                                                      | Device is integrated with host memory.                                                                                         |
-|           19 |*`cudaDevAttrCanMapHostMemory`*                |                                                      | Device can map host memory into CUDA address space.                                                                            |
-|           20 |*`cudaDevAttrComputeMode`*                     |*`hipDeviceAttributeComputeMode`*                     | Compute mode (See cudaComputeMode for details).                                                                                |
-|           21 |*`cudaDevAttrMaxTexture1DWidth`*               |                                                      | Maximum 1D texture width.                                                                                                      |
-|           22 |*`cudaDevAttrMaxTexture2DWidth`*               |                                                      | Maximum 2D texture width.                                                                                                      |
-|           23 |*`cudaDevAttrMaxTexture2DHeight`*              |                                                      | Maximum 2D texture height.                                                                                                     |
-|           24 |*`cudaDevAttrMaxTexture3DWidth`*               |                                                      | Maximum 3D texture width.                                                                                                      |
-|           25 |*`cudaDevAttrMaxTexture3DHeight`*              |                                                      | Maximum 3D texture height.                                                                                                     |
-|           26 |*`cudaDevAttrMaxTexture3DDepth`*               |                                                      | Maximum 3D texture depth.                                                                                                      |
-|           27 |*`cudaDevAttrMaxTexture2DLayeredWidth`*        |                                                      | Maximum 2D layered texture width.                                                                                              |
-|           28 |*`cudaDevAttrMaxTexture2DLayeredHeight`*       |                                                      | Maximum 2D layered texture height.                                                                                             |
-|           29 |*`cudaDevAttrMaxTexture2DLayeredLayers`*       |                                                      | Maximum layers in a 2D layered texture.                                                                                        |
-|           30 |*`cudaDevAttrSurfaceAlignment`*                |                                                      | Alignment requirement for surfaces.                                                                                            |
-|           31 |*`cudaDevAttrConcurrentKernels`*               |*`hipDeviceAttributeConcurrentKernels`*               | Device can possibly execute multiple kernels concurrently.                                                                     |
-|           32 |*`cudaDevAttrEccEnabled`*                      |                                                      | Device has ECC support enabled.                                                                                                |
-|           33 |*`cudaDevAttrPciBusId`*                        |*`hipDeviceAttributePciBusId`*                        | PCI bus ID of the device.                                                                                                      |
-|           34 |*`cudaDevAttrPciDeviceId`*                     |*`hipDeviceAttributePciDeviceId`*                     | PCI device ID of the device.                                                                                                   |
-|           35 |*`cudaDevAttrTccDriver`*                       |                                                      | Device is using TCC driver model.                                                                                              |
-|           36 |*`cudaDevAttrMemoryClockRate`*                 |*`hipDeviceAttributeMemoryClockRate`*                 | Peak memory clock frequency in kilohertz.                                                                                      |
-|           37 |*`cudaDevAttrGlobalMemoryBusWidth`*            |*`hipDeviceAttributeMemoryBusWidth`*                  | Global memory bus width in bits.                                                                                               |
-|           38 |*`cudaDevAttrL2CacheSize`*                     |*`hipDeviceAttributeL2CacheSize`*                     | Size of L2 cache in bytes.                                                                                                     |
-|           39 |*`cudaDevAttrMaxThreadsPerMultiProcessor`*     |*`hipDeviceAttributeMaxThreadsPerMultiProcessor`*     | Maximum resident threads per multiprocessor.                                                                                   |
-|           40 |*`cudaDevAttrAsyncEngineCount`*                |                                                      | Number of asynchronous engines.                                                                                                |
-|           41 |*`cudaDevAttrUnifiedAddressing`*               |                                                      | Device shares a unified address space with the host.                                                                           |
-|           42 |*`cudaDevAttrMaxTexture1DLayeredWidth`*        |                                                      | Maximum 1D layered texture width.                                                                                              |
-|           43 |*`cudaDevAttrMaxTexture1DLayeredLayers`*       |                                                      | Maximum layers in a 1D layered texture.                                                                                        |
-|           44 |                                               |                                                      | *reserved*                                                                                                                     |
-|           45 |*`cudaDevAttrMaxTexture2DGatherWidth`*         |                                                      | Maximum 2D texture width if cudaArrayTextureGather is set.                                                                     |
-|           46 |*`cudaDevAttrMaxTexture2DGatherHeight`*        |                                                      | Maximum 2D texture height if cudaArrayTextureGather is set.                                                                    |
-|           47 |*`cudaDevAttrMaxTexture3DWidthAlt`*            |                                                      | Alternate maximum 3D texture width.                                                                                            |
-|           48 |*`cudaDevAttrMaxTexture3DHeightAlt`*           |                                                      | Alternate maximum 3D texture height.                                                                                           |
-|           49 |*`cudaDevAttrMaxTexture3DDepthAlt`*            |                                                      | Alternate maximum 3D texture depth.                                                                                            |
-|           50 |*`cudaDevAttrPciDomainId`*                     |                                                      | PCI domain ID of the device.                                                                                                   |
-|           51 |*`cudaDevAttrTexturePitchAlignment`*           |                                                      | Pitch alignment requirement for textures.                                                                                      |
-|           52 |*`cudaDevAttrMaxTextureCubemapWidth`*          |                                                      | Maximum cubemap texture width/height.                                                                                          |
-|           53 |*`cudaDevAttrMaxTextureCubemapLayeredWidth`*   |                                                      | Maximum cubemap layered texture width/height.                                                                                  |
-|           54 |*`cudaDevAttrMaxTextureCubemapLayeredLayers`*  |                                                      | Maximum layers in a cubemap layered texture.                                                                                   |
-|           55 |*`cudaDevAttrMaxSurface1DWidth`*               |                                                      | Maximum 1D surface width.                                                                                                      |
-|           56 |*`cudaDevAttrMaxSurface2DWidth`*               |                                                      | Maximum 2D surface width.                                                                                                      |
-|           57 |*`cudaDevAttrMaxSurface2DHeight`*              |                                                      | Maximum 2D surface height.                                                                                                     |
-|           58 |*`cudaDevAttrMaxSurface3DWidth`*               |                                                      | Maximum 3D surface width.                                                                                                      |
-|           59 |*`cudaDevAttrMaxSurface3DHeight`*              |                                                      | Maximum 3D surface height.                                                                                                     |
-|           60 |*`cudaDevAttrMaxSurface3DDepth`*               |                                                      | Maximum 3D surface depth.                                                                                                      |
-|           61 |*`cudaDevAttrMaxSurface1DLayeredWidth`*        |                                                      | Maximum 1D layered surface width.                                                                                              |
-|           62 |*`cudaDevAttrMaxSurface1DLayeredLayers`*       |                                                      | Maximum layers in a 1D layered surface.                                                                                        |
-|           63 |*`cudaDevAttrMaxSurface2DLayeredWidth`*        |                                                      | Maximum 2D layered surface width.                                                                                              |
-|           64 |*`cudaDevAttrMaxSurface2DLayeredHeight`*       |                                                      | Maximum 2D layered surface height.                                                                                             |
-|           65 |*`cudaDevAttrMaxSurface2DLayeredLayers`*       |                                                      | Maximum layers in a 2D layered surface.                                                                                        |
-|           66 |*`cudaDevAttrMaxSurfaceCubemapWidth`*          |                                                      | Maximum cubemap surface width.                                                                                                 |
-|           67 |*`cudaDevAttrMaxSurfaceCubemapLayeredWidth`*   |                                                      | Maximum cubemap layered surface width.                                                                                         |
-|           68 |*`cudaDevAttrMaxSurfaceCubemapLayeredLayers`*  |                                                      | Maximum layers in a cubemap layered surface.                                                                                   |
-|           69 |*`cudaDevAttrMaxTexture1DLinearWidth`*         |                                                      | Maximum 1D linear texture width.                                                                                               |
-|           70 |*`cudaDevAttrMaxTexture2DLinearWidth`*         |                                                      | Maximum 2D linear texture width.                                                                                               |
-|           71 |*`cudaDevAttrMaxTexture2DLinearHeight`*        |                                                      | Maximum 2D linear texture height.                                                                                              |
-|           72 |*`cudaDevAttrMaxTexture2DLinearPitch`*         |                                                      | Maximum 2D linear texture pitch in bytes.                                                                                      |
-|           73 |*`cudaDevAttrMaxTexture2DMipmappedWidth`*      |                                                      | Maximum mipmapped 2D texture width.                                                                                            |
-|           74 |*`cudaDevAttrMaxTexture2DMipmappedHeight`*     |                                                      | Maximum mipmapped 2D texture height.                                                                                           |
-|           75 |*`cudaDevAttrComputeCapabilityMajor`*          |*`hipDeviceAttributeComputeCapabilityMajor`*          | Major compute capability version number.                                                                                       |
-|           76 |*`cudaDevAttrComputeCapabilityMinor`*          |*`hipDeviceAttributeComputeCapabilityMinor`*          | Minor compute capability version number.                                                                                       |
-|           77 |*`cudaDevAttrMaxTexture1DMipmappedWidth`*      |                                                      | Maximum mipmapped 1D texture width.                                                                                            |
-|           78 |*`cudaDevAttrStreamPrioritiesSupported`*       |                                                      | Device supports stream priorities.                                                                                             |
-|           79 |*`cudaDevAttrGlobalL1CacheSupported`*          |                                                      | Device supports caching globals in L1.                                                                                         |
-|           80 |*`cudaDevAttrLocalL1CacheSupported`*           |                                                      | Device supports caching locals in L1.                                                                                          |
-|           81 |*`cudaDevAttrMaxSharedMemoryPerMultiprocessor`*|*`hipDeviceAttributeMaxSharedMemoryPerMultiprocessor`*| Maximum shared memory available per multiprocessor in bytes.                                                                   |
-|           82 |*`cudaDevAttrMaxRegistersPerMultiprocessor`*   |                                                      | Maximum number of 32-bit registers available per multiprocessor.                                                               |
-|           83 |*`cudaDevAttrManagedMemory`*                   |                                                      | Device can allocate managed memory on this system.                                                                             |
-|           84 |*`cudaDevAttrIsMultiGpuBoard`*                 |*`hipDeviceAttributeIsMultiGpuBoard`*                 | Device is on a multi-GPU board.                                                                                                |
-|           85 |*`cudaDevAttrMultiGpuBoardGroupID`*            |                                                      | Unique identifier for a group of devices on the same multi-GPU board.                                                          |
-| enum         |***`cudaError`***                              |***`hipError_t`***                                    | CUDA Error types.                                                                                                              |
-| enum         |***`cudaError_t`***                            |***`hipError_t`***                                    | CUDA Error types.                                                                                                              |
-|            0 |*`cudaSuccess`*                                |*`hipSuccess`*                                        | The API call returned with no errors. In the case of query calls, this can also mean that the operation being queried is complete.|
-|            1 |*`cudaErrorMissingConfiguration`*              |                                                      | The device function being invoked (usually via cudaLaunchKernel()) was not previously configured via the cudaConfigureCall() function.|
-|            2 |*`cudaErrorMemoryAllocation`*                  |*`hipErrorMemoryAllocation`*                          | The API call failed because it was unable to allocate enough memory to perform the requested operation.                        |
-|            3 |*`cudaErrorInitializationError`*               |*`hipErrorInitializationError`*                       | The API call failed because the CUDA driver and runtime could not be initialized.                                              |
-|            4 |*`cudaErrorLaunchFailure`*                     |                                                      | An exception occurred on the device while executing a kernel. Common causes include dereferencing an invalid device pointer and accessing out of bounds shared memory. The device cannot be used until cudaThreadExit() is called. All existing device memory allocations are invalid and must be reconstructed if the program is to continue using CUDA. |
-|            5 |*`cudaErrorPriorLaunchFailure`*                |                                                      | This indicated that a previous kernel launch failed. This was previously used for device emulation of kernel launches. Deprecated This error return is deprecated as of CUDA 3.1. Device emulation mode was removed with the CUDA 3.1 release.|
-|            6 |*`cudaErrorLaunchTimeout`*                     |                                                      | This indicates that the device kernel took too long to execute. This can only occur if timeouts are enabled - see the device property kernelExecTimeoutEnabled for more information. The device cannot be used until cudaThreadExit() is called. All existing device memory allocations are invalid and must be reconstructed if the program is to continue using CUDA.|
-|            7 |*`cudaErrorLaunchOutOfResources`*              |*`hipErrorLaunchOutOfResources`*                      | This indicates that a launch did not occur because it did not have appropriate resources. Although this error is similar to cudaErrorInvalidConfiguration, this error usually indicates that the user has attempted to pass too many arguments to the device kernel, or the kernel launch specifies too many threads for the kernel's register count.|
-|            8 |*`cudaErrorInvalidDeviceFunction`*             |                                                      | The requested device function does not exist or is not compiled for the proper device architecture.                            |
-|            9 |*`cudaErrorInvalidConfiguration`*              |                                                      | This indicates that a kernel launch is requesting resources that can never be satisfied by the current device. Requesting more shared memory per block than the device supports will trigger this error, as will requesting too many threads or blocks. See cudaDeviceProp for more device limitations.|
-|           10 |*`cudaErrorInvalidDevice`*                     |*`hipErrorInvalidDevice`*                             | This indicates that the device ordinal supplied by the user does not correspond to a valid CUDA device.                        |
-|           11 |*`cudaErrorInvalidValue`*                      |*`hipErrorInvalidValue`*                              | This indicates that one or more of the parameters passed to the API call is not within an acceptable range of values.          |
-|           12 |*`cudaErrorInvalidPitchValue`*                 |                                                      | This indicates that one or more of the pitch-related parameters passed to the API call is not within the acceptable range for pitch.|
-|           13 |*`cudaErrorInvalidSymbol`*                     |                                                      | This indicates that the symbol name/identifier passed to the API call is not a valid name or identifier.                       |
-|           14 |*`cudaErrorMapBufferObjectFailed`*             |                                                      | This indicates that the buffer object could not be mapped.                                                                     |
-|           15 |*`cudaErrorUnmapBufferObjectFailed`*           |                                                      | This indicates that the buffer object could not be unmapped.                                                                   |
-|           16 |*`cudaErrorInvalidHostPointer`*                |                                                      | This indicates that at least one host pointer passed to the API call is not a valid host pointer.                              |
-|           17 |*`cudaErrorInvalidDevicePointer`*              |*`hipErrorInvalidDevicePointer`*                      | This indicates that at least one host pointer passed to the API call is not a valid host pointer.                              |
-|           18 |*`cudaErrorInvalidTexture`*                    |                                                      | This indicates that the texture passed to the API call is not a valid texture.                                                 |
-|           19 |*`cudaErrorInvalidTextureBinding`*             |                                                      | This indicates that the texture binding is not valid. This occurs if you call cudaGetTextureAlignmentOffset() with an unbound texture.|
-|           20 |*`cudaErrorInvalidChannelDescriptor`*          |                                                      | This indicates that the channel descriptor passed to the API call is not valid. This occurs if the format is not one of the formats specified by cudaChannelFormatKind, or if one of the dimensions is invalid.|
-|           21 |*`cudaErrorInvalidMemcpyDirection`*            |                                                      | This indicates that the direction of the memcpy passed to the API call is not one of the types specified by cudaMemcpyKind.    |
-|           22 |*`cudaErrorAddressOfConstant`*                 |                                                      | This indicated that the user has taken the address of a constant variable, which was forbidden up until the CUDA 3.1 release. Deprecated This error return is deprecated as of CUDA 3.1. Variables in constant memory may now have their address taken by the runtime via cudaGetSymbolAddress().|
-|           23 |*`cudaErrorTextureFetchFailed`*                |                                                      | This indicated that a texture fetch was not able to be performed. This was previously used for device emulation of texture operations. Deprecated This error return is deprecated as of CUDA 3.1. Device emulation mode was removed with the CUDA 3.1 release.|
-|           24 |*`cudaErrorTextureNotBound`*                   |                                                      | This indicated that a texture was not bound for access. This was previously used for device emulation of texture operations. Deprecated This error return is deprecated as of CUDA 3.1. Device emulation mode was removed with the CUDA 3.1 release.|
-|           25 |*`cudaErrorSynchronizationError`*              |                                                      | This indicated that a synchronization operation had failed. This was previously used for some device emulation functions. Deprecated This error return is deprecated as of CUDA 3.1. Device emulation mode was removed with the CUDA 3.1 release.|
-|           26 |*`cudaErrorInvalidFilterSetting`*              |                                                      | This indicates that a non-float texture was being accessed with linear filtering. This is not supported by CUDA.               |
-|           27 |*`cudaErrorInvalidNormSetting`*                |                                                      | This indicates that an attempt was made to read a non-float texture as a normalized float. This is not supported by CUDA.      |
-|           28 |*`cudaErrorMixedDeviceExecution`*              |                                                      | Mixing of device and device emulation code was not allowed. Deprecated This error return is deprecated as of CUDA 3.1. Device emulation mode was removed with the CUDA 3.1 release.|
-|           29 |*`cudaErrorCudartUnloading`*                   |                                                      | This indicates that a CUDA Runtime API call cannot be executed because it is being called during process shut down, at a point in time after CUDA driver has been unloaded.|
-|           30 |*`cudaErrorUnknown`*                           |*`hipErrorUnknown`*                                   | This indicates that an unknown internal error has occurred.                                                                    |
-|           31 |*`cudaErrorNotYetImplemented`*                 |                                                      | This indicates that the API call is not yet implemented. Production releases of CUDA will never return this error. Deprecated This error return is deprecated as of CUDA 4.1.|
-|           32 |*`cudaErrorMemoryValueTooLarge`*               |                                                      | This indicated that an emulated device pointer exceeded the 32-bit address range. Deprecated This error return is deprecated as of CUDA 3.1. Device emulation mode was removed with the CUDA 3.1 release.|
-|           33 |*`cudaErrorInvalidResourceHandle`*             |*`hipErrorInvalidResourceHandle`*                     | This indicates that a resource handle passed to the API call was not valid. Resource handles are opaque types like cudaStream_t and cudaEvent_t.|
-|           34 |*`cudaErrorNotReady`*                          |*`hipErrorNotReady`*                                  | This indicates that asynchronous operations issued previously have not completed yet. This result is not actually an error, but must be indicated differently than cudaSuccess (which indicates completion). Calls that may return this value include cudaEventQuery() and cudaStreamQuery().|
-|           35 |*`cudaErrorInsufficientDriver`*                |                                                      | This indicates that the installed NVIDIA CUDA driver is older than the CUDA runtime library. This is not a supported configuration. Users should install an updated NVIDIA display driver to allow the application to run.|
-|           36 |*`cudaErrorSetOnActiveProcess`*                |                                                      | This indicates that the user has called cudaSetValidDevices(), cudaSetDeviceFlags(), cudaD3D9SetDirect3DDevice(), cudaD3D10SetDirect3DDevice, cudaD3D11SetDirect3DDevice(), or cudaVDPAUSetVDPAUDevice() after initializing the CUDA runtime by calling non-device management operations (allocating memory and launching kernels are examples of non-device management operations). This error can also be returned if using runtime/driver interoperability and there is an existing CUcontext active on the host thread.|
-|           37 |*`cudaErrorInvalidSurface`*                    |                                                      | This indicates that the surface passed to the API call is not a valid surface.                                                 |
-|           38 |*`cudaErrorNoDevice`*                          |*`hipErrorNoDevice`*                                  | This indicates that no CUDA-capable devices were detected by the installed CUDA driver.                                        |
-|           39 |*`cudaErrorECCUncorrectable`*                  |                                                      | This indicates that an uncorrectable ECC error was detected during execution.                                                  |
-|           40 |*`cudaErrorSharedObjectSymbolNotFound`*        |                                                      | This indicates that a link to a shared object failed to resolve.                                                               |
-|           41 |*`cudaErrorSharedObjectInitFailed`*            |                                                      | This indicates that initialization of a shared object failed.                                                                  |
-|           42 |*`cudaErrorUnsupportedLimit`*                  |*`hipErrorUnsupportedLimit`*                          | This indicates that the cudaLimit passed to the API call is not supported by the active device.                                |
-|           43 |*`cudaErrorDuplicateVariableName`*             |                                                      | This indicates that multiple global or constant variables (across separate CUDA source files in the application) share the same string name.|
-|           44 |*`cudaErrorDuplicateTextureName`*              |                                                      | This indicates that multiple textures (across separate CUDA source files in the application) share the same string name.       |
-|           45 |*`cudaErrorDuplicateSurfaceName`*              |                                                      | This indicates that multiple surfaces (across separate CUDA source files in the application) share the same string name.       |
-|           46 |*`cudaErrorDevicesUnavailable`*                |                                                      | This indicates that all CUDA devices are busy or unavailable at the current time. Devices are often busy/unavailable due to use of cudaComputeModeExclusive, cudaComputeModeProhibited or when long running CUDA kernels have filled up the GPU and are blocking new work from starting. They can also be unavailable due to memory constraints on a device that already has active CUDA work being performed.|
-|           47 |*`cudaErrorInvalidKernelImage`*                |                                                      | This indicates that the device kernel image is invalid.                                                                        |
-|           48 |*`cudaErrorNoKernelImageForDevice`*            |                                                      | This indicates that there is no kernel image available that is suitable for the device. This can occur when a user specifies code generation options for a particular CUDA source file that do not include the corresponding device configuration.|
-|           49 |*`cudaErrorIncompatibleDriverContext`*         |                                                      | This indicates that the current context is not compatible with this the CUDA Runtime. This can only occur if you are using CUDA Runtime/Driver interoperability and have created an existing Driver context using the driver API. The Driver context may be incompatible either because the Driver context was created using an older version of the API, because the Runtime API call expects a primary driver context and the Driver context is not primary, or because the Driver context has been destroyed. Please see Interactions with the CUDA Driver API" for more information.|
-|           50 |*`cudaErrorPeerAccessAlreadyEnabled`*          |*`hipErrorPeerAccessAlreadyEnabled`*                  | This error indicates that a call to cudaDeviceEnablePeerAccess() is trying to re-enable peer addressing on from a context which has already had peer addressing enabled.|
-|           51 |*`cudaErrorPeerAccessNotEnabled`*              |*`hipErrorPeerAccessNotEnabled`*                      | This error indicates that a call to cudaDeviceEnablePeerAccess() is trying to re-enable peer addressing on from a context which has already had peer addressing enabled.|
-|           52 |                                               |                                                      | *reserved*                                                                                                                     |
-|           53 |                                               |                                                      | *reserved*                                                                                                                     |
-|           54 |*`cudaErrorDeviceAlreadyInUse`*                |                                                      | This indicates that a call tried to access an exclusive-thread device that is already in use by a different thread.            |
-|           55 |*`cudaErrorProfilerDisabled`*                  |                                                      | This indicates profiler is not initialized for this run. This can happen when the application is running with external profiling tools like visual profiler.|
-|           56 |*`cudaErrorProfilerNotInitialized`*            |                                                      | Deprecated This error return is deprecated as of CUDA 5.0. It is no longer an error to attempt to enable/disable the profiling via cudaProfilerStart or cudaProfilerStop without initialization.|
-|           57 |*`cudaErrorProfilerAlreadyStarted`*            |                                                      | Deprecated This error return is deprecated as of CUDA 5.0. It is no longer an error to call cudaProfilerStart() when profiling is already enabled.|
-|           58 |*`cudaErrorProfilerAlreadyStopped`*            |                                                      | Deprecated This error return is deprecated as of CUDA 5.0. It is no longer an error to call cudaProfilerStop() when profiling is already disabled.|
-|           59 |*`cudaErrorAssert`*                            |                                                      | An assert triggered in device code during kernel execution. The device cannot be used again until cudaThreadExit() is called. All existing allocations are invalid and must be reconstructed if the program is to continue using CUDA.|
-|           60 |*`cudaErrorTooManyPeers`*                      |                                                      | This error indicates that the hardware resources required to enable peer access have been exhausted for one or more of the devices passed to cudaEnablePeerAccess().|
-|           61 |*`cudaErrorHostMemoryAlreadyRegistered`*       | *`hipErrorHostMemoryAlreadyRegistered`*              | This error indicates that the memory range passed to cudaHostRegister() has already been registered.                           |
-|           62 |*`cudaErrorHostMemoryNotRegistered`*           | *`hipErrorHostMemoryNotRegistered`*                  | This error indicates that the pointer passed to cudaHostUnregister() does not correspond to any currently registered memory region.|
-|           63 |*`cudaErrorOperatingSystem`*                   |                                                      | This error indicates that an OS call failed.                                                                                   |
-|           64 |*`cudaErrorPeerAccessUnsupported`*             |                                                      | This error indicates that P2P access is not supported across the given devices.                                                |
-|           65 |*`cudaErrorLaunchMaxDepthExceeded`*            |                                                      | This error indicates that a device runtime grid launch did not occur because the depth of the child grid would exceed the maximum supported number of nested grid launches.|
-|           66 |*`cudaErrorLaunchFileScopedTex`*               |                                                      | This error indicates that a grid launch did not occur because the kernel uses filescoped textures which are unsupported by the device runtime. Kernels launched via the device runtime only support textures created with the Texture Object API's.|
-|           67 |*`cudaErrorLaunchFileScopedSurf`*              |                                                      | This error indicates that a grid launch did not occur because the kernel uses filescoped surfaces which are unsupported by the device runtime. Kernels launched via the device runtime only support surfaces created with the Surface Object API's.|
-|           68 |*`cudaErrorSyncDepthExceeded`*                 |                                                      | This error indicates that a call to cudaDeviceSynchronize made from the device runtime failed because the call was made at grid depth greater than than either the default (2 levels of grids) or user specified device limit cudaLimitDevRuntimeSyncDepth. To be able to synchronize on launched grids at a greater depth successfully, the maximum nested depth at which cudaDeviceSynchronize will be called must be specified with the cudaLimitDevRuntimeSyncDepth limit to the cudaDeviceSetLimit api before the host-side launch of a kernel using the device runtime. Keep in mind that additional levels of sync depth require the runtime to reserve large amounts of device memory that cannot be used for user allocations.|
-|           69 |*`cudaErrorLaunchPendingCountExceeded`*        |                                                      | This error indicates that a device runtime grid launch failed because the launch would exceed the limit cudaLimitDevRuntimePendingLaunchCount. For this launch to proceed successfully, cudaDeviceSetLimit must be called to set the cudaLimitDevRuntimePendingLaunchCount to be higher than the upper bound of outstanding launches that can be issued to the device runtime. Keep in mind that raising the limit of pending device runtime launches will require the runtime to reserve device memory that cannot be used for user allocations.|
-|           70 |*`cudaErrorNotPermitted`*                      |                                                      | This error indicates the attempted operation is not permitted.                                                                 |
-|           71 |*`cudaErrorNotSupported`*                      |                                                      | This error indicates the attempted operation is not supported on the current system or device.                                 |
-|           72 |*`cudaErrorHardwareStackError`*                |                                                      | Device encountered an error in the call stack during kernel execution, possibly due to stack corruption or exceeding the stack size limit. The context cannot be used, so it must be destroyed (and a new one should be created). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA.|
-|           73 |*`cudaErrorIllegalInstruction`*                |                                                      | The device encountered an illegal instruction during kernel execution The context cannot be used, so it must be destroyed (and a new one should be created). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA.|
-|           74 |*`cudaErrorMisalignedAddress`*                 |                                                      | The device encountered a load or store instruction on a memory address which is not aligned. The context cannot be used, so it must be destroyed (and a new one should be created). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA.|
-|           75 |*`cudaErrorInvalidAddressSpace`*               |                                                      | While executing a kernel, the device encountered an instruction which can only operate on memory locations in certain address spaces (global, shared, or local), but was supplied a memory address not belonging to an allowed address space. The context cannot be used, so it must be destroyed (and a new one should be created). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA.|
-|           76 |*`cudaErrorInvalidPc`*                         |                                                      | The device encountered an invalid program counter. The context cannot be used, so it must be destroyed (and a new one should be created). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA.|
-|           77 |*`cudaErrorIllegalAddress`*                    |                                                      | The device encountered a load or store instruction on an invalid memory address. The context cannot be used, so it must be destroyed (and a new one should be created). All existing device memory allocations from this context are invalid and must be reconstructed if the program is to continue using CUDA.|
-|           78 |*`cudaErrorInvalidPtx`*                        |                                                      | A PTX compilation failed. The runtime may fall back to compiling PTX if an application does not contain a suitable binary for the current device.|
-|           79 |*`cudaErrorInvalidGraphicsContext`*            |                                                      | This indicates an error with the OpenGL or DirectX context.                                                                    |
-|         0x7f |*`cudaErrorStartupFailure`*                    |                                                      | This indicates an internal startup failure in the CUDA runtime.                                                                |
-|         1000 |*`cudaErrorApiFailureBase`*                    |                                                      | Any unhandled CUDA driver error is added to this value and returned via the runtime. Production releases of CUDA should not return such errors. Deprecated This error return is deprecated as of CUDA 4.1.|
-| enum         |***`cudaFuncCache`***                          |***`hipFuncCache_t`***                                | CUDA function cache configurations.                                                                                            |
-|            0 |*`cudaFuncCachePreferNone`*                    |*`hipFuncCachePreferNone`*                            | Default function cache configuration, no preference.                                                                           |
-|            1 |*`cudaFuncCachePreferShared`*                  |*`hipFuncCachePreferShared`*                          | Prefer larger shared memory and smaller L1 cache.                                                                              |
-|            2 |*`cudaFuncCachePreferL1`*                      |*`hipFuncCachePreferL1`*                              | Prefer larger L1 cache and smaller shared memory.                                                                              |
-|            3 |*`cudaFuncCachePreferEqual`*                   |*`hipFuncCachePreferEqual`*                           | Prefer equal size L1 cache and shared memory.                                                                                  |
-| enum         |***`cudaGraphicsCubeFace`***                   |                                                      | CUDA graphics interop array indices for cube maps.                                                                             |
-|         0x00 |*`cudaGraphicsCubeFacePositiveX`*              |                                                      | Positive X face of cubemap.                                                                                                    |
-|         0x01 |*`cudaGraphicsCubeFaceNegativeX`*              |                                                      | Negative X face of cubemap.                                                                                                    |
-|         0x02 |*`cudaGraphicsCubeFacePositiveY`*              |                                                      | Positive Y face of cubemap.                                                                                                    |
-|         0x03 |*`cudaGraphicsCubeFaceNegativeY`*              |                                                      | Negative Y face of cubemap.                                                                                                    |
-|         0x04 |*`cudaGraphicsCubeFacePositiveZ`*              |                                                      | Positive Z face of cubemap.                                                                                                    |
-|         0x05 |*`cudaGraphicsCubeFaceNegativeZ`*              |                                                      | Negative Z face of cubemap.                                                                                                    |
-| enum         |***`cudaGraphicsMapFlags`***                   |                                                      | CUDA graphics interop map flags.                                                                                               |
-|            0 |*`cudaGraphicsMapFlagsNone`*                   |                                                      | Default; Assume resource can be read/written.                                                                                  |
-|            1 |*`cudaGraphicsMapFlagsReadOnly`*               |                                                      | CUDA will not write to this resource.                                                                                          |
-|            2 |*`cudaGraphicsMapFlagsWriteDiscard`*           |                                                      | CUDA will only write to and will not read from this resource.                                                                  |
-| enum         |***`cudaGraphicsRegisterFlags`***              |                                                      | CUDA graphics interop register flags.                                                                                          |
-|            0 |*`cudaGraphicsRegisterFlagsNone`*              |                                                      | Default.                                                                                                                       |
-|            1 |*`cudaGraphicsRegisterFlagsReadOnly`*          |                                                      | CUDA will not write to this resource.                                                                                          |
-|            2 |*`cudaGraphicsRegisterFlagsWriteDiscard`*      |                                                      | CUDA will only write to and will not read from this resource.                                                                  |
-|            4 |*`cudaGraphicsRegisterFlagsSurfaceLoadStore`*  |                                                      | CUDA will bind this resource to a surface reference.                                                                           |
-|            8 |*`cudaGraphicsRegisterFlagsTextureGather`*     |                                                      | CUDA will perform texture gather operations on this resource.                                                                  |
-| enum         |***`cudaLimit`***                              |***`hipLimit_t`***                                    | CUDA Limits.                                                                                                                   |
-|         0x00 |*`cudaLimitStackSize`*                         |                                                      | GPU thread stack size.                                                                                                         |
-|         0x01 |*`cudaLimitPrintfFifoSize`*                    |                                                      | GPU printf/fprintf FIFO size.                                                                                                  |
-|         0x02 |*`cudaLimitMallocHeapSize`*                    |*`hipLimitMallocHeapSize`*                            | GPU malloc heap size.                                                                                                          |
-|         0x03 |*`cudaLimitDevRuntimeSyncDepth`*               |                                                      | GPU device runtime synchronize depth.                                                                                          |
-|         0x04 |*`cudaLimitDevRuntimePendingLaunchCount`*      |                                                      | GPU device runtime pending launch count.                                                                                       |
-| enum         |***`cudaMemcpyKind`***                         |***`hipMemcpyKind`***                                 | CUDA memory copy types.                                                                                                        |
-|            0 |*`cudaMemcpyHostToHost`*                       |*`hipMemcpyHostToHost`*                               | Host -> Host.                                                                                                                  |
-|            1 |*`cudaMemcpyHostToDevice`*                     |*`hipMemcpyHostToDevice`*                             | Host -> Device.                                                                                                                |
-|            2 |*`cudaMemcpyDeviceToHost`*                     |*`hipMemcpyDeviceToHost`*                             | Device -> Host.                                                                                                                |
-|            3 |*`cudaMemcpyDeviceToDevice`*                   |*`hipMemcpyDeviceToDevice`*                           | Device -> Device.                                                                                                              |
-|            4 |*`cudaMemcpyDefault`*                          |*`hipMemcpyDefault`*                                  | Default based unified virtual address space.                                                                                   |
-| enum         |***`cudaMemoryType`***                         |***`hipMemoryType`***                                 | CUDA memory types.                                                                                                             |
-|            1 |*`cudaMemoryTypeHost`*                         |*`hipMemoryTypeHost`*                                 | Host memory.                                                                                                                   |
-|            2 |*`cudaMemoryTypeDevice`*                       |*`hipMemoryTypeDevice`*                               | Device memory.                                                                                                                 |
-| enum         |***`cudaResourceType`***                       |                                                      | CUDA resource types.                                                                                                           |
-|            0 |*`cudaResourceTypeArray`*                      |                                                      | Array resource.                                                                                                                |
-|            1 |*`cudaResourceTypeMipmappedArray`*             |                                                      | Mipmapped array resource.                                                                                                      |
-|            2 |*`cudaResourceTypeLinear`*                     |                                                      | Linear resource.                                                                                                               |
-|            3 |*`cudaResourceTypePitch2D`*                    |                                                      | Pitch 2D resource.                                                                                                             |
-| enum         |***`cudaResourceViewFormat`***                 |                                                      | CUDA texture resource view formats.                                                                                            |
-|         0x00 |*`cudaResViewFormatNone`*                      |                                                      | No resource view format (use underlying resource format).                                                                      |
-|         0x01 |*`cudaResViewFormatUnsignedChar1`*             |                                                      | 1 channel unsigned 8-bit integers.                                                                                             |
-|         0x02 |*`cudaResViewFormatUnsignedChar2`*             |                                                      | 2 channel unsigned 8-bit integers.                                                                                             |
-|         0x03 |*`cudaResViewFormatUnsignedChar4`*             |                                                      | 4 channel unsigned 8-bit integers.                                                                                             |
-|         0x04 |*`cudaResViewFormatSignedChar1`*               |                                                      | 1 channel signed 8-bit integers.                                                                                               |
-|         0x05 |*`cudaResViewFormatSignedChar2`*               |                                                      | 2 channel signed 8-bit integers.                                                                                               |
-|         0x06 |*`cudaResViewFormatSignedChar4`*               |                                                      | 4 channel signed 8-bit integers.                                                                                               |
-|         0x07 |*`cudaResViewFormatUnsignedShort1`*            |                                                      | 1 channel unsigned 16-bit integers.                                                                                            |
-|         0x08 |*`cudaResViewFormatUnsignedShort2`*            |                                                      | 2 channel unsigned 16-bit integers.                                                                                            |
-|         0x09 |*`cudaResViewFormatUnsignedShort4`*            |                                                      | 4 channel unsigned 16-bit integers.                                                                                            |
-|         0x0a |*`cudaResViewFormatSignedShort1`*              |                                                      | 1 channel signed 16-bit integers.                                                                                              |
-|         0x0b |*`cudaResViewFormatSignedShort2`*              |                                                      | 2 channel signed 16-bit integers.                                                                                              |
-|         0x0c |*`cudaResViewFormatSignedShort4`*              |                                                      | 4 channel signed 16-bit integers.                                                                                              |
-|         0x0d |*`cudaResViewFormatUnsignedInt1`*              |                                                      | 1 channel unsigned 32-bit integers.                                                                                            |
-|         0x0e |*`cudaResViewFormatUnsignedInt2`*              |                                                      | 2 channel unsigned 32-bit integers.                                                                                            |
-|         0x0f |*`cudaResViewFormatUnsignedInt4`*              |                                                      | 4 channel unsigned 32-bit integers.                                                                                            |
-|         0x10 |*`cudaResViewFormatSignedInt1`*                |                                                      | 1 channel signed 32-bit integers.                                                                                              |
-|         0x11 |*`cudaResViewFormatSignedInt2`*                |                                                      | 2 channel signed 32-bit integers.                                                                                              |
-|         0x12 |*`cudaResViewFormatSignedInt4`*                |                                                      | 4 channel signed 32-bit integers.                                                                                              |
-|         0x13 |*`cudaResViewFormatHalf1`*                     |                                                      | 1 channel 16-bit floating point.                                                                                               |
-|         0x14 |*`cudaResViewFormatHalf2`*                     |                                                      | 2 channel 16-bit floating point.                                                                                               |
-|         0x15 |*`cudaResViewFormatHalf4`*                     |                                                      | 4 channel 16-bit floating point.                                                                                               |
-|         0x16 |*`cudaResViewFormatFloat1`*                    |                                                      | 1 channel 32-bit floating point.                                                                                               |
-|         0x17 |*`cudaResViewFormatFloat2`*                    |                                                      | 2 channel 32-bit floating point.                                                                                               |
-|         0x18 |*`cudaResViewFormatFloat4`*                    |                                                      | 4 channel 32-bit floating point.                                                                                               |
-|         0x19 |*`cudaResViewFormatUnsignedBlockCompressed1`*  |                                                      | Block compressed 1.                                                                                                            |
-|         0x1a |*`cudaResViewFormatUnsignedBlockCompressed2`*  |                                                      | Block compressed 2.                                                                                                            |
-|         0x1b |*`cudaResViewFormatUnsignedBlockCompressed3`*  |                                                      | Block compressed 3.                                                                                                            |
-|         0x1c |*`cudaResViewFormatUnsignedBlockCompressed4`*  |                                                      | Block compressed 4 unsigned.                                                                                                   |
-|         0x1d |*`cudaResViewFormatSignedBlockCompressed4`*    |                                                      | Block compressed 4 signed.                                                                                                     |
-|         0x1e |*`cudaResViewFormatUnsignedBlockCompressed5`*  |                                                      | Block compressed 5 unsigned.                                                                                                   |
-|         0x1f |*`cudaResViewFormatSignedBlockCompressed5`*    |                                                      | Block compressed 5 signed.                                                                                                     |
-|         0x20 |*`cudaResViewFormatUnsignedBlockCompressed6H`* |                                                      | Block compressed 6 unsigned half-float.                                                                                        |
-|         0x21 |*`cudaResViewFormatSignedBlockCompressed6H`*   |                                                      | Block compressed 6 signed half-float.                                                                                          |
-|         0x22 |*`cudaResViewFormatUnsignedBlockCompressed7`*  |                                                      | Block compressed 7.                                                                                                            |
-| enum         |***`cudaSharedMemConfig`***                    |***`hipSharedMemConfig`***                            | CUDA shared memory configuration.                                                                                              |
-|            0 |*`cudaSharedMemBankSizeDefault`*               |*`hipSharedMemBankSizeDefault`*                       |                                                                                                                                |
-|            1 |*`cudaSharedMemBankSizeFourByte`*              |*`hipSharedMemBankSizeFourByte`*                      |                                                                                                                                |
-|            2 |*`cudaSharedMemBankSizeEightByte`*             |*`hipSharedMemBankSizeEightByte`*                     |                                                                                                                                |
-| enum         |***`cudaSurfaceBoundaryMode`***                |                                                      | CUDA Surface boundary modes.                                                                                                   |
-|            0 |*`cudaBoundaryModeZero`*                       |                                                      | Zero boundary mode.                                                                                                            |
-|            1 |*`cudaBoundaryModeClamp`*                      |                                                      | Clamp boundary mode.                                                                                                           |
-|            2 |*`cudaBoundaryModeTrap`*                       |                                                      | Trap boundary mode.                                                                                                            |
-| enum         |***`cudaSurfaceFormatMode`***                  |                                                      | CUDA Surface format modes.                                                                                                     |
-|            0 |*`cudaFormatModeForced`*                       |                                                      | Forced format mode.                                                                                                            |
-|            1 |*`cudaFormatModeAuto`*                         |                                                      | Auto format mode.                                                                                                              |
-| enum         |***`cudaTextureAddressMode`***                 |                                                      | CUDA texture address modes.                                                                                                    |
-|            0 |*`cudaAddressModeWrap`*                        |                                                      | Wrapping address mode.                                                                                                         |
-|            1 |*`cudaAddressModeClamp`*                       |                                                      | Clamp to edge address mode.                                                                                                    |
-|            2 |*`cudaAddressModeMirror`*                      |                                                      | Mirror address mode.                                                                                                           |
-|            3 |*`cudaAddressModeBorder`*                      |                                                      | Border address mode.                                                                                                           |
-| enum         |***`cudaTextureFilterMode`***                  |***`hipTextureFilterMode`***                          | Point filter mode.                                                                                                             |
-|            0 |*`cudaFilterModePoint`*                        |*`hipFilterModePoint`*                                | Linear filter mode.                                                                                                            |
-|            1 |*`cudaFilterModeLinear`*                       |                                                      | Clamp to edge address mode.                                                                                                    |
-| enum         |***`cudaTextureReadMode`***                    |***`hipTextureReadMode`***                            | CUDA texture read modes.                                                                                                       |
-|            0 |*`cudaReadModeElementType`*                    |*`hipReadModeElementType`*                            | Read texture as specified element type.                                                                                        |
-|            1 |*`cudaReadModeNormalizedFloat`*                |                                                      | Read texture as normalized float.                                                                                              |
-| enum         |***`cudaGLDeviceList`***                       |                                                      | CUDA devices corresponding to an OpenGL device                                                                                 |
-|         0x01 |*`cudaGLDeviceListAll`*                        |                                                      | The CUDA devices for all GPUs used by the current OpenGL context                                                               |
-|         0x02 |*`cudaGLDeviceListCurrentFrame`*               |                                                      | The CUDA devices for the GPUs used by the current OpenGL context in its currently rendering frame                              |
-|         0x03 |*`cudaGLDeviceListNextFrame`*                  |                                                      | The CUDA devices for the GPUs to be used by the current OpenGL context in the next frame                                       |
-| enum         |***`cudaGLMapFlags`***                         |                                                      | CUDA GL Map Flags                                                                                                              |
-|         0x00 |*`cudaGLMapFlagsNone`*                         |                                                      | Default; Assume resource can be read/written                                                                                   |
-|         0x01 |*`cudaGLMapFlagsReadOnly`*                     |                                                      | CUDA kernels will not write to this resource                                                                                   |
-|         0x02 |*`cudaGLMapFlagsWriteDiscard`*                 |                                                      | CUDA kernels will only write to and will not read from this resource                                                           |
-| enum         |***`cudaD3D9DeviceList`***                     |                                                      | CUDA devices corresponding to a D3D9 device                                                                                    |
-|            1 |*`cudaD3D9DeviceListAll`*                      |                                                      | The CUDA devices for all GPUs used by a D3D9 device                                                                            |
-|            2 |*`cudaD3D9DeviceListCurrentFrame`*             |                                                      | The CUDA devices for the GPUs used by a D3D9 device in its currently rendering frame                                           |
-|            3 |*`cudaD3D9DeviceListNextFrame`*                |                                                      | The CUDA devices for the GPUs to be used by a D3D9 device in the next frame                                                    |
-| enum         |***`cudaD3D9MapFlags`***                       |                                                      | Flags to map or unmap a resource                                                                                               |
-|            0 |*`cudaD3D9MapFlagsNone`*                       |                                                      | Default; Assume resource can be read/written                                                                                   |
-|            1 |*`cudaD3D9MapFlagsReadOnly`*                   |                                                      | CUDA kernels will not write to this resource                                                                                   |
-|            2 |*`cudaD3D9MapFlagsWriteDiscard`*               |                                                      | CUDA kernels will only write to and will not read from this resource                                                           |
-| enum         |***`cudaD3D9RegisterFlags`***                  |                                                      | CUDA D3D9 Register Flags                                                                                                       |
-|            0 |*`cudaD3D9RegisterFlagsNone`*                  |                                                      | Default; Resource can be accessed througa void*                                                                                |
-|            1 |*`cudaD3D9RegisterFlagsArray`*                 |                                                      | Resource can be accessed through a CUarray*                                                                                    |
-| enum         |***`cudaD3D10DeviceList`***                    |                                                      | CUDA devices corresponding to a D3D10 device                                                                                   |
-|            1 |*`cudaD3D10DeviceListAll`*                     |                                                      | The CUDA devices for all GPUs used by a D3D10 device                                                                           |
-|            2 |*`cudaD3D10DeviceListCurrentFrame`*            |                                                      | The CUDA devices for the GPUs used by a D3D10 device in its currently rendering frame                                          |
-|            3 |*`cudaD3D10DeviceListNextFrame`*               |                                                      | The CUDA devices for the GPUs to be used by a D3D10 device in the next frame                                                   |
-| enum         |***`cudaD3D10MapFlags`***                      |                                                      | Flags to map or unmap a resource                                                                                               |
-|            0 |*`cudaD3D10MapFlagsNone`*                      |                                                      | Default; Assume resource can be read/written                                                                                   |
-|            1 |*`cudaD3D10MapFlagsReadOnly`*                  |                                                      | CUDA kernels will not write to this resource                                                                                   |
-|            2 |*`cudaD3D10MapFlagsWriteDiscard`*              |                                                      | CUDA kernels will only write to and will not read from this resource                                                           |
-| enum         |***`cudaD3D10RegisterFlags`***                 |                                                      | CUDA D3D10 Register Flags                                                                                                      |
-|            0 |*`cudaD3D10RegisterFlagsNone`*                 |                                                      | Default; Resource can be accessed througa void*                                                                                |
-|            1 |*`cudaD3D10RegisterFlagsArray`*                |                                                      | Resource can be accessed through a CUarray*                                                                                    |
-| enum         |***`cudaD3D11DeviceList`***                    |                                                      | CUDA devices corresponding to a D3D11 device                                                                                   |
-|            1 |*`cudaD3D11DeviceListAll`*                     |                                                      | The CUDA devices for all GPUs used by a D3D11 device                                                                           |
-|            2 |*`cudaD3D11DeviceListCurrentFrame`*            |                                                      | The CUDA devices for the GPUs used by a D3D11 device in its currently rendering frame                                          |
-|            3 |*`cudaD3D11DeviceListNextFrame`*               |                                                      | The CUDA devices for the GPUs to be used by a D3D11 device in the next frame                                                   |
-| struct       | `cudaArray`                                   | `hipArray`                                           | CUDA array [opaque].                                                                                                           |
-| typedef      | `cudaArray_t`                                 | `hipArray *`                                         | CUDA array pointer.                                                                                                            |
-| typedef      | `cudaArray_const_t`                           | `const hipArray *`                                   | CUDA array (as source copy argument).                                                                                          |
-| enum         | `cudaError`                                   | `hipError_t`                                         | CUDA Error types.                                                                                                              |
-| typedef      | `cudaError_t`                                 | `hipError_t`                                         | CUDA Error types.                                                                                                              |
-| typedef      | `cudaEvent_t`                                 | `hipEvent_t`                                         | CUDA event types.                                                                                                              |
-| typedef      | `cudaGraphicsResource_t`                      |                                                      | CUDA graphics resource types.                                                                                                  |
-| typedef      | `cudaMipmappedArray_t`                        |                                                      | CUDA mipmapped array.                                                                                                          |
-| typedef      | `cudaMipmappedArray_const_t`                  |                                                      | CUDA mipmapped array (as source argument).                                                                                     |
-| enum         |***`cudaOutputMode`***                         |                                                      | CUDA Profiler Output modes.                                                                                                    |
-|         0x00 |*`cudaKeyValuePair`*                           |                                                      | Output mode Key-Value pair format.                                                                                             |
-|         0x01 |*`cudaCSV`*                                    |                                                      | Output mode Comma separated values format.                                                                                     |
-| typedef      | `cudaOutputMode_t`                            |                                                      | CUDA output file modes.                                                                                                        |
-| typedef      | `cudaStream_t`                                | `hipStream_t`                                        | CUDA stream.                                                                                                                   |
-| typedef      | `cudaSurfaceObject_t`                         |                                                      | An opaque value that represents a CUDA Surface object.                                                                         |
-| typedef      | `cudaTextureObject_t`                         |                                                      | An opaque value that represents a CUDA texture object.                                                                         |
-| typedef      | `CUuuid_stcudaUUID_t`                         |                                                      | CUDA UUID types.                                                                                                               |
-| define       | `CUDA_IPC_HANDLE_SIZE`                        |                                                      | CUDA IPC Handle Size.                                                                                                          |
-| define       | `cudaArrayCubemap`                            |                                                      | Must be set in cudaMalloc3DArray to create a cubemap CUDA array.                                                               |
-| define       | `cudaArrayDefault`                            |                                                      | Default CUDA array allocation flag.                                                                                            |
-| define       | `cudaArrayLayered`                            |                                                      | Must be set in cudaMalloc3DArray to create a layered CUDA array.                                                               |
-| define       | `cudaArraySurfaceLoadStore`                   |                                                      | Must be set in cudaMallocArray or cudaMalloc3DArray in order to bind surfaces to the CUDA array.                               |
-| define       | `cudaArrayTextureGather`                      |                                                      | Must be set in cudaMallocArray or cudaMalloc3DArray in order to perform texture gather operations on the CUDA array.           |
-| define       | `cudaDeviceBlockingSync`                      | `hipDeviceScheduleBlockingSync`                      | Device flag - Use blocking synchronization. Deprecated as of CUDA 4.0 and replaced with cudaDeviceScheduleBlockingSync.        |
-| define       | `cudaDeviceLmemResizeToMax`                   |                                                      | Device flag - Keep local memory allocation after launch.                                                                       |
-| define       | `cudaDeviceMapHost`                           |                                                      | Device flag - Support mapped pinned allocations.                                                                               |
-| define       | `cudaDeviceMask`                              |                                                      | Device flags mask.                                                                                                             |
-| define       | `cudaDevicePropDontCare`                      |                                                      | Empty device properties.                                                                                                       |
-| define       | `cudaDeviceScheduleAuto`                      | `hipDeviceScheduleAuto`                              | Device flag - Automatic scheduling.                                                                                            |
-| define       | `cudaDeviceScheduleBlockingSync`              | `hipDeviceScheduleBlockingSync`                      | Device flag - Use blocking synchronization.                                                                                    |
-| define       | `cudaDeviceScheduleMask`                      | `hipDeviceScheduleMask`                              | Device schedule flags mask.                                                                                                    |
-| define       | `cudaDeviceScheduleSpin`                      | `hipDeviceScheduleSpin`                              | Device flag - Spin default scheduling.                                                                                         |
-| define       | `cudaDeviceScheduleYield`                     | `hipDeviceScheduleYield`                             | Device flag - Yield default scheduling.                                                                                        |
-| define       | `cudaEventDefault`                            | `hipEventDefault`                                    | Default event flag.                                                                                                            |
-| define       | `cudaEventDisableTiming`                      | `hipEventDisableTiming`                              | Event will not record timing data.                                                                                             |
-| define       | `cudaEventInterprocess`                       | `hipEventInterprocess`                               | Event is suitable for interprocess use. cudaEventDisableTiming must be set.                                                    |
-| define       | `cudaHostAllocDefault`                        | `hipHostMallocDefault`                               | Default page-locked allocation flag.                                                                                           |
-| define       | `cudaHostAllocMapped`                         | `hipHostMallocMapped`                                | Map allocation into device space.                                                                                              |
-| define       | `cudaHostAllocPortable`                       | `hipHostMallocPortable`                              | Pinned memory accessible by all CUDA contexts.                                                                                 |
-| define       | `cudaHostAllocWriteCombined`                  | `hipHostMallocWriteCombined`                         | Write-combined memory.                                                                                                         |
-| define       | `cudaHostRegisterDefault`                     | `hipHostRegisterDefault`                             | Default host memory registration flag.                                                                                         |
-| define       | `cudaHostRegisterIoMemory`                    | `hipHostRegisterIoMemory`                            | Memory-mapped I/O space.                                                                                                       |
-| define       | `cudaHostRegisterMapped`                      | `hipHostRegisterMapped`                              | Map registered memory into device space.                                                                                       |
-| define       | `cudaHostRegisterPortable`                    | `hipHostRegisterPortable`                            | Pinned memory accessible by all CUDA contexts.                                                                                 |
-| define       | `cudaIpcMemLazyEnablePeerAccess`              | `hipIpcMemLazyEnablePeerAccess`                      | Automatically enable peer access between remote devices as needed.                                                             |
-| define       | `cudaMemAttachGlobal`                         |                                                      | Memory can be accessed by any stream on any device.                                                                            |
-| define       | `cudaMemAttachHost`                           |                                                      | Memory cannot be accessed by any stream on any device.                                                                         |
-| define       | `cudaMemAttachSingle`                         |                                                      | Memory can only be accessed by a single stream on the associated device.                                                       |
-| define       | `cudaOccupancyDefault`                        |                                                      | Default behavior.                                                                                                              |
-| define       | `cudaOccupancyDisableCachingOverride`         |                                                      | Assume global caching is enabled and cannot be automatically turned off.                                                       |
-| define       | `cudaPeerAccessDefault`                       |                                                      | Default peer addressing enable flag.                                                                                           |
-| define       | `cudaStreamDefault`                           | `hipStreamDefault`                                   | Default stream flag.                                                                                                           |
-| define       | `cudaStreamLegacy`                            |                                                      | Default stream flag.                                                                                                           |
-| define       | `cudaStreamNonBlocking`                       | `hipStreamNonBlocking`                               | Stream does not synchronize with stream 0 (the NULL stream).                                                                   |
-| define       | `cudaStreamPerThread`                         |                                                      | Per-thread stream handle.                                                                                                      |
+| **type**     |   **CUDA**                                    |   **HIP**                                            |
+|-------------:|-----------------------------------------------|------------------------------------------------------|
+| struct       | `cudaChannelFormatDesc`                       | `hipChannelFormatDesc`                               |
+| struct       | `cudaDeviceProp`                              | `hipDeviceProp_t`                                    |
+| struct       | `cudaExtent`                                  |                                                      |
+| struct       | `cudaFuncAttributes`                          |                                                      |
+| struct       | `cudaIpcEventHandle_t`                        | `hipIpcEventHandle_t`                                |
+| struct       | `cudaIpcMemHandle_t`                          | `hipIpcMemHandle_t`                                  |
+| struct       | `cudaMemcpy3DParms`                           |                                                      |
+| struct       | `cudaMemcpy3DPeerParms`                       |                                                      |
+| struct       | `cudaPitchedPtr`                              |                                                      |
+| struct       | `cudaPointerAttributes`                       | `hipPointerAttribute_t`                              |
+| struct       | `cudaPos`                                     |                                                      |
+| struct       | `cudaResourceDesc`                            |                                                      |
+| struct       | `cudaResourceViewDesc`                        |                                                      |
+| struct       | `cudaTextureDesc`                             |                                                      |
+| struct       | `surfaceReference`                            |                                                      |
+| struct       | `textureReference`                            | `textureReference`                                   |
+| enum         |***`cudaChannelFormatKind`***                  |***`hipChannelFormatKind`***                          |
+|            0 |*`cudaChannelFormatKindSigned`*                |*`hipChannelFormatKindSigned`*                        |
+|            1 |*`cudaChannelFormatKindUnsigned`*              |*`hipChannelFormatKindUnsigned`*                      |
+|            2 |*`cudaChannelFormatKindFloat`*                 |*`hipChannelFormatKindFloat`*                         |
+|            3 |*`cudaChannelFormatKindNone`*                  |*`hipChannelFormatKindNone`*                          |
+| enum         |***`cudaComputeMode`***                        |                                                      |
+|            0 |*`cudaComputeModeDefault`*                     |                                                      |
+|            1 |*`cudaComputeModeExclusive`*                   |                                                      |
+|            2 |*`cudaComputeModeProhibited`*                  |                                                      |
+|            3 |*`cudaComputeModeExclusiveProcess`*            |                                                      |
+| enum         |***`cudaDeviceAttr`***                         |***`hipDeviceAttribute_t`***                          |
+|            1 |*`cudaDevAttrMaxThreadsPerBlock`*              |*`hipDeviceAttributeMaxThreadsPerBlock`*              |
+|            2 |*`cudaDevAttrMaxBlockDimX`*                    |*`hipDeviceAttributeMaxBlockDimX`*                    |
+|            3 |*`cudaDevAttrMaxBlockDimY`*                    |*`hipDeviceAttributeMaxBlockDimY`*                    |
+|            4 |*`cudaDevAttrMaxBlockDimZ`*                    |*`hipDeviceAttributeMaxBlockDimZ`*                    |
+|            5 |*`cudaDevAttrMaxGridDimX`*                     |*`hipDeviceAttributeMaxGridDimX`*                     |
+|            6 |*`cudaDevAttrMaxGridDimY`*                     |*`hipDeviceAttributeMaxGridDimY`*                     |
+|            7 |*`cudaDevAttrMaxGridDimZ`*                     |*`hipDeviceAttributeMaxGridDimZ`*                     |
+|            8 |*`cudaDevAttrMaxSharedMemoryPerBlock`*         |*`hipDeviceAttributeMaxSharedMemoryPerBlock`*         |
+|            9 |*`cudaDevAttrTotalConstantMemory`*             |*`hipDeviceAttributeTotalConstantMemory`*             |
+|           10 |*`cudaDevAttrWarpSize`*                        |*`hipDeviceAttributeWarpSize`*                        |
+|           11 |*`cudaDevAttrMaxPitch`*                        |                                                      |
+|           12 |*`cudaDevAttrMaxRegistersPerBlock`*            |*`hipDeviceAttributeMaxRegistersPerBlock`*            |
+|           13 |*`cudaDevAttrClockRate`*                       |*`hipDeviceAttributeClockRate`*                       |
+|           14 |*`cudaDevAttrTextureAlignment`*                |                                                      |
+|           15 |*`cudaDevAttrGpuOverlap`*                      |                                                      |
+|           16 |*`cudaDevAttrMultiProcessorCount`*             |*`hipDeviceAttributeMultiprocessorCount`*             |
+|           17 |*`cudaDevAttrKernelExecTimeout`*               |                                                      |
+|           18 |*`cudaDevAttrIntegrated`*                      |                                                      |
+|           19 |*`cudaDevAttrCanMapHostMemory`*                |                                                      |
+|           20 |*`cudaDevAttrComputeMode`*                     |*`hipDeviceAttributeComputeMode`*                     |
+|           21 |*`cudaDevAttrMaxTexture1DWidth`*               |                                                      |
+|           22 |*`cudaDevAttrMaxTexture2DWidth`*               |                                                      |
+|           23 |*`cudaDevAttrMaxTexture2DHeight`*              |                                                      |
+|           24 |*`cudaDevAttrMaxTexture3DWidth`*               |                                                      |
+|           25 |*`cudaDevAttrMaxTexture3DHeight`*              |                                                      |
+|           26 |*`cudaDevAttrMaxTexture3DDepth`*               |                                                      |
+|           27 |*`cudaDevAttrMaxTexture2DLayeredWidth`*        |                                                      |
+|           28 |*`cudaDevAttrMaxTexture2DLayeredHeight`*       |                                                      |
+|           29 |*`cudaDevAttrMaxTexture2DLayeredLayers`*       |                                                      |
+|           30 |*`cudaDevAttrSurfaceAlignment`*                |                                                      |
+|           31 |*`cudaDevAttrConcurrentKernels`*               |*`hipDeviceAttributeConcurrentKernels`*               |
+|           32 |*`cudaDevAttrEccEnabled`*                      |                                                      |
+|           33 |*`cudaDevAttrPciBusId`*                        |*`hipDeviceAttributePciBusId`*                        |
+|           34 |*`cudaDevAttrPciDeviceId`*                     |*`hipDeviceAttributePciDeviceId`*                     |
+|           35 |*`cudaDevAttrTccDriver`*                       |                                                      |
+|           36 |*`cudaDevAttrMemoryClockRate`*                 |*`hipDeviceAttributeMemoryClockRate`*                 |
+|           37 |*`cudaDevAttrGlobalMemoryBusWidth`*            |*`hipDeviceAttributeMemoryBusWidth`*                  |
+|           38 |*`cudaDevAttrL2CacheSize`*                     |*`hipDeviceAttributeL2CacheSize`*                     |
+|           39 |*`cudaDevAttrMaxThreadsPerMultiProcessor`*     |*`hipDeviceAttributeMaxThreadsPerMultiProcessor`*     |
+|           40 |*`cudaDevAttrAsyncEngineCount`*                |                                                      |
+|           41 |*`cudaDevAttrUnifiedAddressing`*               |                                                      |
+|           42 |*`cudaDevAttrMaxTexture1DLayeredWidth`*        |                                                      |
+|           43 |*`cudaDevAttrMaxTexture1DLayeredLayers`*       |                                                      |
+|           44 |                                               |                                                      |
+|           45 |*`cudaDevAttrMaxTexture2DGatherWidth`*         |                                                      |
+|           46 |*`cudaDevAttrMaxTexture2DGatherHeight`*        |                                                      |
+|           47 |*`cudaDevAttrMaxTexture3DWidthAlt`*            |                                                      |
+|           48 |*`cudaDevAttrMaxTexture3DHeightAlt`*           |                                                      |
+|           49 |*`cudaDevAttrMaxTexture3DDepthAlt`*            |                                                      |
+|           50 |*`cudaDevAttrPciDomainId`*                     |                                                      |
+|           51 |*`cudaDevAttrTexturePitchAlignment`*           |                                                      |
+|           52 |*`cudaDevAttrMaxTextureCubemapWidth`*          |                                                      |
+|           53 |*`cudaDevAttrMaxTextureCubemapLayeredWidth`*   |                                                      |
+|           54 |*`cudaDevAttrMaxTextureCubemapLayeredLayers`*  |                                                      |
+|           55 |*`cudaDevAttrMaxSurface1DWidth`*               |                                                      |
+|           56 |*`cudaDevAttrMaxSurface2DWidth`*               |                                                      |
+|           57 |*`cudaDevAttrMaxSurface2DHeight`*              |                                                      |
+|           58 |*`cudaDevAttrMaxSurface3DWidth`*               |                                                      |
+|           59 |*`cudaDevAttrMaxSurface3DHeight`*              |                                                      |
+|           60 |*`cudaDevAttrMaxSurface3DDepth`*               |                                                      |
+|           61 |*`cudaDevAttrMaxSurface1DLayeredWidth`*        |                                                      |
+|           62 |*`cudaDevAttrMaxSurface1DLayeredLayers`*       |                                                      |
+|           63 |*`cudaDevAttrMaxSurface2DLayeredWidth`*        |                                                      |
+|           64 |*`cudaDevAttrMaxSurface2DLayeredHeight`*       |                                                      |
+|           65 |*`cudaDevAttrMaxSurface2DLayeredLayers`*       |                                                      |
+|           66 |*`cudaDevAttrMaxSurfaceCubemapWidth`*          |                                                      |
+|           67 |*`cudaDevAttrMaxSurfaceCubemapLayeredWidth`*   |                                                      |
+|           68 |*`cudaDevAttrMaxSurfaceCubemapLayeredLayers`*  |                                                      |
+|           69 |*`cudaDevAttrMaxTexture1DLinearWidth`*         |                                                      |
+|           70 |*`cudaDevAttrMaxTexture2DLinearWidth`*         |                                                      |
+|           71 |*`cudaDevAttrMaxTexture2DLinearHeight`*        |                                                      |
+|           72 |*`cudaDevAttrMaxTexture2DLinearPitch`*         |                                                      |
+|           73 |*`cudaDevAttrMaxTexture2DMipmappedWidth`*      |                                                      |
+|           74 |*`cudaDevAttrMaxTexture2DMipmappedHeight`*     |                                                      |
+|           75 |*`cudaDevAttrComputeCapabilityMajor`*          |*`hipDeviceAttributeComputeCapabilityMajor`*          |
+|           76 |*`cudaDevAttrComputeCapabilityMinor`*          |*`hipDeviceAttributeComputeCapabilityMinor`*          |
+|           77 |*`cudaDevAttrMaxTexture1DMipmappedWidth`*      |                                                      |
+|           78 |*`cudaDevAttrStreamPrioritiesSupported`*       |                                                      |
+|           79 |*`cudaDevAttrGlobalL1CacheSupported`*          |                                                      |
+|           80 |*`cudaDevAttrLocalL1CacheSupported`*           |                                                      |
+|           81 |*`cudaDevAttrMaxSharedMemoryPerMultiprocessor`*|*`hipDeviceAttributeMaxSharedMemoryPerMultiprocessor`*|
+|           82 |*`cudaDevAttrMaxRegistersPerMultiprocessor`*   |                                                      |
+|           83 |*`cudaDevAttrManagedMemory`*                   |                                                      |
+|           84 |*`cudaDevAttrIsMultiGpuBoard`*                 |*`hipDeviceAttributeIsMultiGpuBoard`*                 |
+|           85 |*`cudaDevAttrMultiGpuBoardGroupID`*            |                                                      |
+| enum         |***`cudaError`***                              |***`hipError_t`***                                    |
+| enum         |***`cudaError_t`***                            |***`hipError_t`***                                    |
+|            0 |*`cudaSuccess`*                                |*`hipSuccess`*                                        |
+|            1 |*`cudaErrorMissingConfiguration`*              |                                                      |
+|            2 |*`cudaErrorMemoryAllocation`*                  |*`hipErrorMemoryAllocation`*                          |
+|            3 |*`cudaErrorInitializationError`*               |*`hipErrorInitializationError`*                       |
+|            4 |*`cudaErrorLaunchFailure`*                     |                                                      |
+|            5 |*`cudaErrorPriorLaunchFailure`*                |                                                      |
+|            6 |*`cudaErrorLaunchTimeout`*                     |                                                      |
+|            7 |*`cudaErrorLaunchOutOfResources`*              |*`hipErrorLaunchOutOfResources`*                      |
+|            8 |*`cudaErrorInvalidDeviceFunction`*             |                                                      |
+|            9 |*`cudaErrorInvalidConfiguration`*              |                                                      |
+|           10 |*`cudaErrorInvalidDevice`*                     |*`hipErrorInvalidDevice`*                             |
+|           11 |*`cudaErrorInvalidValue`*                      |*`hipErrorInvalidValue`*                              |
+|           12 |*`cudaErrorInvalidPitchValue`*                 |                                                      |
+|           13 |*`cudaErrorInvalidSymbol`*                     |                                                      |
+|           14 |*`cudaErrorMapBufferObjectFailed`*             |                                                      |
+|           15 |*`cudaErrorUnmapBufferObjectFailed`*           |                                                      |
+|           16 |*`cudaErrorInvalidHostPointer`*                |                                                      |
+|           17 |*`cudaErrorInvalidDevicePointer`*              |*`hipErrorInvalidDevicePointer`*                      |
+|           18 |*`cudaErrorInvalidTexture`*                    |                                                      |
+|           19 |*`cudaErrorInvalidTextureBinding`*             |                                                      |
+|           20 |*`cudaErrorInvalidChannelDescriptor`*          |                                                      |
+|           21 |*`cudaErrorInvalidMemcpyDirection`*            |                                                      |
+|           22 |*`cudaErrorAddressOfConstant`*                 |                                                      |
+|           23 |*`cudaErrorTextureFetchFailed`*                |                                                      |
+|           24 |*`cudaErrorTextureNotBound`*                   |                                                      |
+|           25 |*`cudaErrorSynchronizationError`*              |                                                      |
+|           26 |*`cudaErrorInvalidFilterSetting`*              |                                                      |
+|           27 |*`cudaErrorInvalidNormSetting`*                |                                                      |
+|           28 |*`cudaErrorMixedDeviceExecution`*              |                                                      |
+|           29 |*`cudaErrorCudartUnloading`*                   |                                                      |
+|           30 |*`cudaErrorUnknown`*                           |*`hipErrorUnknown`*                                   |
+|           31 |*`cudaErrorNotYetImplemented`*                 |                                                      |
+|           32 |*`cudaErrorMemoryValueTooLarge`*               |                                                      |
+|           33 |*`cudaErrorInvalidResourceHandle`*             |*`hipErrorInvalidResourceHandle`*                     |
+|           34 |*`cudaErrorNotReady`*                          |*`hipErrorNotReady`*                                  |
+|           35 |*`cudaErrorInsufficientDriver`*                |                                                      |
+|           36 |*`cudaErrorSetOnActiveProcess`*                |                                                      |
+|           37 |*`cudaErrorInvalidSurface`*                    |                                                      |
+|           38 |*`cudaErrorNoDevice`*                          |*`hipErrorNoDevice`*                                  |
+|           39 |*`cudaErrorECCUncorrectable`*                  |                                                      |
+|           40 |*`cudaErrorSharedObjectSymbolNotFound`*        |                                                      |
+|           41 |*`cudaErrorSharedObjectInitFailed`*            |                                                      |
+|           42 |*`cudaErrorUnsupportedLimit`*                  |*`hipErrorUnsupportedLimit`*                          |
+|           43 |*`cudaErrorDuplicateVariableName`*             |                                                      |
+|           44 |*`cudaErrorDuplicateTextureName`*              |                                                      |
+|           45 |*`cudaErrorDuplicateSurfaceName`*              |                                                      |
+|           46 |*`cudaErrorDevicesUnavailable`*                |                                                      |
+|           47 |*`cudaErrorInvalidKernelImage`*                |                                                      |
+|           48 |*`cudaErrorNoKernelImageForDevice`*            |                                                      |
+|           49 |*`cudaErrorIncompatibleDriverContext`*         |                                                      |
+|           50 |*`cudaErrorPeerAccessAlreadyEnabled`*          |*`hipErrorPeerAccessAlreadyEnabled`*                  |
+|           51 |*`cudaErrorPeerAccessNotEnabled`*              |*`hipErrorPeerAccessNotEnabled`*                      |
+|           52 |                                               |                                                      |
+|           53 |                                               |                                                      |
+|           54 |*`cudaErrorDeviceAlreadyInUse`*                |                                                      |
+|           55 |*`cudaErrorProfilerDisabled`*                  |                                                      |
+|           56 |*`cudaErrorProfilerNotInitialized`*            |                                                      |
+|           57 |*`cudaErrorProfilerAlreadyStarted`*            |                                                      |
+|           58 |*`cudaErrorProfilerAlreadyStopped`*            |                                                      |
+|           59 |*`cudaErrorAssert`*                            |                                                      |
+|           60 |*`cudaErrorTooManyPeers`*                      |                                                      |
+|           61 |*`cudaErrorHostMemoryAlreadyRegistered`*       | *`hipErrorHostMemoryAlreadyRegistered`*              |
+|           62 |*`cudaErrorHostMemoryNotRegistered`*           | *`hipErrorHostMemoryNotRegistered`*                  |
+|           63 |*`cudaErrorOperatingSystem`*                   |                                                      |
+|           64 |*`cudaErrorPeerAccessUnsupported`*             |                                                      |
+|           65 |*`cudaErrorLaunchMaxDepthExceeded`*            |                                                      |
+|           66 |*`cudaErrorLaunchFileScopedTex`*               |                                                      |
+|           67 |*`cudaErrorLaunchFileScopedSurf`*              |                                                      |
+|           68 |*`cudaErrorSyncDepthExceeded`*                 |                                                      |
+|           69 |*`cudaErrorLaunchPendingCountExceeded`*        |                                                      |
+|           70 |*`cudaErrorNotPermitted`*                      |                                                      |
+|           71 |*`cudaErrorNotSupported`*                      |                                                      |
+|           72 |*`cudaErrorHardwareStackError`*                |                                                      |
+|           73 |*`cudaErrorIllegalInstruction`*                |                                                      |
+|           74 |*`cudaErrorMisalignedAddress`*                 |                                                      |
+|           75 |*`cudaErrorInvalidAddressSpace`*               |                                                      |
+|           76 |*`cudaErrorInvalidPc`*                         |                                                      |
+|           77 |*`cudaErrorIllegalAddress`*                    |                                                      |
+|           78 |*`cudaErrorInvalidPtx`*                        |                                                      |
+|           79 |*`cudaErrorInvalidGraphicsContext`*            |                                                      |
+|         0x7f |*`cudaErrorStartupFailure`*                    |                                                      |
+|         1000 |*`cudaErrorApiFailureBase`*                    |                                                      |
+| enum         |***`cudaFuncCache`***                          |***`hipFuncCache_t`***                                |
+|            0 |*`cudaFuncCachePreferNone`*                    |*`hipFuncCachePreferNone`*                            |
+|            1 |*`cudaFuncCachePreferShared`*                  |*`hipFuncCachePreferShared`*                          |
+|            2 |*`cudaFuncCachePreferL1`*                      |*`hipFuncCachePreferL1`*                              |
+|            3 |*`cudaFuncCachePreferEqual`*                   |*`hipFuncCachePreferEqual`*                           |
+| enum         |***`cudaGraphicsCubeFace`***                   |                                                      |
+|         0x00 |*`cudaGraphicsCubeFacePositiveX`*              |                                                      |
+|         0x01 |*`cudaGraphicsCubeFaceNegativeX`*              |                                                      |
+|         0x02 |*`cudaGraphicsCubeFacePositiveY`*              |                                                      |
+|         0x03 |*`cudaGraphicsCubeFaceNegativeY`*              |                                                      |
+|         0x04 |*`cudaGraphicsCubeFacePositiveZ`*              |                                                      |
+|         0x05 |*`cudaGraphicsCubeFaceNegativeZ`*              |                                                      |
+| enum         |***`cudaGraphicsMapFlags`***                   |                                                      |
+|            0 |*`cudaGraphicsMapFlagsNone`*                   |                                                      |
+|            1 |*`cudaGraphicsMapFlagsReadOnly`*               |                                                      |
+|            2 |*`cudaGraphicsMapFlagsWriteDiscard`*           |                                                      |
+| enum         |***`cudaGraphicsRegisterFlags`***              |                                                      |
+|            0 |*`cudaGraphicsRegisterFlagsNone`*              |                                                      |
+|            1 |*`cudaGraphicsRegisterFlagsReadOnly`*          |                                                      |
+|            2 |*`cudaGraphicsRegisterFlagsWriteDiscard`*      |                                                      |
+|            4 |*`cudaGraphicsRegisterFlagsSurfaceLoadStore`*  |                                                      |
+|            8 |*`cudaGraphicsRegisterFlagsTextureGather`*     |                                                      |
+| enum         |***`cudaLimit`***                              |***`hipLimit_t`***                                    |
+|         0x00 |*`cudaLimitStackSize`*                         |                                                      |
+|         0x01 |*`cudaLimitPrintfFifoSize`*                    |                                                      |
+|         0x02 |*`cudaLimitMallocHeapSize`*                    |*`hipLimitMallocHeapSize`*                            |
+|         0x03 |*`cudaLimitDevRuntimeSyncDepth`*               |                                                      |
+|         0x04 |*`cudaLimitDevRuntimePendingLaunchCount`*      |                                                      |
+| enum         |***`cudaMemcpyKind`***                         |***`hipMemcpyKind`***                                 |
+|            0 |*`cudaMemcpyHostToHost`*                       |*`hipMemcpyHostToHost`*                               |
+|            1 |*`cudaMemcpyHostToDevice`*                     |*`hipMemcpyHostToDevice`*                             |
+|            2 |*`cudaMemcpyDeviceToHost`*                     |*`hipMemcpyDeviceToHost`*                             |
+|            3 |*`cudaMemcpyDeviceToDevice`*                   |*`hipMemcpyDeviceToDevice`*                           |
+|            4 |*`cudaMemcpyDefault`*                          |*`hipMemcpyDefault`*                                  |
+| enum         |***`cudaMemoryType`***                         |***`hipMemoryType`***                                 |
+|            1 |*`cudaMemoryTypeHost`*                         |*`hipMemoryTypeHost`*                                 |
+|            2 |*`cudaMemoryTypeDevice`*                       |*`hipMemoryTypeDevice`*                               |
+| enum         |***`cudaResourceType`***                       |                                                      |
+|            0 |*`cudaResourceTypeArray`*                      |                                                      |
+|            1 |*`cudaResourceTypeMipmappedArray`*             |                                                      |
+|            2 |*`cudaResourceTypeLinear`*                     |                                                      |
+|            3 |*`cudaResourceTypePitch2D`*                    |                                                      |
+| enum         |***`cudaResourceViewFormat`***                 |                                                      |
+|         0x00 |*`cudaResViewFormatNone`*                      |                                                      |
+|         0x01 |*`cudaResViewFormatUnsignedChar1`*             |                                                      |
+|         0x02 |*`cudaResViewFormatUnsignedChar2`*             |                                                      |
+|         0x03 |*`cudaResViewFormatUnsignedChar4`*             |                                                      |
+|         0x04 |*`cudaResViewFormatSignedChar1`*               |                                                      |
+|         0x05 |*`cudaResViewFormatSignedChar2`*               |                                                      |
+|         0x06 |*`cudaResViewFormatSignedChar4`*               |                                                      |
+|         0x07 |*`cudaResViewFormatUnsignedShort1`*            |                                                      |
+|         0x08 |*`cudaResViewFormatUnsignedShort2`*            |                                                      |
+|         0x09 |*`cudaResViewFormatUnsignedShort4`*            |                                                      |
+|         0x0a |*`cudaResViewFormatSignedShort1`*              |                                                      |
+|         0x0b |*`cudaResViewFormatSignedShort2`*              |                                                      |
+|         0x0c |*`cudaResViewFormatSignedShort4`*              |                                                      |
+|         0x0d |*`cudaResViewFormatUnsignedInt1`*              |                                                      |
+|         0x0e |*`cudaResViewFormatUnsignedInt2`*              |                                                      |
+|         0x0f |*`cudaResViewFormatUnsignedInt4`*              |                                                      |
+|         0x10 |*`cudaResViewFormatSignedInt1`*                |                                                      |
+|         0x11 |*`cudaResViewFormatSignedInt2`*                |                                                      |
+|         0x12 |*`cudaResViewFormatSignedInt4`*                |                                                      |
+|         0x13 |*`cudaResViewFormatHalf1`*                     |                                                      |
+|         0x14 |*`cudaResViewFormatHalf2`*                     |                                                      |
+|         0x15 |*`cudaResViewFormatHalf4`*                     |                                                      |
+|         0x16 |*`cudaResViewFormatFloat1`*                    |                                                      |
+|         0x17 |*`cudaResViewFormatFloat2`*                    |                                                      |
+|         0x18 |*`cudaResViewFormatFloat4`*                    |                                                      |
+|         0x19 |*`cudaResViewFormatUnsignedBlockCompressed1`*  |                                                      |
+|         0x1a |*`cudaResViewFormatUnsignedBlockCompressed2`*  |                                                      |
+|         0x1b |*`cudaResViewFormatUnsignedBlockCompressed3`*  |                                                      |
+|         0x1c |*`cudaResViewFormatUnsignedBlockCompressed4`*  |                                                      |
+|         0x1d |*`cudaResViewFormatSignedBlockCompressed4`*    |                                                      |
+|         0x1e |*`cudaResViewFormatUnsignedBlockCompressed5`*  |                                                      |
+|         0x1f |*`cudaResViewFormatSignedBlockCompressed5`*    |                                                      |
+|         0x20 |*`cudaResViewFormatUnsignedBlockCompressed6H`* |                                                      |
+|         0x21 |*`cudaResViewFormatSignedBlockCompressed6H`*   |                                                      |
+|         0x22 |*`cudaResViewFormatUnsignedBlockCompressed7`*  |                                                      |
+| enum         |***`cudaSharedMemConfig`***                    |***`hipSharedMemConfig`***                            |
+|            0 |*`cudaSharedMemBankSizeDefault`*               |*`hipSharedMemBankSizeDefault`*                       |
+|            1 |*`cudaSharedMemBankSizeFourByte`*              |*`hipSharedMemBankSizeFourByte`*                      |
+|            2 |*`cudaSharedMemBankSizeEightByte`*             |*`hipSharedMemBankSizeEightByte`*                     |
+| enum         |***`cudaSurfaceBoundaryMode`***                |                                                      |
+|            0 |*`cudaBoundaryModeZero`*                       |                                                      |
+|            1 |*`cudaBoundaryModeClamp`*                      |                                                      |
+|            2 |*`cudaBoundaryModeTrap`*                       |                                                      |
+| enum         |***`cudaSurfaceFormatMode`***                  |                                                      |
+|            0 |*`cudaFormatModeForced`*                       |                                                      |
+|            1 |*`cudaFormatModeAuto`*                         |                                                      |
+| enum         |***`cudaTextureAddressMode`***                 |                                                      |
+|            0 |*`cudaAddressModeWrap`*                        |                                                      |
+|            1 |*`cudaAddressModeClamp`*                       |                                                      |
+|            2 |*`cudaAddressModeMirror`*                      |                                                      |
+|            3 |*`cudaAddressModeBorder`*                      |                                                      |
+| enum         |***`cudaTextureFilterMode`***                  |***`hipTextureFilterMode`***                          |
+|            0 |*`cudaFilterModePoint`*                        |*`hipFilterModePoint`*                                |
+|            1 |*`cudaFilterModeLinear`*                       |                                                      |
+| enum         |***`cudaTextureReadMode`***                    |***`hipTextureReadMode`***                            |
+|            0 |*`cudaReadModeElementType`*                    |*`hipReadModeElementType`*                            |
+|            1 |*`cudaReadModeNormalizedFloat`*                |                                                      |
+| enum         |***`cudaGLDeviceList`***                       |                                                      |
+|         0x01 |*`cudaGLDeviceListAll`*                        |                                                      |
+|         0x02 |*`cudaGLDeviceListCurrentFrame`*               |                                                      |
+|         0x03 |*`cudaGLDeviceListNextFrame`*                  |                                                      |
+| enum         |***`cudaGLMapFlags`***                         |                                                      |
+|         0x00 |*`cudaGLMapFlagsNone`*                         |                                                      |
+|         0x01 |*`cudaGLMapFlagsReadOnly`*                     |                                                      |
+|         0x02 |*`cudaGLMapFlagsWriteDiscard`*                 |                                                      |
+| enum         |***`cudaD3D9DeviceList`***                     |                                                      |
+|            1 |*`cudaD3D9DeviceListAll`*                      |                                                      |
+|            2 |*`cudaD3D9DeviceListCurrentFrame`*             |                                                      |
+|            3 |*`cudaD3D9DeviceListNextFrame`*                |                                                      |
+| enum         |***`cudaD3D9MapFlags`***                       |                                                      |
+|            0 |*`cudaD3D9MapFlagsNone`*                       |                                                      |
+|            1 |*`cudaD3D9MapFlagsReadOnly`*                   |                                                      |
+|            2 |*`cudaD3D9MapFlagsWriteDiscard`*               |                                                      |
+| enum         |***`cudaD3D9RegisterFlags`***                  |                                                      |
+|            0 |*`cudaD3D9RegisterFlagsNone`*                  |                                                      |
+|            1 |*`cudaD3D9RegisterFlagsArray`*                 |                                                      |
+| enum         |***`cudaD3D10DeviceList`***                    |                                                      |
+|            1 |*`cudaD3D10DeviceListAll`*                     |                                                      |
+|            2 |*`cudaD3D10DeviceListCurrentFrame`*            |                                                      |
+|            3 |*`cudaD3D10DeviceListNextFrame`*               |                                                      |
+| enum         |***`cudaD3D10MapFlags`***                      |                                                      |
+|            0 |*`cudaD3D10MapFlagsNone`*                      |                                                      |
+|            1 |*`cudaD3D10MapFlagsReadOnly`*                  |                                                      |
+|            2 |*`cudaD3D10MapFlagsWriteDiscard`*              |                                                      |
+| enum         |***`cudaD3D10RegisterFlags`***                 |                                                      |
+|            0 |*`cudaD3D10RegisterFlagsNone`*                 |                                                      |
+|            1 |*`cudaD3D10RegisterFlagsArray`*                |                                                      |
+| enum         |***`cudaD3D11DeviceList`***                    |                                                      |
+|            1 |*`cudaD3D11DeviceListAll`*                     |                                                      |
+|            2 |*`cudaD3D11DeviceListCurrentFrame`*            |                                                      |
+|            3 |*`cudaD3D11DeviceListNextFrame`*               |                                                      |
+| struct       | `cudaArray`                                   | `hipArray`                                           |
+| typedef      | `cudaArray_t`                                 | `hipArray *`                                         |
+| typedef      | `cudaArray_const_t`                           | `const hipArray *`                                   |
+| enum         | `cudaError`                                   | `hipError_t`                                         |
+| typedef      | `cudaError_t`                                 | `hipError_t`                                         |
+| typedef      | `cudaEvent_t`                                 | `hipEvent_t`                                         |
+| typedef      | `cudaGraphicsResource_t`                      |                                                      |
+| typedef      | `cudaMipmappedArray_t`                        |                                                      |
+| typedef      | `cudaMipmappedArray_const_t`                  |                                                      |
+| enum         |***`cudaOutputMode`***                         |                                                      |
+|         0x00 |*`cudaKeyValuePair`*                           |                                                      |
+|         0x01 |*`cudaCSV`*                                    |                                                      |
+| typedef      | `cudaOutputMode_t`                            |                                                      |
+| typedef      | `cudaStream_t`                                | `hipStream_t`                                        |
+| typedef      | `cudaSurfaceObject_t`                         |                                                      |
+| typedef      | `cudaTextureObject_t`                         |                                                      |
+| typedef      | `CUuuid_stcudaUUID_t`                         |                                                      |
+| define       | `CUDA_IPC_HANDLE_SIZE`                        |                                                      |
+| define       | `cudaArrayCubemap`                            |                                                      |
+| define       | `cudaArrayDefault`                            |                                                      |
+| define       | `cudaArrayLayered`                            |                                                      |
+| define       | `cudaArraySurfaceLoadStore`                   |                                                      |
+| define       | `cudaArrayTextureGather`                      |                                                      |
+| define       | `cudaDeviceBlockingSync`                      | `hipDeviceScheduleBlockingSync`                      |
+| define       | `cudaDeviceLmemResizeToMax`                   |                                                      |
+| define       | `cudaDeviceMapHost`                           |                                                      |
+| define       | `cudaDeviceMask`                              |                                                      |
+| define       | `cudaDevicePropDontCare`                      |                                                      |
+| define       | `cudaDeviceScheduleAuto`                      | `hipDeviceScheduleAuto`                              |
+| define       | `cudaDeviceScheduleBlockingSync`              | `hipDeviceScheduleBlockingSync`                      |
+| define       | `cudaDeviceScheduleMask`                      | `hipDeviceScheduleMask`                              |
+| define       | `cudaDeviceScheduleSpin`                      | `hipDeviceScheduleSpin`                              |
+| define       | `cudaDeviceScheduleYield`                     | `hipDeviceScheduleYield`                             |
+| define       | `cudaEventDefault`                            | `hipEventDefault`                                    |
+| define       | `cudaEventDisableTiming`                      | `hipEventDisableTiming`                              |
+| define       | `cudaEventInterprocess`                       | `hipEventInterprocess`                               |
+| define       | `cudaHostAllocDefault`                        | `hipHostMallocDefault`                               |
+| define       | `cudaHostAllocMapped`                         | `hipHostMallocMapped`                                |
+| define       | `cudaHostAllocPortable`                       | `hipHostMallocPortable`                              |
+| define       | `cudaHostAllocWriteCombined`                  | `hipHostMallocWriteCombined`                         |
+| define       | `cudaHostRegisterDefault`                     | `hipHostRegisterDefault`                             |
+| define       | `cudaHostRegisterIoMemory`                    | `hipHostRegisterIoMemory`                            |
+| define       | `cudaHostRegisterMapped`                      | `hipHostRegisterMapped`                              |
+| define       | `cudaHostRegisterPortable`                    | `hipHostRegisterPortable`                            |
+| define       | `cudaIpcMemLazyEnablePeerAccess`              | `hipIpcMemLazyEnablePeerAccess`                      |
+| define       | `cudaMemAttachGlobal`                         |                                                      |
+| define       | `cudaMemAttachHost`                           |                                                      |
+| define       | `cudaMemAttachSingle`                         |                                                      |
+| define       | `cudaOccupancyDefault`                        |                                                      |
+| define       | `cudaOccupancyDisableCachingOverride`         |                                                      |
+| define       | `cudaPeerAccessDefault`                       |                                                      |
+| define       | `cudaStreamDefault`                           | `hipStreamDefault`                                   |
+| define       | `cudaStreamLegacy`                            |                                                      |
+| define       | `cudaStreamNonBlocking`                       | `hipStreamNonBlocking`                               |
+| define       | `cudaStreamPerThread`                         |                                                      |

--- a/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -30,7 +30,18 @@
 | `cudaSetDeviceFlags`                                      | `hipSetDeviceFlags`           | Sets flags to be used for device executions.                                                                                   |
 | `cudaSetValidDevices`                                     |                               | Set a list of devices that can be used for CUDA.                                                                               |
 
-## **2. Error Handling**
+## **2. Thread Management [DEPRECATED]**
+
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cudaThreadExit`                                          | `hipDeviceReset`              | Exit and clean up from CUDA launches.                                                                                          |
+| `cudaThreadGetCacheConfig`                                | `hipDeviceGetCacheConfig`     | Returns the preferred cache configuration for the current device.                                                              |
+| `cudaThreadGetLimit`                                      |                               | Returns resource limits.                                                                                                       |
+| `cudaThreadSetCacheConfig`                                | `hipDeviceSetCacheConfig`     | Sets the preferred cache configuration for the current device.                                                                 |
+| `cudaThreadSetLimit`                                      |                               | Set resource limits.                                                                                                           |
+| `cudaThreadSynchronize`                                   | `hipDeviceSynchronize`        | Wait for compute device to finish.                                                                                             |
+
+## **3. Error Handling**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -39,7 +50,7 @@
 | `cudaGetLastError`                                        | `hipGetLastError`             | Returns the last error from a runtime call.                                                                                    |
 | `cudaPeekAtLastError`                                     | `hipPeekAtLastError`          | Returns the last error from a runtime call.                                                                                    |
 
-## **3. Stream Management**
+## **4. Stream Management**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -55,7 +66,7 @@
 | `cudaStreamSynchronize`                                   | `hipStreamSynchronize`        | Waits for stream tasks to complete.                                                                                            |
 | `cudaStreamWaitEvent`                                     | `hipStreamWaitEvent`          | Make a compute stream wait on an event.                                                                                        |
 
-## **4. Event Management**
+## **5. Event Management**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -67,7 +78,7 @@
 | `cudaEventRecord`                                         | `hipEventRecord`              | Records an event.                                                                                                              |
 | `cudaEventSynchronize`                                    | `hipEventSynchronize`         | Waits for an event to complete.                                                                                                |
 
-## **5. Execution Control**
+## **6. Execution Control**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -80,14 +91,14 @@
 | `cudaSetDoubleForDevice`                                  |                               | Converts a double argument to be executed on a device.                                                                         |
 | `cudaSetDoubleForHost`                                    |                               | Converts a double argument after execution on a device.                                                                        |
 
-## **6. Occupancy**
+## **7. Occupancy**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | `cudaOccupancyMaxActiveBlocksPerMultiprocessor`           | `hipOccupancyMaxActiveBlocksPerMultiprocessor`| Returns occupancy for a device function.                                                                       |
 | `cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`  |                               | Returns occupancy for a device function with the specified flags.                                                              |
 
-## **7. Execution Control [deprecated since 7.0]**
+## **8. Execution Control [deprecated since 7.0]**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -95,7 +106,7 @@
 | `cudaLaunch`                                              |                               | Launches a device function.                                                                                                    |
 | `cudaSetupArgument`                                       |                               | Configure a device launch.                                                                                                     |
 
-## **8. Memory Management**
+## **9. Memory Management**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -155,13 +166,13 @@
 | `make_cudaPitchedPtr`                                     |                               | Returns a cudaPitchedPtr based on input parameters.                                                                            |
 | `make_cudaPos`                                            |                               | Returns a cudaPos based on input parameters.                                                                                   |
 
-## **9. Unified Addressing**
+## **10. Unified Addressing**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | `cudaPointerGetAttributes`                                | `hipPointerGetAttributes`     | Returns attributes about a specified pointer.                                                                                  |
 
-## **10. Peer Device Memory Access**
+## **11. Peer Device Memory Access**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -169,7 +180,7 @@
 | `cudaDeviceDisablePeerAccess`                             | `hipDeviceDisablePeerAccess`  | Disables direct access to memory allocations on a peer device.                                                                 |
 | `cudaDeviceEnablePeerAccess`                              | `hipDeviceEnablePeerAccess`   | Enables direct access to memory allocations on a peer device.                                                                  |
 
-## **11. OpenGL Interoperability**
+## **12. OpenGL Interoperability**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -178,7 +189,109 @@
 | `cudaGraphicsGLRegisterImage`                             |                               | Register an OpenGL texture or renderbuffer object.                                                                             |
 | `cudaWGLGetDevice`                                        |                               | Gets the CUDA device associated with hGpu.                                                                                     |
 
-## **12. Graphics Interoperability**
+## **13. OpenGL Interoperability [DEPRECATED]**
+
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cudaGLMapBufferObject`                                   |                               | Maps a buffer object for access by CUDA.                                                                                       |
+| `cudaGLMapBufferObjectAsync`                              |                               | Maps a buffer object for access by CUDA.                                                                                       |
+| `cudaGLRegisterBufferObject`                              |                               | Registers a buffer object for access by CUDA.                                                                                  |
+| `cudaGLSetBufferObjectMapFlags`                           |                               | Set usage flags for mapping an OpenGL buffer.                                                                                  |
+| `cudaGLSetGLDevice`                                       |                               | Sets a CUDA device to use OpenGL interoperability.                                                                             |
+| `cudaGLUnmapBufferObject`                                 |                               | Unmaps a buffer object for access by CUDA.                                                                                     |
+| `cudaGLUnmapBufferObjectAsync`                            |                               | Unmaps a buffer object for access by CUDA.                                                                                     |
+| `cudaGLUnregisterBufferObject`                            |                               | Unregisters a buffer object for access by CUDA.                                                                                |
+
+## **14. Direct3D 9 Interoperability**
+
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cudaD3D9GetDevice`                                       |                               | Gets the device number for an adapter.                                                                                         |
+| `cudaD3D9GetDevices`                                      |                               | Gets the CUDA devices corresponding to a Direct3D 9 device.                                                                    |
+| `cudaD3D9GetDirect3DDevice`                               |                               | Gets the Direct3D device against which the current CUDA context was created.                                                   |
+| `cudaD3D9SetDirect3DDevice`                               |                               | Sets the Direct3D 9 device to use for interoperability with a CUDA device.                                                     |
+| `cudaGraphicsD3D9RegisterResource`                        |                               | Register a Direct3D 9 resource for access by CUDA.                                                                             |
+
+## **15. Direct3D 9 Interoperability [DEPRECATED]**
+
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cudaD3D9MapResources`                                    |                               | Map Direct3D resources for access by CUDA.                                                                                     |
+| `cudaD3D9RegisterResource`                                |                               | Register a Direct3D resource for access by CUDA.                                                                               |
+| `cudaD3D9ResourceGetMappedArray`                          |                               | Get an array through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.            |
+| `cudaD3D9ResourceGetMappedPitch`                          |                               | Get the pitch of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                |
+| `cudaD3D9ResourceGetMappedPointer`                        |                               | Get the pointer through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.         |
+| `cudaD3D9ResourceGetMappedSize`                           |                               | Get the size of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                 |
+| `cudaD3D9ResourceGetSurfaceDimensions`                    |                               | Get the dimensions of a registered surface.                                                                                    |
+| `cudaD3D9ResourceSetMapFlags`                             |                               | Set usage flags for mapping a Direct3D resource.                                                                               |
+| `cudaD3D9UnmapResources`                                  |                               | Unmaps Direct3D resources.                                                                                                     |
+| `cudaD3D9UnregisterResource`                              |                               | Unregister a Direct3D resource.                                                                                                |
+
+## **16. Direct3D 10 Interoperability**
+
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cudaD3D10GetDevice`                                      |                               | Gets the device number for an adapter.                                                                                         |
+| `cudaD3D10GetDevices`                                     |                               | Gets the CUDA devices corresponding to a Direct3D 10 device.                                                                   |
+| `cudaGraphicsD3D10RegisterResource`                       |                               | Register a Direct3D 10 resource for access by CUDA.                                                                            |
+
+## **17. Direct3D 10 Interoperability [DEPRECATED]**
+
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cudaD3D10GetDirect3DDevice`                              |                               | Gets the Direct3D device against which the current CUDA context was created.                                                   |
+| `cudaD3D10MapResources`                                   |                               | Map Direct3D resources for access by CUDA.                                                                                     |
+| `cudaD3D10RegisterResource`                               |                               | Register a Direct3D resource for access by CUDA.                                                                               |
+| `cudaD3D10ResourceGetMappedArray`                         |                               | Get an array through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.            |
+| `cudaD3D10ResourceGetMappedPitch`                         |                               | Get the pitch of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                |
+| `cudaD3D10ResourceGetMappedPointer`                       |                               | Get the pointer through which to access a subresource of a Direct3D resource which has been mapped for access by CUDA.         |
+| `cudaD3D10ResourceGetMappedSize`                          |                               | Get the size of a subresource of a Direct3D resource which has been mapped for access by CUDA.                                 |
+| `cudaD3D10ResourceGetSurfaceDimensions`                   |                               | Get the dimensions of a registered surface.                                                                                    |
+| `cudaD3D10ResourceSetMapFlags`                            |                               | Set usage flags for mapping a Direct3D resource.                                                                               |
+| `cudaD3D10SetDirect3DDevice`                              |                               | Sets the Direct3D 10 device to use for interoperability with a CUDA device.                                                    |
+| `cudaD3D10UnmapResources`                                 |                               | Unmaps Direct3D resources.                                                                                                     |
+| `cudaD3D10UnregisterResource`                             |                               | Unregister a Direct3D resource.                                                                                                |
+
+## **18. Direct3D 11 Interoperability**
+
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cudaD3D11GetDevice`                                      |                               | Gets the device number for an adapter.                                                                                         |
+| `cudaD3D11GetDevices`                                     |                               | Gets the CUDA devices corresponding to a Direct3D 11 device.                                                                   |
+| `cudaGraphicsD3D11RegisterResource`                       |                               | Register a Direct3D 11 resource for access by CUDA.                                                                            |
+
+## **19. Direct3D 11 Interoperability [DEPRECATED]**
+
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cudaD3D11GetDirect3DDevice`                              |                               | Gets the Direct3D device against which the current CUDA context was created.                                                   |
+| `cudaD3D11SetDirect3DDevice`                              |                               | Sets the Direct3D 11 device to use for interoperability with a CUDA device.                                                    |
+
+## **20. VDPAU Interoperability**
+
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cudaGraphicsVDPAURegisterOutputSurface`                  |                               | Registers a VDPAU VdpOutputSurface object.                                                                                     |
+| `cudaGraphicsVDPAURegisterVideoSurface`                   |                               | Registers a VDPAU VdpVideoSurface object.                                                                                      |
+| `cudaVDPAUGetDevice`                                      |                               | Gets the CUDA device associated with a VDPAU device.                                                                           |
+| `cudaVDPAUSetVDPAUDevice`                                 |                               | Sets a CUDA device to use VDPAU interoperability.                                                                              |
+
+## **21. EGL Interoperability**
+
+|   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
+|-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `cudaEGLStreamConsumerAcquireFrame`                       |                               | Acquire an image frame from the EGLStream with CUDA as a consumer.                                                             |
+| `cudaEGLStreamConsumerConnect`                            |                               | Connect CUDA to EGLStream as a consumer.                                                                                       |
+| `cudaEGLStreamConsumerConnectWithFlags`                   |                               | Connect CUDA to EGLStream as a consumer with given flags.                                                                      |
+| `cudaEGLStreamConsumerReleaseFrame`                       |                               | Releases the last frame acquired from the EGLStream.                                                                           |
+| `cudaEGLStreamProducerConnect`                            |                               | Connect CUDA to EGLStream as a producer.                                                                                       |
+| `cudaEGLStreamProducerDisconnect`                         |                               | Disconnect CUDA as a producer to EGLStream .                                                                                   |
+| `cudaEGLStreamProducerPresentFrame`                       |                               | Present a CUDA eglFrame to the EGLStream with CUDA as a producer.                                                              |
+| `cudaEGLStreamProducerReturnFrame`                        |                               | Return the CUDA eglFrame to the EGLStream last released by the consumer.                                                       |
+| `cudaGraphicsEGLRegisterImage`                            |                               | Registers an EGL image.                                                                                                        |
+| `cudaGraphicsResourceGetMappedEglFrame`                   |                               | Get an eglFrame through which to access a registered EGL graphics resource.                                                    |
+
+## **22. Graphics Interoperability**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -190,7 +303,7 @@
 | `cudaGraphicsUnmapResources`                              |                               | Unmap graphics resources.                                                                                                      |
 | `cudaGraphicsUnregisterResource`                          |                               | Unregisters a graphics resource for access by CUDA.                                                                            |
 
-## **13. Texture Reference Management**
+## **23. Texture Reference Management**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -204,14 +317,14 @@
 | `cudaGetTextureReference`                                 |                               | Get the texture reference associated with a symbol.                                                                            |
 | `cudaUnbindTexture`                                       |                               | Unbinds a texture.                                                                                                             |
 
-## **14. Surface Reference Management**
+## **24. Surface Reference Management**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | `cudaBindSurfaceToArray`                                  |                               | Binds an array to a surface.                                                                                                   |
 | `cudaGetSurfaceReference`                                 |                               | Get the surface reference associated with a symbol.                                                                            |
 
-## **15. Texture Object Management**
+## **25. Texture Object Management**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -221,7 +334,7 @@
 | `cudaGetTextureObjectResourceViewDesc`                    |                               | Returns a texture object's resource view descriptor.                                                                           |
 | `cudaGetTextureObjectTextureDesc`                         |                               | Returns a texture object's texture descriptor.                                                                                 |
 
-## **16. Surface Object Management**
+## **26. Surface Object Management**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -229,14 +342,14 @@
 | `cudaDestroySurfaceObject`                                |                               | Destroys a surface object.                                                                                                     |
 | `cudaGetSurfaceObjectResourceDesc`                        |                               | Returns a surface object's resource descriptor Returns the resource descriptor for the surface object specified by surfObject. |
 
-## **17. Version Management**
+## **27. Version Management**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
 | `cudaDriverGetVersion`                                    | `hipDriverGetVersion`         | Returns the CUDA driver version.                                                                                               |
 | `cudaRuntimeGetVersion`                                   | `hipRuntimeGetVersion`        | Returns the CUDA Runtime version.                                                                                              |
 
-## **18. C++ API Routines**
+## **28. C++ API Routines**
 *(7.0 contains, 7.5 doesn’t)*
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
@@ -270,7 +383,7 @@
 | `cudaStreamAttachMemAsync`                                |                               | Attach memory to a stream asynchronously.                                                                                      |
 | `cudaUnbindTexture`                                       | `hipUnbindTexture`            | Unbinds a texture.                                                                                                             |
 
-## **19. Profiler Control**
+## **30. Profiler Control**
 
 |   **CUDA**                                                |   **HIP**                     | **CUDA description**                                                                                                           |
 |-----------------------------------------------------------|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -280,7 +393,7 @@
 
 # Data types used by CUDA Runtime API and supported by HIP
 
-## **20. Data types**
+## **31. Data types**
 
 | **type**     |   **CUDA**                                    |   **HIP**                                            | **CUDA description**                                                                                                           |
 |-------------:|-----------------------------------------------|------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
@@ -580,6 +693,40 @@
 | enum         |***`cudaTextureReadMode`***                    |***`hipTextureReadMode`***                            | CUDA texture read modes.                                                                                                       |
 |            0 |*`cudaReadModeElementType`*                    |*`hipReadModeElementType`*                            | Read texture as specified element type.                                                                                        |
 |            1 |*`cudaReadModeNormalizedFloat`*                |                                                      | Read texture as normalized float.                                                                                              |
+| enum         |***`cudaGLDeviceList`***                       |                                                      | CUDA devices corresponding to an OpenGL device                                                                                 |
+|         0x01 |*`cudaGLDeviceListAll`*                        |                                                      | The CUDA devices for all GPUs used by the current OpenGL context                                                               |
+|         0x02 |*`cudaGLDeviceListCurrentFrame`*               |                                                      | The CUDA devices for the GPUs used by the current OpenGL context in its currently rendering frame                              |
+|         0x03 |*`cudaGLDeviceListNextFrame`*                  |                                                      | The CUDA devices for the GPUs to be used by the current OpenGL context in the next frame                                       |
+| enum         |***`cudaGLMapFlags`***                         |                                                      | CUDA GL Map Flags                                                                                                              |
+|         0x00 |*`cudaGLMapFlagsNone`*                         |                                                      | Default; Assume resource can be read/written                                                                                   |
+|         0x01 |*`cudaGLMapFlagsReadOnly`*                     |                                                      | CUDA kernels will not write to this resource                                                                                   |
+|         0x02 |*`cudaGLMapFlagsWriteDiscard`*                 |                                                      | CUDA kernels will only write to and will not read from this resource                                                           |
+| enum         |***`cudaD3D9DeviceList`***                     |                                                      | CUDA devices corresponding to a D3D9 device                                                                                    |
+|            1 |*`cudaD3D9DeviceListAll`*                      |                                                      | The CUDA devices for all GPUs used by a D3D9 device                                                                            |
+|            2 |*`cudaD3D9DeviceListCurrentFrame`*             |                                                      | The CUDA devices for the GPUs used by a D3D9 device in its currently rendering frame                                           |
+|            3 |*`cudaD3D9DeviceListNextFrame`*                |                                                      | The CUDA devices for the GPUs to be used by a D3D9 device in the next frame                                                    |
+| enum         |***`cudaD3D9MapFlags`***                       |                                                      | Flags to map or unmap a resource                                                                                               |
+|            0 |*`cudaD3D9MapFlagsNone`*                       |                                                      | Default; Assume resource can be read/written                                                                                   |
+|            1 |*`cudaD3D9MapFlagsReadOnly`*                   |                                                      | CUDA kernels will not write to this resource                                                                                   |
+|            2 |*`cudaD3D9MapFlagsWriteDiscard`*               |                                                      | CUDA kernels will only write to and will not read from this resource                                                           |
+| enum         |***`cudaD3D9RegisterFlags`***                  |                                                      | CUDA D3D9 Register Flags                                                                                                       |
+|            0 |*`cudaD3D9RegisterFlagsNone`*                  |                                                      | Default; Resource can be accessed througa void*                                                                                |
+|            1 |*`cudaD3D9RegisterFlagsArray`*                 |                                                      | Resource can be accessed through a CUarray*                                                                                    |
+| enum         |***`cudaD3D10DeviceList`***                    |                                                      | CUDA devices corresponding to a D3D10 device                                                                                   |
+|            1 |*`cudaD3D10DeviceListAll`*                     |                                                      | The CUDA devices for all GPUs used by a D3D10 device                                                                           |
+|            2 |*`cudaD3D10DeviceListCurrentFrame`*            |                                                      | The CUDA devices for the GPUs used by a D3D10 device in its currently rendering frame                                          |
+|            3 |*`cudaD3D10DeviceListNextFrame`*               |                                                      | The CUDA devices for the GPUs to be used by a D3D10 device in the next frame                                                   |
+| enum         |***`cudaD3D10MapFlags`***                      |                                                      | Flags to map or unmap a resource                                                                                               |
+|            0 |*`cudaD3D10MapFlagsNone`*                      |                                                      | Default; Assume resource can be read/written                                                                                   |
+|            1 |*`cudaD3D10MapFlagsReadOnly`*                  |                                                      | CUDA kernels will not write to this resource                                                                                   |
+|            2 |*`cudaD3D10MapFlagsWriteDiscard`*              |                                                      | CUDA kernels will only write to and will not read from this resource                                                           |
+| enum         |***`cudaD3D10RegisterFlags`***                 |                                                      | CUDA D3D10 Register Flags                                                                                                      |
+|            0 |*`cudaD3D10RegisterFlagsNone`*                 |                                                      | Default; Resource can be accessed througa void*                                                                                |
+|            1 |*`cudaD3D10RegisterFlagsArray`*                |                                                      | Resource can be accessed through a CUarray*                                                                                    |
+| enum         |***`cudaD3D11DeviceList`***                    |                                                      | CUDA devices corresponding to a D3D11 device                                                                                   |
+|            1 |*`cudaD3D11DeviceListAll`*                     |                                                      | The CUDA devices for all GPUs used by a D3D11 device                                                                           |
+|            2 |*`cudaD3D11DeviceListCurrentFrame`*            |                                                      | The CUDA devices for the GPUs used by a D3D11 device in its currently rendering frame                                          |
+|            3 |*`cudaD3D11DeviceListNextFrame`*               |                                                      | The CUDA devices for the GPUs to be used by a D3D11 device in the next frame                                                   |
 | struct       | `cudaArray`                                   | `hipArray`                                           | CUDA array [opaque].                                                                                                           |
 | typedef      | `cudaArray_t`                                 | `hipArray *`                                         | CUDA array pointer.                                                                                                            |
 | typedef      | `cudaArray_const_t`                           | `const hipArray *`                                   | CUDA array (as source copy argument).                                                                                          |

--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -61,8 +61,9 @@ using namespace llvm;
 #define HIP_UNSUPPORTED -1
 
 enum ConvTypes {
-  CONV_DRIVER = 0,
-  CONV_DEV,
+  CONV_VERSION = 0,
+  CONV_INIT,
+  CONV_DEVICE,
   CONV_MEM,
   CONV_KERN,
   CONV_COORD_FUNC,
@@ -72,16 +73,23 @@ enum ConvTypes {
   CONV_EVENT,
   CONV_OCCUPANCY,
   CONV_CONTEXT,
+  CONV_PEER,
   CONV_MODULE,
   CONV_CACHE,
   CONV_EXEC,
-  CONV_ERR,
+  CONV_ERROR,
   CONV_DEF,
   CONV_TEX,
   CONV_GL,
   CONV_GRAPHICS,
   CONV_SURFACE,
   CONV_JIT,
+  CONV_D3D9,
+  CONV_D3D10,
+  CONV_D3D11,
+  CONV_VDPAU,
+  CONV_EGL,
+  CONV_THREAD,
   CONV_OTHER,
   CONV_INCLUDE,
   CONV_INCLUDE_CUDA_MAIN_H,
@@ -92,11 +100,12 @@ enum ConvTypes {
 };
 
 const char *counterNames[CONV_LAST] = {
-    "driver",       "dev",     "mem",   "kern",      "coord_func", "math_func",
-    "special_func", "stream",  "event", "occupancy", "ctx",        "module",
-    "cache",        "exec",    "err",   "def",       "tex",        "gl",
-    "graphics",     "surface", "jit",   "other",     "include",    "include_cuda_main_header",
-    "type",         "literal", "numeric_literal"};
+    "version",      "init",     "device",  "mem",       "kern",        "coord_func", "math_func",
+    "special_func", "stream",   "event",   "occupancy", "ctx",         "peer",       "module",
+    "cache",        "exec",     "err",     "def",       "tex",         "gl",         "graphics",
+    "surface",      "jit",      "d3d9",    "d3d10",     "d3d11",       "vdpau",      "egl",
+    "thread",       "other",    "include", "include_cuda_main_header", "type",       "literal",
+    "numeric_literal"};
 
 enum ApiTypes {
   API_DRIVER = 0,
@@ -196,199 +205,199 @@ struct cuda2hipMap {
     cuda2hipRename["cudaError"]                                 = {"hipError_t", CONV_TYPE, API_RUNTIME};
 
     // CUDA Driver API error codes only
-    cuda2hipRename["CUDA_ERROR_INVALID_CONTEXT"]                = {"hipErrorInvalidContext", CONV_ERR, API_DRIVER};                                 // 201
-    cuda2hipRename["CUDA_ERROR_CONTEXT_ALREADY_CURRENT"]        = {"hipErrorContextAlreadyCurrent", CONV_ERR, API_DRIVER};                          // 202
-    cuda2hipRename["CUDA_ERROR_ARRAY_IS_MAPPED"]                = {"hipErrorArrayIsMapped", CONV_ERR, API_DRIVER};                                  // 207
-    cuda2hipRename["CUDA_ERROR_ALREADY_MAPPED"]                 = {"hipErrorAlreadyMapped", CONV_ERR, API_DRIVER};                                  // 208
-    cuda2hipRename["CUDA_ERROR_ALREADY_ACQUIRED"]               = {"hipErrorAlreadyAcquired", CONV_ERR, API_DRIVER};                                // 210
-    cuda2hipRename["CUDA_ERROR_NOT_MAPPED"]                     = {"hipErrorNotMapped", CONV_ERR, API_DRIVER};                                      // 211
-    cuda2hipRename["CUDA_ERROR_NOT_MAPPED_AS_ARRAY"]            = {"hipErrorNotMappedAsArray", CONV_ERR, API_DRIVER};                               // 212
-    cuda2hipRename["CUDA_ERROR_NOT_MAPPED_AS_POINTER"]          = {"hipErrorNotMappedAsPointer", CONV_ERR, API_DRIVER};                             // 213
-    cuda2hipRename["CUDA_ERROR_CONTEXT_ALREADY_IN_USE"]         = {"hipErrorContextAlreadyInUse", CONV_ERR, API_DRIVER};                            // 216
-    cuda2hipRename["CUDA_ERROR_INVALID_SOURCE"]                 = {"hipErrorInvalidSource", CONV_ERR, API_DRIVER};                                  // 300
-    cuda2hipRename["CUDA_ERROR_FILE_NOT_FOUND"]                 = {"hipErrorFileNotFound", CONV_ERR, API_DRIVER};                                   // 301
-    cuda2hipRename["CUDA_ERROR_NOT_FOUND"]                      = {"hipErrorNotFound", CONV_ERR, API_DRIVER};                                       // 500
-    cuda2hipRename["CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING"]  = {"hipErrorLaunchIncompatibleTexturing", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};   // 703
-    cuda2hipRename["CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE"]         = {"hipErrorPrimaryContextActive", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};          // 708
-    cuda2hipRename["CUDA_ERROR_CONTEXT_IS_DESTROYED"]           = {"hipErrorContextIsDestroyed", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};            // 709
-    cuda2hipRename["CUDA_ERROR_NOT_PERMITTED"]                  = {"hipErrorNotPermitted", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};                  // 800
-    cuda2hipRename["CUDA_ERROR_NOT_SUPPORTED"]                  = {"hipErrorNotSupported", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};                  // 801
+    cuda2hipRename["CUDA_ERROR_INVALID_CONTEXT"]                = {"hipErrorInvalidContext", CONV_TYPE, API_DRIVER};                                 // 201
+    cuda2hipRename["CUDA_ERROR_CONTEXT_ALREADY_CURRENT"]        = {"hipErrorContextAlreadyCurrent", CONV_TYPE, API_DRIVER};                          // 202
+    cuda2hipRename["CUDA_ERROR_ARRAY_IS_MAPPED"]                = {"hipErrorArrayIsMapped", CONV_TYPE, API_DRIVER};                                  // 207
+    cuda2hipRename["CUDA_ERROR_ALREADY_MAPPED"]                 = {"hipErrorAlreadyMapped", CONV_TYPE, API_DRIVER};                                  // 208
+    cuda2hipRename["CUDA_ERROR_ALREADY_ACQUIRED"]               = {"hipErrorAlreadyAcquired", CONV_TYPE, API_DRIVER};                                // 210
+    cuda2hipRename["CUDA_ERROR_NOT_MAPPED"]                     = {"hipErrorNotMapped", CONV_TYPE, API_DRIVER};                                      // 211
+    cuda2hipRename["CUDA_ERROR_NOT_MAPPED_AS_ARRAY"]            = {"hipErrorNotMappedAsArray", CONV_TYPE, API_DRIVER};                               // 212
+    cuda2hipRename["CUDA_ERROR_NOT_MAPPED_AS_POINTER"]          = {"hipErrorNotMappedAsPointer", CONV_TYPE, API_DRIVER};                             // 213
+    cuda2hipRename["CUDA_ERROR_CONTEXT_ALREADY_IN_USE"]         = {"hipErrorContextAlreadyInUse", CONV_TYPE, API_DRIVER};                            // 216
+    cuda2hipRename["CUDA_ERROR_INVALID_SOURCE"]                 = {"hipErrorInvalidSource", CONV_TYPE, API_DRIVER};                                  // 300
+    cuda2hipRename["CUDA_ERROR_FILE_NOT_FOUND"]                 = {"hipErrorFileNotFound", CONV_TYPE, API_DRIVER};                                   // 301
+    cuda2hipRename["CUDA_ERROR_NOT_FOUND"]                      = {"hipErrorNotFound", CONV_TYPE, API_DRIVER};                                       // 500
+    cuda2hipRename["CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING"]  = {"hipErrorLaunchIncompatibleTexturing", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};   // 703
+    cuda2hipRename["CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE"]         = {"hipErrorPrimaryContextActive", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};          // 708
+    cuda2hipRename["CUDA_ERROR_CONTEXT_IS_DESTROYED"]           = {"hipErrorContextIsDestroyed", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};            // 709
+    cuda2hipRename["CUDA_ERROR_NOT_PERMITTED"]                  = {"hipErrorNotPermitted", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                  // 800
+    cuda2hipRename["CUDA_ERROR_NOT_SUPPORTED"]                  = {"hipErrorNotSupported", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                  // 801
 
     // CUDA RT API error code only
-    cuda2hipRename["cudaErrorMissingConfiguration"]             = {"hipErrorMissingConfiguration", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};         // 1
-    cuda2hipRename["cudaErrorPriorLaunchFailure"]               = {"hipErrorPriorLaunchFailure", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};           // 5
-    cuda2hipRename["cudaErrorInvalidDeviceFunction"]            = {"hipErrorInvalidDeviceFunction", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};        // 8
-    cuda2hipRename["cudaErrorInvalidConfiguration"]             = {"hipErrorInvalidConfiguration", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};         // 9
-    cuda2hipRename["cudaErrorInvalidPitchValue"]                = {"hipErrorInvalidPitchValue", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};            // 12
-    cuda2hipRename["cudaErrorInvalidSymbol"]                    = {"hipErrorInvalidSymbol", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};                // 13
-    cuda2hipRename["cudaErrorInvalidHostPointer"]               = {"hipErrorInvalidHostPointer", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};           // 16
-    cuda2hipRename["cudaErrorInvalidDevicePointer"]             = {"hipErrorInvalidDevicePointer", CONV_ERR, API_RUNTIME};                          // 17
-    cuda2hipRename["cudaErrorInvalidTexture"]                   = {"hipErrorInvalidTexture", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};               // 18
-    cuda2hipRename["cudaErrorInvalidTextureBinding"]            = {"hipErrorInvalidTextureBinding", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};        // 19
-    cuda2hipRename["cudaErrorInvalidChannelDescriptor"]         = {"hipErrorInvalidChannelDescriptor", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};     // 20
-    cuda2hipRename["cudaErrorInvalidMemcpyDirection"]           = {"hipErrorInvalidMemcpyDirection", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};       // 21
-    cuda2hipRename["cudaErrorAddressOfConstant"]                = {"hipErrorAddressOfConstant", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};            // 22
-    cuda2hipRename["cudaErrorTextureFetchFailed"]               = {"hipErrorTextureFetchFailed", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};           // 23
-    cuda2hipRename["cudaErrorTextureNotBound"]                  = {"hipErrorTextureNotBound", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};              // 24
-    cuda2hipRename["cudaErrorSynchronizationError"]             = {"hipErrorSynchronizationError", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};         // 25
-    cuda2hipRename["cudaErrorInvalidFilterSetting"]             = {"hipErrorInvalidFilterSetting", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};         // 26
-    cuda2hipRename["cudaErrorInvalidNormSetting"]               = {"hipErrorInvalidNormSetting", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};           // 27
-    cuda2hipRename["cudaErrorMixedDeviceExecution"]             = {"hipErrorMixedDeviceExecution", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};         // 28
+    cuda2hipRename["cudaErrorMissingConfiguration"]             = {"hipErrorMissingConfiguration", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 1
+    cuda2hipRename["cudaErrorPriorLaunchFailure"]               = {"hipErrorPriorLaunchFailure", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 5
+    cuda2hipRename["cudaErrorInvalidDeviceFunction"]            = {"hipErrorInvalidDeviceFunction", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};        // 8
+    cuda2hipRename["cudaErrorInvalidConfiguration"]             = {"hipErrorInvalidConfiguration", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 9
+    cuda2hipRename["cudaErrorInvalidPitchValue"]                = {"hipErrorInvalidPitchValue", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};            // 12
+    cuda2hipRename["cudaErrorInvalidSymbol"]                    = {"hipErrorInvalidSymbol", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                // 13
+    cuda2hipRename["cudaErrorInvalidHostPointer"]               = {"hipErrorInvalidHostPointer", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 16
+    cuda2hipRename["cudaErrorInvalidDevicePointer"]             = {"hipErrorInvalidDevicePointer", CONV_TYPE, API_RUNTIME};                          // 17
+    cuda2hipRename["cudaErrorInvalidTexture"]                   = {"hipErrorInvalidTexture", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};               // 18
+    cuda2hipRename["cudaErrorInvalidTextureBinding"]            = {"hipErrorInvalidTextureBinding", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};        // 19
+    cuda2hipRename["cudaErrorInvalidChannelDescriptor"]         = {"hipErrorInvalidChannelDescriptor", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};     // 20
+    cuda2hipRename["cudaErrorInvalidMemcpyDirection"]           = {"hipErrorInvalidMemcpyDirection", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};       // 21
+    cuda2hipRename["cudaErrorAddressOfConstant"]                = {"hipErrorAddressOfConstant", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};            // 22
+    cuda2hipRename["cudaErrorTextureFetchFailed"]               = {"hipErrorTextureFetchFailed", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 23
+    cuda2hipRename["cudaErrorTextureNotBound"]                  = {"hipErrorTextureNotBound", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};              // 24
+    cuda2hipRename["cudaErrorSynchronizationError"]             = {"hipErrorSynchronizationError", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 25
+    cuda2hipRename["cudaErrorInvalidFilterSetting"]             = {"hipErrorInvalidFilterSetting", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 26
+    cuda2hipRename["cudaErrorInvalidNormSetting"]               = {"hipErrorInvalidNormSetting", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 27
+    cuda2hipRename["cudaErrorMixedDeviceExecution"]             = {"hipErrorMixedDeviceExecution", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 28
     // Deprecated as of CUDA 4.1
-    cuda2hipRename["cudaErrorNotYetImplemented"]                = {"hipErrorNotYetImplemented", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};            // 31
+    cuda2hipRename["cudaErrorNotYetImplemented"]                = {"hipErrorNotYetImplemented", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};            // 31
     // Deprecated as of CUDA 3.1
-    cuda2hipRename["cudaErrorMemoryValueTooLarge"]              = {"hipErrorMemoryValueTooLarge", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};          // 32
-    cuda2hipRename["cudaErrorInsufficientDriver"]               = {"hipErrorInsufficientDriver", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};           // 35
-    cuda2hipRename["cudaErrorSetOnActiveProcess"]               = {"hipErrorSetOnActiveProcess", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};           // 36
-    cuda2hipRename["cudaErrorInvalidSurface"]                   = {"hipErrorInvalidSurface", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};               // 37
-    cuda2hipRename["cudaErrorDuplicateVariableName"]            = {"hipErrorDuplicateVariableName", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};        // 43
-    cuda2hipRename["cudaErrorDuplicateTextureName"]             = {"hipErrorDuplicateTextureName", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};         // 44
-    cuda2hipRename["cudaErrorDuplicateSurfaceName"]             = {"hipErrorDuplicateSurfaceName", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};         // 45
-    cuda2hipRename["cudaErrorDevicesUnavailable"]               = {"hipErrorDevicesUnavailable", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};           // 46
-    cuda2hipRename["cudaErrorIncompatibleDriverContext"]        = {"hipErrorIncompatibleDriverContext", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};    // 49
-    cuda2hipRename["cudaErrorDeviceAlreadyInUse"]               = {"hipErrorDeviceAlreadyInUse", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};           // 54
-    cuda2hipRename["cudaErrorLaunchMaxDepthExceeded"]           = {"hipErrorLaunchMaxDepthExceeded", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};       // 65
-    cuda2hipRename["cudaErrorLaunchFileScopedTex"]              = {"hipErrorLaunchFileScopedTex", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};          // 66
-    cuda2hipRename["cudaErrorLaunchFileScopedSurf"]             = {"hipErrorLaunchFileScopedSurf", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};         // 67
-    cuda2hipRename["cudaErrorSyncDepthExceeded"]                = {"hipErrorSyncDepthExceeded", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};            // 68
-    cuda2hipRename["cudaErrorLaunchPendingCountExceeded"]       = {"hipErrorLaunchPendingCountExceeded", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};   // 69
-    cuda2hipRename["cudaErrorNotPermitted"]                     = {"hipErrorNotPermitted", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};                 // 70
-    cuda2hipRename["cudaErrorNotSupported"]                     = {"hipErrorNotSupported", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};                 // 71
-    cuda2hipRename["cudaErrorStartupFailure"]                   = {"hipErrorStartupFailure", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};               // 0x7f
+    cuda2hipRename["cudaErrorMemoryValueTooLarge"]              = {"hipErrorMemoryValueTooLarge", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};          // 32
+    cuda2hipRename["cudaErrorInsufficientDriver"]               = {"hipErrorInsufficientDriver", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 35
+    cuda2hipRename["cudaErrorSetOnActiveProcess"]               = {"hipErrorSetOnActiveProcess", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 36
+    cuda2hipRename["cudaErrorInvalidSurface"]                   = {"hipErrorInvalidSurface", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};               // 37
+    cuda2hipRename["cudaErrorDuplicateVariableName"]            = {"hipErrorDuplicateVariableName", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};        // 43
+    cuda2hipRename["cudaErrorDuplicateTextureName"]             = {"hipErrorDuplicateTextureName", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 44
+    cuda2hipRename["cudaErrorDuplicateSurfaceName"]             = {"hipErrorDuplicateSurfaceName", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 45
+    cuda2hipRename["cudaErrorDevicesUnavailable"]               = {"hipErrorDevicesUnavailable", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 46
+    cuda2hipRename["cudaErrorIncompatibleDriverContext"]        = {"hipErrorIncompatibleDriverContext", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};    // 49
+    cuda2hipRename["cudaErrorDeviceAlreadyInUse"]               = {"hipErrorDeviceAlreadyInUse", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 54
+    cuda2hipRename["cudaErrorLaunchMaxDepthExceeded"]           = {"hipErrorLaunchMaxDepthExceeded", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};       // 65
+    cuda2hipRename["cudaErrorLaunchFileScopedTex"]              = {"hipErrorLaunchFileScopedTex", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};          // 66
+    cuda2hipRename["cudaErrorLaunchFileScopedSurf"]             = {"hipErrorLaunchFileScopedSurf", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 67
+    cuda2hipRename["cudaErrorSyncDepthExceeded"]                = {"hipErrorSyncDepthExceeded", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};            // 68
+    cuda2hipRename["cudaErrorLaunchPendingCountExceeded"]       = {"hipErrorLaunchPendingCountExceeded", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};   // 69
+    cuda2hipRename["cudaErrorNotPermitted"]                     = {"hipErrorNotPermitted", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 70
+    cuda2hipRename["cudaErrorNotSupported"]                     = {"hipErrorNotSupported", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 71
+    cuda2hipRename["cudaErrorStartupFailure"]                   = {"hipErrorStartupFailure", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};               // 0x7f
     // Deprecated as of CUDA 4.1
-    cuda2hipRename["cudaErrorApiFailureBase"]                   = {"hipErrorApiFailureBase", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};               // 10000
+    cuda2hipRename["cudaErrorApiFailureBase"]                   = {"hipErrorApiFailureBase", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};               // 10000
 
-    cuda2hipRename["CUDA_SUCCESS"]                              = {"hipSuccess", CONV_ERR, API_DRIVER};                                             // 0
-    cuda2hipRename["cudaSuccess"]                               = {"hipSuccess", CONV_ERR, API_RUNTIME};                                            // 0
+    cuda2hipRename["CUDA_SUCCESS"]                              = {"hipSuccess", CONV_TYPE, API_DRIVER};                                             // 0
+    cuda2hipRename["cudaSuccess"]                               = {"hipSuccess", CONV_TYPE, API_RUNTIME};                                            // 0
 
-    cuda2hipRename["CUDA_ERROR_INVALID_VALUE"]                  = {"hipErrorInvalidValue", CONV_ERR, API_DRIVER};                                   // 1
-    cuda2hipRename["cudaErrorInvalidValue"]                     = {"hipErrorInvalidValue", CONV_ERR, API_RUNTIME};                                  // 11
+    cuda2hipRename["CUDA_ERROR_INVALID_VALUE"]                  = {"hipErrorInvalidValue", CONV_TYPE, API_DRIVER};                                   // 1
+    cuda2hipRename["cudaErrorInvalidValue"]                     = {"hipErrorInvalidValue", CONV_TYPE, API_RUNTIME};                                  // 11
 
-    cuda2hipRename["CUDA_ERROR_OUT_OF_MEMORY"]                  = {"hipErrorMemoryAllocation", CONV_ERR, API_DRIVER};                               // 2
-    cuda2hipRename["cudaErrorMemoryAllocation"]                 = {"hipErrorMemoryAllocation", CONV_ERR, API_RUNTIME};                              // 2
+    cuda2hipRename["CUDA_ERROR_OUT_OF_MEMORY"]                  = {"hipErrorMemoryAllocation", CONV_TYPE, API_DRIVER};                               // 2
+    cuda2hipRename["cudaErrorMemoryAllocation"]                 = {"hipErrorMemoryAllocation", CONV_TYPE, API_RUNTIME};                              // 2
 
-    cuda2hipRename["CUDA_ERROR_NOT_INITIALIZED"]                = {"hipErrorNotInitialized", CONV_ERR, API_DRIVER};                                 // 3
-    cuda2hipRename["cudaErrorInitializationError"]              = {"hipErrorInitializationError", CONV_ERR, API_RUNTIME};                           // 3
+    cuda2hipRename["CUDA_ERROR_NOT_INITIALIZED"]                = {"hipErrorNotInitialized", CONV_TYPE, API_DRIVER};                                 // 3
+    cuda2hipRename["cudaErrorInitializationError"]              = {"hipErrorInitializationError", CONV_TYPE, API_RUNTIME};                           // 3
 
-    cuda2hipRename["CUDA_ERROR_DEINITIALIZED"]                  = {"hipErrorDeinitialized", CONV_ERR, API_DRIVER};                                  // 4
+    cuda2hipRename["CUDA_ERROR_DEINITIALIZED"]                  = {"hipErrorDeinitialized", CONV_TYPE, API_DRIVER};                                  // 4
     // TODO: double check, that these errors match
-    cuda2hipRename["cudaErrorCudartUnloading"]                  = {"hipErrorDeinitialized", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};                // 29
+    cuda2hipRename["cudaErrorCudartUnloading"]                  = {"hipErrorDeinitialized", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                // 29
 
-    cuda2hipRename["CUDA_ERROR_PROFILER_DISABLED"]              = {"hipErrorProfilerDisabled", CONV_ERR, API_DRIVER};                               // 5
-    cuda2hipRename["cudaErrorProfilerDisabled"]                 = {"hipErrorProfilerDisabled", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};             // 55
+    cuda2hipRename["CUDA_ERROR_PROFILER_DISABLED"]              = {"hipErrorProfilerDisabled", CONV_TYPE, API_DRIVER};                               // 5
+    cuda2hipRename["cudaErrorProfilerDisabled"]                 = {"hipErrorProfilerDisabled", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};             // 55
 
-    cuda2hipRename["CUDA_ERROR_PROFILER_NOT_INITIALIZED"]       = {"hipErrorProfilerNotInitialized", CONV_ERR, API_DRIVER};                         // 6
+    cuda2hipRename["CUDA_ERROR_PROFILER_NOT_INITIALIZED"]       = {"hipErrorProfilerNotInitialized", CONV_TYPE, API_DRIVER};                         // 6
     // Deprecated as of CUDA 5.0
-    cuda2hipRename["cudaErrorProfilerNotInitialized"]           = {"hipErrorProfilerNotInitialized", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};       // 56
+    cuda2hipRename["cudaErrorProfilerNotInitialized"]           = {"hipErrorProfilerNotInitialized", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};       // 56
 
-    cuda2hipRename["CUDA_ERROR_PROFILER_ALREADY_STARTED"]       = {"hipErrorProfilerAlreadyStarted", CONV_ERR, API_DRIVER};                         // 7
+    cuda2hipRename["CUDA_ERROR_PROFILER_ALREADY_STARTED"]       = {"hipErrorProfilerAlreadyStarted", CONV_TYPE, API_DRIVER};                         // 7
     // Deprecated as of CUDA 5.0
-    cuda2hipRename["cudaErrorProfilerAlreadyStarted"]           = {"hipErrorProfilerAlreadyStarted", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};       // 57
+    cuda2hipRename["cudaErrorProfilerAlreadyStarted"]           = {"hipErrorProfilerAlreadyStarted", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};       // 57
 
-    cuda2hipRename["CUDA_ERROR_PROFILER_ALREADY_STOPPED"]       = {"hipErrorProfilerAlreadyStopped", CONV_ERR, API_DRIVER};                         // 8
+    cuda2hipRename["CUDA_ERROR_PROFILER_ALREADY_STOPPED"]       = {"hipErrorProfilerAlreadyStopped", CONV_TYPE, API_DRIVER};                         // 8
     // Deprecated as of CUDA 5.0
-    cuda2hipRename["cudaErrorProfilerAlreadyStopped"]           = {"hipErrorProfilerAlreadyStopped", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};       // 58
+    cuda2hipRename["cudaErrorProfilerAlreadyStopped"]           = {"hipErrorProfilerAlreadyStopped", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};       // 58
 
-    cuda2hipRename["CUDA_ERROR_NO_DEVICE"]                      = {"hipErrorNoDevice", CONV_ERR, API_DRIVER};                                       // 100
-    cuda2hipRename["cudaErrorNoDevice"]                         = {"hipErrorNoDevice", CONV_ERR, API_RUNTIME};                                      // 38
+    cuda2hipRename["CUDA_ERROR_NO_DEVICE"]                      = {"hipErrorNoDevice", CONV_TYPE, API_DRIVER};                                       // 100
+    cuda2hipRename["cudaErrorNoDevice"]                         = {"hipErrorNoDevice", CONV_TYPE, API_RUNTIME};                                      // 38
 
-    cuda2hipRename["CUDA_ERROR_INVALID_DEVICE"]                 = {"hipErrorInvalidDevice", CONV_ERR, API_DRIVER};                                  // 101
-    cuda2hipRename["cudaErrorInvalidDevice"]                    = {"hipErrorInvalidDevice", CONV_ERR, API_RUNTIME};                                 // 10
+    cuda2hipRename["CUDA_ERROR_INVALID_DEVICE"]                 = {"hipErrorInvalidDevice", CONV_TYPE, API_DRIVER};                                  // 101
+    cuda2hipRename["cudaErrorInvalidDevice"]                    = {"hipErrorInvalidDevice", CONV_TYPE, API_RUNTIME};                                 // 10
 
-    cuda2hipRename["CUDA_ERROR_INVALID_IMAGE"]                  = {"hipErrorInvalidImage", CONV_ERR, API_DRIVER};                                   // 200
-    cuda2hipRename["cudaErrorInvalidKernelImage"]               = {"hipErrorInvalidImage", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};                 // 47
+    cuda2hipRename["CUDA_ERROR_INVALID_IMAGE"]                  = {"hipErrorInvalidImage", CONV_TYPE, API_DRIVER};                                   // 200
+    cuda2hipRename["cudaErrorInvalidKernelImage"]               = {"hipErrorInvalidImage", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 47
 
-    cuda2hipRename["CUDA_ERROR_MAP_FAILED"]                     = {"hipErrorMapFailed", CONV_ERR, API_DRIVER};                                      // 205
+    cuda2hipRename["CUDA_ERROR_MAP_FAILED"]                     = {"hipErrorMapFailed", CONV_TYPE, API_DRIVER};                                      // 205
     // TODO: double check, that these errors match
-    cuda2hipRename["cudaErrorMapBufferObjectFailed"]            = {"hipErrorMapFailed", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};                    // 14
+    cuda2hipRename["cudaErrorMapBufferObjectFailed"]            = {"hipErrorMapFailed", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                    // 14
 
-    cuda2hipRename["CUDA_ERROR_UNMAP_FAILED"]                   = {"hipErrorUnmapFailed", CONV_ERR, API_DRIVER};                                    // 206
+    cuda2hipRename["CUDA_ERROR_UNMAP_FAILED"]                   = {"hipErrorUnmapFailed", CONV_TYPE, API_DRIVER};                                    // 206
     // TODO: double check, that these errors match
-    cuda2hipRename["cudaErrorUnmapBufferObjectFailed"]          = {"hipErrorUnmapFailed", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};                  // 15
+    cuda2hipRename["cudaErrorUnmapBufferObjectFailed"]          = {"hipErrorUnmapFailed", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                  // 15
 
-    cuda2hipRename["CUDA_ERROR_NO_BINARY_FOR_GPU"]              = {"hipErrorNoBinaryForGpu", CONV_ERR, API_DRIVER};                                 // 209
-    cuda2hipRename["cudaErrorNoKernelImageForDevice"]           = {"hipErrorNoBinaryForGpu", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};               // 48
+    cuda2hipRename["CUDA_ERROR_NO_BINARY_FOR_GPU"]              = {"hipErrorNoBinaryForGpu", CONV_TYPE, API_DRIVER};                                 // 209
+    cuda2hipRename["cudaErrorNoKernelImageForDevice"]           = {"hipErrorNoBinaryForGpu", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};               // 48
 
-    cuda2hipRename["CUDA_ERROR_ECC_UNCORRECTABLE"]              = {"hipErrorECCNotCorrectable", CONV_ERR, API_DRIVER};                              // 214
-    cuda2hipRename["cudaErrorECCUncorrectable"]                 = {"hipErrorECCNotCorrectable", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};            // 39
+    cuda2hipRename["CUDA_ERROR_ECC_UNCORRECTABLE"]              = {"hipErrorECCNotCorrectable", CONV_TYPE, API_DRIVER};                              // 214
+    cuda2hipRename["cudaErrorECCUncorrectable"]                 = {"hipErrorECCNotCorrectable", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};            // 39
 
-    cuda2hipRename["CUDA_ERROR_UNSUPPORTED_LIMIT"]              = {"hipErrorUnsupportedLimit", CONV_ERR, API_DRIVER};                               // 215
-    cuda2hipRename["cudaErrorUnsupportedLimit"]                 = {"hipErrorUnsupportedLimit", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};             // 42
+    cuda2hipRename["CUDA_ERROR_UNSUPPORTED_LIMIT"]              = {"hipErrorUnsupportedLimit", CONV_TYPE, API_DRIVER};                               // 215
+    cuda2hipRename["cudaErrorUnsupportedLimit"]                 = {"hipErrorUnsupportedLimit", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};             // 42
 
-    cuda2hipRename["CUDA_ERROR_PEER_ACCESS_UNSUPPORTED"]        = {"hipErrorPeerAccessUnsupported", CONV_ERR, API_DRIVER};                          // 217
-    cuda2hipRename["cudaErrorPeerAccessUnsupported"]            = {"hipErrorPeerAccessUnsupported", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};        // 64
+    cuda2hipRename["CUDA_ERROR_PEER_ACCESS_UNSUPPORTED"]        = {"hipErrorPeerAccessUnsupported", CONV_TYPE, API_DRIVER};                          // 217
+    cuda2hipRename["cudaErrorPeerAccessUnsupported"]            = {"hipErrorPeerAccessUnsupported", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};        // 64
 
-    cuda2hipRename["CUDA_ERROR_INVALID_PTX"]                    = {"hipErrorInvalidKernelFile", CONV_ERR, API_DRIVER};                              // 218
-    cuda2hipRename["cudaErrorInvalidPtx"]                       = {"hipErrorInvalidKernelFile", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};            // 78
+    cuda2hipRename["CUDA_ERROR_INVALID_PTX"]                    = {"hipErrorInvalidKernelFile", CONV_TYPE, API_DRIVER};                              // 218
+    cuda2hipRename["cudaErrorInvalidPtx"]                       = {"hipErrorInvalidKernelFile", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};            // 78
 
-    cuda2hipRename["CUDA_ERROR_INVALID_GRAPHICS_CONTEXT"]       = {"hipErrorInvalidGraphicsContext", CONV_ERR, API_DRIVER};                         // 219
-    cuda2hipRename["cudaErrorInvalidGraphicsContext"]           = {"hipErrorInvalidGraphicsContext", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};       // 79
+    cuda2hipRename["CUDA_ERROR_INVALID_GRAPHICS_CONTEXT"]       = {"hipErrorInvalidGraphicsContext", CONV_TYPE, API_DRIVER};                         // 219
+    cuda2hipRename["cudaErrorInvalidGraphicsContext"]           = {"hipErrorInvalidGraphicsContext", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};       // 79
 
-    cuda2hipRename["CUDA_ERROR_NVLINK_UNCORRECTABLE"]           = {"hipErrorNvlinkUncorrectable", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};           // 220 [CUDA 8.0.44]
-    cuda2hipRename["cudaErrorNvlinkUncorrectable"]              = {"hipErrorNvlinkUncorrectable", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};          // 80  [CUDA 8.0.44]
+    cuda2hipRename["CUDA_ERROR_NVLINK_UNCORRECTABLE"]           = {"hipErrorNvlinkUncorrectable", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           // 220 [CUDA 8.0.44]
+    cuda2hipRename["cudaErrorNvlinkUncorrectable"]              = {"hipErrorNvlinkUncorrectable", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};          // 80  [CUDA 8.0.44]
 
-    cuda2hipRename["CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND"] = {"hipErrorSharedObjectSymbolNotFound", CONV_ERR, API_DRIVER};                     // 302
-    cuda2hipRename["cudaErrorSharedObjectSymbolNotFound"]       = {"hipErrorSharedObjectSymbolNotFound", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};   // 40
+    cuda2hipRename["CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND"] = {"hipErrorSharedObjectSymbolNotFound", CONV_TYPE, API_DRIVER};                     // 302
+    cuda2hipRename["cudaErrorSharedObjectSymbolNotFound"]       = {"hipErrorSharedObjectSymbolNotFound", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};   // 40
 
-    cuda2hipRename["CUDA_ERROR_SHARED_OBJECT_INIT_FAILED"]      = {"hipErrorSharedObjectInitFailed", CONV_ERR, API_DRIVER};                         // 303
-    cuda2hipRename["cudaErrorSharedObjectInitFailed"]           = {"hipErrorSharedObjectInitFailed", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};       // 41
+    cuda2hipRename["CUDA_ERROR_SHARED_OBJECT_INIT_FAILED"]      = {"hipErrorSharedObjectInitFailed", CONV_TYPE, API_DRIVER};                         // 303
+    cuda2hipRename["cudaErrorSharedObjectInitFailed"]           = {"hipErrorSharedObjectInitFailed", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};       // 41
 
-    cuda2hipRename["CUDA_ERROR_OPERATING_SYSTEM"]               = {"hipErrorOperatingSystem", CONV_ERR, API_DRIVER};                                // 304
-    cuda2hipRename["cudaErrorOperatingSystem"]                  = {"hipErrorOperatingSystem", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};              // 63
+    cuda2hipRename["CUDA_ERROR_OPERATING_SYSTEM"]               = {"hipErrorOperatingSystem", CONV_TYPE, API_DRIVER};                                // 304
+    cuda2hipRename["cudaErrorOperatingSystem"]                  = {"hipErrorOperatingSystem", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};              // 63
 
-    cuda2hipRename["CUDA_ERROR_INVALID_HANDLE"]                 = {"hipErrorInvalidResourceHandle", CONV_ERR, API_DRIVER};                          // 400
-    cuda2hipRename["cudaErrorInvalidResourceHandle"]            = {"hipErrorInvalidResourceHandle", CONV_ERR, API_RUNTIME};                         // 33
+    cuda2hipRename["CUDA_ERROR_INVALID_HANDLE"]                 = {"hipErrorInvalidResourceHandle", CONV_TYPE, API_DRIVER};                          // 400
+    cuda2hipRename["cudaErrorInvalidResourceHandle"]            = {"hipErrorInvalidResourceHandle", CONV_TYPE, API_RUNTIME};                         // 33
 
-    cuda2hipRename["CUDA_ERROR_NOT_READY"]                      = {"hipErrorNotReady", CONV_ERR, API_DRIVER};                                       // 600
-    cuda2hipRename["cudaErrorNotReady"]                         = {"hipErrorNotReady", CONV_ERR, API_RUNTIME};                                      // 34
+    cuda2hipRename["CUDA_ERROR_NOT_READY"]                      = {"hipErrorNotReady", CONV_TYPE, API_DRIVER};                                       // 600
+    cuda2hipRename["cudaErrorNotReady"]                         = {"hipErrorNotReady", CONV_TYPE, API_RUNTIME};                                      // 34
 
-    cuda2hipRename["CUDA_ERROR_ILLEGAL_ADDRESS"]                = {"hipErrorIllegalAddress", CONV_ERR, API_DRIVER};                                 // 700
-    cuda2hipRename["cudaErrorIllegalAddress"]                   = {"hipErrorIllegalAddress", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};               // 77
+    cuda2hipRename["CUDA_ERROR_ILLEGAL_ADDRESS"]                = {"hipErrorIllegalAddress", CONV_TYPE, API_DRIVER};                                 // 700
+    cuda2hipRename["cudaErrorIllegalAddress"]                   = {"hipErrorIllegalAddress", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};               // 77
 
-    cuda2hipRename["CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES"]        = {"hipErrorLaunchOutOfResources", CONV_ERR, API_DRIVER};                           // 701
-    cuda2hipRename["cudaErrorLaunchOutOfResources"]             = {"hipErrorLaunchOutOfResources", CONV_ERR, API_RUNTIME};                          // 7
+    cuda2hipRename["CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES"]        = {"hipErrorLaunchOutOfResources", CONV_TYPE, API_DRIVER};                           // 701
+    cuda2hipRename["cudaErrorLaunchOutOfResources"]             = {"hipErrorLaunchOutOfResources", CONV_TYPE, API_RUNTIME};                          // 7
 
-    cuda2hipRename["CUDA_ERROR_LAUNCH_TIMEOUT"]                 = {"hipErrorLaunchTimeOut", CONV_ERR, API_DRIVER};                                  // 702
-    cuda2hipRename["cudaErrorLaunchTimeout"]                    = {"hipErrorLaunchTimeOut", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};                // 6
+    cuda2hipRename["CUDA_ERROR_LAUNCH_TIMEOUT"]                 = {"hipErrorLaunchTimeOut", CONV_TYPE, API_DRIVER};                                  // 702
+    cuda2hipRename["cudaErrorLaunchTimeout"]                    = {"hipErrorLaunchTimeOut", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                // 6
 
-    cuda2hipRename["CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED"]    = {"hipErrorPeerAccessAlreadyEnabled", CONV_ERR, API_DRIVER};                       // 704
-    cuda2hipRename["cudaErrorPeerAccessAlreadyEnabled"]         = {"hipErrorPeerAccessAlreadyEnabled", CONV_ERR, API_RUNTIME};                      // 50
+    cuda2hipRename["CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED"]    = {"hipErrorPeerAccessAlreadyEnabled", CONV_TYPE, API_DRIVER};                       // 704
+    cuda2hipRename["cudaErrorPeerAccessAlreadyEnabled"]         = {"hipErrorPeerAccessAlreadyEnabled", CONV_TYPE, API_RUNTIME};                      // 50
 
-    cuda2hipRename["CUDA_ERROR_PEER_ACCESS_NOT_ENABLED"]        = {"hipErrorPeerAccessNotEnabled", CONV_ERR, API_DRIVER};                           // 705
-    cuda2hipRename["cudaErrorPeerAccessNotEnabled"]             = {"hipErrorPeerAccessNotEnabled", CONV_ERR, API_RUNTIME};                          // 51
+    cuda2hipRename["CUDA_ERROR_PEER_ACCESS_NOT_ENABLED"]        = {"hipErrorPeerAccessNotEnabled", CONV_TYPE, API_DRIVER};                           // 705
+    cuda2hipRename["cudaErrorPeerAccessNotEnabled"]             = {"hipErrorPeerAccessNotEnabled", CONV_TYPE, API_RUNTIME};                          // 51
 
-    cuda2hipRename["CUDA_ERROR_ASSERT"]                         = {"hipErrorAssert", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};                        // 710
-    cuda2hipRename["cudaErrorAssert"]                           = {"hipErrorAssert", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};                       // 59
+    cuda2hipRename["CUDA_ERROR_ASSERT"]                         = {"hipErrorAssert", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                        // 710
+    cuda2hipRename["cudaErrorAssert"]                           = {"hipErrorAssert", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                       // 59
 
-    cuda2hipRename["CUDA_ERROR_TOO_MANY_PEERS"]                 = {"hipErrorTooManyPeers", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};                  // 711
-    cuda2hipRename["cudaErrorTooManyPeers"]                     = {"hipErrorTooManyPeers", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};                 // 60
+    cuda2hipRename["CUDA_ERROR_TOO_MANY_PEERS"]                 = {"hipErrorTooManyPeers", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                  // 711
+    cuda2hipRename["cudaErrorTooManyPeers"]                     = {"hipErrorTooManyPeers", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 60
 
-    cuda2hipRename["CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED"] = {"hipErrorHostMemoryAlreadyRegistered", CONV_ERR, API_DRIVER};                    // 712
-    cuda2hipRename["cudaErrorHostMemoryAlreadyRegistered"]      = {"hipErrorHostMemoryAlreadyRegistered", CONV_ERR, API_RUNTIME};                   // 61
+    cuda2hipRename["CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED"] = {"hipErrorHostMemoryAlreadyRegistered", CONV_TYPE, API_DRIVER};                    // 712
+    cuda2hipRename["cudaErrorHostMemoryAlreadyRegistered"]      = {"hipErrorHostMemoryAlreadyRegistered", CONV_TYPE, API_RUNTIME};                   // 61
 
-    cuda2hipRename["CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED"]     = {"hipErrorHostMemoryNotRegistered", CONV_ERR, API_DRIVER};                        // 713
-    cuda2hipRename["cudaErrorHostMemoryNotRegistered"]          = {"hipErrorHostMemoryNotRegistered", CONV_ERR, API_RUNTIME};                       // 62
+    cuda2hipRename["CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED"]     = {"hipErrorHostMemoryNotRegistered", CONV_TYPE, API_DRIVER};                        // 713
+    cuda2hipRename["cudaErrorHostMemoryNotRegistered"]          = {"hipErrorHostMemoryNotRegistered", CONV_TYPE, API_RUNTIME};                       // 62
 
-    cuda2hipRename["CUDA_ERROR_HARDWARE_STACK_ERROR"]           = {"hipErrorHardwareStackError", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};            // 714
-    cuda2hipRename["cudaErrorHardwareStackError"]               = {"hipErrorHardwareStackError", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};           // 72
+    cuda2hipRename["CUDA_ERROR_HARDWARE_STACK_ERROR"]           = {"hipErrorHardwareStackError", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};            // 714
+    cuda2hipRename["cudaErrorHardwareStackError"]               = {"hipErrorHardwareStackError", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 72
 
-    cuda2hipRename["CUDA_ERROR_ILLEGAL_INSTRUCTION"]            = {"hipErrorIllegalInstruction", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};            // 715
-    cuda2hipRename["cudaErrorIllegalInstruction"]               = {"hipErrorIllegalInstruction", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};           // 73
+    cuda2hipRename["CUDA_ERROR_ILLEGAL_INSTRUCTION"]            = {"hipErrorIllegalInstruction", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};            // 715
+    cuda2hipRename["cudaErrorIllegalInstruction"]               = {"hipErrorIllegalInstruction", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 73
 
-    cuda2hipRename["CUDA_ERROR_MISALIGNED_ADDRESS"]             = {"hipErrorMisalignedAddress", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};             // 716
-    cuda2hipRename["cudaErrorMisalignedAddress"]                = {"hipErrorMisalignedAddress", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};            // 74
+    cuda2hipRename["CUDA_ERROR_MISALIGNED_ADDRESS"]             = {"hipErrorMisalignedAddress", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};             // 716
+    cuda2hipRename["cudaErrorMisalignedAddress"]                = {"hipErrorMisalignedAddress", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};            // 74
 
-    cuda2hipRename["CUDA_ERROR_INVALID_ADDRESS_SPACE"]          = {"hipErrorInvalidAddressSpace", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};           // 717
-    cuda2hipRename["cudaErrorInvalidAddressSpace"]              = {"hipErrorInvalidAddressSpace", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};          // 75
+    cuda2hipRename["CUDA_ERROR_INVALID_ADDRESS_SPACE"]          = {"hipErrorInvalidAddressSpace", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           // 717
+    cuda2hipRename["cudaErrorInvalidAddressSpace"]              = {"hipErrorInvalidAddressSpace", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};          // 75
 
-    cuda2hipRename["CUDA_ERROR_INVALID_PC"]                     = {"hipErrorInvalidPc", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};                     // 718
-    cuda2hipRename["cudaErrorInvalidPc"]                        = {"hipErrorInvalidPc", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};                    // 76
+    cuda2hipRename["CUDA_ERROR_INVALID_PC"]                     = {"hipErrorInvalidPc", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                     // 718
+    cuda2hipRename["cudaErrorInvalidPc"]                        = {"hipErrorInvalidPc", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                    // 76
 
-    cuda2hipRename["CUDA_ERROR_LAUNCH_FAILED"]                  = {"hipErrorLaunchFailure", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};                 // 719
-    cuda2hipRename["cudaErrorLaunchFailure"]                    = {"hipErrorLaunchFailure", CONV_ERR, API_RUNTIME, HIP_UNSUPPORTED};                // 4
+    cuda2hipRename["CUDA_ERROR_LAUNCH_FAILED"]                  = {"hipErrorLaunchFailure", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                 // 719
+    cuda2hipRename["cudaErrorLaunchFailure"]                    = {"hipErrorLaunchFailure", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                // 4
 
-    cuda2hipRename["CUDA_ERROR_UNKNOWN"]                        = {"hipErrorUnknown", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED};                       // 999
-    cuda2hipRename["cudaErrorUnknown"]                          = {"hipErrorUnknown", CONV_ERR, API_RUNTIME};                                       // 30
+    cuda2hipRename["CUDA_ERROR_UNKNOWN"]                        = {"hipErrorUnknown", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                       // 999
+    cuda2hipRename["cudaErrorUnknown"]                          = {"hipErrorUnknown", CONV_TYPE, API_RUNTIME};                                       // 30
 
     ///////////////////////////// CUDA DRIVER API /////////////////////////////
     // structs
@@ -428,11 +437,11 @@ struct cuda2hipMap {
     cuda2hipRename["CU_AD_FORMAT_HALF"]                                           = {"HIP_AD_FORMAT_HALF", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};            // 0x10
     cuda2hipRename["CU_AD_FORMAT_FLOAT"]                                          = {"HIP_AD_FORMAT_FLOAT", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           // 0x20
     // Compute mode
-    cuda2hipRename["CUcomputemode"]                                               = {"hipComputemode", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                     // API_RUNTIME ANALOGUE (cudaComputeMode)
-    cuda2hipRename["CU_COMPUTEMODE_DEFAULT"]                                      = {"hipComputeModeDefault", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};          // 0 // API_RUNTIME ANALOGUE (cudaComputeModeDefault = 0)
-    cuda2hipRename["CU_COMPUTEMODE_EXCLUSIVE"]                                    = {"hipComputeModeExclusive", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};        // 1 // API_RUNTIME ANALOGUE (cudaComputeModeExclusive = 1)
-    cuda2hipRename["CU_COMPUTEMODE_PROHIBITED"]                                   = {"hipComputeModeProhibited", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};       // 2 // API_RUNTIME ANALOGUE (cudaComputeModeProhibited = 2)
-    cuda2hipRename["CU_COMPUTEMODE_EXCLUSIVE_PROCESS"]                            = {"hipComputeModeExclusiveProcess", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED}; // 3 // API_RUNTIME ANALOGUE (cudaComputeModeExclusiveProcess = 3)
+    cuda2hipRename["CUcomputemode"]                                               = {"hipComputemode", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                      // API_RUNTIME ANALOGUE (cudaComputeMode)
+    cuda2hipRename["CU_COMPUTEMODE_DEFAULT"]                                      = {"hipComputeModeDefault", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};          // 0 // API_RUNTIME ANALOGUE (cudaComputeModeDefault = 0)
+    cuda2hipRename["CU_COMPUTEMODE_EXCLUSIVE"]                                    = {"hipComputeModeExclusive", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};        // 1 // API_RUNTIME ANALOGUE (cudaComputeModeExclusive = 1)
+    cuda2hipRename["CU_COMPUTEMODE_PROHIBITED"]                                   = {"hipComputeModeProhibited", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};       // 2 // API_RUNTIME ANALOGUE (cudaComputeModeProhibited = 2)
+    cuda2hipRename["CU_COMPUTEMODE_EXCLUSIVE_PROCESS"]                            = {"hipComputeModeExclusiveProcess", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED}; // 3 // API_RUNTIME ANALOGUE (cudaComputeModeExclusiveProcess = 3)
 
     // unsupported yet by HIP [CUDA 8.0.44]
     // Memory advise values
@@ -465,31 +474,31 @@ struct cuda2hipMap {
     cuda2hipRename["CU_CTX_FLAGS_MASK"]                                            = {"HIP_CTX_FLAGS_MASK", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           // 0x1f
 
     // Defines
-    cuda2hipRename["CU_LAUNCH_PARAM_BUFFER_POINTER"]                              = {"HIP_LAUNCH_PARAM_BUFFER_POINTER", CONV_DEV, API_DRIVER};                 // ((void*)0x01)
-    cuda2hipRename["CU_LAUNCH_PARAM_BUFFER_SIZE"]                                 = {"HIP_LAUNCH_PARAM_BUFFER_SIZE", CONV_DEV, API_DRIVER};                    // ((void*)0x02)
-    cuda2hipRename["CU_LAUNCH_PARAM_END"]                                         = {"HIP_LAUNCH_PARAM_END", CONV_DEV, API_DRIVER};                            // ((void*)0x00)
-    cuda2hipRename["CU_IPC_HANDLE_SIZE"]                                          = {"HIP_LAUNCH_PARAM_END", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};           // 64
-    cuda2hipRename["CU_MEMHOSTALLOC_DEVICEMAP"]                                   = {"HIP_MEMHOSTALLOC_DEVICEMAP", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};     // 0x02
-    cuda2hipRename["CU_MEMHOSTALLOC_PORTABLE"]                                    = {"HIP_MEMHOSTALLOC_PORTABLE", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};      // 0x01
-    cuda2hipRename["CU_MEMHOSTALLOC_WRITECOMBINED"]                               = {"HIP_MEMHOSTALLOC_WRITECOMBINED", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED}; // 0x04
-    cuda2hipRename["CU_MEMHOSTREGISTER_DEVICEMAP"]                                = {"HIP_MEMHOSTREGISTER_DEVICEMAP", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};  // 0x02
-    cuda2hipRename["CU_MEMHOSTREGISTER_IOMEMORY"]                                 = {"HIP_MEMHOSTREGISTER_IOMEMORY", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};   // 0x04
-    cuda2hipRename["CU_MEMHOSTREGISTER_PORTABLE"]                                 = {"HIP_MEMHOSTREGISTER_PORTABLE", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};   // 0x01
-    cuda2hipRename["CU_PARAM_TR_DEFAULT"]                                         = {"HIP_PARAM_TR_DEFAULT", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};           // -1
-    cuda2hipRename["CU_STREAM_LEGACY"]                                            = {"HIP_STREAM_LEGACY", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};              // ((CUstream)0x1)
-    cuda2hipRename["CU_STREAM_PER_THREAD"]                                        = {"HIP_STREAM_PER_THREAD", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};          // ((CUstream)0x2)
-    cuda2hipRename["CU_TRSA_OVERRIDE_FORMAT"]                                     = {"HIP_TRSA_OVERRIDE_FORMAT", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};       // 0x01
-    cuda2hipRename["CU_TRSF_NORMALIZED_COORDINATES"]                              = {"HIP_TRSF_NORMALIZED_COORDINATES", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};// 0x02
-    cuda2hipRename["CU_TRSF_READ_AS_INTEGER"]                                     = {"HIP_TRSF_READ_AS_INTEGER", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};       // 0x01
-    cuda2hipRename["CU_TRSF_SRGB"]                                                = {"HIP_TRSF_SRGB", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                  // 0x10
+    cuda2hipRename["CU_LAUNCH_PARAM_BUFFER_POINTER"]                              = {"HIP_LAUNCH_PARAM_BUFFER_POINTER", CONV_TYPE, API_DRIVER};                 // ((void*)0x01)
+    cuda2hipRename["CU_LAUNCH_PARAM_BUFFER_SIZE"]                                 = {"HIP_LAUNCH_PARAM_BUFFER_SIZE", CONV_TYPE, API_DRIVER};                    // ((void*)0x02)
+    cuda2hipRename["CU_LAUNCH_PARAM_END"]                                         = {"HIP_LAUNCH_PARAM_END", CONV_TYPE, API_DRIVER};                            // ((void*)0x00)
+    cuda2hipRename["CU_IPC_HANDLE_SIZE"]                                          = {"HIP_LAUNCH_PARAM_END", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           // 64
+    cuda2hipRename["CU_MEMHOSTALLOC_DEVICEMAP"]                                   = {"HIP_MEMHOSTALLOC_DEVICEMAP", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};     // 0x02
+    cuda2hipRename["CU_MEMHOSTALLOC_PORTABLE"]                                    = {"HIP_MEMHOSTALLOC_PORTABLE", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};      // 0x01
+    cuda2hipRename["CU_MEMHOSTALLOC_WRITECOMBINED"]                               = {"HIP_MEMHOSTALLOC_WRITECOMBINED", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED}; // 0x04
+    cuda2hipRename["CU_MEMHOSTREGISTER_DEVICEMAP"]                                = {"HIP_MEMHOSTREGISTER_DEVICEMAP", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};  // 0x02
+    cuda2hipRename["CU_MEMHOSTREGISTER_IOMEMORY"]                                 = {"HIP_MEMHOSTREGISTER_IOMEMORY", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};   // 0x04
+    cuda2hipRename["CU_MEMHOSTREGISTER_PORTABLE"]                                 = {"HIP_MEMHOSTREGISTER_PORTABLE", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};   // 0x01
+    cuda2hipRename["CU_PARAM_TR_DEFAULT"]                                         = {"HIP_PARAM_TR_DEFAULT", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           // -1
+    cuda2hipRename["CU_STREAM_LEGACY"]                                            = {"HIP_STREAM_LEGACY", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};              // ((CUstream)0x1)
+    cuda2hipRename["CU_STREAM_PER_THREAD"]                                        = {"HIP_STREAM_PER_THREAD", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};          // ((CUstream)0x2)
+    cuda2hipRename["CU_TRSA_OVERRIDE_FORMAT"]                                     = {"HIP_TRSA_OVERRIDE_FORMAT", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};       // 0x01
+    cuda2hipRename["CU_TRSF_NORMALIZED_COORDINATES"]                              = {"HIP_TRSF_NORMALIZED_COORDINATES", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};// 0x02
+    cuda2hipRename["CU_TRSF_READ_AS_INTEGER"]                                     = {"HIP_TRSF_READ_AS_INTEGER", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};       // 0x01
+    cuda2hipRename["CU_TRSF_SRGB"]                                                = {"HIP_TRSF_SRGB", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                  // 0x10
     // Deprecated, use CUDA_ARRAY3D_LAYERED
-    cuda2hipRename["CUDA_ARRAY3D_2DARRAY"]                                        = {"HIP_ARRAY3D_LAYERED", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};            // 0x01
-    cuda2hipRename["CUDA_ARRAY3D_CUBEMAP"]                                        = {"HIP_ARRAY3D_CUBEMAP", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};            // 0x04
-    cuda2hipRename["CUDA_ARRAY3D_DEPTH_TEXTURE"]                                  = {"HIP_ARRAY3D_DEPTH_TEXTURE", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};      // 0x10
-    cuda2hipRename["CUDA_ARRAY3D_LAYERED"]                                        = {"HIP_ARRAY3D_LAYERED", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};            // 0x01
-    cuda2hipRename["CUDA_ARRAY3D_SURFACE_LDST"]                                   = {"HIP_ARRAY3D_SURFACE_LDST", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};       // 0x02
-    cuda2hipRename["CUDA_ARRAY3D_TEXTURE_GATHER"]                                 = {"HIP_ARRAY3D_TEXTURE_GATHER", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};     // 0x08
-    cuda2hipRename["CUDA_VERSION"]                                                = {"HIP_VERSION", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                    // 7050
+    cuda2hipRename["CUDA_ARRAY3D_2DARRAY"]                                        = {"HIP_ARRAY3D_LAYERED", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};            // 0x01
+    cuda2hipRename["CUDA_ARRAY3D_CUBEMAP"]                                        = {"HIP_ARRAY3D_CUBEMAP", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};            // 0x04
+    cuda2hipRename["CUDA_ARRAY3D_DEPTH_TEXTURE"]                                  = {"HIP_ARRAY3D_DEPTH_TEXTURE", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};      // 0x10
+    cuda2hipRename["CUDA_ARRAY3D_LAYERED"]                                        = {"HIP_ARRAY3D_LAYERED", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};            // 0x01
+    cuda2hipRename["CUDA_ARRAY3D_SURFACE_LDST"]                                   = {"HIP_ARRAY3D_SURFACE_LDST", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};       // 0x02
+    cuda2hipRename["CUDA_ARRAY3D_TEXTURE_GATHER"]                                 = {"HIP_ARRAY3D_TEXTURE_GATHER", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};     // 0x08
+    cuda2hipRename["CUDA_VERSION"]                                                = {"HIP_VERSION", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                    // 7050
 
     // Types
     // NOTE: CUdevice might be changed to typedef int in the future.
@@ -500,115 +509,115 @@ struct cuda2hipMap {
     // CUDA: "The types::CUarray and struct ::cudaArray * represent the same data type and may be used interchangeably by casting the two types between each other."
     //    typedef struct cudaArray  *cudaArray_t;
     //    typedef struct CUarray_st *CUarray;
-    cuda2hipRename["CUarray_st"]                                                  = {"hipArray", CONV_MEM, API_RUNTIME};                                       // API_Runtime ANALOGUE (cudaArray)
+    cuda2hipRename["CUarray_st"]                                                  = {"hipArray", CONV_TYPE, API_DRIVER};                                       // API_Runtime ANALOGUE (cudaArray)
     cuda2hipRename["CUarray"]                                                     = {"hipArray *", CONV_TYPE, API_DRIVER};                                     // API_Runtime ANALOGUE (cudaArray_t)
 
     // unsupported yet by HIP
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK"]                   = {"hipDeviceAttributeMaxThreadsPerBlock", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                //  1 // API_Runtime ANALOGUE (cudaDevAttrMaxThreadsPerBlock = 1)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X"]                         = {"hipDeviceAttributeMaxBlockDimX", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                      //  2 // API_Runtime ANALOGUE (cudaDevAttrMaxBlockDimX = 2)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y"]                         = {"hipDeviceAttributeMaxBlockDimY", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                      //  3 // API_Runtime ANALOGUE (cudaDevAttrMaxBlockDimY = 3)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z"]                         = {"hipDeviceAttributeMaxBlockDimZ", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                      //  4 // API_Runtime ANALOGUE (cudaDevAttrMaxBlockDimZ = 4)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X"]                          = {"hipDeviceAttributeMaxGridDimX", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                       //  5 // API_Runtime ANALOGUE (cudaDevAttrMaxGridDimX =5)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y"]                          = {"hipDeviceAttributeMaxGridDimY", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                       //  6 // API_Runtime ANALOGUE (cudaDevAttrMaxGridDimY = 6)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z"]                          = {"hipDeviceAttributeMaxGridDimZ", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                       //  7 // API_Runtime ANALOGUE (cudaDevAttrMaxGridDimZ - 7)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK"]             = {"hipDeviceAttributeMaxSharedMemoryPerBlock", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};           //  8 // API_Runtime ANALOGUE (cudaDevAttrMaxSharedMemoryPerBlock = 8)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK"]                   = {"hipDeviceAttributeMaxThreadsPerBlock", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                //  1 // API_Runtime ANALOGUE (cudaDevAttrMaxThreadsPerBlock = 1)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X"]                         = {"hipDeviceAttributeMaxBlockDimX", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                      //  2 // API_Runtime ANALOGUE (cudaDevAttrMaxBlockDimX = 2)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y"]                         = {"hipDeviceAttributeMaxBlockDimY", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                      //  3 // API_Runtime ANALOGUE (cudaDevAttrMaxBlockDimY = 3)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z"]                         = {"hipDeviceAttributeMaxBlockDimZ", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                      //  4 // API_Runtime ANALOGUE (cudaDevAttrMaxBlockDimZ = 4)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X"]                          = {"hipDeviceAttributeMaxGridDimX", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                       //  5 // API_Runtime ANALOGUE (cudaDevAttrMaxGridDimX =5)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y"]                          = {"hipDeviceAttributeMaxGridDimY", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                       //  6 // API_Runtime ANALOGUE (cudaDevAttrMaxGridDimY = 6)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z"]                          = {"hipDeviceAttributeMaxGridDimZ", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                       //  7 // API_Runtime ANALOGUE (cudaDevAttrMaxGridDimZ - 7)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK"]             = {"hipDeviceAttributeMaxSharedMemoryPerBlock", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           //  8 // API_Runtime ANALOGUE (cudaDevAttrMaxSharedMemoryPerBlock = 8)
     // Deprecated, use CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_SHARED_MEMORY_PER_BLOCK"]                 = {"hipDeviceAttributeMaxSharedMemoryPerBlock", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};           //  8
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY"]                   = {"hipDeviceAttributeTotalConstantMemory", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};               //  9 // API_Runtime ANALOGUE (cudaDevAttrTotalConstantMemory = 9)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_WARP_SIZE"]                               = {"hipDeviceAttributeWarpSize", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                          // 10 // API_Runtime ANALOGUE (cudaDevAttrWarpSize = 10)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_PITCH"]                               = {"hipDeviceAttributeMaxPitch", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                          // 11 // API_Runtime ANALOGUE (cudaDevAttrMaxPitch = 11)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK"]                 = {"hipDeviceAttributeMaxRegistersPerBlock", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};              // 12 // API_Runtime ANALOGUE (cudaDevAttrMaxRegistersPerBlock = 12)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_REGISTERS_PER_BLOCK"]                     = {"hipDeviceAttributeMaxRegistersPerBlock", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};              // 12
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_CLOCK_RATE"]                              = {"hipDeviceAttributeClockRate", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                         // 13 // API_Runtime ANALOGUE (cudaDevAttrMaxRegistersPerBlock = 13)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT"]                       = {"hipDeviceAttributeTextureAlignment", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                  // 14 // API_Runtime ANALOGUE (cudaDevAttrTextureAlignment = 14)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_SHARED_MEMORY_PER_BLOCK"]                 = {"hipDeviceAttributeMaxSharedMemoryPerBlock", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           //  8
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY"]                   = {"hipDeviceAttributeTotalConstantMemory", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};               //  9 // API_Runtime ANALOGUE (cudaDevAttrTotalConstantMemory = 9)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_WARP_SIZE"]                               = {"hipDeviceAttributeWarpSize", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                          // 10 // API_Runtime ANALOGUE (cudaDevAttrWarpSize = 10)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_PITCH"]                               = {"hipDeviceAttributeMaxPitch", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                          // 11 // API_Runtime ANALOGUE (cudaDevAttrMaxPitch = 11)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK"]                 = {"hipDeviceAttributeMaxRegistersPerBlock", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};              // 12 // API_Runtime ANALOGUE (cudaDevAttrMaxRegistersPerBlock = 12)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_REGISTERS_PER_BLOCK"]                     = {"hipDeviceAttributeMaxRegistersPerBlock", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};              // 12
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_CLOCK_RATE"]                              = {"hipDeviceAttributeClockRate", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                         // 13 // API_Runtime ANALOGUE (cudaDevAttrMaxRegistersPerBlock = 13)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT"]                       = {"hipDeviceAttributeTextureAlignment", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                  // 14 // API_Runtime ANALOGUE (cudaDevAttrTextureAlignment = 14)
     // Deprecated. Use instead CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_GPU_OVERLAP"]                             = {"hipDeviceAttributeAsyncEngineCount", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                  // 15 // API_Runtime ANALOGUE (cudaDevAttrGpuOverlap = 15)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT"]                    = {"hipDeviceAttributeMultiprocessorCount", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};               // 16 // API_Runtime ANALOGUE (cudaDevAttrMultiProcessorCount = 16)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT"]                     = {"hipDeviceAttributeKernelExecTimeout", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                 // 17 // API_Runtime ANALOGUE (cudaDevAttrKernelExecTimeout = 17)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_INTEGRATED"]                              = {"hipDeviceAttributeIntegrated", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                        // 18 // API_Runtime ANALOGUE (cudaDevAttrIntegrated = 18)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY"]                     = {"hipDeviceAttributeCanMapHostMemory", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                  // 19 // API_Runtime ANALOGUE (cudaDevAttrCanMapHostMemory = 19)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_COMPUTE_MODE"]                            = {"hipDeviceAttributeComputeMode", CONV_DEV, API_DRIVER};                                        // 20 // API_Runtime ANALOGUE (cudaDevAttrComputeMode = 20)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH"]                 = {"hipDeviceAttributeMaxTexture1DWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                 // 21 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture1DWidth = 21)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH"]                 = {"hipDeviceAttributeMaxTexture2DWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                 // 22 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DWidth = 22)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT"]                = {"hipDeviceAttributeMaxTexture2DHeight", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                // 23 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DHeight = 23)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH"]                 = {"hipDeviceAttributeMaxTexture3DWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                 // 24 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture3DWidth = 24)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT"]                = {"hipDeviceAttributeMaxTexture3DHeight", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                // 25 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture3DHeight = 25)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH"]                 = {"hipDeviceAttributeMaxTexture3DDepth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                 // 26 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture3DDepth = 26)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH"]         = {"hipDeviceAttributeMaxTexture2DLayeredWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};          // 27 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLayeredWidth = 27)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT"]        = {"hipDeviceAttributeMaxTexture2DLayeredHeight", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};         // 28 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLayeredHeight = 28)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS"]        = {"hipDeviceAttributeMaxTexture2DLayeredLayers", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};         // 29 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLayeredLayers = 29)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_GPU_OVERLAP"]                             = {"hipDeviceAttributeAsyncEngineCount", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                  // 15 // API_Runtime ANALOGUE (cudaDevAttrGpuOverlap = 15)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT"]                    = {"hipDeviceAttributeMultiprocessorCount", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};               // 16 // API_Runtime ANALOGUE (cudaDevAttrMultiProcessorCount = 16)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT"]                     = {"hipDeviceAttributeKernelExecTimeout", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                 // 17 // API_Runtime ANALOGUE (cudaDevAttrKernelExecTimeout = 17)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_INTEGRATED"]                              = {"hipDeviceAttributeIntegrated", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                        // 18 // API_Runtime ANALOGUE (cudaDevAttrIntegrated = 18)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY"]                     = {"hipDeviceAttributeCanMapHostMemory", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                  // 19 // API_Runtime ANALOGUE (cudaDevAttrCanMapHostMemory = 19)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_COMPUTE_MODE"]                            = {"hipDeviceAttributeComputeMode", CONV_TYPE, API_DRIVER};                                        // 20 // API_Runtime ANALOGUE (cudaDevAttrComputeMode = 20)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH"]                 = {"hipDeviceAttributeMaxTexture1DWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                 // 21 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture1DWidth = 21)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH"]                 = {"hipDeviceAttributeMaxTexture2DWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                 // 22 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DWidth = 22)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT"]                = {"hipDeviceAttributeMaxTexture2DHeight", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                // 23 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DHeight = 23)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH"]                 = {"hipDeviceAttributeMaxTexture3DWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                 // 24 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture3DWidth = 24)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT"]                = {"hipDeviceAttributeMaxTexture3DHeight", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                // 25 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture3DHeight = 25)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH"]                 = {"hipDeviceAttributeMaxTexture3DDepth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                 // 26 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture3DDepth = 26)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH"]         = {"hipDeviceAttributeMaxTexture2DLayeredWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};          // 27 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLayeredWidth = 27)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT"]        = {"hipDeviceAttributeMaxTexture2DLayeredHeight", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};         // 28 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLayeredHeight = 28)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS"]        = {"hipDeviceAttributeMaxTexture2DLayeredLayers", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};         // 29 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLayeredLayers = 29)
     // Deprecated, use CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_WIDTH"]           = {"hipDeviceAttributeMaxTexture2DLayeredWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};          // 27 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLayeredWidth = 27)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_WIDTH"]           = {"hipDeviceAttributeMaxTexture2DLayeredWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};          // 27 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLayeredWidth = 27)
     // Deprecated, use CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_HEIGHT"]          = {"hipDeviceAttributeMaxTexture2DLayeredHeight", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};         // 28 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLayeredHeight = 28)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_HEIGHT"]          = {"hipDeviceAttributeMaxTexture2DLayeredHeight", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};         // 28 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLayeredHeight = 28)
     // Deprecated, use CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_NUMSLICES"]       = {"hipDeviceAttributeMaxTexture2DLayeredLayers", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};         // 29 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLayeredLayers = 29)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_SURFACE_ALIGNMENT"]                       = {"hipDeviceAttributeSurfaceAlignment", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                  // 30 // API_Runtime ANALOGUE (cudaDevAttrSurfaceAlignment = 30)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS"]                      = {"hipDeviceAttributeConcurrentKernels", CONV_DEV, API_DRIVER};                                  // 31 // API_Runtime ANALOGUE (cudaDevAttrConcurrentKernels = 31)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_ECC_ENABLED"]                             = {"hipDeviceAttributeEccEnabled", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                        // 32 // API_Runtime ANALOGUE (cudaDevAttrEccEnabled = 32)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_PCI_BUS_ID"]                              = {"hipDeviceAttributePciBusId", CONV_DEV, API_DRIVER};                                           // 33 // API_Runtime ANALOGUE (cudaDevAttrPciBusId = 33)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID"]                           = {"hipDeviceAttributePciDeviceId", CONV_DEV, API_DRIVER};                                        // 34 // API_Runtime ANALOGUE (cudaDevAttrPciDeviceId = 34)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_TCC_DRIVER"]                              = {"hipDeviceAttributeTccDriver", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                         // 35 // API_Runtime ANALOGUE (cudaDevAttrTccDriver = 35)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE"]                       = {"hipDeviceAttributeMemoryClockRate", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                   // 36 // API_Runtime ANALOGUE (cudaDevAttrMemoryClockRate = 36)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH"]                 = {"hipDeviceAttributeMemoryBusWidth", CONV_DEV, API_DRIVER};                                     // 37 // API_Runtime ANALOGUE (cudaDevAttrGlobalMemoryBusWidth = 37)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE"]                           = {"hipDeviceAttributeL2CacheSize", CONV_DEV, API_DRIVER};                                        // 38 // API_Runtime ANALOGUE (cudaDevAttrL2CacheSize = 38)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR"]          = {"hipDeviceAttributeMaxThreadsPerMultiProcessor", CONV_DEV, API_DRIVER};                        // 39 // API_Runtime ANALOGUE (cudaDevAttrMaxThreadsPerMultiProcessor = 39)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT"]                      = {"hipDeviceAttributeAsyncEngineCount", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                  // 40 // API_Runtime ANALOGUE (cudaDevAttrAsyncEngineCount = 40)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING"]                      = {"hipDeviceAttributeUnifiedAddressing", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                 // 41 // API_Runtime ANALOGUE (cudaDevAttrUnifiedAddressing = 41)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_WIDTH"]         = {"hipDeviceAttributeMaxTexture1DLayeredWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};          // 42 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture1DLayeredWidth = 42)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_LAYERS"]        = {"hipDeviceAttributeMaxTexture1DLayeredLayers", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};         // 43 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture1DLayeredLayers = 43)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_NUMSLICES"]       = {"hipDeviceAttributeMaxTexture2DLayeredLayers", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};         // 29 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLayeredLayers = 29)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_SURFACE_ALIGNMENT"]                       = {"hipDeviceAttributeSurfaceAlignment", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                  // 30 // API_Runtime ANALOGUE (cudaDevAttrSurfaceAlignment = 30)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS"]                      = {"hipDeviceAttributeConcurrentKernels", CONV_TYPE, API_DRIVER};                                  // 31 // API_Runtime ANALOGUE (cudaDevAttrConcurrentKernels = 31)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_ECC_ENABLED"]                             = {"hipDeviceAttributeEccEnabled", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                        // 32 // API_Runtime ANALOGUE (cudaDevAttrEccEnabled = 32)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_PCI_BUS_ID"]                              = {"hipDeviceAttributePciBusId", CONV_TYPE, API_DRIVER};                                           // 33 // API_Runtime ANALOGUE (cudaDevAttrPciBusId = 33)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID"]                           = {"hipDeviceAttributePciDeviceId", CONV_TYPE, API_DRIVER};                                        // 34 // API_Runtime ANALOGUE (cudaDevAttrPciDeviceId = 34)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_TCC_DRIVER"]                              = {"hipDeviceAttributeTccDriver", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                         // 35 // API_Runtime ANALOGUE (cudaDevAttrTccDriver = 35)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE"]                       = {"hipDeviceAttributeMemoryClockRate", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                   // 36 // API_Runtime ANALOGUE (cudaDevAttrMemoryClockRate = 36)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH"]                 = {"hipDeviceAttributeMemoryBusWidth", CONV_TYPE, API_DRIVER};                                     // 37 // API_Runtime ANALOGUE (cudaDevAttrGlobalMemoryBusWidth = 37)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE"]                           = {"hipDeviceAttributeL2CacheSize", CONV_TYPE, API_DRIVER};                                        // 38 // API_Runtime ANALOGUE (cudaDevAttrL2CacheSize = 38)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR"]          = {"hipDeviceAttributeMaxThreadsPerMultiProcessor", CONV_TYPE, API_DRIVER};                        // 39 // API_Runtime ANALOGUE (cudaDevAttrMaxThreadsPerMultiProcessor = 39)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT"]                      = {"hipDeviceAttributeAsyncEngineCount", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                  // 40 // API_Runtime ANALOGUE (cudaDevAttrAsyncEngineCount = 40)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING"]                      = {"hipDeviceAttributeUnifiedAddressing", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                 // 41 // API_Runtime ANALOGUE (cudaDevAttrUnifiedAddressing = 41)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_WIDTH"]         = {"hipDeviceAttributeMaxTexture1DLayeredWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};          // 42 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture1DLayeredWidth = 42)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_LAYERS"]        = {"hipDeviceAttributeMaxTexture1DLayeredLayers", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};         // 43 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture1DLayeredLayers = 43)
     // deprecated, do not use
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_CAN_TEX2D_GATHER"]                        = {"hipDeviceAttributeCanTex2DGather", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                    // 44 // API_Runtime ANALOGUE (no)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_WIDTH"]          = {"hipDeviceAttributeMaxTexture2DGatherWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};           // 45 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DGatherWidth = 45)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_HEIGHT"]         = {"hipDeviceAttributeMaxTexture2DGatherHeight", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};          // 46 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DGatherHeight = 46)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH_ALTERNATE"]       = {"hipDeviceAttributeMaxTexture3DWidthAlternate", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};        // 47 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture3DWidthAlt = 47)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT_ALTERNATE"]      = {"hipDeviceAttributeMaxTexture3DHeightAlternate", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};       // 48 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture3DHeightAlt = 48)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH_ALTERNATE"]       = {"hipDeviceAttributeMaxTexture3DDepthAlternate", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};        // 49 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture3DDepthAlt = 49)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID"]                           = {"hipDeviceAttributePciDomainId", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                       // 50 // API_Runtime ANALOGUE (cudaDevAttrPciDomainId = 50)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT"]                 = {"hipDeviceAttributeTexturePitchAlignment", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};             // 51 // API_Runtime ANALOGUE (cudaDevAttrTexturePitchAlignment = 51)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_WIDTH"]            = {"hipDeviceAttributeMaxTextureCubemapWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};            // 52 // API_Runtime ANALOGUE (cudaDevAttrMaxTextureCubemapWidth = 52)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_WIDTH"]    = {"hipDeviceAttributeMaxTextureCubemapLayeredWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};     // 53 // API_Runtime ANALOGUE (cudaDevAttrMaxTextureCubemapLayeredWidth = 53)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_LAYERS"]   = {"hipDeviceAttributeMaxTextureCubemapLayeredLayers", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};    // 54 // API_Runtime ANALOGUE (cudaDevAttrMaxTextureCubemapLayeredLayers = 54)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH"]                 = {"hipDeviceAttributeMaxSurface1DWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                 // 55 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface1DWidth = 55)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH"]                 = {"hipDeviceAttributeMaxSurface2DWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                 // 56 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface2DWidth = 56)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT"]                = {"hipDeviceAttributeMaxSurface2DHeight", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                // 57 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface2DHeight = 57)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH"]                 = {"hipDeviceAttributeMaxSurface3DWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                 // 58 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface3DWidth = 58)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT"]                = {"hipDeviceAttributeMaxSurface3DHeight", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                // 59 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface3DHeight = 59)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH"]                 = {"hipDeviceAttributeMaxSurface3DDepth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                 // 60 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface3DDepth = 60)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_WIDTH"]         = {"hipDeviceAttributeMaxSurface1DLayeredWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};          // 61 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface1DLayeredWidth = 61)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_LAYERS"]        = {"hipDeviceAttributeMaxSurface1DLayeredLayers", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};         // 62 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface1DLayeredLayers = 62)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_WIDTH"]         = {"hipDeviceAttributeMaxSurface2DLayeredWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};          // 63 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface2DLayeredWidth = 63)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_HEIGHT"]        = {"hipDeviceAttributeMaxSurface2DLayeredHeight", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};         // 64 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface2DLayeredHeight = 64)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_LAYERS"]        = {"hipDeviceAttributeMaxSurface2DLayeredLayers", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};         // 65 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface2DLayeredLayers = 65)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_WIDTH"]            = {"hipDeviceAttributeMaxSurfaceCubemapWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};            // 66 // API_Runtime ANALOGUE (cudaDevAttrMaxSurfaceCubemapWidth = 66)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_WIDTH"]    = {"hipDeviceAttributeMaxSurfaceCubemapLayeredWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};     // 67 // API_Runtime ANALOGUE (cudaDevAttrMaxSurfaceCubemapLayeredWidth = 67)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_LAYERS"]   = {"hipDeviceAttributeMaxSurfaceCubemapLayeredLayers", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};    // 68 // API_Runtime ANALOGUE (cudaDevAttrMaxSurfaceCubemapLayeredLayers = 68)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LINEAR_WIDTH"]          = {"hipDeviceAttributeMaxTexture1DLinearWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};           // 69 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture1DLinearWidth = 69)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH"]          = {"hipDeviceAttributeMaxTexture2DLinearWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};           // 70 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLinearWidth = 70)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT"]         = {"hipDeviceAttributeMaxTexture2DLinearHeight", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};          // 71 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLinearHeight = 71)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH"]          = {"hipDeviceAttributeMaxTexture2DLinearPitch", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};           // 72 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLinearPitch = 72)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_WIDTH"]       = {"hipDeviceAttributeMaxTexture2DMipmappedWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};        // 73 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DMipmappedWidth = 73)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_HEIGHT"]      = {"hipDeviceAttributeMaxTexture2DMipmappedHeight", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};       // 74 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DMipmappedHeight = 74)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR"]                = {"hipDeviceAttributeComputeCapabilityMajor", CONV_DEV, API_DRIVER};                             // 75 // API_Runtime ANALOGUE (cudaDevAttrComputeCapabilityMajor = 75)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR"]                = {"hipDeviceAttributeComputeCapabilityMinor", CONV_DEV, API_DRIVER};                             // 76 // API_Runtime ANALOGUE (cudaDevAttrComputeCapabilityMinor = 76)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_MIPMAPPED_WIDTH"]       = {"hipDeviceAttributeMaxTexture1DMipmappedWidth", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};        // 77 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture1DMipmappedWidth = 77)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_STREAM_PRIORITIES_SUPPORTED"]             = {"hipDeviceAttributeStreamPrioritiesSupported", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};         // 78 // API_Runtime ANALOGUE (cudaDevAttrStreamPrioritiesSupported = 78)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED"]               = {"hipDeviceAttributeGlobalL1CacheSupported", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};            // 79 // API_Runtime ANALOGUE (cudaDevAttrGlobalL1CacheSupported = 79)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED"]                = {"hipDeviceAttributeLocalL1CacheSupported", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};             // 80 // API_Runtime ANALOGUE (cudaDevAttrLocalL1CacheSupported = 80)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR"]    = {"hipDeviceAttributeMaxSharedMemoryPerMultiprocessor", CONV_DEV, API_DRIVER};                   // 81 // API_Runtime ANALOGUE (cudaDevAttrMaxSharedMemoryPerMultiprocessor = 81)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR"]        = {"hipDeviceAttributeMaxRegistersPerMultiprocessor", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};     // 82 // API_Runtime ANALOGUE (cudaDevAttrMaxRegistersPerMultiprocessor = 82)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY"]                          = {"hipDeviceAttributeManagedMemory", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                     // 83 // API_Runtime ANALOGUE (cudaDevAttrManagedMemory = 83)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD"]                         = {"hipDeviceAttributeIsMultiGpuBoard", CONV_DEV, API_DRIVER};                                    // 84 // API_Runtime ANALOGUE (cudaDevAttrIsMultiGpuBoard = 84)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID"]                = {"hipDeviceAttributeMultiGpuBoardGroupId", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};              // 85 // API_Runtime ANALOGUE (cudaDevAttrMultiGpuBoardGroupID = 85)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_CAN_TEX2D_GATHER"]                        = {"hipDeviceAttributeCanTex2DGather", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                    // 44 // API_Runtime ANALOGUE (no)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_WIDTH"]          = {"hipDeviceAttributeMaxTexture2DGatherWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           // 45 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DGatherWidth = 45)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_HEIGHT"]         = {"hipDeviceAttributeMaxTexture2DGatherHeight", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};          // 46 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DGatherHeight = 46)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH_ALTERNATE"]       = {"hipDeviceAttributeMaxTexture3DWidthAlternate", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};        // 47 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture3DWidthAlt = 47)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT_ALTERNATE"]      = {"hipDeviceAttributeMaxTexture3DHeightAlternate", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};       // 48 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture3DHeightAlt = 48)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH_ALTERNATE"]       = {"hipDeviceAttributeMaxTexture3DDepthAlternate", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};        // 49 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture3DDepthAlt = 49)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID"]                           = {"hipDeviceAttributePciDomainId", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                       // 50 // API_Runtime ANALOGUE (cudaDevAttrPciDomainId = 50)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT"]                 = {"hipDeviceAttributeTexturePitchAlignment", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};             // 51 // API_Runtime ANALOGUE (cudaDevAttrTexturePitchAlignment = 51)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_WIDTH"]            = {"hipDeviceAttributeMaxTextureCubemapWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};            // 52 // API_Runtime ANALOGUE (cudaDevAttrMaxTextureCubemapWidth = 52)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_WIDTH"]    = {"hipDeviceAttributeMaxTextureCubemapLayeredWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};     // 53 // API_Runtime ANALOGUE (cudaDevAttrMaxTextureCubemapLayeredWidth = 53)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_LAYERS"]   = {"hipDeviceAttributeMaxTextureCubemapLayeredLayers", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};    // 54 // API_Runtime ANALOGUE (cudaDevAttrMaxTextureCubemapLayeredLayers = 54)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH"]                 = {"hipDeviceAttributeMaxSurface1DWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                 // 55 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface1DWidth = 55)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH"]                 = {"hipDeviceAttributeMaxSurface2DWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                 // 56 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface2DWidth = 56)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT"]                = {"hipDeviceAttributeMaxSurface2DHeight", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                // 57 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface2DHeight = 57)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH"]                 = {"hipDeviceAttributeMaxSurface3DWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                 // 58 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface3DWidth = 58)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT"]                = {"hipDeviceAttributeMaxSurface3DHeight", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                // 59 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface3DHeight = 59)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH"]                 = {"hipDeviceAttributeMaxSurface3DDepth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                 // 60 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface3DDepth = 60)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_WIDTH"]         = {"hipDeviceAttributeMaxSurface1DLayeredWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};          // 61 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface1DLayeredWidth = 61)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_LAYERS"]        = {"hipDeviceAttributeMaxSurface1DLayeredLayers", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};         // 62 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface1DLayeredLayers = 62)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_WIDTH"]         = {"hipDeviceAttributeMaxSurface2DLayeredWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};          // 63 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface2DLayeredWidth = 63)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_HEIGHT"]        = {"hipDeviceAttributeMaxSurface2DLayeredHeight", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};         // 64 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface2DLayeredHeight = 64)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_LAYERS"]        = {"hipDeviceAttributeMaxSurface2DLayeredLayers", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};         // 65 // API_Runtime ANALOGUE (cudaDevAttrMaxSurface2DLayeredLayers = 65)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_WIDTH"]            = {"hipDeviceAttributeMaxSurfaceCubemapWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};            // 66 // API_Runtime ANALOGUE (cudaDevAttrMaxSurfaceCubemapWidth = 66)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_WIDTH"]    = {"hipDeviceAttributeMaxSurfaceCubemapLayeredWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};     // 67 // API_Runtime ANALOGUE (cudaDevAttrMaxSurfaceCubemapLayeredWidth = 67)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_LAYERS"]   = {"hipDeviceAttributeMaxSurfaceCubemapLayeredLayers", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};    // 68 // API_Runtime ANALOGUE (cudaDevAttrMaxSurfaceCubemapLayeredLayers = 68)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LINEAR_WIDTH"]          = {"hipDeviceAttributeMaxTexture1DLinearWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           // 69 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture1DLinearWidth = 69)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH"]          = {"hipDeviceAttributeMaxTexture2DLinearWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           // 70 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLinearWidth = 70)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT"]         = {"hipDeviceAttributeMaxTexture2DLinearHeight", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};          // 71 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLinearHeight = 71)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH"]          = {"hipDeviceAttributeMaxTexture2DLinearPitch", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           // 72 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DLinearPitch = 72)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_WIDTH"]       = {"hipDeviceAttributeMaxTexture2DMipmappedWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};        // 73 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DMipmappedWidth = 73)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_HEIGHT"]      = {"hipDeviceAttributeMaxTexture2DMipmappedHeight", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};       // 74 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture2DMipmappedHeight = 74)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR"]                = {"hipDeviceAttributeComputeCapabilityMajor", CONV_TYPE, API_DRIVER};                             // 75 // API_Runtime ANALOGUE (cudaDevAttrComputeCapabilityMajor = 75)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR"]                = {"hipDeviceAttributeComputeCapabilityMinor", CONV_TYPE, API_DRIVER};                             // 76 // API_Runtime ANALOGUE (cudaDevAttrComputeCapabilityMinor = 76)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_MIPMAPPED_WIDTH"]       = {"hipDeviceAttributeMaxTexture1DMipmappedWidth", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};        // 77 // API_Runtime ANALOGUE (cudaDevAttrMaxTexture1DMipmappedWidth = 77)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_STREAM_PRIORITIES_SUPPORTED"]             = {"hipDeviceAttributeStreamPrioritiesSupported", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};         // 78 // API_Runtime ANALOGUE (cudaDevAttrStreamPrioritiesSupported = 78)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED"]               = {"hipDeviceAttributeGlobalL1CacheSupported", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};            // 79 // API_Runtime ANALOGUE (cudaDevAttrGlobalL1CacheSupported = 79)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED"]                = {"hipDeviceAttributeLocalL1CacheSupported", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};             // 80 // API_Runtime ANALOGUE (cudaDevAttrLocalL1CacheSupported = 80)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR"]    = {"hipDeviceAttributeMaxSharedMemoryPerMultiprocessor", CONV_TYPE, API_DRIVER};                   // 81 // API_Runtime ANALOGUE (cudaDevAttrMaxSharedMemoryPerMultiprocessor = 81)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR"]        = {"hipDeviceAttributeMaxRegistersPerMultiprocessor", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};     // 82 // API_Runtime ANALOGUE (cudaDevAttrMaxRegistersPerMultiprocessor = 82)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY"]                          = {"hipDeviceAttributeManagedMemory", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                     // 83 // API_Runtime ANALOGUE (cudaDevAttrManagedMemory = 83)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD"]                         = {"hipDeviceAttributeIsMultiGpuBoard", CONV_TYPE, API_DRIVER};                                    // 84 // API_Runtime ANALOGUE (cudaDevAttrIsMultiGpuBoard = 84)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID"]                = {"hipDeviceAttributeMultiGpuBoardGroupId", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};              // 85 // API_Runtime ANALOGUE (cudaDevAttrMultiGpuBoardGroupID = 85)
     // unsupported yet by HIP [CUDA 8.0.44]
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED"]            = {"hipDeviceAttributeHostNativeAtomicSupported", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};         // 86 // API_Runtime ANALOGUE (cudaDevAttrHostNativeAtomicSupported = 86)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO"]   = {"hipDeviceAttributeSingleToDoublePrecisionPerfRatio", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};  // 87 // API_Runtime ANALOGUE (cudaDevAttrSingleToDoublePrecisionPerfRatio = 87)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS"]                  = {"hipDeviceAttributePageableMemoryAccess", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};              // 88 // API_Runtime ANALOGUE (cudaDevAttrPageableMemoryAccess = 88)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS"]               = {"hipDeviceAttributeConcurrentManagedAccess", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};           // 89 // API_Runtime ANALOGUE (cudaDevAttrConcurrentManagedAccess = 89)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED"]            = {"hipDeviceAttributeComputePreemptionSupported", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};        // 90 // API_Runtime ANALOGUE (cudaDevAttrComputePreemptionSupported = 90)
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM"] = {"hipDeviceAttributeCanUseHostPointerForRegisteredMem", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED}; // 91 // API_Runtime ANALOGUE (cudaDevAttrCanUseHostPointerForRegisteredMem = 91)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED"]            = {"hipDeviceAttributeHostNativeAtomicSupported", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};         // 86 // API_Runtime ANALOGUE (cudaDevAttrHostNativeAtomicSupported = 86)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO"]   = {"hipDeviceAttributeSingleToDoublePrecisionPerfRatio", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};  // 87 // API_Runtime ANALOGUE (cudaDevAttrSingleToDoublePrecisionPerfRatio = 87)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS"]                  = {"hipDeviceAttributePageableMemoryAccess", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};              // 88 // API_Runtime ANALOGUE (cudaDevAttrPageableMemoryAccess = 88)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS"]               = {"hipDeviceAttributeConcurrentManagedAccess", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           // 89 // API_Runtime ANALOGUE (cudaDevAttrConcurrentManagedAccess = 89)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED"]            = {"hipDeviceAttributeComputePreemptionSupported", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};        // 90 // API_Runtime ANALOGUE (cudaDevAttrComputePreemptionSupported = 90)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM"] = {"hipDeviceAttributeCanUseHostPointerForRegisteredMem", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED}; // 91 // API_Runtime ANALOGUE (cudaDevAttrCanUseHostPointerForRegisteredMem = 91)
 
-    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX"]                                     = {"hipDeviceAttributeMax", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                               // 92 // API_Runtime ANALOGUE (no)
+    cuda2hipRename["CU_DEVICE_ATTRIBUTE_MAX"]                                     = {"hipDeviceAttributeMax", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                               // 92 // API_Runtime ANALOGUE (no)
 
     cuda2hipRename["CUdevprop_st"]                                                = {"hipDeviceProp_t", CONV_TYPE, API_DRIVER};
     cuda2hipRename["CUdevprop"]                                                   = {"hipDeviceProp_t", CONV_TYPE, API_DRIVER};
@@ -617,14 +626,14 @@ struct cuda2hipMap {
     // TODO: Do for Pointer Attributes the same as for Device Attributes.
     // cuda2hipRename["CUpointer_attribute_enum"]                                 = {"hipPointerAttribute_t", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                                 // API_Runtime ANALOGUE (no)
     // cuda2hipRename["CUpointer_attribute"]                                      = {"hipPointerAttribute_t", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                                 // API_Runtime ANALOGUE (no)
-    cuda2hipRename["CU_POINTER_ATTRIBUTE_CONTEXT"]                                = {"hipPointerAttributeContext", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                        // 1 // API_Runtime ANALOGUE (no)
-    cuda2hipRename["CU_POINTER_ATTRIBUTE_MEMORY_TYPE"]                            = {"hipPointerAttributeMemoryType", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                     // 2 // API_Runtime ANALOGUE (no)
-    cuda2hipRename["CU_POINTER_ATTRIBUTE_DEVICE_POINTER"]                         = {"hipPointerAttributeDevicePointer", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                  // 3 // API_Runtime ANALOGUE (no)
-    cuda2hipRename["CU_POINTER_ATTRIBUTE_HOST_POINTER"]                           = {"hipPointerAttributeHostPointer", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                    // 4 // API_Runtime ANALOGUE (no)
-    cuda2hipRename["CU_POINTER_ATTRIBUTE_P2P_TOKENS"]                             = {"hipPointerAttributeP2pTokens", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                      // 5 // API_Runtime ANALOGUE (no)
-    cuda2hipRename["CU_POINTER_ATTRIBUTE_SYNC_MEMOPS"]                            = {"hipPointerAttributeSyncMemops", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                     // 6 // API_Runtime ANALOGUE (no)
-    cuda2hipRename["CU_POINTER_ATTRIBUTE_BUFFER_ID"]                              = {"hipPointerAttributeBufferId", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                       // 7 // API_Runtime ANALOGUE (no)
-    cuda2hipRename["CU_POINTER_ATTRIBUTE_IS_MANAGED"]                             = {"hipPointerAttributeIsManaged", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                      // 8 // API_Runtime ANALOGUE (no)
+    cuda2hipRename["CU_POINTER_ATTRIBUTE_CONTEXT"]                                = {"hipPointerAttributeContext", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                        // 1 // API_Runtime ANALOGUE (no)
+    cuda2hipRename["CU_POINTER_ATTRIBUTE_MEMORY_TYPE"]                            = {"hipPointerAttributeMemoryType", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                     // 2 // API_Runtime ANALOGUE (no)
+    cuda2hipRename["CU_POINTER_ATTRIBUTE_DEVICE_POINTER"]                         = {"hipPointerAttributeDevicePointer", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                  // 3 // API_Runtime ANALOGUE (no)
+    cuda2hipRename["CU_POINTER_ATTRIBUTE_HOST_POINTER"]                           = {"hipPointerAttributeHostPointer", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                    // 4 // API_Runtime ANALOGUE (no)
+    cuda2hipRename["CU_POINTER_ATTRIBUTE_P2P_TOKENS"]                             = {"hipPointerAttributeP2pTokens", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                      // 5 // API_Runtime ANALOGUE (no)
+    cuda2hipRename["CU_POINTER_ATTRIBUTE_SYNC_MEMOPS"]                            = {"hipPointerAttributeSyncMemops", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                     // 6 // API_Runtime ANALOGUE (no)
+    cuda2hipRename["CU_POINTER_ATTRIBUTE_BUFFER_ID"]                              = {"hipPointerAttributeBufferId", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                       // 7 // API_Runtime ANALOGUE (no)
+    cuda2hipRename["CU_POINTER_ATTRIBUTE_IS_MANAGED"]                             = {"hipPointerAttributeIsManaged", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                      // 8 // API_Runtime ANALOGUE (no)
 
     // pointer to CUfunc_st
     cuda2hipRename["CUfunction"]                                                  = {"hipFunction_t", CONV_TYPE, API_DRIVER};
@@ -826,9 +835,9 @@ struct cuda2hipMap {
 
     cuda2hipRename["CUsharedconfig"]                               = {"hipSharedMemConfig", CONV_TYPE, API_DRIVER};
     cuda2hipRename["CUsharedconfig_enum"]                          = {"hipSharedMemConfig", CONV_TYPE, API_DRIVER};
-    cuda2hipRename["CU_SHARED_MEM_CONFIG_DEFAULT_BANK_SIZE"]       = {"hipSharedMemBankSizeDefault", CONV_DEV, API_DRIVER};
-    cuda2hipRename["CU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE"]     = {"hipSharedMemBankSizeFourByte", CONV_DEV, API_DRIVER};
-    cuda2hipRename["CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE"]    = {"hipSharedMemBankSizeEightByte", CONV_DEV, API_DRIVER};
+    cuda2hipRename["CU_SHARED_MEM_CONFIG_DEFAULT_BANK_SIZE"]       = {"hipSharedMemBankSizeDefault", CONV_TYPE, API_DRIVER};
+    cuda2hipRename["CU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE"]     = {"hipSharedMemBankSizeFourByte", CONV_TYPE, API_DRIVER};
+    cuda2hipRename["CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE"]    = {"hipSharedMemBankSizeEightByte", CONV_TYPE, API_DRIVER};
 
     cuda2hipRename["CUcontext"]                                    = {"hipCtx_t", CONV_TYPE, API_DRIVER};
     // TODO: move "typedef struct ihipCtx_t *hipCtx_t;" from hcc_details to HIP
@@ -857,40 +866,40 @@ struct cuda2hipMap {
     // cuda2hipRename["CUtexref_st"]                               = {"ihipTextureReference_t", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};
 
     // Stream Flags enum
-    cuda2hipRename["CUstream_flags"]                               = {"hipStreamFlags", CONV_STREAM, API_DRIVER};
-    // cuda2hipRename["CUstream_flags_enum"]                       = {"hipStreamFlags", CONV_STREAM, API_DRIVER};
-    cuda2hipRename["CU_STREAM_DEFAULT"]                            = {"hipStreamDefault", CONV_STREAM, API_DRIVER};
-    cuda2hipRename["CU_STREAM_NON_BLOCKING"]                       = {"hipStreamNonBlocking", CONV_STREAM, API_DRIVER};
+    cuda2hipRename["CUstream_flags"]                               = {"hipStreamFlags", CONV_TYPE, API_DRIVER};
+    // cuda2hipRename["CUstream_flags_enum"]                       = {"hipStreamFlags", CONV_TYPE, API_DRIVER};
+    cuda2hipRename["CU_STREAM_DEFAULT"]                            = {"hipStreamDefault", CONV_TYPE, API_DRIVER};
+    cuda2hipRename["CU_STREAM_NON_BLOCKING"]                       = {"hipStreamNonBlocking", CONV_TYPE, API_DRIVER};
 
     // unsupported yet by HIP [CUDA 8.0.44]
     // Flags for ::cuStreamWaitValue32
-    cuda2hipRename["CUstreamWaitValue_flags"]                      = {"hipStreamWaitValueFlags", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    // cuda2hipRename["CUstreamWaitValue_flags_enum"]              = {"hipStreamWaitValueFlags", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["CU_STREAM_WAIT_VALUE_GEQ"]                     = {"hipStreamWaitValueGeq", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};                // 0x0
-    cuda2hipRename["CU_STREAM_WAIT_VALUE_EQ"]                      = {"hipStreamWaitValueEq", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};                 // 0x1
-    cuda2hipRename["CU_STREAM_WAIT_VALUE_AND"]                     = {"hipStreamWaitValueAnd", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};                // 0x2
-    cuda2hipRename["CU_STREAM_WAIT_VALUE_FLUSH"]                   = {"hipStreamWaitValueFlush", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};              // 1<<30
+    cuda2hipRename["CUstreamWaitValue_flags"]                      = {"hipStreamWaitValueFlags", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};
+    // cuda2hipRename["CUstreamWaitValue_flags_enum"]              = {"hipStreamWaitValueFlags", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["CU_STREAM_WAIT_VALUE_GEQ"]                     = {"hipStreamWaitValueGeq", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                // 0x0
+    cuda2hipRename["CU_STREAM_WAIT_VALUE_EQ"]                      = {"hipStreamWaitValueEq", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                 // 0x1
+    cuda2hipRename["CU_STREAM_WAIT_VALUE_AND"]                     = {"hipStreamWaitValueAnd", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                // 0x2
+    cuda2hipRename["CU_STREAM_WAIT_VALUE_FLUSH"]                   = {"hipStreamWaitValueFlush", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};              // 1<<30
     // Flags for ::cuStreamWriteValue32
-    cuda2hipRename["CUstreamWriteValue_flags"]                     = {"hipStreamWriteValueFlags", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    // cuda2hipRename["CUstreamWriteValue_flags"]                  = {"hipStreamWriteValueFlags", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["CU_STREAM_WRITE_VALUE_DEFAULT"]                = {"hipStreamWriteValueDefault", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};           // 0x0
-    cuda2hipRename["CU_STREAM_WRITE_VALUE_NO_MEMORY_BARRIER"]      = {"hipStreamWriteValueNoMemoryBarrier", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};   // 0x1
+    cuda2hipRename["CUstreamWriteValue_flags"]                     = {"hipStreamWriteValueFlags", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};
+    // cuda2hipRename["CUstreamWriteValue_flags"]                  = {"hipStreamWriteValueFlags", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["CU_STREAM_WRITE_VALUE_DEFAULT"]                = {"hipStreamWriteValueDefault", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};           // 0x0
+    cuda2hipRename["CU_STREAM_WRITE_VALUE_NO_MEMORY_BARRIER"]      = {"hipStreamWriteValueNoMemoryBarrier", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};   // 0x1
     // Flags for ::cuStreamBatchMemOp
-    cuda2hipRename["CUstreamBatchMemOpType"]                       = {"hipStreamBatchMemOpType", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    // cuda2hipRename["CUstreamBatchMemOpType_enum"]               = {"hipStreamBatchMemOpType", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["CU_STREAM_MEM_OP_WAIT_VALUE_32"]               = {"hipStreamBatchMemOpWaitValue32", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};       // 1
-    cuda2hipRename["CU_STREAM_MEM_OP_WRITE_VALUE_32"]              = {"hipStreamBatchMemOpWriteValue32", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};      // 2
-    cuda2hipRename["CU_STREAM_MEM_OP_FLUSH_REMOTE_WRITES"]         = {"hipStreamBatchMemOpFlushRemoteWrites", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED}; // 3
+    cuda2hipRename["CUstreamBatchMemOpType"]                       = {"hipStreamBatchMemOpType", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};
+    // cuda2hipRename["CUstreamBatchMemOpType_enum"]               = {"hipStreamBatchMemOpType", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["CU_STREAM_MEM_OP_WAIT_VALUE_32"]               = {"hipStreamBatchMemOpWaitValue32", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};       // 1
+    cuda2hipRename["CU_STREAM_MEM_OP_WRITE_VALUE_32"]              = {"hipStreamBatchMemOpWriteValue32", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};      // 2
+    cuda2hipRename["CU_STREAM_MEM_OP_FLUSH_REMOTE_WRITES"]         = {"hipStreamBatchMemOpFlushRemoteWrites", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED}; // 3
 
     // Error Handling
-    cuda2hipRename["cuGetErrorName"]                               = {"hipGetErrorName___", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED}; // cudaGetErrorName (hipGetErrorName) has different signature
-    cuda2hipRename["cuGetErrorString"]                             = {"hipGetErrorString___", CONV_ERR, API_DRIVER, HIP_UNSUPPORTED}; // cudaGetErrorString (hipGetErrorString) has different signature
+    cuda2hipRename["cuGetErrorName"]                               = {"hipGetErrorName___", CONV_ERROR, API_DRIVER, HIP_UNSUPPORTED};   // cudaGetErrorName (hipGetErrorName) has different signature
+    cuda2hipRename["cuGetErrorString"]                             = {"hipGetErrorString___", CONV_ERROR, API_DRIVER, HIP_UNSUPPORTED}; // cudaGetErrorString (hipGetErrorString) has different signature
 
     // Init
-    cuda2hipRename["cuInit"]                                       = {"hipInit", CONV_DRIVER, API_DRIVER};
+    cuda2hipRename["cuInit"]                                       = {"hipInit", CONV_INIT, API_DRIVER};
 
     // Driver
-    cuda2hipRename["cuDriverGetVersion"]                           = {"hipDriverGetVersion", CONV_DRIVER, API_DRIVER};
+    cuda2hipRename["cuDriverGetVersion"]                           = {"hipDriverGetVersion", CONV_VERSION, API_DRIVER};
 
     // Context Management
     cuda2hipRename["cuCtxCreate_v2"]                            = {"hipCtxCreate", CONV_CONTEXT, API_DRIVER};
@@ -915,10 +924,10 @@ struct cuda2hipMap {
     cuda2hipRename["cuCtxDetach"]                               = {"hipCtxDetach", CONV_CONTEXT, API_DRIVER, HIP_UNSUPPORTED};
 
     // Peer Context Memory Access
-    cuda2hipRename["cuCtxEnablePeerAccess"]                     = {"hipCtxEnablePeerAccess", CONV_CONTEXT, API_DRIVER};
-    cuda2hipRename["cuCtxDisablePeerAccess"]                    = {"hipCtxDisablePeerAccess", CONV_CONTEXT, API_DRIVER};
-    cuda2hipRename["cuDeviceCanAccessPeer"]                     = {"hipDeviceCanAccessPeer", CONV_DEV, API_DRIVER};
-
+    cuda2hipRename["cuCtxEnablePeerAccess"]                     = {"hipCtxEnablePeerAccess", CONV_PEER, API_DRIVER};
+    cuda2hipRename["cuCtxDisablePeerAccess"]                    = {"hipCtxDisablePeerAccess", CONV_PEER, API_DRIVER};
+    cuda2hipRename["cuDeviceCanAccessPeer"]                     = {"hipDeviceCanAccessPeer", CONV_PEER, API_DRIVER};
+    cuda2hipRename["cuDeviceGetP2PAttribute"]                   = {"hipDeviceGetP2PAttribute", CONV_PEER, API_DRIVER, HIP_UNSUPPORTED};  // API_Runtime ANALOGUE (cudaDeviceGetP2PAttribute)
 
     // Primary Context Management
     cuda2hipRename["cuDevicePrimaryCtxGetState"]                = {"hipDevicePrimaryCtxGetState", CONV_CONTEXT, API_DRIVER};
@@ -928,28 +937,28 @@ struct cuda2hipMap {
     cuda2hipRename["cuDevicePrimaryCtxSetFlags"]                = {"hipDevicePrimaryCtxSetFlags", CONV_CONTEXT, API_DRIVER};
 
     // Device Management
-    cuda2hipRename["cuDeviceGet"]                               = {"hipGetDevice", CONV_DEV, API_DRIVER};
-    cuda2hipRename["cuDeviceGetName"]                           = {"hipDeviceGetName", CONV_DEV, API_DRIVER};
-    cuda2hipRename["cuDeviceGetCount"]                          = {"hipGetDeviceCount", CONV_DEV, API_DRIVER};
-    cuda2hipRename["cuDeviceGetAttribute"]                      = {"hipDeviceGetAttribute", CONV_DEV, API_DRIVER};
-    cuda2hipRename["cuDeviceGetPCIBusId"]                       = {"hipDeviceGetPCIBusId", CONV_DEV, API_DRIVER};
-    cuda2hipRename["cuDeviceGetByPCIBusId"]                     = {"hipDeviceGetByPCIBusId", CONV_DEV, API_DRIVER};
-    cuda2hipRename["cuDeviceTotalMem_v2"]                       = {"hipDeviceTotalMem", CONV_DEV, API_DRIVER};
+    cuda2hipRename["cuDeviceGet"]                               = {"hipGetDevice", CONV_DEVICE, API_DRIVER};
+    cuda2hipRename["cuDeviceGetName"]                           = {"hipDeviceGetName", CONV_DEVICE, API_DRIVER};
+    cuda2hipRename["cuDeviceGetCount"]                          = {"hipGetDeviceCount", CONV_DEVICE, API_DRIVER};
+    cuda2hipRename["cuDeviceGetAttribute"]                      = {"hipDeviceGetAttribute", CONV_DEVICE, API_DRIVER};
+    cuda2hipRename["cuDeviceGetPCIBusId"]                       = {"hipDeviceGetPCIBusId", CONV_DEVICE, API_DRIVER};
+    cuda2hipRename["cuDeviceGetByPCIBusId"]                     = {"hipDeviceGetByPCIBusId", CONV_DEVICE, API_DRIVER};
+    cuda2hipRename["cuDeviceTotalMem_v2"]                       = {"hipDeviceTotalMem", CONV_DEVICE, API_DRIVER};
 
     // Device Management [DEPRECATED]
-    cuda2hipRename["cuDeviceComputeCapability"]                 = {"hipDeviceComputeCapability", CONV_DEV, API_DRIVER};
-    cuda2hipRename["cuDeviceGetProperties"]                     = {"hipGetDeviceProperties", CONV_DEV, API_DRIVER};
+    cuda2hipRename["cuDeviceComputeCapability"]                 = {"hipDeviceComputeCapability", CONV_DEVICE, API_DRIVER};
+    cuda2hipRename["cuDeviceGetProperties"]                     = {"hipGetDeviceProperties", CONV_DEVICE, API_DRIVER};
 
     // Module Management
-    cuda2hipRename["cuLinkAddData"]                             = {"hipLinkAddData", CONV_EVENT, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuLinkAddFile"]                             = {"hipLinkAddFile", CONV_EVENT, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuLinkComplete"]                            = {"hipLinkComplete", CONV_EVENT, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuLinkCreate"]                              = {"hipLinkCreate", CONV_EVENT, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuLinkDestroy"]                             = {"hipLinkDestroy", CONV_EVENT, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuLinkAddData"]                             = {"hipLinkAddData", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuLinkAddFile"]                             = {"hipLinkAddFile", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuLinkComplete"]                            = {"hipLinkComplete", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuLinkCreate"]                              = {"hipLinkCreate", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuLinkDestroy"]                             = {"hipLinkDestroy", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
     cuda2hipRename["cuModuleGetFunction"]                       = {"hipModuleGetFunction", CONV_MODULE, API_DRIVER};
     cuda2hipRename["cuModuleGetGlobal_v2"]                      = {"hipModuleGetGlobal", CONV_MODULE, API_DRIVER};
-    cuda2hipRename["cuModuleGetSurfRef"]                        = {"hipModuleGetSurfRef", CONV_EVENT, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuModuleGetTexRef"]                         = {"hipModuleGetTexRef", CONV_EVENT, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuModuleGetSurfRef"]                        = {"hipModuleGetSurfRef", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuModuleGetTexRef"]                         = {"hipModuleGetTexRef", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
     cuda2hipRename["cuModuleLoad"]                              = {"hipModuleLoad", CONV_MODULE, API_DRIVER};
     cuda2hipRename["cuModuleLoadData"]                          = {"hipModuleLoadData", CONV_MODULE, API_DRIVER};
     cuda2hipRename["cuModuleLoadDataEx"]                        = {"hipModuleLoadDataEx", CONV_MODULE, API_DRIVER};
@@ -958,13 +967,11 @@ struct cuda2hipMap {
 
     // unsupported yet by HIP [CUDA 8.0.44]
     // P2P Attributes
-    cuda2hipRename["CUdevice_P2PAttribute"]                            = {"hipDeviceP2PAttribute", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                              // API_Runtime ANALOGUE (cudaDeviceP2PAttr)
-    // cuda2hipRename["CUdevice_P2PAttribute_enum"]                    = {"hipDeviceP2PAttribute", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK"]         = {"hipDeviceP2PAttributePerformanceRank", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};       // 0x01 // API_Runtime ANALOGUE (cudaDevP2PAttrPerformanceRank = 0x01)
-    cuda2hipRename["CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED"]         = {"hipDeviceP2PAttributeAccessSupported", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};       // 0x02 // API_Runtime ANALOGUE (cudaDevP2PAttrAccessSupported = 0x02)
-    cuda2hipRename["CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED"]  = {"hipDeviceP2PAttributeNativeAtomicSupported", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED}; // 0x03 // API_Runtime ANALOGUE (cudaDevP2PAttrNativeAtomicSupported = 0x03)
-
-    cuda2hipRename["cuDeviceGetP2PAttribute"]                          = {"hipDeviceGetP2PAttribute", CONV_DEV, API_DRIVER, HIP_UNSUPPORTED};                           // API_Runtime ANALOGUE (cudaDeviceGetP2PAttribute)
+    cuda2hipRename["CUdevice_P2PAttribute"]                            = {"hipDeviceP2PAttribute", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};                              // API_Runtime ANALOGUE (cudaDeviceP2PAttr)
+    // cuda2hipRename["CUdevice_P2PAttribute_enum"]                    = {"hipDeviceP2PAttribute", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK"]         = {"hipDeviceP2PAttributePerformanceRank", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};       // 0x01 // API_Runtime ANALOGUE (cudaDevP2PAttrPerformanceRank = 0x01)
+    cuda2hipRename["CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED"]         = {"hipDeviceP2PAttributeAccessSupported", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED};       // 0x02 // API_Runtime ANALOGUE (cudaDevP2PAttrAccessSupported = 0x02)
+    cuda2hipRename["CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED"]  = {"hipDeviceP2PAttributeNativeAtomicSupported", CONV_TYPE, API_DRIVER, HIP_UNSUPPORTED}; // 0x03 // API_Runtime ANALOGUE (cudaDevP2PAttrNativeAtomicSupported = 0x03)
 
     // Events
     // pointer to CUevent_st
@@ -992,6 +999,24 @@ struct cuda2hipMap {
     cuda2hipRename["cuFuncSetCacheConfig"]                      = {"hipFuncSetCacheConfig", CONV_MODULE, API_DRIVER};
     cuda2hipRename["cuFuncSetSharedMemConfig"]                  = {"hipFuncSetSharedMemConfig", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
     cuda2hipRename["cuLaunchKernel"]                            = {"hipModuleLaunchKernel", CONV_MODULE, API_DRIVER};
+
+    // Execution Control [DEPRECATED]
+    cuda2hipRename["cuFuncSetBlockShape"]                       = {"hipFuncSetBlockShape", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuFuncSetSharedSize"]                       = {"hipFuncSetSharedSize", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuLaunch"]                                  = {"hipLaunch", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};              // API_Runtime ANALOGUE (cudaLaunch)
+    cuda2hipRename["cuLaunchGrid"]                              = {"hipLaunchGrid", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuLaunchGridAsync"]                         = {"hipLaunchGridAsync", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuParamSetf"]                               = {"hipParamSetf", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuParamSeti"]                               = {"hipParamSeti", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuParamSetSize"]                            = {"hipParamSetSize", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuParamSetSize"]                            = {"hipParamSetSize", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuParamSetv"]                               = {"hipParamSetv", CONV_MODULE, API_DRIVER, HIP_UNSUPPORTED};
+
+    // Occupancy
+    cuda2hipRename["cuOccupancyMaxActiveBlocksPerMultiprocessor"]          = {"hipOccupancyMaxActiveBlocksPerMultiprocessor", CONV_OCCUPANCY, API_DRIVER};                           // API_Runtime ANALOGUE (cudaOccupancyMaxActiveBlocksPerMultiprocessor)
+    cuda2hipRename["cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags"] = {"hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags", CONV_OCCUPANCY, API_DRIVER, HIP_UNSUPPORTED}; // API_Runtime ANALOGUE (cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags)
+    cuda2hipRename["cuOccupancyMaxPotentialBlockSize"]                     = {"hipOccupancyMaxPotentialBlockSize", CONV_OCCUPANCY, API_DRIVER};                                      // API_Runtime ANALOGUE (cudaOccupancyMaxPotentialBlockSize)
+    cuda2hipRename["cuOccupancyMaxPotentialBlockSizeWithFlags"]            = {"hipOccupancyMaxPotentialBlockSizeWithFlags", CONV_OCCUPANCY, API_DRIVER, HIP_UNSUPPORTED};            // API_Runtime ANALOGUE (cudaOccupancyMaxPotentialBlockSizeWithFlags)
 
     // Streams
     cuda2hipRename["cuStreamAddCallback"]                       = {"hipStreamAddCallback", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
@@ -1028,10 +1053,10 @@ struct cuda2hipMap {
     cuda2hipRename["cuMemcpy2DAsync"]                           = {"hipMemcpy2DAsync__", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};        // Not equal to cudaMemcpy2DAsync due to different signatures
     cuda2hipRename["cuMemcpy2DUnaligned"]                       = {"hipMemcpy2DUnaligned", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
     cuda2hipRename["cuMemcpy3D"]                                = {"hipMemcpy3D__", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};             // Not equal to cudaMemcpy3D due to different signatures
-    cuda2hipRename["cuMemcpy3DAsync"]                           = {"hipMemcpy3DAsync__", CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED};       // Not equal to cudaMemcpy3DAsync due to different signatures
-    cuda2hipRename["cuMemcpy3DPeer"]                            = {"hipMemcpy3DPeer__", CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED};        // Not equal to cudaMemcpy3DPeer due to different signatures
-    cuda2hipRename["cuMemcpy3DPeerAsync"]                       = {"hipMemcpy3DPeerAsync__", CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED};   // Not equal to cudaMemcpy3DPeerAsync due to different signatures
-    cuda2hipRename["cuMemcpyAsync"]                             = {"hipMemcpyAsync__", CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED};         // Not equal to cudaMemcpyAsync due to different signatures
+    cuda2hipRename["cuMemcpy3DAsync"]                           = {"hipMemcpy3DAsync__", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};        // Not equal to cudaMemcpy3DAsync due to different signatures
+    cuda2hipRename["cuMemcpy3DPeer"]                            = {"hipMemcpy3DPeer__", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};         // Not equal to cudaMemcpy3DPeer due to different signatures
+    cuda2hipRename["cuMemcpy3DPeerAsync"]                       = {"hipMemcpy3DPeerAsync__", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};    // Not equal to cudaMemcpy3DPeerAsync due to different signatures
+    cuda2hipRename["cuMemcpyAsync"]                             = {"hipMemcpyAsync__", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};          // Not equal to cudaMemcpyAsync due to different signatures
     cuda2hipRename["cuMemcpyAtoA"]                              = {"hipMemcpyAtoA", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
     cuda2hipRename["cuMemcpyAtoD"]                              = {"hipMemcpyAtoD", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
     cuda2hipRename["cuMemcpyAtoH"]                              = {"hipMemcpyAtoH", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
@@ -1056,30 +1081,30 @@ struct cuda2hipMap {
     cuda2hipRename["cuMemHostGetFlags"]                         = {"hipMemHostGetFlags", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
     cuda2hipRename["cuMemHostRegister_v2"]                      = {"hipHostRegister", CONV_MEM, API_DRIVER};                            // API_Runtime ANALOGUE (cudaHostAlloc)
     cuda2hipRename["cuMemHostUnregister"]                       = {"hipHostUnregister", CONV_MEM, API_DRIVER};                          // API_Runtime ANALOGUE (cudaHostUnregister)
-    cuda2hipRename["cuMemsetD16_v2"]                            = {"hipMemsetD16", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuMemsetD16Async"]                          = {"hipMemsetD16Async", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuMemsetD2D16_v2"]                          = {"hipMemsetD2D16", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuMemsetD2D16Async"]                        = {"hipMemsetD2D16Async", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuMemsetD2D32_v2"]                          = {"hipMemsetD2D32", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuMemsetD2D32Async"]                        = {"hipMemsetD2D32Async", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuMemsetD2D8_v2"]                           = {"hipMemsetD2D8", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuMemsetD2D8Async"]                         = {"hipMemsetD2D8Async", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMemsetD16_v2"]                            = {"hipMemsetD16", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMemsetD16Async"]                          = {"hipMemsetD16Async", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMemsetD2D16_v2"]                          = {"hipMemsetD2D16", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMemsetD2D16Async"]                        = {"hipMemsetD2D16Async", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMemsetD2D32_v2"]                          = {"hipMemsetD2D32", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMemsetD2D32Async"]                        = {"hipMemsetD2D32Async", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMemsetD2D8_v2"]                           = {"hipMemsetD2D8", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMemsetD2D8Async"]                         = {"hipMemsetD2D8Async", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
     cuda2hipRename["cuMemsetD32_v2"]                            = {"hipMemset", CONV_MEM, API_DRIVER};                                  // API_Runtime ANALOGUE (cudaMemset)
     cuda2hipRename["cuMemsetD32Async"]                          = {"hipMemsetAsync", CONV_MEM, API_DRIVER};                             // API_Runtime ANALOGUE (cudaMemsetAsync)
-    cuda2hipRename["cuMemsetD8_v2"]                             = {"hipMemsetD8", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuMemsetD8Async"]                           = {"hipMemsetD8Async", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuMipmappedArrayCreate"]                    = {"hipMipmappedArrayCreate", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuMipmappedArrayDestroy"]                   = {"hipMipmappedArrayDestroy", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cuMipmappedArrayGetLevel"]                  = {"hipMipmappedArrayGetLevel", CONV_STREAM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMemsetD8_v2"]                             = {"hipMemsetD8", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMemsetD8Async"]                           = {"hipMemsetD8Async", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMipmappedArrayCreate"]                    = {"hipMipmappedArrayCreate", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMipmappedArrayDestroy"]                   = {"hipMipmappedArrayDestroy", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMipmappedArrayGetLevel"]                  = {"hipMipmappedArrayGetLevel", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
 
     // Unified Addressing
-    cuda2hipRename["cuMemPrefetchAsync"]                        = {"hipMemPrefetchAsync__", CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED};    // [CUDA 8.0.44] // no API_Runtime ANALOGUE (cudaMemPrefetchAsync has different signature)
-    cuda2hipRename["cuMemAdvise"]                               = {"hipMemAdvise", CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED};             // [CUDA 8.0.44] // API_Runtime ANALOGUE (cudaMemAdvise)
-    cuda2hipRename["cuMemRangeGetAttribute"]                    = {"hipMemRangeGetAttribute", CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED};  // [CUDA 8.0.44] // API_Runtime ANALOGUE (cudaMemRangeGetAttribute)
-    cuda2hipRename["cuMemRangeGetAttributes"]                   = {"hipMemRangeGetAttributes", CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED}; // [CUDA 8.0.44] // API_Runtime ANALOGUE (cudaMemRangeGetAttributes)
-    cuda2hipRename["cuPointerGetAttribute"]                     = {"hipPointerGetAttribute", CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED};
-    cuda2hipRename["cuPointerGetAttributes"]                    = {"hipPointerGetAttributes", CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED};
-    cuda2hipRename["cuPointerSetAttribute"]                     = {"hipPointerSetAttribute", CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["cuMemPrefetchAsync"]                        = {"hipMemPrefetchAsync__", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};    // [CUDA 8.0.44] // no API_Runtime ANALOGUE (cudaMemPrefetchAsync has different signature)
+    cuda2hipRename["cuMemAdvise"]                               = {"hipMemAdvise", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};             // [CUDA 8.0.44] // API_Runtime ANALOGUE (cudaMemAdvise)
+    cuda2hipRename["cuMemRangeGetAttribute"]                    = {"hipMemRangeGetAttribute", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};  // [CUDA 8.0.44] // API_Runtime ANALOGUE (cudaMemRangeGetAttribute)
+    cuda2hipRename["cuMemRangeGetAttributes"]                   = {"hipMemRangeGetAttributes", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED}; // [CUDA 8.0.44] // API_Runtime ANALOGUE (cudaMemRangeGetAttributes)
+    cuda2hipRename["cuPointerGetAttribute"]                     = {"hipPointerGetAttribute", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuPointerGetAttributes"]                    = {"hipPointerGetAttributes", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuPointerSetAttribute"]                     = {"hipPointerSetAttribute", CONV_MEM, API_DRIVER, HIP_UNSUPPORTED};
 
     // Texture Reference Mngmnt
     // Texture reference filtering modes
@@ -1089,17 +1114,217 @@ struct cuda2hipMap {
     cuda2hipRename["CU_TR_FILTER_MODE_POINT"]                   = {"hipFilterModePoint", CONV_TEX, API_DRIVER};                      // 0 // API_Runtime ANALOGUE (cudaFilterModePoint = 0)
     cuda2hipRename["CU_TR_FILTER_MODE_LINEAR"]                  = {"hipFilterModeLinear", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};    // 1 // API_Runtime ANALOGUE (cudaFilterModeLinear = 1)
 
-    cuda2hipRename["cuTexRefSetBorderColor"]                    = {"hipTexRefSetBorderColor", CONV_TEX, API_RUNTIME, HIP_UNSUPPORTED}; // [CUDA 8.0.44] // no API_Runtime ANALOGUE
-    cuda2hipRename["cuTexRefGetBorderColor"]                    = {"hipTexRefGetBorderColor", CONV_TEX, API_RUNTIME, HIP_UNSUPPORTED}; // [CUDA 8.0.44] // no API_Runtime ANALOGUE
+    cuda2hipRename["cuTexRefGetAddress"]                        = {"hipTexRefGetAddress", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefGetAddressMode"]                    = {"hipTexRefGetAddressMode", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefGetArray"]                          = {"hipTexRefGetArray", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefGetBorderColor"]                    = {"hipTexRefGetBorderColor", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED}; // [CUDA 8.0.44] // no API_Runtime ANALOGUE
+    cuda2hipRename["cuTexRefGetFilterMode"]                     = {"hipTexRefGetFilterMode", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefGetFlags"]                          = {"hipTexRefGetFlags", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefGetFormat"]                         = {"hipTexRefGetFormat", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefGetMaxAnisotropy"]                  = {"hipTexRefGetMaxAnisotropy", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefGetMipmapFilterMode"]               = {"hipTexRefGetMipmapFilterMode", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefGetMipmapLevelBias"]                = {"hipTexRefGetMipmapLevelBias", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefGetMipmapLevelClamp"]               = {"hipTexRefGetMipmapLevelClamp", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefGetMipmappedArray"]                 = {"hipTexRefGetMipmappedArray", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefSetAddress"]                        = {"hipTexRefSetAddress", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefSetAddress2D"]                      = {"hipTexRefSetAddress2D", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefSetAddressMode"]                    = {"hipTexRefSetAddressMode", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefSetArray"]                          = {"hipTexRefSetArray", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefSetBorderColor"]                    = {"hipTexRefSetBorderColor", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED}; // [CUDA 8.0.44] // no API_Runtime ANALOGUE
+    cuda2hipRename["cuTexRefSetFilterMode"]                     = {"hipTexRefSetFilterMode", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefSetFlags"]                          = {"hipTexRefSetFlags", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefSetFormat"]                         = {"hipTexRefSetFormat", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefSetMaxAnisotropy"]                  = {"hipTexRefSetMaxAnisotropy", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefSetMipmapFilterMode"]               = {"hipTexRefSetMipmapFilterMode", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefSetMipmapLevelBias"]                = {"hipTexRefSetMipmapLevelBias", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefSetMipmapLevelClamp"]               = {"hipTexRefSetMipmapLevelClamp", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefSetMipmappedArray"]                 = {"hipTexRefSetMipmappedArray", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+
+    // Texture Reference Mngmnt [DEPRECATED]
+    cuda2hipRename["cuTexRefCreate"]                            = {"hipTexRefCreate", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexRefDestroy"]                           = {"hipTexRefDestroy", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+
+    // Surface Reference Mngmnt
+    cuda2hipRename["cuSurfRefGetArray"]                         = {"hipSurfRefGetArray", CONV_SURFACE, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuSurfRefSetArray"]                         = {"hipSurfRefSetArray", CONV_SURFACE, API_DRIVER, HIP_UNSUPPORTED};
+
+    // Texture Object Mngmnt
+    cuda2hipRename["cuTexObjectCreate"]                         = {"hipTexObjectCreate", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexObjectDestroy"]                        = {"hipTexObjectDestroy", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexObjectGetResourceDesc"]                = {"hipTexObjectGetResourceDesc", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexObjectGetResourceViewDesc"]            = {"hipTexObjectGetResourceViewDesc", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuTexObjectGetTextureDesc"]                 = {"hipTexObjectGetTextureDesc", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+
+    // Surface Object Mngmnt
+    cuda2hipRename["cuSurfObjectCreate"]                        = {"hipSurfObjectCreate", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuSurfObjectDestroy"]                       = {"hipSurfObjectDestroy", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuSurfObjectGetResourceDesc"]               = {"hipSurfObjectGetResourceDesc", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};
+
+    // Graphics Interoperability
+    cuda2hipRename["cuGraphicsMapResources"]                    = {"hipGraphicsMapResources", CONV_GRAPHICS, API_DRIVER, HIP_UNSUPPORTED};                     // API_Runtime ANALOGUE (cudaGraphicsMapResources)
+    cuda2hipRename["cuGraphicsResourceGetMappedMipmappedArray"] = {"hipGraphicsResourceGetMappedMipmappedArray", CONV_GRAPHICS, API_DRIVER, HIP_UNSUPPORTED};  // API_Runtime ANALOGUE (cudaGraphicsResourceGetMappedMipmappedArray)
+    cuda2hipRename["cuGraphicsResourceGetMappedPointer"]        = {"hipGraphicsResourceGetMappedPointer", CONV_GRAPHICS, API_DRIVER, HIP_UNSUPPORTED};         // API_Runtime ANALOGUE (cudaGraphicsResourceGetMappedPointer)
+    cuda2hipRename["cuGraphicsResourceSetMapFlags"]             = {"hipGraphicsResourceSetMapFlags", CONV_GRAPHICS, API_DRIVER, HIP_UNSUPPORTED};              // API_Runtime ANALOGUE (cudaGraphicsResourceSetMapFlags)
+    cuda2hipRename["cuGraphicsSubResourceGetMappedArray"]       = {"hipGraphicsSubResourceGetMappedArray", CONV_GRAPHICS, API_DRIVER, HIP_UNSUPPORTED};        // API_Runtime ANALOGUE (cudaGraphicsSubResourceGetMappedArray)
+    cuda2hipRename["cuGraphicsUnmapResources"]                  = {"hipGraphicsUnmapResources", CONV_GRAPHICS, API_DRIVER, HIP_UNSUPPORTED};                    // API_Runtime ANALOGUE (cudaGraphicsUnmapResources)
+    cuda2hipRename["cuGraphicsUnregisterResource"]              = {"hipGraphicsUnregisterResource", CONV_GRAPHICS, API_DRIVER, HIP_UNSUPPORTED};                // API_Runtime ANALOGUE (cudaGraphicsUnregisterResource)
 
     // Profiler
-    // unsupported yet by HIP
-    cuda2hipRename["cuProfilerInitialize"]                      = {"hipProfilerInitialize", CONV_OTHER, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cuProfilerInitialize"]                      = {"hipProfilerInitialize", CONV_OTHER, API_DRIVER, HIP_UNSUPPORTED};                           // API_Runtime ANALOGUE (cudaProfilerInitialize)
+    cuda2hipRename["cuProfilerStart"]                           = {"hipProfilerStart", CONV_OTHER, API_DRIVER};                                                 // API_Runtime ANALOGUE (cudaProfilerStart)
+    cuda2hipRename["cuProfilerStop"]                            = {"hipProfilerStop", CONV_OTHER, API_DRIVER};                                                  // API_Runtime ANALOGUE (cudaProfilerStop)
 
-    cuda2hipRename["cuProfilerStart"]                           = {"hipProfilerStart", CONV_OTHER, API_DRIVER};
-    cuda2hipRename["cuProfilerStop"]                            = {"hipProfilerStop", CONV_OTHER, API_DRIVER};
+    // OpenGL Interoperability
+    // enum CUGLDeviceList/CUGLDeviceList_enum
+    cuda2hipRename["CUGLDeviceList"]                            = {"hipGLDeviceList", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                                     // API_Runtime ANALOGUE (cudaGLDeviceList)
+    // cuda2hipRename["CUGLDeviceList_enum"]                    = {"hipGLDeviceList", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["CU_GL_DEVICE_LIST_ALL"]                     = {"HIP_GL_DEVICE_LIST_ALL", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                      // 0x01 // API_Runtime ANALOGUE (cudaGLDeviceListAll)
+    cuda2hipRename["CU_GL_DEVICE_LIST_CURRENT_FRAME"]           = {"HIP_GL_DEVICE_LIST_CURRENT_FRAME", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};            // 0x02 // API_Runtime ANALOGUE (cudaGLDeviceListCurrentFrame)
+    cuda2hipRename["CU_GL_DEVICE_LIST_NEXT_FRAME"]              = {"HIP_GL_DEVICE_LIST_NEXT_FRAME", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};               // 0x03 // API_Runtime ANALOGUE (cudaGLDeviceListNextFrame)
 
-    /////////////////////////////// CUDA RT API ///////////////////////////////
+    cuda2hipRename["cuGLGetDevices"]                            = {"hipGLGetDevices", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                                     // API_Runtime ANALOGUE (cudaGLGetDevices)
+    cuda2hipRename["cuGraphicsGLRegisterBuffer"]                = {"hipGraphicsGLRegisterBuffer", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                         // API_Runtime ANALOGUE (cudaGraphicsGLRegisterBuffer)
+    cuda2hipRename["cuGraphicsGLRegisterImage"]                 = {"hipGraphicsGLRegisterImage", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                          // API_Runtime ANALOGUE (cudaGraphicsGLRegisterImage)
+    cuda2hipRename["cuWGLGetDevice"]                            = {"hipWGLGetDevice", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                                     // API_Runtime ANALOGUE (cudaWGLGetDevice)
+
+    // OpenGL Interoperability [DEPRECATED]
+    // enum CUGLmap_flags/CUGLmap_flags_enum
+    cuda2hipRename["CUGLmap_flags"]                             = {"hipGLMapFlags", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                                       // API_Runtime ANALOGUE (cudaGLMapFlags)
+    // cuda2hipRename["CUGLmap_flags_enum"]                     = {"hipGLMapFlags", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["CU_GL_MAP_RESOURCE_FLAGS_NONE"]             = {"HIP_GL_MAP_RESOURCE_FLAGS_NONE", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};              // 0x00 // API_Runtime ANALOGUE (cudaGLMapFlagsNone)
+    cuda2hipRename["CU_GL_MAP_RESOURCE_FLAGS_READ_ONLY"]        = {"HIP_GL_MAP_RESOURCE_FLAGS_READ_ONLY", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};         // 0x01 // API_Runtime ANALOGUE (cudaGLMapFlagsReadOnly)
+    cuda2hipRename["CU_GL_MAP_RESOURCE_FLAGS_WRITE_DISCARD"]    = {"HIP_GL_MAP_RESOURCE_FLAGS_WRITE_DISCARD", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};     // 0x02 // API_Runtime ANALOGUE (cudaGLMapFlagsWriteDiscard)
+
+    cuda2hipRename["cuGLCtxCreate"]                             = {"hipGLCtxCreate", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                                      // no API_Runtime ANALOGUE
+    cuda2hipRename["cuGLInit"]                                  = {"hipGLInit", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                                           // no API_Runtime ANALOGUE
+    cuda2hipRename["cuGLMapBufferObject"]                       = {"hipGLMapBufferObject", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                                // Not equal to cudaGLMapBufferObject due to different signatures
+    cuda2hipRename["cuGLMapBufferObjectAsync"]                  = {"hipGLMapBufferObjectAsync", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                           // Not equal to cudaGLMapBufferObjectAsync due to different signatures
+    cuda2hipRename["cuGLRegisterBufferObject"]                  = {"hipGLRegisterBufferObject", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                           // API_Runtime ANALOGUE (cudaGLRegisterBufferObject)
+    cuda2hipRename["cuGLSetBufferObjectMapFlags"]               = {"hipGLSetBufferObjectMapFlags", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                        // API_Runtime ANALOGUE (cudaGLSetBufferObjectMapFlags)
+    cuda2hipRename["cuGLUnmapBufferObject"]                     = {"hipGLUnmapBufferObject", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                              // API_Runtime ANALOGUE (cudaGLUnmapBufferObject)
+    cuda2hipRename["cuGLUnmapBufferObjectAsync"]                = {"hipGLUnmapBufferObjectAsync", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                         // API_Runtime ANALOGUE (cudaGLUnmapBufferObjectAsync)
+    cuda2hipRename["cuGLUnregisterBufferObject"]                = {"hipGLUnregisterBufferObject", CONV_GL, API_DRIVER, HIP_UNSUPPORTED};                         // API_Runtime ANALOGUE (cudaGLUnregisterBufferObject)
+
+    // Direct3D 9 Interoperability
+    // enum CUd3d9DeviceList/CUd3d9DeviceList_enum
+    cuda2hipRename["CUd3d9DeviceList"]                          = {"hipD3D9DeviceList", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                                 // API_Runtime ANALOGUE (cudaD3D9DeviceList)
+    // cuda2hipRename["CUd3d9DeviceList_enum"]                  = {"hipD3D9DeviceList", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["CU_D3D9_DEVICE_LIST_ALL"]                   = {"HIP_D3D9_DEVICE_LIST_ALL", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                  // 0x01 // API_Runtime ANALOGUE (cudaD3D9DeviceListAll)
+    cuda2hipRename["CU_D3D9_DEVICE_LIST_CURRENT_FRAME"]         = {"HIP_D3D9_DEVICE_LIST_CURRENT_FRAME", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};        // 0x02 // API_Runtime ANALOGUE (cudaD3D9DeviceListCurrentFrame)
+    cuda2hipRename["CU_D3D9_DEVICE_LIST_NEXT_FRAME"]            = {"HIP_D3D9_DEVICE_LIST_NEXT_FRAME", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};           // 0x03 // API_Runtime ANALOGUE (cudaD3D9DeviceListNextFrame)
+
+    cuda2hipRename["cuD3D9CtxCreate"]                           = {"hipD3D9CtxCreate", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                                  // no API_Runtime ANALOGUE
+    cuda2hipRename["cuD3D9CtxCreateOnDevice"]                   = {"hipD3D9CtxCreateOnDevice", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                          // no API_Runtime ANALOGUE
+    cuda2hipRename["cuD3D9GetDevice"]                           = {"hipD3D9GetDevice", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                                  // API_Runtime ANALOGUE (cudaD3D9GetDevice)
+    cuda2hipRename["cuD3D9GetDevices"]                          = {"hipD3D9GetDevices", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                                 // API_Runtime ANALOGUE (cudaD3D9GetDevices)
+    cuda2hipRename["cuD3D9GetDirect3DDevice"]                   = {"hipD3D9GetDirect3DDevice", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                          // API_Runtime ANALOGUE (cudaD3D9GetDirect3DDevice)
+    cuda2hipRename["cuGraphicsD3D9RegisterResource"]            = {"hipGraphicsD3D9RegisterResource", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                   // API_Runtime ANALOGUE (cudaGraphicsD3D9RegisterResource)
+
+    // Direct3D 9 Interoperability [DEPRECATED]
+    // enum CUd3d9map_flags/CUd3d9map_flags_enum
+    cuda2hipRename["CUd3d9map_flags"]                           = {"hipD3D9MapFlags", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                                   // API_Runtime ANALOGUE (cudaD3D9MapFlags)
+    // cuda2hipRename["CUd3d9map_flags_enum"]                   = {"hipD3D9MapFlags", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["CU_D3D9_MAPRESOURCE_FLAGS_NONE"]            = {"HIP_D3D9_MAPRESOURCE_FLAGS_NONE", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};           // 0x00 // API_Runtime ANALOGUE (cudaD3D9MapFlagsNone)
+    cuda2hipRename["CU_D3D9_MAPRESOURCE_FLAGS_READONLY"]        = {"HIP_D3D9_MAPRESOURCE_FLAGS_READONLY", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};       // 0x01 // API_Runtime ANALOGUE (cudaD3D9MapFlagsReadOnly)
+    cuda2hipRename["CU_D3D9_MAPRESOURCE_FLAGS_WRITEDISCARD"]    = {"HIP_D3D9_MAPRESOURCE_FLAGS_WRITEDISCARD", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};   // 0x02 // API_Runtime ANALOGUE (cudaD3D9MapFlagsWriteDiscard)
+
+    // enum CUd3d9register_flags/CUd3d9register_flags_enum
+    cuda2hipRename["CUd3d9register_flags"]                      = {"hipD3D9RegisterFlags", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                              // API_Runtime ANALOGUE (cudaD3D9RegisterFlags)
+    // cuda2hipRename["CUd3d9register_flags_enum"]              = {"hipD3D9RegisterFlags", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["CU_D3D9_REGISTER_FLAGS_NONE"]               = {"HIP_D3D9_REGISTER_FLAGS_NONE", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};              // 0x00 // API_Runtime ANALOGUE (cudaD3D9RegisterFlagsNone)
+    cuda2hipRename["CU_D3D9_REGISTER_FLAGS_ARRAY"]              = {"HIP_D3D9_REGISTER_FLAGS_ARRAY", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};             // 0x01 // API_Runtime ANALOGUE (cudaD3D9RegisterFlagsArray)
+
+    cuda2hipRename["cuD3D9MapResources"]                        = {"hipD3D9MapResources", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                               // API_Runtime ANALOGUE (cudaD3D9MapResources)
+    cuda2hipRename["cuD3D9RegisterResource"]                    = {"hipD3D9RegisterResource", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                           // API_Runtime ANALOGUE (cudaD3D9RegisterResource)
+    cuda2hipRename["cuD3D9ResourceGetMappedArray"]              = {"hipD3D9ResourceGetMappedArray", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                     // API_Runtime ANALOGUE (cudaD3D9ResourceGetMappedArray)
+    cuda2hipRename["cuD3D9ResourceGetMappedPitch"]              = {"hipD3D9ResourceGetMappedPitch", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                     // API_Runtime ANALOGUE (cudaD3D9ResourceGetMappedPitch)
+    cuda2hipRename["cuD3D9ResourceGetMappedPointer"]            = {"hipD3D9ResourceGetMappedPointer", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                   // API_Runtime ANALOGUE (cudaD3D9ResourceGetMappedPointer)
+    cuda2hipRename["cuD3D9ResourceGetMappedSize"]               = {"hipD3D9ResourceGetMappedSize", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                      // API_Runtime ANALOGUE (cudaD3D9ResourceGetMappedSize)
+    cuda2hipRename["cuD3D9ResourceGetSurfaceDimensions"]        = {"hipD3D9ResourceGetSurfaceDimensions", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};               // API_Runtime ANALOGUE (cudaD3D9ResourceGetSurfaceDimensions)
+    cuda2hipRename["cuD3D9ResourceSetMapFlags"]                 = {"hipD3D9ResourceSetMapFlags", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                        // API_Runtime ANALOGUE (cudaD3D9ResourceSetMapFlags)
+    cuda2hipRename["cuD3D9UnmapResources"]                      = {"hipD3D9UnmapResources", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                             // API_Runtime ANALOGUE (cudaD3D9UnmapResources)
+    cuda2hipRename["cuD3D9UnregisterResource"]                  = {"hipD3D9UnregisterResource", CONV_D3D9, API_DRIVER, HIP_UNSUPPORTED};                         // API_Runtime ANALOGUE (cudaD3D9UnregisterResource)
+
+    // Direct3D 10 Interoperability
+    // enum CUd3d10DeviceList/CUd3d10DeviceList_enum
+    cuda2hipRename["CUd3d10DeviceList"]                         = {"hipd3d10DeviceList", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                               // API_Runtime ANALOGUE (cudaD3D10DeviceList)
+    // cuda2hipRename["CUd3d10DeviceList_enum"]                 = {"hipD3D10DeviceList", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["CU_D3D10_DEVICE_LIST_ALL"]                  = {"HIP_D3D10_DEVICE_LIST_ALL", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                // 0x01 // API_Runtime ANALOGUE (cudaD3D10DeviceListAll)
+    cuda2hipRename["CU_D3D10_DEVICE_LIST_CURRENT_FRAME"]        = {"HIP_D3D10_DEVICE_LIST_CURRENT_FRAME", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};      // 0x02 // API_Runtime ANALOGUE (cudaD3D10DeviceListCurrentFrame)
+    cuda2hipRename["CU_D3D10_DEVICE_LIST_NEXT_FRAME"]           = {"HIP_D3D10_DEVICE_LIST_NEXT_FRAME", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};         // 0x03 // API_Runtime ANALOGUE (cudaD3D10DeviceListNextFrame)
+
+    cuda2hipRename["cuD3D10GetDevice"]                          = {"hipD3D10GetDevice", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                                // API_Runtime ANALOGUE (cudaD3D10GetDevice)
+    cuda2hipRename["cuD3D10GetDevices"]                         = {"hipD3D10GetDevices", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                               // API_Runtime ANALOGUE (cudaD3D10GetDevices)
+    cuda2hipRename["cuGraphicsD3D10RegisterResource"]           = {"hipGraphicsD3D10RegisterResource", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                 // API_Runtime ANALOGUE (cudaGraphicsD3D10RegisterResource)
+
+    // Direct3D 10 Interoperability [DEPRECATED]
+    // enum CUd3d10map_flags/CUd3d10map_flags_enum
+    cuda2hipRename["CUd3d10map_flags"]                          = {"hipD3D10MapFlags", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                                 // API_Runtime ANALOGUE (cudaD3D10MapFlags)
+    // cuda2hipRename["CUd3d10map_flags_enum"]                  = {"hipD3D10MapFlags", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["CU_D3D10_MAPRESOURCE_FLAGS_NONE"]           = {"HIP_D3D10_MAPRESOURCE_FLAGS_NONE", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};         // 0x00 // API_Runtime ANALOGUE (cudaD3D10MapFlagsNone)
+    cuda2hipRename["CU_D3D10_MAPRESOURCE_FLAGS_READONLY"]       = {"HIP_D3D10_MAPRESOURCE_FLAGS_READONLY", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};     // 0x01 // API_Runtime ANALOGUE (cudaD3D10MapFlagsReadOnly)
+    cuda2hipRename["CU_D3D10_MAPRESOURCE_FLAGS_WRITEDISCARD"]   = {"HIP_D3D10_MAPRESOURCE_FLAGS_WRITEDISCARD", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED}; // 0x02 // API_Runtime ANALOGUE (cudaD3D10MapFlagsWriteDiscard)
+
+    // enum CUd3d10register_flags/CUd3d10register_flags_enum
+    cuda2hipRename["CUd3d10register_flags"]                     = {"hipD3D10RegisterFlags", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                            // API_Runtime ANALOGUE (cudaD3D10RegisterFlags)
+    // cuda2hipRename["CUd3d10register_flags_enum"]             = {"hipD3D10RegisterFlags", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["CU_D3D10_REGISTER_FLAGS_NONE"]              = {"HIP_D3D10_REGISTER_FLAGS_NONE", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};            // 0x00 // API_Runtime ANALOGUE (cudaD3D10RegisterFlagsNone)
+    cuda2hipRename["CU_D3D10_REGISTER_FLAGS_ARRAY"]             = {"HIP_D3D10_REGISTER_FLAGS_ARRAY", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};           // 0x01 // API_Runtime ANALOGUE (cudaD3D10RegisterFlagsArray)
+
+    cuda2hipRename["cuD3D10CtxCreate"]                          = {"hipD3D10CtxCreate", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                                // no API_Runtime ANALOGUE
+    cuda2hipRename["cuD3D10CtxCreateOnDevice"]                  = {"hipD3D10CtxCreateOnDevice", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                        // no API_Runtime ANALOGUE
+    cuda2hipRename["cuD3D10GetDirect3DDevice"]                  = {"hipD3D10GetDirect3DDevice", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                        // API_Runtime ANALOGUE (cudaD3D10GetDirect3DDevice)
+    cuda2hipRename["cuD3D10MapResources"]                       = {"hipD3D10MapResources", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                             // API_Runtime ANALOGUE (cudaD3D10MapResources)
+    cuda2hipRename["cuD3D10RegisterResource"]                   = {"hipD3D10RegisterResource", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                         // API_Runtime ANALOGUE (cudaD3D10RegisterResource)
+    cuda2hipRename["cuD3D10ResourceGetMappedArray"]             = {"hipD3D10ResourceGetMappedArray", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                   // API_Runtime ANALOGUE (cudaD3D10ResourceGetMappedArray)
+    cuda2hipRename["cuD3D10ResourceGetMappedPitch"]             = {"hipD3D10ResourceGetMappedPitch", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                   // API_Runtime ANALOGUE (cudaD3D10ResourceGetMappedPitch)
+    cuda2hipRename["cuD3D10ResourceGetMappedPointer"]           = {"hipD3D10ResourceGetMappedPointer", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                 // API_Runtime ANALOGUE (cudaD3D10ResourceGetMappedPointer)
+    cuda2hipRename["cuD3D10ResourceGetMappedSize"]              = {"hipD3D10ResourceGetMappedSize", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                    // API_Runtime ANALOGUE (cudaD3D10ResourceGetMappedSize)
+    cuda2hipRename["cuD3D10ResourceGetSurfaceDimensions"]       = {"hipD3D10ResourceGetSurfaceDimensions", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};             // API_Runtime ANALOGUE (cudaD3D10ResourceGetSurfaceDimensions)
+    cuda2hipRename["cuD310ResourceSetMapFlags"]                 = {"hipD3D10ResourceSetMapFlags", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                      // API_Runtime ANALOGUE (cudaD3D10ResourceSetMapFlags)
+    cuda2hipRename["cuD3D10UnmapResources"]                     = {"hipD3D10UnmapResources", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                           // API_Runtime ANALOGUE (cudaD3D10UnmapResources)
+    cuda2hipRename["cuD3D10UnregisterResource"]                 = {"hipD3D10UnregisterResource", CONV_D3D10, API_DRIVER, HIP_UNSUPPORTED};                       // API_Runtime ANALOGUE (cudaD3D10UnregisterResource)
+
+    // Direct3D 11 Interoperability
+    // enum CUd3d11DeviceList/CUd3d11DeviceList_enum
+    cuda2hipRename["CUd3d11DeviceList"]                         = {"hipd3d11DeviceList", CONV_D3D11, API_DRIVER, HIP_UNSUPPORTED};                               // API_Runtime ANALOGUE (cudaD3D11DeviceList)
+    // cuda2hipRename["CUd3d11DeviceList_enum"]                 = {"hipD3D11DeviceList", CONV_D3D11, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["CU_D3D11_DEVICE_LIST_ALL"]                  = {"HIP_D3D11_DEVICE_LIST_ALL", CONV_D3D11, API_DRIVER, HIP_UNSUPPORTED};                // 0x01 // API_Runtime ANALOGUE (cudaD3D11DeviceListAll)
+    cuda2hipRename["CU_D3D11_DEVICE_LIST_CURRENT_FRAME"]        = {"HIP_D3D11_DEVICE_LIST_CURRENT_FRAME", CONV_D3D11, API_DRIVER, HIP_UNSUPPORTED};      // 0x02 // API_Runtime ANALOGUE (cudaD3D11DeviceListCurrentFrame)
+    cuda2hipRename["CU_D3D11_DEVICE_LIST_NEXT_FRAME"]           = {"HIP_D3D11_DEVICE_LIST_NEXT_FRAME", CONV_D3D11, API_DRIVER, HIP_UNSUPPORTED};         // 0x03 // API_Runtime ANALOGUE (cudaD3D11DeviceListNextFrame)
+
+    cuda2hipRename["cuD3D11GetDevice"]                          = {"hipD3D11GetDevice", CONV_D3D11, API_DRIVER, HIP_UNSUPPORTED};                                // API_Runtime ANALOGUE (cudaD3D11GetDevice)
+    cuda2hipRename["cuD3D11GetDevices"]                         = {"hipD3D11GetDevices", CONV_D3D11, API_DRIVER, HIP_UNSUPPORTED};                               // API_Runtime ANALOGUE (cudaD3D11GetDevices)
+    cuda2hipRename["cuGraphicsD3D11RegisterResource"]           = {"hipGraphicsD3D11RegisterResource", CONV_D3D11, API_DRIVER, HIP_UNSUPPORTED};                 // API_Runtime ANALOGUE (cudaGraphicsD3D11RegisterResource)
+
+    // Direct3D 11 Interoperability [DEPRECATED]
+    cuda2hipRename["cuD3D11CtxCreate"]                          = {"hipD3D11CtxCreate", CONV_D3D11, API_DRIVER, HIP_UNSUPPORTED};                                // no API_Runtime ANALOGUE
+    cuda2hipRename["cuD3D11CtxCreateOnDevice"]                  = {"hipD3D11CtxCreateOnDevice", CONV_D3D11, API_DRIVER, HIP_UNSUPPORTED};                        // no API_Runtime ANALOGUE
+    cuda2hipRename["cuD3D11GetDirect3DDevice"]                  = {"hipD3D11GetDirect3DDevice", CONV_D3D11, API_DRIVER, HIP_UNSUPPORTED};                        // API_Runtime ANALOGUE (cudaD3D11GetDirect3DDevice)
+
+    // VDPAU Interoperability
+    cuda2hipRename["cuGraphicsVDPAURegisterOutputSurface"]      = {"hipGraphicsVDPAURegisterOutputSurface", CONV_VDPAU, API_DRIVER, HIP_UNSUPPORTED};            // API_Runtime ANALOGUE (cudaGraphicsVDPAURegisterOutputSurface)
+    cuda2hipRename["cuGraphicsVDPAURegisterVideoSurface"]       = {"hipGraphicsVDPAURegisterVideoSurface", CONV_VDPAU, API_DRIVER, HIP_UNSUPPORTED};             // API_Runtime ANALOGUE (cudaGraphicsVDPAURegisterVideoSurface)
+    cuda2hipRename["cuVDPAUGetDevice"]                          = {"hipVDPAUGetDevice", CONV_VDPAU, API_DRIVER, HIP_UNSUPPORTED};                                // API_Runtime ANALOGUE (cudaVDPAUGetDevice)
+    cuda2hipRename["cuVDPAUCtxCreate"]                          = {"hipVDPAUCtxCreate", CONV_VDPAU, API_DRIVER, HIP_UNSUPPORTED};                                // no API_Runtime ANALOGUE
+
+    // EGL Interoperability
+    cuda2hipRename["CUeglStreamConnection_st"]                  = {"hipEglStreamConnection", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED};                             // API_Runtime ANALOGUE (cudaEglStreamConnection)
+    cuda2hipRename["CUeglStreamConnection"]                     = {"hipEglStreamConnection", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED};                             // API_Runtime ANALOGUE (cudaEglStreamConnection)
+
+    cuda2hipRename["cuEGLStreamConsumerAcquireFrame"]           = {"hipEGLStreamConsumerAcquireFrame", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED};                   // API_Runtime ANALOGUE (cudaEGLStreamConsumerAcquireFrame)
+    cuda2hipRename["cuEGLStreamConsumerConnect"]                = {"hipEGLStreamConsumerConnect", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED};                        // API_Runtime ANALOGUE (cudaEGLStreamConsumerConnect)
+    cuda2hipRename["cuEGLStreamConsumerConnectWithFlags"]       = {"hipEGLStreamConsumerConnectWithFlags", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED};               // API_Runtime ANALOGUE (cudaEGLStreamConsumerConnectWithFlags)
+    cuda2hipRename["cuEGLStreamConsumerDisconnect"]             = {"hipEGLStreamConsumerDisconnect", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED};                     // no API_Runtime ANALOGUE
+    cuda2hipRename["cuEGLStreamConsumerReleaseFrame"]           = {"hipEGLStreamConsumerReleaseFrame", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED};                   // API_Runtime ANALOGUE (cudaEGLStreamConsumerReleaseFrame)
+    cuda2hipRename["cuEGLStreamProducerConnect"]                = {"hipEGLStreamProducerConnect", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED};                        // API_Runtime ANALOGUE (cudaEGLStreamProducerConnect)
+    cuda2hipRename["cuEGLStreamProducerDisconnect"]             = {"hipEGLStreamProducerDisconnect", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED};                     // API_Runtime ANALOGUE (cudaEGLStreamProducerDisconnect)
+    cuda2hipRename["cuEGLStreamProducerPresentFrame"]           = {"hipEGLStreamProducerPresentFrame", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED};                   // API_Runtime ANALOGUE (cudaEGLStreamProducerPresentFrame)
+    cuda2hipRename["cuEGLStreamProducerReturnFrame"]            = {"hipEGLStreamProducerReturnFrame", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED};                    // API_Runtime ANALOGUE (cudaEGLStreamProducerReturnFrame)
+    cuda2hipRename["cuGraphicsEGLRegisterImage"]                = {"hipGraphicsEGLRegisterImage", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED};                        // API_Runtime ANALOGUE (cudaGraphicsEGLRegisterImage)
+    cuda2hipRename["cuGraphicsResourceGetMappedEglFrame"]       = {"hipGraphicsResourceGetMappedEglFrame", CONV_EGL, API_DRIVER, HIP_UNSUPPORTED};               // API_Runtime ANALOGUE (cudaGraphicsResourceGetMappedEglFrame)
+
+/////////////////////////////// CUDA RT API ///////////////////////////////
     // Data types
     // unsupported yet by HIP [CUDA 8.0.44]
     cuda2hipRename["cudaDataType_t"]              = {"hipDataType_t", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};
@@ -1138,10 +1363,10 @@ struct cuda2hipMap {
     cuda2hipRename["cudaOccupancyDisableCachingOverride"]        = {"hipOccupancyDisableCachingOverride", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};       // 0x01 // API_Driver ANALOGUE (CU_OCCUPANCY_DISABLE_CACHING_OVERRIDE = 0x1)
 
     // Error API
-    cuda2hipRename["cudaGetLastError"]            = {"hipGetLastError", CONV_ERR, API_RUNTIME};
-    cuda2hipRename["cudaPeekAtLastError"]         = {"hipPeekAtLastError", CONV_ERR, API_RUNTIME};
-    cuda2hipRename["cudaGetErrorName"]            = {"hipGetErrorName", CONV_ERR, API_RUNTIME};
-    cuda2hipRename["cudaGetErrorString"]          = {"hipGetErrorString", CONV_ERR, API_RUNTIME};
+    cuda2hipRename["cudaGetLastError"]            = {"hipGetLastError", CONV_ERROR, API_RUNTIME};
+    cuda2hipRename["cudaPeekAtLastError"]         = {"hipPeekAtLastError", CONV_ERROR, API_RUNTIME};
+    cuda2hipRename["cudaGetErrorName"]            = {"hipGetErrorName", CONV_ERROR, API_RUNTIME};
+    cuda2hipRename["cudaGetErrorString"]          = {"hipGetErrorString", CONV_ERROR, API_RUNTIME};
 
     // Arrays
     cuda2hipRename["cudaArray"]                   = {"hipArray", CONV_MEM, API_RUNTIME};
@@ -1324,7 +1549,6 @@ struct cuda2hipMap {
     cuda2hipRename["cudaStream_t"]                  = {"hipStream_t", CONV_TYPE, API_RUNTIME};
     cuda2hipRename["cudaStreamCreate"]              = {"hipStreamCreate", CONV_STREAM, API_RUNTIME};
     cuda2hipRename["cudaStreamCreateWithFlags"]     = {"hipStreamCreateWithFlags", CONV_STREAM, API_RUNTIME};
-    // unsupported yet by HIP
     cuda2hipRename["cudaStreamCreateWithPriority"]  = {"hipStreamCreateWithPriority", CONV_STREAM, API_RUNTIME, HIP_UNSUPPORTED};
     cuda2hipRename["cudaStreamDestroy"]             = {"hipStreamDestroy", CONV_STREAM, API_RUNTIME};
     cuda2hipRename["cudaStreamWaitEvent"]           = {"hipStreamWaitEvent", CONV_STREAM, API_RUNTIME};
@@ -1332,124 +1556,127 @@ struct cuda2hipMap {
     cuda2hipRename["cudaStreamGetFlags"]            = {"hipStreamGetFlags", CONV_STREAM, API_RUNTIME};
     cuda2hipRename["cudaStreamQuery"]               = {"hipStreamQuery", CONV_STREAM, API_RUNTIME};
     cuda2hipRename["cudaStreamAddCallback"]         = {"hipStreamAddCallback", CONV_STREAM, API_RUNTIME};
-    // unsupported yet by HIP
     cuda2hipRename["cudaStreamAttachMemAsync"]      = {"hipStreamAttachMemAsync", CONV_STREAM, API_RUNTIME, HIP_UNSUPPORTED};
     cuda2hipRename["cudaStreamGetPriority"]         = {"hipStreamGetPriority", CONV_STREAM, API_RUNTIME, HIP_UNSUPPORTED};
 
     // Stream Flags
-    cuda2hipRename["cudaStreamDefault"]             = {"hipStreamDefault", CONV_STREAM, API_RUNTIME};
-    cuda2hipRename["cudaStreamNonBlocking"]         = {"hipStreamNonBlocking", CONV_STREAM, API_RUNTIME};
+    cuda2hipRename["cudaStreamDefault"]             = {"hipStreamDefault", CONV_TYPE, API_RUNTIME};
+    cuda2hipRename["cudaStreamNonBlocking"]         = {"hipStreamNonBlocking", CONV_TYPE, API_RUNTIME};
 
     // Other synchronization
-    cuda2hipRename["cudaDeviceSynchronize"]         = {"hipDeviceSynchronize", CONV_DEV, API_RUNTIME};
-    // translate deprecated cudaThreadSynchronize
-    cuda2hipRename["cudaThreadSynchronize"]         = {"hipDeviceSynchronize", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaDeviceReset"]               = {"hipDeviceReset", CONV_DEV, API_RUNTIME};
-    // translate deprecated cudaThreadExit
-    cuda2hipRename["cudaThreadExit"]                = {"hipDeviceReset", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaSetDevice"]                 = {"hipSetDevice", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaGetDevice"]                 = {"hipGetDevice", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaGetDeviceCount"]            = {"hipGetDeviceCount", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaChooseDevice"]              = {"hipChooseDevice", CONV_DEV, API_RUNTIME};
+    cuda2hipRename["cudaDeviceSynchronize"]         = {"hipDeviceSynchronize", CONV_DEVICE, API_RUNTIME};
+    cuda2hipRename["cudaDeviceReset"]               = {"hipDeviceReset", CONV_DEVICE, API_RUNTIME};
+    cuda2hipRename["cudaSetDevice"]                 = {"hipSetDevice", CONV_DEVICE, API_RUNTIME};
+    cuda2hipRename["cudaGetDevice"]                 = {"hipGetDevice", CONV_DEVICE, API_RUNTIME};
+    cuda2hipRename["cudaGetDeviceCount"]            = {"hipGetDeviceCount", CONV_DEVICE, API_RUNTIME};
+    cuda2hipRename["cudaChooseDevice"]              = {"hipChooseDevice", CONV_DEVICE, API_RUNTIME};
+
+    // Thread Management
+    cuda2hipRename["cudaThreadExit"]                = {"hipDeviceReset", CONV_THREAD, API_RUNTIME};
+    cuda2hipRename["cudaThreadGetCacheConfig"]      = {"hipDeviceGetCacheConfig", CONV_THREAD, API_RUNTIME};
+    cuda2hipRename["cudaThreadGetLimit"]            = {"hipThreadGetLimit", CONV_THREAD, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["cudaThreadSetCacheConfig"]      = {"hipDeviceSetCacheConfig", CONV_THREAD, API_RUNTIME};
+    cuda2hipRename["cudaThreadSetLimit"]            = {"hipThreadSetLimit", CONV_THREAD, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["cudaThreadSynchronize"]         = {"hipDeviceSynchronize", CONV_THREAD, API_RUNTIME};
 
     // Attributes
-    cuda2hipRename["cudaDeviceGetAttribute"]                       = {"hipDeviceGetAttribute", CONV_DEV, API_RUNTIME};
+    cuda2hipRename["cudaDeviceGetAttribute"]                       = {"hipDeviceGetAttribute", CONV_DEVICE, API_RUNTIME};
 
     cuda2hipRename["cudaDeviceAttr"]                               = {"hipDeviceAttribute_t", CONV_TYPE, API_RUNTIME};                                                      // API_DRIVER ANALOGUE (CUdevice_attribute)
-    cuda2hipRename["cudaDevAttrMaxThreadsPerBlock"]                = {"hipDeviceAttributeMaxThreadsPerBlock", CONV_DEV, API_RUNTIME};                                 //  1 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1)
-    cuda2hipRename["cudaDevAttrMaxBlockDimX"]                      = {"hipDeviceAttributeMaxBlockDimX", CONV_DEV, API_RUNTIME};                                       //  2 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X = 2)
-    cuda2hipRename["cudaDevAttrMaxBlockDimY"]                      = {"hipDeviceAttributeMaxBlockDimY", CONV_DEV, API_RUNTIME};                                       //  3 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y = 3)
-    cuda2hipRename["cudaDevAttrMaxBlockDimZ"]                      = {"hipDeviceAttributeMaxBlockDimZ", CONV_DEV, API_RUNTIME};                                       //  4 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z = 4)
-    cuda2hipRename["cudaDevAttrMaxGridDimX"]                       = {"hipDeviceAttributeMaxGridDimX", CONV_DEV, API_RUNTIME};                                        //  5 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X = 5)
-    cuda2hipRename["cudaDevAttrMaxGridDimY"]                       = {"hipDeviceAttributeMaxGridDimY", CONV_DEV, API_RUNTIME};                                        //  6 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X = 6)
-    cuda2hipRename["cudaDevAttrMaxGridDimZ"]                       = {"hipDeviceAttributeMaxGridDimZ", CONV_DEV, API_RUNTIME};                                        //  7 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X = 7)
-    cuda2hipRename["cudaDevAttrMaxSharedMemoryPerBlock"]           = {"hipDeviceAttributeMaxSharedMemoryPerBlock", CONV_DEV, API_RUNTIME};                            //  8 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK = 8)
-    cuda2hipRename["cudaDevAttrTotalConstantMemory"]               = {"hipDeviceAttributeTotalConstantMemory", CONV_DEV, API_RUNTIME};                                //  9 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY =9)
-    cuda2hipRename["cudaDevAttrWarpSize"]                          = {"hipDeviceAttributeWarpSize", CONV_DEV, API_RUNTIME};                                           // 10 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_WARP_SIZE = 10)
-    cuda2hipRename["cudaDevAttrMaxPitch"]                          = {"hipDeviceAttributeMaxPitch", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                          // 11 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_PITCH = 11)
-    cuda2hipRename["cudaDevAttrMaxRegistersPerBlock"]              = {"hipDeviceAttributeMaxRegistersPerBlock", CONV_DEV, API_RUNTIME};                               // 12 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK = 12)
-    cuda2hipRename["cudaDevAttrClockRate"]                         = {"hipDeviceAttributeClockRate", CONV_DEV, API_RUNTIME};                                          // 13 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_CLOCK_RATE = 13)
-    cuda2hipRename["cudaDevAttrTextureAlignment"]                  = {"hipDeviceAttributeTextureAlignment", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                  // 14 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT = 14)
+    cuda2hipRename["cudaDevAttrMaxThreadsPerBlock"]                = {"hipDeviceAttributeMaxThreadsPerBlock", CONV_TYPE, API_RUNTIME};                                 //  1 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK = 1)
+    cuda2hipRename["cudaDevAttrMaxBlockDimX"]                      = {"hipDeviceAttributeMaxBlockDimX", CONV_TYPE, API_RUNTIME};                                       //  2 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X = 2)
+    cuda2hipRename["cudaDevAttrMaxBlockDimY"]                      = {"hipDeviceAttributeMaxBlockDimY", CONV_TYPE, API_RUNTIME};                                       //  3 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y = 3)
+    cuda2hipRename["cudaDevAttrMaxBlockDimZ"]                      = {"hipDeviceAttributeMaxBlockDimZ", CONV_TYPE, API_RUNTIME};                                       //  4 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z = 4)
+    cuda2hipRename["cudaDevAttrMaxGridDimX"]                       = {"hipDeviceAttributeMaxGridDimX", CONV_TYPE, API_RUNTIME};                                        //  5 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X = 5)
+    cuda2hipRename["cudaDevAttrMaxGridDimY"]                       = {"hipDeviceAttributeMaxGridDimY", CONV_TYPE, API_RUNTIME};                                        //  6 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X = 6)
+    cuda2hipRename["cudaDevAttrMaxGridDimZ"]                       = {"hipDeviceAttributeMaxGridDimZ", CONV_TYPE, API_RUNTIME};                                        //  7 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X = 7)
+    cuda2hipRename["cudaDevAttrMaxSharedMemoryPerBlock"]           = {"hipDeviceAttributeMaxSharedMemoryPerBlock", CONV_TYPE, API_RUNTIME};                            //  8 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK = 8)
+    cuda2hipRename["cudaDevAttrTotalConstantMemory"]               = {"hipDeviceAttributeTotalConstantMemory", CONV_TYPE, API_RUNTIME};                                //  9 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY =9)
+    cuda2hipRename["cudaDevAttrWarpSize"]                          = {"hipDeviceAttributeWarpSize", CONV_TYPE, API_RUNTIME};                                           // 10 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_WARP_SIZE = 10)
+    cuda2hipRename["cudaDevAttrMaxPitch"]                          = {"hipDeviceAttributeMaxPitch", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                          // 11 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_PITCH = 11)
+    cuda2hipRename["cudaDevAttrMaxRegistersPerBlock"]              = {"hipDeviceAttributeMaxRegistersPerBlock", CONV_TYPE, API_RUNTIME};                               // 12 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK = 12)
+    cuda2hipRename["cudaDevAttrClockRate"]                         = {"hipDeviceAttributeClockRate", CONV_TYPE, API_RUNTIME};                                          // 13 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_CLOCK_RATE = 13)
+    cuda2hipRename["cudaDevAttrTextureAlignment"]                  = {"hipDeviceAttributeTextureAlignment", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                  // 14 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT = 14)
     // Is not deprecated as CUDA Driver's API analogue CU_DEVICE_ATTRIBUTE_GPU_OVERLAP
-    cuda2hipRename["cudaDevAttrGpuOverlap"]                        = {"hipDeviceAttributeGpuOverlap", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                        // 15 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_GPU_OVERLAP = 15)
-    cuda2hipRename["cudaDevAttrMultiProcessorCount"]               = {"hipDeviceAttributeMultiprocessorCount", CONV_DEV, API_RUNTIME};                                // 16 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT = 16)
-    cuda2hipRename["cudaDevAttrKernelExecTimeout"]                 = {"hipDeviceAttributeKernelExecTimeout", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                 // 17 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT = 17)
-    cuda2hipRename["cudaDevAttrIntegrated"]                        = {"hipDeviceAttributeIntegrated", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                        // 18 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_INTEGRATED = 18)
-    cuda2hipRename["cudaDevAttrCanMapHostMemory"]                  = {"hipDeviceAttributeCanMapHostMemory", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                  // 19 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY = 19)
-    cuda2hipRename["cudaDevAttrComputeMode"]                       = {"hipDeviceAttributeComputeMode", CONV_DEV, API_RUNTIME};                                        // 20 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_COMPUTE_MODE = 20)
-    cuda2hipRename["cudaDevAttrMaxTexture1DWidth"]                 = {"hipDeviceAttributeMaxTexture1DWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                 // 21 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH = 21)
-    cuda2hipRename["cudaDevAttrMaxTexture2DWidth"]                 = {"hipDeviceAttributeMaxTexture2DWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                 // 22 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH = 22)
-    cuda2hipRename["cudaDevAttrMaxTexture2DHeight"]                = {"hipDeviceAttributeMaxTexture2DHeight", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                // 23 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT = 23)
-    cuda2hipRename["cudaDevAttrMaxTexture3DWidth"]                 = {"hipDeviceAttributeMaxTexture3DWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                 // 24 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH = 24)
-    cuda2hipRename["cudaDevAttrMaxTexture3DHeight"]                = {"hipDeviceAttributeMaxTexture3DHeight", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                // 25 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT = 25)
-    cuda2hipRename["cudaDevAttrMaxTexture3DDepth"]                 = {"hipDeviceAttributeMaxTexture3DDepth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                 // 26 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH = 26)
-    cuda2hipRename["cudaDevAttrMaxTexture2DLayeredWidth"]          = {"hipDeviceAttributeMaxTexture2DLayeredWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};          // 27 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH = 27)
-    cuda2hipRename["cudaDevAttrMaxTexture2DLayeredHeight"]         = {"hipDeviceAttributeMaxTexture2DLayeredHeight", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};         // 28 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT = 28)
-    cuda2hipRename["cudaDevAttrMaxTexture2DLayeredLayers"]         = {"hipDeviceAttributeMaxTexture2DLayeredLayers", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};         // 29 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS = 29)
-    cuda2hipRename["cudaDevAttrSurfaceAlignment"]                  = {"hipDeviceAttributeSurfaceAlignment", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                  // 30 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_SURFACE_ALIGNMENT = 30)
-    cuda2hipRename["cudaDevAttrConcurrentKernels"]                 = {"hipDeviceAttributeConcurrentKernels", CONV_DEV, API_RUNTIME};                                  // 31 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS = 31)
-    cuda2hipRename["cudaDevAttrEccEnabled"]                        = {"hipDeviceAttributeEccEnabled", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                        // 32 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_ECC_ENABLED = 32)
-    cuda2hipRename["cudaDevAttrPciBusId"]                          = {"hipDeviceAttributePciBusId", CONV_DEV, API_RUNTIME};                                           // 33 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_PCI_BUS_ID = 33)
-    cuda2hipRename["cudaDevAttrPciDeviceId"]                       = {"hipDeviceAttributePciDeviceId", CONV_DEV, API_RUNTIME};                                        // 34 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID = 34)
-    cuda2hipRename["cudaDevAttrTccDriver"]                         = {"hipDeviceAttributeTccDriver", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                         // 35 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_TCC_DRIVER = 35)
-    cuda2hipRename["cudaDevAttrMemoryClockRate"]                   = {"hipDeviceAttributeMemoryClockRate", CONV_DEV, API_RUNTIME};                                    // 36 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE = 36)
-    cuda2hipRename["cudaDevAttrGlobalMemoryBusWidth"]              = {"hipDeviceAttributeMemoryBusWidth", CONV_DEV, API_RUNTIME};                                     // 37 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH = 37)
-    cuda2hipRename["cudaDevAttrL2CacheSize"]                       = {"hipDeviceAttributeL2CacheSize", CONV_DEV, API_RUNTIME};                                        // 38 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE = 38)
-    cuda2hipRename["cudaDevAttrMaxThreadsPerMultiProcessor"]       = {"hipDeviceAttributeMaxThreadsPerMultiProcessor", CONV_DEV, API_RUNTIME};                        // 39 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR = 39)
-    cuda2hipRename["cudaDevAttrAsyncEngineCount"]                  = {"hipDeviceAttributeAsyncEngineCount", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                  // 40 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT = 40)
-    cuda2hipRename["cudaDevAttrUnifiedAddressing"]                 = {"hipDeviceAttributeUnifiedAddressing", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                 // 41 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING = 41)
-    cuda2hipRename["cudaDevAttrMaxTexture1DLayeredWidth"]          = {"hipDeviceAttributeMaxTexture1DLayeredWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};          // 42 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_WIDTH = 42)
-    cuda2hipRename["cudaDevAttrMaxTexture1DLayeredLayers"]         = {"hipDeviceAttributeMaxTexture1DLayeredLayers", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};         // 43 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_LAYERS = 43)
+    cuda2hipRename["cudaDevAttrGpuOverlap"]                        = {"hipDeviceAttributeGpuOverlap", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                        // 15 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_GPU_OVERLAP = 15)
+    cuda2hipRename["cudaDevAttrMultiProcessorCount"]               = {"hipDeviceAttributeMultiprocessorCount", CONV_TYPE, API_RUNTIME};                                // 16 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT = 16)
+    cuda2hipRename["cudaDevAttrKernelExecTimeout"]                 = {"hipDeviceAttributeKernelExecTimeout", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 17 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT = 17)
+    cuda2hipRename["cudaDevAttrIntegrated"]                        = {"hipDeviceAttributeIntegrated", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                        // 18 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_INTEGRATED = 18)
+    cuda2hipRename["cudaDevAttrCanMapHostMemory"]                  = {"hipDeviceAttributeCanMapHostMemory", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                  // 19 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY = 19)
+    cuda2hipRename["cudaDevAttrComputeMode"]                       = {"hipDeviceAttributeComputeMode", CONV_TYPE, API_RUNTIME};                                        // 20 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_COMPUTE_MODE = 20)
+    cuda2hipRename["cudaDevAttrMaxTexture1DWidth"]                 = {"hipDeviceAttributeMaxTexture1DWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 21 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH = 21)
+    cuda2hipRename["cudaDevAttrMaxTexture2DWidth"]                 = {"hipDeviceAttributeMaxTexture2DWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 22 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH = 22)
+    cuda2hipRename["cudaDevAttrMaxTexture2DHeight"]                = {"hipDeviceAttributeMaxTexture2DHeight", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                // 23 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT = 23)
+    cuda2hipRename["cudaDevAttrMaxTexture3DWidth"]                 = {"hipDeviceAttributeMaxTexture3DWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 24 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH = 24)
+    cuda2hipRename["cudaDevAttrMaxTexture3DHeight"]                = {"hipDeviceAttributeMaxTexture3DHeight", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                // 25 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT = 25)
+    cuda2hipRename["cudaDevAttrMaxTexture3DDepth"]                 = {"hipDeviceAttributeMaxTexture3DDepth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 26 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH = 26)
+    cuda2hipRename["cudaDevAttrMaxTexture2DLayeredWidth"]          = {"hipDeviceAttributeMaxTexture2DLayeredWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};          // 27 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH = 27)
+    cuda2hipRename["cudaDevAttrMaxTexture2DLayeredHeight"]         = {"hipDeviceAttributeMaxTexture2DLayeredHeight", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 28 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT = 28)
+    cuda2hipRename["cudaDevAttrMaxTexture2DLayeredLayers"]         = {"hipDeviceAttributeMaxTexture2DLayeredLayers", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 29 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS = 29)
+    cuda2hipRename["cudaDevAttrSurfaceAlignment"]                  = {"hipDeviceAttributeSurfaceAlignment", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                  // 30 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_SURFACE_ALIGNMENT = 30)
+    cuda2hipRename["cudaDevAttrConcurrentKernels"]                 = {"hipDeviceAttributeConcurrentKernels", CONV_TYPE, API_RUNTIME};                                  // 31 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS = 31)
+    cuda2hipRename["cudaDevAttrEccEnabled"]                        = {"hipDeviceAttributeEccEnabled", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                        // 32 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_ECC_ENABLED = 32)
+    cuda2hipRename["cudaDevAttrPciBusId"]                          = {"hipDeviceAttributePciBusId", CONV_TYPE, API_RUNTIME};                                           // 33 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_PCI_BUS_ID = 33)
+    cuda2hipRename["cudaDevAttrPciDeviceId"]                       = {"hipDeviceAttributePciDeviceId", CONV_TYPE, API_RUNTIME};                                        // 34 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID = 34)
+    cuda2hipRename["cudaDevAttrTccDriver"]                         = {"hipDeviceAttributeTccDriver", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                         // 35 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_TCC_DRIVER = 35)
+    cuda2hipRename["cudaDevAttrMemoryClockRate"]                   = {"hipDeviceAttributeMemoryClockRate", CONV_TYPE, API_RUNTIME};                                    // 36 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE = 36)
+    cuda2hipRename["cudaDevAttrGlobalMemoryBusWidth"]              = {"hipDeviceAttributeMemoryBusWidth", CONV_TYPE, API_RUNTIME};                                     // 37 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH = 37)
+    cuda2hipRename["cudaDevAttrL2CacheSize"]                       = {"hipDeviceAttributeL2CacheSize", CONV_TYPE, API_RUNTIME};                                        // 38 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE = 38)
+    cuda2hipRename["cudaDevAttrMaxThreadsPerMultiProcessor"]       = {"hipDeviceAttributeMaxThreadsPerMultiProcessor", CONV_TYPE, API_RUNTIME};                        // 39 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR = 39)
+    cuda2hipRename["cudaDevAttrAsyncEngineCount"]                  = {"hipDeviceAttributeAsyncEngineCount", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                  // 40 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT = 40)
+    cuda2hipRename["cudaDevAttrUnifiedAddressing"]                 = {"hipDeviceAttributeUnifiedAddressing", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 41 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING = 41)
+    cuda2hipRename["cudaDevAttrMaxTexture1DLayeredWidth"]          = {"hipDeviceAttributeMaxTexture1DLayeredWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};          // 42 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_WIDTH = 42)
+    cuda2hipRename["cudaDevAttrMaxTexture1DLayeredLayers"]         = {"hipDeviceAttributeMaxTexture1DLayeredLayers", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 43 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_LAYERS = 43)
     // 44 - no
-    cuda2hipRename["cudaDevAttrMaxTexture2DGatherWidth"]           = {"hipDeviceAttributeMaxTexture2DGatherWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};           // 45 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_WIDTH = 45)
-    cuda2hipRename["cudaDevAttrMaxTexture2DGatherHeight"]          = {"hipDeviceAttributeMaxTexture2DGatherHeight", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};          // 46 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_HEIGHT = 46)
-    cuda2hipRename["cudaDevAttrMaxTexture3DWidthAlt"]              = {"hipDeviceAttributeMaxTexture3DWidthAlternate", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};        // 47 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH_ALTERNATE = 47)
-    cuda2hipRename["cudaDevAttrMaxTexture3DHeightAlt"]             = {"hipDeviceAttributeMaxTexture3DHeightAlternate", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};       // 48 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT_ALTERNATE = 48)
-    cuda2hipRename["cudaDevAttrMaxTexture3DDepthAlt"]              = {"hipDeviceAttributeMaxTexture3DDepthAlternate", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};        // 49 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH_ALTERNATE = 49)
-    cuda2hipRename["cudaDevAttrPciDomainId"]                       = {"hipDeviceAttributePciDomainId", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                       // 50 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID = 50)
-    cuda2hipRename["cudaDevAttrTexturePitchAlignment"]             = {"hipDeviceAttributeTexturePitchAlignment", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};             // 51 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT = 51)
-    cuda2hipRename["cudaDevAttrMaxTextureCubemapWidth"]            = {"hipDeviceAttributeMaxTextureCubemapWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};            // 52 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_WIDTH = 52)
-    cuda2hipRename["cudaDevAttrMaxTextureCubemapLayeredWidth"]     = {"hipDeviceAttributeMaxTextureCubemapLayeredWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};     // 53 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_WIDTH = 53)
-    cuda2hipRename["cudaDevAttrMaxTextureCubemapLayeredLayers"]    = {"hipDeviceAttributeMaxTextureCubemapLayeredLayers", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};    // 54 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_LAYERS = 54)
-    cuda2hipRename["cudaDevAttrMaxSurface1DWidth"]                 = {"hipDeviceAttributeMaxSurface1DWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                 // 55 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH = 55)
-    cuda2hipRename["cudaDevAttrMaxSurface2DWidth"]                 = {"hipDeviceAttributeMaxSurface2DWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                 // 56 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH = 56)
-    cuda2hipRename["cudaDevAttrMaxSurface2DHeight"]                = {"hipDeviceAttributeMaxSurface2DHeight", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                // 57 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT = 57)
-    cuda2hipRename["cudaDevAttrMaxSurface3DWidth"]                 = {"hipDeviceAttributeMaxSurface3DWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                 // 58 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH = 58)
-    cuda2hipRename["cudaDevAttrMaxSurface3DHeight"]                = {"hipDeviceAttributeMaxSurface3DHeight", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                // 59 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT = 59)
-    cuda2hipRename["cudaDevAttrMaxSurface3DDepth"]                 = {"hipDeviceAttributeMaxSurface3DDepth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                 // 60 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH = 60)
-    cuda2hipRename["cudaDevAttrMaxSurface1DLayeredWidth"]          = {"hipDeviceAttributeMaxSurface1DLayeredWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};          // 61 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_WIDTH = 61)
-    cuda2hipRename["cudaDevAttrMaxSurface1DLayeredLayers"]         = {"hipDeviceAttributeMaxSurface1DLayeredLayers", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};         // 62 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_LAYERS = 62)
-    cuda2hipRename["cudaDevAttrMaxSurface2DLayeredWidth"]          = {"hipDeviceAttributeMaxSurface2DLayeredWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};          // 63 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_WIDTH = 63)
-    cuda2hipRename["cudaDevAttrMaxSurface2DLayeredHeight"]         = {"hipDeviceAttributeMaxSurface2DLayeredHeight", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};         // 64 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_HEIGHT = 64)
-    cuda2hipRename["cudaDevAttrMaxSurface2DLayeredLayers"]         = {"hipDeviceAttributeMaxSurface2DLayeredLayers", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};         // 65 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_LAYERS = 65)
-    cuda2hipRename["cudaDevAttrMaxSurfaceCubemapWidth"]            = {"hipDeviceAttributeMaxSurfaceCubemapWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};            // 66 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_WIDTH = 66)
-    cuda2hipRename["cudaDevAttrMaxSurfaceCubemapLayeredWidth"]     = {"hipDeviceAttributeMaxSurfaceCubemapLayeredWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};     // 67 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_WIDTH = 67)
-    cuda2hipRename["cudaDevAttrMaxSurfaceCubemapLayeredLayers"]    = {"hipDeviceAttributeMaxSurfaceCubemapLayeredLayers", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};    // 68 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_LAYERS = 68)
-    cuda2hipRename["cudaDevAttrMaxTexture1DLinearWidth"]           = {"hipDeviceAttributeMaxTexture1DLinearWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};           // 69 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LINEAR_WIDTH = 69)
-    cuda2hipRename["cudaDevAttrMaxTexture2DLinearWidth"]           = {"hipDeviceAttributeMaxTexture2DLinearWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};           // 70 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH = 70)
-    cuda2hipRename["cudaDevAttrMaxTexture2DLinearHeight"]          = {"hipDeviceAttributeMaxTexture2DLinearHeight", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};          // 71 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT = 71)
-    cuda2hipRename["cudaDevAttrMaxTexture2DLinearPitch"]           = {"hipDeviceAttributeMaxTexture2DLinearPitch", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};           // 72 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH = 72)
-    cuda2hipRename["cudaDevAttrMaxTexture2DMipmappedWidth"]        = {"hipDeviceAttributeMaxTexture2DMipmappedWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};        // 73 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_WIDTH = 73)
-    cuda2hipRename["cudaDevAttrMaxTexture2DMipmappedHeight"]       = {"hipDeviceAttributeMaxTexture2DMipmappedHeight", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};       // 74 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_HEIGHT = 74)
-    cuda2hipRename["cudaDevAttrComputeCapabilityMajor"]            = {"hipDeviceAttributeComputeCapabilityMajor", CONV_DEV, API_RUNTIME};                             // 75 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR = 75)
-    cuda2hipRename["cudaDevAttrComputeCapabilityMinor"]            = {"hipDeviceAttributeComputeCapabilityMinor", CONV_DEV, API_RUNTIME};                             // 76 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR = 76)
-    cuda2hipRename["cudaDevAttrMaxTexture1DMipmappedWidth"]        = {"hipDeviceAttributeMaxTexture1DMipmappedWidth", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};        // 77 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_MIPMAPPED_WIDTH = 77)
-    cuda2hipRename["cudaDevAttrStreamPrioritiesSupported"]         = {"hipDeviceAttributeStreamPrioritiesSupported", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};         // 78 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_STREAM_PRIORITIES_SUPPORTED = 78)
-    cuda2hipRename["cudaDevAttrGlobalL1CacheSupported"]            = {"hipDeviceAttributeGlobalL1CacheSupported", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};            // 79 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED = 79)
-    cuda2hipRename["cudaDevAttrLocalL1CacheSupported"]             = {"hipDeviceAttributeLocalL1CacheSupported", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};             // 80 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED = 80)
-    cuda2hipRename["cudaDevAttrMaxSharedMemoryPerMultiprocessor"]  = {"hipDeviceAttributeMaxSharedMemoryPerMultiprocessor", CONV_DEV, API_RUNTIME};                   // 81 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR = 81)
-    cuda2hipRename["cudaDevAttrMaxRegistersPerMultiprocessor"]     = {"hipDeviceAttributeMaxRegistersPerMultiprocessor", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};     // 82 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR = 82)
-    cuda2hipRename["cudaDevAttrManagedMemory"]                     = {"hipDeviceAttributeManagedMemory", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                     // 83 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY = 83)
-    cuda2hipRename["cudaDevAttrIsMultiGpuBoard"]                   = {"hipDeviceAttributeIsMultiGpuBoard", CONV_DEV, API_RUNTIME};                                    // 84 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD = 84)
-    cuda2hipRename["cudaDevAttrMultiGpuBoardGroupID"]              = {"hipDeviceAttributeMultiGpuBoardGroupID", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};              // 85 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID = 85)
+    cuda2hipRename["cudaDevAttrMaxTexture2DGatherWidth"]           = {"hipDeviceAttributeMaxTexture2DGatherWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 45 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_WIDTH = 45)
+    cuda2hipRename["cudaDevAttrMaxTexture2DGatherHeight"]          = {"hipDeviceAttributeMaxTexture2DGatherHeight", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};          // 46 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_HEIGHT = 46)
+    cuda2hipRename["cudaDevAttrMaxTexture3DWidthAlt"]              = {"hipDeviceAttributeMaxTexture3DWidthAlternate", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};        // 47 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH_ALTERNATE = 47)
+    cuda2hipRename["cudaDevAttrMaxTexture3DHeightAlt"]             = {"hipDeviceAttributeMaxTexture3DHeightAlternate", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};       // 48 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT_ALTERNATE = 48)
+    cuda2hipRename["cudaDevAttrMaxTexture3DDepthAlt"]              = {"hipDeviceAttributeMaxTexture3DDepthAlternate", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};        // 49 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH_ALTERNATE = 49)
+    cuda2hipRename["cudaDevAttrPciDomainId"]                       = {"hipDeviceAttributePciDomainId", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                       // 50 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID = 50)
+    cuda2hipRename["cudaDevAttrTexturePitchAlignment"]             = {"hipDeviceAttributeTexturePitchAlignment", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};             // 51 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT = 51)
+    cuda2hipRename["cudaDevAttrMaxTextureCubemapWidth"]            = {"hipDeviceAttributeMaxTextureCubemapWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};            // 52 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_WIDTH = 52)
+    cuda2hipRename["cudaDevAttrMaxTextureCubemapLayeredWidth"]     = {"hipDeviceAttributeMaxTextureCubemapLayeredWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};     // 53 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_WIDTH = 53)
+    cuda2hipRename["cudaDevAttrMaxTextureCubemapLayeredLayers"]    = {"hipDeviceAttributeMaxTextureCubemapLayeredLayers", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};    // 54 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_LAYERS = 54)
+    cuda2hipRename["cudaDevAttrMaxSurface1DWidth"]                 = {"hipDeviceAttributeMaxSurface1DWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 55 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH = 55)
+    cuda2hipRename["cudaDevAttrMaxSurface2DWidth"]                 = {"hipDeviceAttributeMaxSurface2DWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 56 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH = 56)
+    cuda2hipRename["cudaDevAttrMaxSurface2DHeight"]                = {"hipDeviceAttributeMaxSurface2DHeight", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                // 57 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT = 57)
+    cuda2hipRename["cudaDevAttrMaxSurface3DWidth"]                 = {"hipDeviceAttributeMaxSurface3DWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 58 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH = 58)
+    cuda2hipRename["cudaDevAttrMaxSurface3DHeight"]                = {"hipDeviceAttributeMaxSurface3DHeight", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                // 59 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT = 59)
+    cuda2hipRename["cudaDevAttrMaxSurface3DDepth"]                 = {"hipDeviceAttributeMaxSurface3DDepth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                 // 60 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH = 60)
+    cuda2hipRename["cudaDevAttrMaxSurface1DLayeredWidth"]          = {"hipDeviceAttributeMaxSurface1DLayeredWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};          // 61 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_WIDTH = 61)
+    cuda2hipRename["cudaDevAttrMaxSurface1DLayeredLayers"]         = {"hipDeviceAttributeMaxSurface1DLayeredLayers", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 62 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_LAYERS = 62)
+    cuda2hipRename["cudaDevAttrMaxSurface2DLayeredWidth"]          = {"hipDeviceAttributeMaxSurface2DLayeredWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};          // 63 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_WIDTH = 63)
+    cuda2hipRename["cudaDevAttrMaxSurface2DLayeredHeight"]         = {"hipDeviceAttributeMaxSurface2DLayeredHeight", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 64 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_HEIGHT = 64)
+    cuda2hipRename["cudaDevAttrMaxSurface2DLayeredLayers"]         = {"hipDeviceAttributeMaxSurface2DLayeredLayers", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 65 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_LAYERS = 65)
+    cuda2hipRename["cudaDevAttrMaxSurfaceCubemapWidth"]            = {"hipDeviceAttributeMaxSurfaceCubemapWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};            // 66 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_WIDTH = 66)
+    cuda2hipRename["cudaDevAttrMaxSurfaceCubemapLayeredWidth"]     = {"hipDeviceAttributeMaxSurfaceCubemapLayeredWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};     // 67 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_WIDTH = 67)
+    cuda2hipRename["cudaDevAttrMaxSurfaceCubemapLayeredLayers"]    = {"hipDeviceAttributeMaxSurfaceCubemapLayeredLayers", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};    // 68 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_LAYERS = 68)
+    cuda2hipRename["cudaDevAttrMaxTexture1DLinearWidth"]           = {"hipDeviceAttributeMaxTexture1DLinearWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 69 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LINEAR_WIDTH = 69)
+    cuda2hipRename["cudaDevAttrMaxTexture2DLinearWidth"]           = {"hipDeviceAttributeMaxTexture2DLinearWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 70 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH = 70)
+    cuda2hipRename["cudaDevAttrMaxTexture2DLinearHeight"]          = {"hipDeviceAttributeMaxTexture2DLinearHeight", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};          // 71 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT = 71)
+    cuda2hipRename["cudaDevAttrMaxTexture2DLinearPitch"]           = {"hipDeviceAttributeMaxTexture2DLinearPitch", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 72 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH = 72)
+    cuda2hipRename["cudaDevAttrMaxTexture2DMipmappedWidth"]        = {"hipDeviceAttributeMaxTexture2DMipmappedWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};        // 73 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_WIDTH = 73)
+    cuda2hipRename["cudaDevAttrMaxTexture2DMipmappedHeight"]       = {"hipDeviceAttributeMaxTexture2DMipmappedHeight", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};       // 74 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_HEIGHT = 74)
+    cuda2hipRename["cudaDevAttrComputeCapabilityMajor"]            = {"hipDeviceAttributeComputeCapabilityMajor", CONV_TYPE, API_RUNTIME};                             // 75 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR = 75)
+    cuda2hipRename["cudaDevAttrComputeCapabilityMinor"]            = {"hipDeviceAttributeComputeCapabilityMinor", CONV_TYPE, API_RUNTIME};                             // 76 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR = 76)
+    cuda2hipRename["cudaDevAttrMaxTexture1DMipmappedWidth"]        = {"hipDeviceAttributeMaxTexture1DMipmappedWidth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};        // 77 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_MIPMAPPED_WIDTH = 77)
+    cuda2hipRename["cudaDevAttrStreamPrioritiesSupported"]         = {"hipDeviceAttributeStreamPrioritiesSupported", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 78 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_STREAM_PRIORITIES_SUPPORTED = 78)
+    cuda2hipRename["cudaDevAttrGlobalL1CacheSupported"]            = {"hipDeviceAttributeGlobalL1CacheSupported", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};            // 79 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED = 79)
+    cuda2hipRename["cudaDevAttrLocalL1CacheSupported"]             = {"hipDeviceAttributeLocalL1CacheSupported", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};             // 80 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED = 80)
+    cuda2hipRename["cudaDevAttrMaxSharedMemoryPerMultiprocessor"]  = {"hipDeviceAttributeMaxSharedMemoryPerMultiprocessor", CONV_TYPE, API_RUNTIME};                   // 81 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR = 81)
+    cuda2hipRename["cudaDevAttrMaxRegistersPerMultiprocessor"]     = {"hipDeviceAttributeMaxRegistersPerMultiprocessor", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};     // 82 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR = 82)
+    cuda2hipRename["cudaDevAttrManagedMemory"]                     = {"hipDeviceAttributeManagedMemory", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                     // 83 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY = 83)
+    cuda2hipRename["cudaDevAttrIsMultiGpuBoard"]                   = {"hipDeviceAttributeIsMultiGpuBoard", CONV_TYPE, API_RUNTIME};                                    // 84 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD = 84)
+    cuda2hipRename["cudaDevAttrMultiGpuBoardGroupID"]              = {"hipDeviceAttributeMultiGpuBoardGroupID", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};              // 85 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID = 85)
 
     // unsupported yet by HIP [CUDA 8.0.44]
-    cuda2hipRename["cudaDevAttrHostNativeAtomicSupported"]         = {"hipDeviceAttributeHostNativeAtomicSupported", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};         // 86 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED = 86)
-    cuda2hipRename["cudaDevAttrSingleToDoublePrecisionPerfRatio"]  = {"hipDeviceAttributeSingleToDoublePrecisionPerfRatio", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};  // 87 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO = 87)
-    cuda2hipRename["cudaDevAttrPageableMemoryAccess"]              = {"hipDeviceAttributePageableMemoryAccess", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};              // 88 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS = 88)
-    cuda2hipRename["cudaDevAttrConcurrentManagedAccess"]           = {"hipDeviceAttributeConcurrentManagedAccess", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};           // 89 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS = 89)
-    cuda2hipRename["cudaDevAttrComputePreemptionSupported"]        = {"hipDeviceAttributeComputePreemptionSupported", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};        // 90 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED = 90)
-    cuda2hipRename["cudaDevAttrCanUseHostPointerForRegisteredMem"] = {"hipDeviceAttributeCanUseHostPointerForRegisteredMem", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED}; // 91 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM = 91)
+    cuda2hipRename["cudaDevAttrHostNativeAtomicSupported"]         = {"hipDeviceAttributeHostNativeAtomicSupported", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};         // 86 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED = 86)
+    cuda2hipRename["cudaDevAttrSingleToDoublePrecisionPerfRatio"]  = {"hipDeviceAttributeSingleToDoublePrecisionPerfRatio", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};  // 87 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO = 87)
+    cuda2hipRename["cudaDevAttrPageableMemoryAccess"]              = {"hipDeviceAttributePageableMemoryAccess", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};              // 88 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS = 88)
+    cuda2hipRename["cudaDevAttrConcurrentManagedAccess"]           = {"hipDeviceAttributeConcurrentManagedAccess", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};           // 89 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS = 89)
+    cuda2hipRename["cudaDevAttrComputePreemptionSupported"]        = {"hipDeviceAttributeComputePreemptionSupported", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};        // 90 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED = 90)
+    cuda2hipRename["cudaDevAttrCanUseHostPointerForRegisteredMem"] = {"hipDeviceAttributeCanUseHostPointerForRegisteredMem", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED}; // 91 // API_DRIVER ANALOGUE (CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM = 91)
 
     // Pointer Attributes
     // struct cudaPointerAttributes
@@ -1460,54 +1687,49 @@ struct cuda2hipMap {
 
     // Device
     cuda2hipRename["cudaDeviceProp"]                   = {"hipDeviceProp_t", CONV_TYPE, API_RUNTIME};
-    cuda2hipRename["cudaGetDeviceProperties"]          = {"hipGetDeviceProperties", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaDeviceGetPCIBusId"]            = {"hipDeviceGetPCIBusId", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaDeviceGetByPCIBusId"]          = {"hipDeviceGetByPCIBusId", CONV_DEV, API_RUNTIME};
+    cuda2hipRename["cudaGetDeviceProperties"]          = {"hipGetDeviceProperties", CONV_DEVICE, API_RUNTIME};
+    cuda2hipRename["cudaDeviceGetPCIBusId"]            = {"hipDeviceGetPCIBusId", CONV_DEVICE, API_RUNTIME};
+    cuda2hipRename["cudaDeviceGetByPCIBusId"]          = {"hipDeviceGetByPCIBusId", CONV_DEVICE, API_RUNTIME};
     // unsupported yet by HIP
-    cuda2hipRename["cudaDeviceGetStreamPriorityRange"] = {"hipDeviceGetStreamPriorityRange", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};
-    cuda2hipRename["cudaSetValidDevices"]              = {"hipSetValidDevices", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["cudaDeviceGetStreamPriorityRange"] = {"hipDeviceGetStreamPriorityRange", CONV_DEVICE, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["cudaSetValidDevices"]              = {"hipSetValidDevices", CONV_DEVICE, API_RUNTIME, HIP_UNSUPPORTED};
 
     // unsupported yet by HIP [CUDA 8.0.44]
     // P2P Attributes
-    cuda2hipRename["cudaDeviceP2PAttr"]                    = {"hipDeviceP2PAttribute", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                              // API_DRIVER ANALOGUE (CUdevice_P2PAttribute)
-    cuda2hipRename["cudaDevP2PAttrPerformanceRank"]        = {"hipDeviceP2PAttributePerformanceRank", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};       // 0x01 // API_DRIVER ANALOGUE (CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK = 0x01)
-    cuda2hipRename["cudaDevP2PAttrAccessSupported"]        = {"hipDeviceP2PAttributeAccessSupported", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};       // 0x02 // API_DRIVER ANALOGUE (CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED = 0x02)
-    cuda2hipRename["cudaDevP2PAttrNativeAtomicSupported"]  = {"hipDeviceP2PAttributeNativeAtomicSupported", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED}; // 0x03 // API_DRIVER ANALOGUE (CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED = 0x03)
+    cuda2hipRename["cudaDeviceP2PAttr"]                    = {"hipDeviceP2PAttribute", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                              // API_DRIVER ANALOGUE (CUdevice_P2PAttribute)
+    cuda2hipRename["cudaDevP2PAttrPerformanceRank"]        = {"hipDeviceP2PAttributePerformanceRank", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};       // 0x01 // API_DRIVER ANALOGUE (CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK = 0x01)
+    cuda2hipRename["cudaDevP2PAttrAccessSupported"]        = {"hipDeviceP2PAttributeAccessSupported", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};       // 0x02 // API_DRIVER ANALOGUE (CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED = 0x02)
+    cuda2hipRename["cudaDevP2PAttrNativeAtomicSupported"]  = {"hipDeviceP2PAttributeNativeAtomicSupported", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED}; // 0x03 // API_DRIVER ANALOGUE (CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED = 0x03)
     // [CUDA 8.0.44]
-    cuda2hipRename["cudaDeviceGetP2PAttribute"]            = {"hipDeviceGetP2PAttribute", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                              // API_DRIVER ANALOGUE (cuDeviceGetP2PAttribute)
+    cuda2hipRename["cudaDeviceGetP2PAttribute"]            = {"hipDeviceGetP2PAttribute", CONV_DEVICE, API_RUNTIME, HIP_UNSUPPORTED};                              // API_DRIVER ANALOGUE (cuDeviceGetP2PAttribute)
 
     // Compute mode
-    cuda2hipRename["cudaComputeMode"]                  = {"hipComputeMode", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};                      // API_DRIVER ANALOGUE (CUcomputemode)
-    cuda2hipRename["cudaComputeModeDefault"]           = {"hipComputeModeDefault", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};          // 0 // API_DRIVER ANALOGUE (CU_COMPUTEMODE_DEFAULT = 0)
-    cuda2hipRename["cudaComputeModeExclusive"]         = {"hipComputeModeExclusive", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};        // 1 // API_DRIVER ANALOGUE (CU_COMPUTEMODE_EXCLUSIVE = 1)
-    cuda2hipRename["cudaComputeModeProhibited"]        = {"hipComputeModeProhibited", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};       // 2 // API_DRIVER ANALOGUE (CU_COMPUTEMODE_PROHIBITED = 2)
-    cuda2hipRename["cudaComputeModeExclusiveProcess"]  = {"hipComputeModeExclusiveProcess", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED}; // 3 // API_DRIVER ANALOGUE (CU_COMPUTEMODE_EXCLUSIVE_PROCESS = 3)
+    cuda2hipRename["cudaComputeMode"]                  = {"hipComputeMode", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};                      // API_DRIVER ANALOGUE (CUcomputemode)
+    cuda2hipRename["cudaComputeModeDefault"]           = {"hipComputeModeDefault", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};          // 0 // API_DRIVER ANALOGUE (CU_COMPUTEMODE_DEFAULT = 0)
+    cuda2hipRename["cudaComputeModeExclusive"]         = {"hipComputeModeExclusive", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};        // 1 // API_DRIVER ANALOGUE (CU_COMPUTEMODE_EXCLUSIVE = 1)
+    cuda2hipRename["cudaComputeModeProhibited"]        = {"hipComputeModeProhibited", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};       // 2 // API_DRIVER ANALOGUE (CU_COMPUTEMODE_PROHIBITED = 2)
+    cuda2hipRename["cudaComputeModeExclusiveProcess"]  = {"hipComputeModeExclusiveProcess", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED}; // 3 // API_DRIVER ANALOGUE (CU_COMPUTEMODE_EXCLUSIVE_PROCESS = 3)
 
     // Device Flags
-    // unsupported yet by HIP
-    cuda2hipRename["cudaGetDeviceFlags"]               = {"hipGetDeviceFlags", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};
-    cuda2hipRename["cudaSetDeviceFlags"]               = {"hipSetDeviceFlags", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaDeviceScheduleAuto"]           = {"hipDeviceScheduleAuto", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaDeviceScheduleSpin"]           = {"hipDeviceScheduleSpin", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaDeviceScheduleYield"]          = {"hipDeviceScheduleYield", CONV_DEV, API_RUNTIME};
-    // deprecated as of CUDA 4.0 and replaced with cudaDeviceScheduleBlockingSync
-    cuda2hipRename["cudaDeviceBlockingSync"]           = {"hipDeviceScheduleBlockingSync", CONV_DEV, API_RUNTIME};
-    // unsupported yet by HIP
-    cuda2hipRename["cudaDeviceScheduleBlockingSync"]   = {"hipDeviceScheduleBlockingSync", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaDeviceScheduleMask"]           = {"hipDeviceScheduleMask", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["cudaGetDeviceFlags"]               = {"hipGetDeviceFlags", CONV_DEVICE, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["cudaSetDeviceFlags"]               = {"hipSetDeviceFlags", CONV_DEVICE, API_RUNTIME};
 
-    cuda2hipRename["cudaDeviceMapHost"]                = {"hipDeviceMapHost", CONV_DEV, API_RUNTIME};
+    cuda2hipRename["cudaDeviceScheduleAuto"]           = {"hipDeviceScheduleAuto", CONV_TYPE, API_RUNTIME};
+    cuda2hipRename["cudaDeviceScheduleSpin"]           = {"hipDeviceScheduleSpin", CONV_TYPE, API_RUNTIME};
+    cuda2hipRename["cudaDeviceScheduleYield"]          = {"hipDeviceScheduleYield", CONV_TYPE, API_RUNTIME};
+    // deprecated as of CUDA 4.0 and replaced with cudaDeviceScheduleBlockingSync
+    cuda2hipRename["cudaDeviceBlockingSync"]           = {"hipDeviceScheduleBlockingSync", CONV_TYPE, API_RUNTIME};
     // unsupported yet by HIP
-    cuda2hipRename["cudaDeviceLmemResizeToMax"]        = {"hipDeviceLmemResizeToMax", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};
-    cuda2hipRename["cudaDeviceMask"]                   = {"hipDeviceMask", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["cudaDeviceScheduleBlockingSync"]   = {"hipDeviceScheduleBlockingSync", CONV_TYPE, API_RUNTIME};
+    cuda2hipRename["cudaDeviceScheduleMask"]           = {"hipDeviceScheduleMask", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};
+
+    cuda2hipRename["cudaDeviceMapHost"]                = {"hipDeviceMapHost", CONV_TYPE, API_RUNTIME};
+    cuda2hipRename["cudaDeviceLmemResizeToMax"]        = {"hipDeviceLmemResizeToMax", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["cudaDeviceMask"]                   = {"hipDeviceMask", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};
 
     // Cache config
     cuda2hipRename["cudaDeviceSetCacheConfig"]         = {"hipDeviceSetCacheConfig", CONV_CACHE, API_RUNTIME};
-    // translate deprecated
-    cuda2hipRename["cudaThreadSetCacheConfig"]         = {"hipDeviceSetCacheConfig", CONV_CACHE, API_RUNTIME};
     cuda2hipRename["cudaDeviceGetCacheConfig"]         = {"hipDeviceGetCacheConfig", CONV_CACHE, API_RUNTIME};
-    // translate deprecated
-    cuda2hipRename["cudaThreadGetCacheConfig"]         = {"hipDeviceGetCacheConfig", CONV_CACHE, API_RUNTIME};
     cuda2hipRename["cudaFuncSetCacheConfig"]           = {"hipFuncSetCacheConfig", CONV_CACHE, API_RUNTIME};
 
     // Execution control
@@ -1533,25 +1755,25 @@ struct cuda2hipMap {
     cuda2hipRename["cudaLaunch"]                       = {"hipLaunch", CONV_EXEC, API_RUNTIME, HIP_UNSUPPORTED};
     cuda2hipRename["cudaSetupArgument"]                = {"hipSetupArgument", CONV_EXEC, API_RUNTIME, HIP_UNSUPPORTED};
 
-    // Driver/Runtime
-    cuda2hipRename["cudaDriverGetVersion"]      = {"hipDriverGetVersion", CONV_DRIVER, API_RUNTIME};
-    // unsupported yet by HIP
-    cuda2hipRename["cudaRuntimeGetVersion"]     = {"hipRuntimeGetVersion", CONV_DEV, API_RUNTIME, HIP_UNSUPPORTED};
+    // Version Management
+    cuda2hipRename["cudaDriverGetVersion"]      = {"hipDriverGetVersion", CONV_VERSION, API_RUNTIME};
+    cuda2hipRename["cudaRuntimeGetVersion"]     = {"hipRuntimeGetVersion", CONV_VERSION, API_RUNTIME, HIP_UNSUPPORTED};
 
     // Occupancy
-    cuda2hipRename["cudaOccupancyMaxPotentialBlockSize"]                      = {"hipOccupancyMaxPotentialBlockSize", CONV_OCCUPANCY, API_DRIVER};
+    cuda2hipRename["cudaOccupancyMaxPotentialBlockSize"]                      = {"hipOccupancyMaxPotentialBlockSize", CONV_OCCUPANCY, API_RUNTIME};
     // unsupported yet by HIP
-    cuda2hipRename["cudaOccupancyMaxPotentialBlockSizeWithFlags"]             = {"hipOccupancyMaxPotentialBlockSizeWithFlags", CONV_OCCUPANCY, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cudaOccupancyMaxActiveBlocksPerMultiprocessor"]           = {"hipOccupancyMaxActiveBlocksPerMultiprocessor", CONV_OCCUPANCY, API_DRIVER};
+    cuda2hipRename["cudaOccupancyMaxPotentialBlockSizeWithFlags"]             = {"hipOccupancyMaxPotentialBlockSizeWithFlags", CONV_OCCUPANCY, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["cudaOccupancyMaxActiveBlocksPerMultiprocessor"]           = {"hipOccupancyMaxActiveBlocksPerMultiprocessor", CONV_OCCUPANCY, API_RUNTIME};
     // unsupported yet by HIP
-    cuda2hipRename["cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags"]  = {"hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags", CONV_OCCUPANCY, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cudaOccupancyMaxPotentialBlockSizeVariableSMem"]          = {"hipOccupancyMaxPotentialBlockSizeVariableSMem", CONV_OCCUPANCY, API_DRIVER, HIP_UNSUPPORTED};
-    cuda2hipRename["cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags"] = {"hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags", CONV_OCCUPANCY, API_DRIVER, HIP_UNSUPPORTED};
+    cuda2hipRename["cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags"]  = {"hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags", CONV_OCCUPANCY, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["cudaOccupancyMaxPotentialBlockSizeVariableSMem"]          = {"hipOccupancyMaxPotentialBlockSizeVariableSMem", CONV_OCCUPANCY, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags"] = {"hipOccupancyMaxPotentialBlockSizeVariableSMemWithFlags", CONV_OCCUPANCY, API_RUNTIME, HIP_UNSUPPORTED};
 
     // Peer2Peer
-    cuda2hipRename["cudaDeviceCanAccessPeer"]        = {"hipDeviceCanAccessPeer", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaDeviceDisablePeerAccess"]    = {"hipDeviceDisablePeerAccess", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaDeviceEnablePeerAccess"]     = {"hipDeviceEnablePeerAccess", CONV_DEV, API_RUNTIME};
+    cuda2hipRename["cudaDeviceCanAccessPeer"]        = {"hipDeviceCanAccessPeer", CONV_PEER, API_RUNTIME};
+    cuda2hipRename["cudaDeviceDisablePeerAccess"]    = {"hipDeviceDisablePeerAccess", CONV_PEER, API_RUNTIME};
+    cuda2hipRename["cudaDeviceEnablePeerAccess"]     = {"hipDeviceEnablePeerAccess", CONV_PEER, API_RUNTIME};
+
     cuda2hipRename["cudaMemcpyPeerAsync"]            = {"hipMemcpyPeerAsync", CONV_MEM, API_RUNTIME};
     cuda2hipRename["cudaMemcpyPeer"]                 = {"hipMemcpyPeer", CONV_MEM, API_RUNTIME};
 
@@ -1559,17 +1781,16 @@ struct cuda2hipMap {
     cuda2hipRename["cudaIpcMemLazyEnablePeerAccess"] = {"hipIpcMemLazyEnablePeerAccess", CONV_TYPE, API_RUNTIME};              // 0x01 // API_Driver ANALOGUE (CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS = 0x1)
 
     // Shared memory
-    cuda2hipRename["cudaDeviceSetSharedMemConfig"]   = {"hipDeviceSetSharedMemConfig", CONV_DEV, API_RUNTIME};
+    cuda2hipRename["cudaDeviceSetSharedMemConfig"]   = {"hipDeviceSetSharedMemConfig", CONV_DEVICE, API_RUNTIME};
+    cuda2hipRename["cudaDeviceGetSharedMemConfig"]   = {"hipDeviceGetSharedMemConfig", CONV_DEVICE, API_RUNTIME};
     // translate deprecated
-    cuda2hipRename["cudaThreadSetSharedMemConfig"]   = {"hipDeviceSetSharedMemConfig", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaDeviceGetSharedMemConfig"]   = {"hipDeviceGetSharedMemConfig", CONV_DEV, API_RUNTIME};
-    // translate deprecated
-    cuda2hipRename["cudaThreadGetSharedMemConfig"]   = {"hipDeviceGetSharedMemConfig", CONV_DEV, API_RUNTIME};
+    // cuda2hipRename["cudaThreadGetSharedMemConfig"] = {"hipDeviceGetSharedMemConfig", CONV_DEVICE, API_RUNTIME};
+    // cuda2hipRename["cudaThreadSetSharedMemConfig"] = {"hipDeviceSetSharedMemConfig", CONV_DEVICE, API_RUNTIME};
 
-    cuda2hipRename["cudaSharedMemConfig"]            = {"hipSharedMemConfig", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaSharedMemBankSizeDefault"]   = {"hipSharedMemBankSizeDefault", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaSharedMemBankSizeFourByte"]  = {"hipSharedMemBankSizeFourByte", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaSharedMemBankSizeEightByte"] = {"hipSharedMemBankSizeEightByte", CONV_DEV, API_RUNTIME};
+    cuda2hipRename["cudaSharedMemConfig"]            = {"hipSharedMemConfig", CONV_TYPE, API_RUNTIME};
+    cuda2hipRename["cudaSharedMemBankSizeDefault"]   = {"hipSharedMemBankSizeDefault", CONV_TYPE, API_RUNTIME};
+    cuda2hipRename["cudaSharedMemBankSizeFourByte"]  = {"hipSharedMemBankSizeFourByte", CONV_TYPE, API_RUNTIME};
+    cuda2hipRename["cudaSharedMemBankSizeEightByte"] = {"hipSharedMemBankSizeEightByte", CONV_TYPE, API_RUNTIME};
 
     // Limits
     cuda2hipRename["cudaLimit"]                             = {"hipLimit_t", CONV_TYPE, API_RUNTIME};                                                    // API_Driver ANALOGUE (CUlimit)
@@ -1579,14 +1800,12 @@ struct cuda2hipMap {
     cuda2hipRename["cudaLimitDevRuntimeSyncDepth"]          = {"hipLimitDevRuntimeSyncDepth", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED};          // 0x03 // API_Driver ANALOGUE (CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH = 0x03)
     cuda2hipRename["cudaLimitDevRuntimePendingLaunchCount"] = {"hipLimitDevRuntimePendingLaunchCount", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED}; // 0x04 // API_Driver ANALOGUE (CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT = 0x04)
 
-    cuda2hipRename["cudaDeviceGetLimit"]                    = {"hipDeviceGetLimit", CONV_DEV, API_RUNTIME};
+    cuda2hipRename["cudaDeviceGetLimit"]                    = {"hipDeviceGetLimit", CONV_DEVICE, API_RUNTIME};
 
     // Profiler
-    // unsupported yet by HIP
-    cuda2hipRename["cudaProfilerInitialize"]                = {"hipProfilerInitialize", CONV_OTHER, API_RUNTIME, HIP_UNSUPPORTED};
-
-    cuda2hipRename["cudaProfilerStart"]                     = {"hipProfilerStart", CONV_OTHER, API_RUNTIME};
-    cuda2hipRename["cudaProfilerStop"]                      = {"hipProfilerStop", CONV_OTHER, API_RUNTIME};
+    cuda2hipRename["cudaProfilerInitialize"]                = {"hipProfilerInitialize", CONV_OTHER, API_RUNTIME, HIP_UNSUPPORTED};                       // API_Driver ANALOGUE (cuProfilerInitialize)
+    cuda2hipRename["cudaProfilerStart"]                     = {"hipProfilerStart", CONV_OTHER, API_RUNTIME};                                             // API_Driver ANALOGUE (cuProfilerStart)
+    cuda2hipRename["cudaProfilerStop"]                      = {"hipProfilerStop", CONV_OTHER, API_RUNTIME};                                              // API_Driver ANALOGUE (cuProfilerStop)
 
     // unsupported yet by HIP
     cuda2hipRename["cudaOutputMode"]                        = {"hipOutputMode", CONV_OTHER, API_RUNTIME, HIP_UNSUPPORTED};
@@ -1630,6 +1849,8 @@ struct cuda2hipMap {
     cuda2hipRename["cudaResourceDesc"]                            = {"hipResourceDesc", CONV_TEX, API_RUNTIME, HIP_UNSUPPORTED};
     cuda2hipRename["cudaResourceViewDesc"]                        = {"hipResourceViewDesc", CONV_TEX, API_RUNTIME, HIP_UNSUPPORTED};
     cuda2hipRename["cudaTextureDesc"]                             = {"hipTextureDesc", CONV_TEX, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["surfaceReference"]                            = {"hipSurfaceReference", CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["textureReference"]                            = {"hipTextureReference", CONV_TEX, API_RUNTIME, HIP_UNSUPPORTED};
 
     // enums
     // enum cudaResourceType
@@ -1673,7 +1894,7 @@ struct cuda2hipMap {
     cuda2hipRename["cudaResViewFormatSignedBlockCompressed4"]     = {"hipResViewFormatSignedBlockCompressed4", CONV_TEX, API_RUNTIME, HIP_UNSUPPORTED};     // 0x1d // API_Driver ANALOGUE (CU_RES_VIEW_FORMAT_SIGNED_BC4 = 0x1d)
     cuda2hipRename["cudaResViewFormatUnsignedBlockCompressed5"]   = {"hipResViewFormatUnsignedBlockCompressed5", CONV_TEX, API_RUNTIME, HIP_UNSUPPORTED};   // 0x1e // API_Driver ANALOGUE (CU_RES_VIEW_FORMAT_UNSIGNED_BC5 = 0x1e)
     cuda2hipRename["cudaResViewFormatSignedBlockCompressed5"]     = {"hipResViewFormatSignedBlockCompressed5", CONV_TEX, API_RUNTIME, HIP_UNSUPPORTED};     // 0x1f // API_Driver ANALOGUE (CU_RES_VIEW_FORMAT_SIGNED_BC5 = 0x1f)
-    cuda2hipRename["cudaResViewFormatUnsignedBlockCompressed6H"]  = {"hipResViewFormatUnsignedBlockCompressed6H", CONV_TEX, API_DRIVER, HIP_UNSUPPORTED};   // 0x20 // API_Driver ANALOGUE (CU_RES_VIEW_FORMAT_UNSIGNED_BC6H = 0x20)
+    cuda2hipRename["cudaResViewFormatUnsignedBlockCompressed6H"]  = {"hipResViewFormatUnsignedBlockCompressed6H", CONV_TEX, API_RUNTIME, HIP_UNSUPPORTED};  // 0x20 // API_Driver ANALOGUE (CU_RES_VIEW_FORMAT_UNSIGNED_BC6H = 0x20)
     cuda2hipRename["cudaResViewFormatSignedBlockCompressed6H"]    = {"hipResViewFormatSignedBlockCompressed6H", CONV_TEX, API_RUNTIME, HIP_UNSUPPORTED};    // 0x21 // API_Driver ANALOGUE (CU_RES_VIEW_FORMAT_SIGNED_BC6H = 0x21)
     cuda2hipRename["cudaResViewFormatUnsignedBlockCompressed7"]   = {"hipResViewFormatUnsignedBlockCompressed7", CONV_TEX, API_RUNTIME, HIP_UNSUPPORTED};   // 0x22 // API_Driver ANALOGUE (CU_RES_VIEW_FORMAT_UNSIGNED_BC7 = 0x22)
 
@@ -1718,28 +1939,26 @@ struct cuda2hipMap {
     cuda2hipRename["cudaIpcMemHandle_st"]                         = {"hipIpcMemHandle_t", CONV_TYPE, API_RUNTIME};
 
     // IPC functions
-    cuda2hipRename["cudaIpcCloseMemHandle"]                       = {"hipIpcCloseMemHandle", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaIpcGetEventHandle"]                       = {"hipIpcGetEventHandle", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaIpcGetMemHandle"]                         = {"hipIpcGetMemHandle", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaIpcOpenEventHandle"]                      = {"hipIpcOpenEventHandle", CONV_DEV, API_RUNTIME};
-    cuda2hipRename["cudaIpcOpenMemHandle"]                        = {"hipIpcOpenMemHandle", CONV_DEV, API_RUNTIME};
+    cuda2hipRename["cudaIpcCloseMemHandle"]                       = {"hipIpcCloseMemHandle", CONV_DEVICE, API_RUNTIME};
+    cuda2hipRename["cudaIpcGetEventHandle"]                       = {"hipIpcGetEventHandle", CONV_DEVICE, API_RUNTIME};
+    cuda2hipRename["cudaIpcGetMemHandle"]                         = {"hipIpcGetMemHandle", CONV_DEVICE, API_RUNTIME};
+    cuda2hipRename["cudaIpcOpenEventHandle"]                      = {"hipIpcOpenEventHandle", CONV_DEVICE, API_RUNTIME};
+    cuda2hipRename["cudaIpcOpenMemHandle"]                        = {"hipIpcOpenMemHandle", CONV_DEVICE, API_RUNTIME};
 
     // OpenGL Interoperability
-    // unsupported yet by HIP
     cuda2hipRename["cudaGLGetDevices"]                            = {"hipGLGetDevices", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};
     cuda2hipRename["cudaGraphicsGLRegisterBuffer"]                = {"hipGraphicsGLRegisterBuffer", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};
     cuda2hipRename["cudaGraphicsGLRegisterImage"]                 = {"hipGraphicsGLRegisterImage", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};
     cuda2hipRename["cudaWGLGetDevice"]                            = {"hipWGLGetDevice", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};
 
     // Graphics Interoperability
-    // unsupported yet by HIP
-    cuda2hipRename["cudaGraphicsMapResources"]                    = {"hipGraphicsMapResources", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};
-    cuda2hipRename["cudaGraphicsResourceGetMappedMipmappedArray"] = {"hipGraphicsResourceGetMappedMipmappedArray", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};
-    cuda2hipRename["cudaGraphicsResourceGetMappedPointer"]        = {"hipGraphicsResourceGetMappedPointer", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};
-    cuda2hipRename["cudaGraphicsResourceSetMapFlags"]             = {"hipGraphicsResourceSetMapFlags", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};
-    cuda2hipRename["cudaGraphicsSubResourceGetMappedArray"]       = {"hipGraphicsSubResourceGetMappedArray", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};
-    cuda2hipRename["cudaGraphicsUnmapResources"]                  = {"hipGraphicsUnmapResources", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};
-    cuda2hipRename["cudaGraphicsUnregisterResource"]              = {"hipGraphicsUnregisterResource", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};
+    cuda2hipRename["cudaGraphicsMapResources"]                    = {"hipGraphicsMapResources", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};                      // API_Driver ANALOGUE (cuGraphicsMapResources)
+    cuda2hipRename["cudaGraphicsResourceGetMappedMipmappedArray"] = {"hipGraphicsResourceGetMappedMipmappedArray", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};   // API_Driver ANALOGUE (cuGraphicsResourceGetMappedMipmappedArray)
+    cuda2hipRename["cudaGraphicsResourceGetMappedPointer"]        = {"hipGraphicsResourceGetMappedPointer", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};          // API_Driver ANALOGUE (cuGraphicsResourceGetMappedPointer)
+    cuda2hipRename["cudaGraphicsResourceSetMapFlags"]             = {"hipGraphicsResourceSetMapFlags", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};               // API_Driver ANALOGUE (cuGraphicsResourceSetMapFlags)
+    cuda2hipRename["cudaGraphicsSubResourceGetMappedArray"]       = {"hipGraphicsSubResourceGetMappedArray", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};         // API_Driver ANALOGUE (cuGraphicsSubResourceGetMappedArray)
+    cuda2hipRename["cudaGraphicsUnmapResources"]                  = {"hipGraphicsUnmapResources", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};                    // API_Driver ANALOGUE (cuGraphicsUnmapResources)
+    cuda2hipRename["cudaGraphicsUnregisterResource"]              = {"hipGraphicsUnregisterResource", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};                // API_Driver ANALOGUE (cuGraphicsUnregisterResource)
 
     cuda2hipRename["cudaGraphicsCubeFace"]                        = {"hipGraphicsCubeFace", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};
     cuda2hipRename["cudaGraphicsCubeFacePositiveX"]               = {"hipGraphicsCubeFacePositiveX", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};
@@ -1762,6 +1981,142 @@ struct cuda2hipMap {
     cuda2hipRename["cudaGraphicsRegisterFlagsWriteDiscard"]       = {"hipGraphicsRegisterFlagsWriteDiscard", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};     // 2 // API_Driver ANALOGUE (CU_GRAPHICS_REGISTER_FLAGS_WRITE_DISCARD = 0x02)
     cuda2hipRename["cudaGraphicsRegisterFlagsSurfaceLoadStore"]   = {"hipGraphicsRegisterFlagsSurfaceLoadStore", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED}; // 4 // API_Driver ANALOGUE (CU_GRAPHICS_REGISTER_FLAGS_SURFACE_LDST = 0x04)
     cuda2hipRename["cudaGraphicsRegisterFlagsTextureGather"]      = {"hipGraphicsRegisterFlagsTextureGather", CONV_GRAPHICS, API_RUNTIME, HIP_UNSUPPORTED};    // 8 // API_Driver ANALOGUE (CU_GRAPHICS_REGISTER_FLAGS_TEXTURE_GATHER = 0x08)
+
+    // OpenGL Interoperability
+    // enum cudaGLDeviceList
+    cuda2hipRename["cudaGLDeviceList"]                          = {"hipGLDeviceList", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                                    // API_Driver ANALOGUE (CUGLDeviceList)
+    cuda2hipRename["cudaGLDeviceListAll"]                       = {"HIP_GL_DEVICE_LIST_ALL", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                     // 0x01 // API_Driver ANALOGUE (CU_GL_DEVICE_LIST_ALL)
+    cuda2hipRename["cudaGLDeviceListCurrentFrame"]              = {"HIP_GL_DEVICE_LIST_CURRENT_FRAME", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};           // 0x02 // API_Driver ANALOGUE (CU_GL_DEVICE_LIST_CURRENT_FRAME)
+    cuda2hipRename["cudaGLDeviceListNextFrame"]                 = {"HIP_GL_DEVICE_LIST_NEXT_FRAME", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};              // 0x03 // API_Driver ANALOGUE (CU_GL_DEVICE_LIST_NEXT_FRAME)
+
+    cuda2hipRename["cudaGLGetDevices"]                          = {"hipGLGetDevices", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                                     // API_Driver ANALOGUE (cuGLGetDevices)
+    cuda2hipRename["cudaGraphicsGLRegisterBuffer"]              = {"hipGraphicsGLRegisterBuffer", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                         // API_Driver ANALOGUE (cuGraphicsGLRegisterBuffer)
+    cuda2hipRename["cudaGraphicsGLRegisterImage"]               = {"hipGraphicsGLRegisterImage", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                          // API_Driver ANALOGUE (cuGraphicsGLRegisterImage)
+    cuda2hipRename["cudaWGLGetDevice"]                          = {"hipWGLGetDevice", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                                     // API_Driver ANALOGUE (cuWGLGetDevice)
+
+    // OpenGL Interoperability [DEPRECATED]
+    // enum cudaGLMapFlags
+    cuda2hipRename["cudaGLMapFlags"]                            = {"hipGLMapFlags", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                                       // API_Driver ANALOGUE (CUGLmap_flags)
+    cuda2hipRename["cudaGLMapFlagsNone"]                        = {"HIP_GL_MAP_RESOURCE_FLAGS_NONE", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};              // 0x00 // API_Driver ANALOGUE (CU_GL_MAP_RESOURCE_FLAGS_NONE)
+    cuda2hipRename["cudaGLMapFlagsReadOnly"]                    = {"HIP_GL_MAP_RESOURCE_FLAGS_READ_ONLY", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};         // 0x01 // API_Driver ANALOGUE (CU_GL_MAP_RESOURCE_FLAGS_READ_ONLY)
+    cuda2hipRename["cudaGLMapFlagsWriteDiscard"]                = {"HIP_GL_MAP_RESOURCE_FLAGS_WRITE_DISCARD", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};     // 0x02 // API_Driver ANALOGUE (CU_GL_MAP_RESOURCE_FLAGS_WRITE_DISCARD)
+
+    cuda2hipRename["cudaGLMapBufferObject"]                     = {"hipGLMapBufferObject__", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                              // Not equal to cuGLMapBufferObject due to different signatures
+    cuda2hipRename["cudaGLMapBufferObjectAsync"]                = {"hipGLMapBufferObjectAsync__", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                         // Not equal to cuGLMapBufferObjectAsync due to different signatures
+    cuda2hipRename["cudaGLRegisterBufferObject"]                = {"hipGLRegisterBufferObject", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                           // API_Driver ANALOGUE (cuGLRegisterBufferObject)
+    cuda2hipRename["cudaGLSetBufferObjectMapFlags"]             = {"hipGLSetBufferObjectMapFlags", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                        // API_Driver ANALOGUE (cuGLSetBufferObjectMapFlags)
+    cuda2hipRename["cudaGLSetGLDevice"]                         = {"hipGLSetGLDevice", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                                    // no API_Driver ANALOGUE
+    cuda2hipRename["cudaGLUnmapBufferObject"]                   = {"hipGLUnmapBufferObject", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                              // API_Driver ANALOGUE (cuGLUnmapBufferObject)
+    cuda2hipRename["cudaGLUnmapBufferObjectAsync"]              = {"hipGLUnmapBufferObjectAsync", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                         // API_Driver ANALOGUE (cuGLUnmapBufferObjectAsync)
+    cuda2hipRename["cudaGLUnregisterBufferObject"]              = {"hipGLUnregisterBufferObject", CONV_GL, API_RUNTIME, HIP_UNSUPPORTED};                         // API_Driver ANALOGUE (cuGLUnregisterBufferObject)
+
+    // Direct3D 9 Interoperability
+    // enum CUd3d9DeviceList
+    cuda2hipRename["cudaD3D9DeviceList"]                        = {"hipD3D9DeviceList", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                                // API_Driver ANALOGUE (CUd3d9DeviceList)
+    cuda2hipRename["cudaD3D9DeviceListAll"]                     = {"HIP_D3D9_DEVICE_LIST_ALL", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                    // 1 // API_Driver ANALOGUE (CU_D3D9_DEVICE_LIST_ALL)
+    cuda2hipRename["cudaD3D9DeviceListCurrentFrame"]            = {"HIP_D3D9_DEVICE_LIST_CURRENT_FRAME", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};          // 2 // API_Driver ANALOGUE (CU_D3D9_DEVICE_LIST_CURRENT_FRAME)
+    cuda2hipRename["cudaD3D9DeviceListNextFrame"]               = {"HIP_D3D9_DEVICE_LIST_NEXT_FRAME", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};             // 3 // API_Driver ANALOGUE (CU_D3D9_DEVICE_LIST_NEXT_FRAME)
+
+    cuda2hipRename["cudaD3D9GetDevice"]                         = {"hipD3D9GetDevice", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                                 // API_Driver ANALOGUE (cuD3D9GetDevice)
+    cuda2hipRename["cudaD3D9GetDevices"]                        = {"hipD3D9GetDevices", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                                // API_Driver ANALOGUE (cuD3D9GetDevices)
+    cuda2hipRename["cudaD3D9GetDirect3DDevice"]                 = {"hipD3D9GetDirect3DDevice", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                         // API_Driver ANALOGUE (cuD3D9GetDirect3DDevice)
+    cuda2hipRename["cudaD3D9SetDirect3DDevice"]                 = {"hipD3D9SetDirect3DDevice", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                         // no API_Driver ANALOGUE
+    cuda2hipRename["cudaGraphicsD3D9RegisterResource"]          = {"hipGraphicsD3D9RegisterResource", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                  // API_Driver ANALOGUE (cuGraphicsD3D9RegisterResource)
+
+    // Direct3D 9 Interoperability [DEPRECATED]
+    // enum cudaD3D9MapFlags
+    cuda2hipRename["cudaD3D9MapFlags"]                          = {"hipD3D9MapFlags", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                                   // API_Driver ANALOGUE (CUd3d9map_flags)
+    cuda2hipRename["cudaD3D9MapFlagsNone"]                      = {"HIP_D3D9_MAPRESOURCE_FLAGS_NONE", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};              // 0 // API_Driver ANALOGUE (CU_D3D9_MAPRESOURCE_FLAGS_NONE)
+    cuda2hipRename["cudaD3D9MapFlagsReadOnly"]                  = {"HIP_D3D9_MAPRESOURCE_FLAGS_READONLY", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};          // 1 // API_Driver ANALOGUE (CU_D3D9_MAPRESOURCE_FLAGS_READONLY)
+    cuda2hipRename["cudaD3D9MapFlagsWriteDiscard"]              = {"HIP_D3D9_MAPRESOURCE_FLAGS_WRITEDISCARD", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};      // 2 // API_Driver ANALOGUE (CU_D3D9_MAPRESOURCE_FLAGS_WRITEDISCARD)
+
+    // enum cudaD3D9RegisterFlags
+    cuda2hipRename["cudaD3D9RegisterFlags"]                     = {"hipD3D9RegisterFlags", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                              // API_Driver ANALOGUE (CUd3d9Register_flags)
+    cuda2hipRename["cudaD3D9RegisterFlagsNone"]                 = {"HIP_D3D9_REGISTER_FLAGS_NONE", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                 // 0 // API_Driver ANALOGUE (CU_D3D9_REGISTER_FLAGS_NONE)
+    cuda2hipRename["cudaD3D9RegisterFlagsArray"]                = {"HIP_D3D9_REGISTER_FLAGS_ARRAY", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                // 1 // API_Driver ANALOGUE (CU_D3D9_REGISTER_FLAGS_ARRAY)
+
+    cuda2hipRename["cudaD3D9MapResources"]                      = {"hipD3D9MapResources", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                               // API_Driver ANALOGUE (cuD3D9MapResources)
+    cuda2hipRename["cudaD3D9RegisterResource"]                  = {"hipD3D9RegisterResource", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                           // API_Driver ANALOGUE (cuD3D9RegisterResource)
+    cuda2hipRename["cudaD3D9ResourceGetMappedArray"]            = {"hipD3D9ResourceGetMappedArray", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                     // API_Driver ANALOGUE (cuD3D9ResourceGetMappedArray)
+    cuda2hipRename["cudaD3D9ResourceGetMappedPitch"]            = {"hipD3D9ResourceGetMappedPitch", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                     // API_Driver ANALOGUE (cudaD3D9ResourceGetMappedPitch)
+    cuda2hipRename["cudaD3D9ResourceGetMappedPointer"]          = {"hipD3D9ResourceGetMappedPointer", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                   // API_Driver ANALOGUE (cuD3D9ResourceGetMappedPointer)
+    cuda2hipRename["cudaD3D9ResourceGetMappedSize"]             = {"hipD3D9ResourceGetMappedSize", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                      // API_Driver ANALOGUE (cuD3D9ResourceGetMappedSize)
+    cuda2hipRename["cudaD3D9ResourceGetSurfaceDimensions"]      = {"hipD3D9ResourceGetSurfaceDimensions", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};               // API_Driver ANALOGUE (cuD3D9ResourceGetSurfaceDimensions)
+    cuda2hipRename["cudaD3D9ResourceSetMapFlags"]               = {"hipD3D9ResourceSetMapFlags", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                        // API_Driver ANALOGUE (cuD3D9ResourceSetMapFlags)
+    cuda2hipRename["cudaD3D9UnmapResources"]                    = {"hipD3D9UnmapResources", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                             // API_Driver ANALOGUE (cuD3D9UnmapResources)
+    cuda2hipRename["cudaD3D9UnregisterResource"]                = {"hipD3D9UnregisterResource", CONV_D3D9, API_RUNTIME, HIP_UNSUPPORTED};                         // API_Driver ANALOGUE (cuD3D9UnregisterResource)
+
+    // Direct3D 10 Interoperability
+    // enum cudaD3D10DeviceList
+    cuda2hipRename["cudaD3D10DeviceList"]                       = {"hipd3d10DeviceList", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                              // API_Driver ANALOGUE (CUd3d10DeviceList)
+    cuda2hipRename["cudaD3D10DeviceListAll"]                    = {"HIP_D3D10_DEVICE_LIST_ALL", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                  // 1 // API_Driver ANALOGUE (CU_D3D10_DEVICE_LIST_ALL)
+    cuda2hipRename["cudaD3D10DeviceListCurrentFrame"]           = {"HIP_D3D10_DEVICE_LIST_CURRENT_FRAME", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};        // 2 // API_Driver ANALOGUE (CU_D3D10_DEVICE_LIST_CURRENT_FRAME)
+    cuda2hipRename["cudaD3D10DeviceListNextFrame"]              = {"HIP_D3D10_DEVICE_LIST_NEXT_FRAME", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};           // 3 // API_Driver ANALOGUE (CU_D3D10_DEVICE_LIST_NEXT_FRAME)
+
+    cuda2hipRename["cudaD3D10GetDevice"]                        = {"hipD3D10GetDevice", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                               // API_Driver ANALOGUE (cuD3D10GetDevice)
+    cuda2hipRename["cudaD3D10GetDevices"]                       = {"hipD3D10GetDevices", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                              // API_Driver ANALOGUE (cuD3D10GetDevices)
+    cuda2hipRename["cudaGraphicsD3D10RegisterResource"]         = {"hipGraphicsD3D10RegisterResource", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                // API_Driver ANALOGUE (cuGraphicsD3D10RegisterResource)
+
+    // Direct3D 10 Interoperability [DEPRECATED]
+    // enum cudaD3D10MapFlags
+    cuda2hipRename["cudaD3D10MapFlags"]                         = {"hipD3D10MapFlags", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                                // API_Driver ANALOGUE (CUd3d10map_flags)
+    cuda2hipRename["cudaD3D10MapFlagsNone"]                     = {"HIP_D3D10_MAPRESOURCE_FLAGS_NONE", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};           // 0 // API_Driver ANALOGUE (CU_D3D10_MAPRESOURCE_FLAGS_NONE)
+    cuda2hipRename["cudaD3D10MapFlagsReadOnly"]                 = {"HIP_D3D10_MAPRESOURCE_FLAGS_READONLY", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};       // 1 // API_Driver ANALOGUE (CU_D3D10_MAPRESOURCE_FLAGS_READONLY)
+    cuda2hipRename["cudaD3D10MapFlagsWriteDiscard"]             = {"HIP_D3D10_MAPRESOURCE_FLAGS_WRITEDISCARD", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};   // 2 // API_Driver ANALOGUE (CU_D3D10_MAPRESOURCE_FLAGS_WRITEDISCARD)
+
+    // enum cudaD3D10RegisterFlags
+    cuda2hipRename["cudaD3D10RegisterFlags"]                    = {"hipD3D10RegisterFlags", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                           // API_Driver ANALOGUE (CUd3d10Register_flags)
+    cuda2hipRename["cudaD3D10RegisterFlagsNone"]                = {"HIP_D3D10_REGISTER_FLAGS_NONE", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};              // 0 // API_Driver ANALOGUE (CU_D3D10_REGISTER_FLAGS_NONE)
+    cuda2hipRename["cudaD3D10RegisterFlagsArray"]               = {"HIP_D3D10_REGISTER_FLAGS_ARRAY", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};             // 1 // API_Driver ANALOGUE (CU_D3D10_REGISTER_FLAGS_ARRAY)
+
+    cuda2hipRename["cudaD3D10GetDirect3DDevice"]                = {"hipD3D10GetDirect3DDevice", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                          // API_Driver ANALOGUE (cudaD3D10GetDirect3DDevice)
+    cuda2hipRename["cudaD3D10MapResources"]                     = {"hipD3D10MapResources", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                               // API_Driver ANALOGUE (cuD3D10MapResources)
+    cuda2hipRename["cudaD3D10RegisterResource"]                 = {"hipD3D10RegisterResource", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                           // API_Driver ANALOGUE (cuD3D10RegisterResource)
+    cuda2hipRename["cudaD3D10ResourceGetMappedArray"]           = {"hipD3D10ResourceGetMappedArray", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                     // API_Driver ANALOGUE (cuD3D10ResourceGetMappedArray)
+    cuda2hipRename["cudaD3D10ResourceGetMappedPitch"]           = {"hipD3D10ResourceGetMappedPitch", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                     // API_Driver ANALOGUE (cudaD3D10ResourceGetMappedPitch)
+    cuda2hipRename["cudaD3D10ResourceGetMappedPointer"]         = {"hipD3D10ResourceGetMappedPointer", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                   // API_Driver ANALOGUE (cuD3D10ResourceGetMappedPointer)
+    cuda2hipRename["cudaD3D10ResourceGetMappedSize"]            = {"hipD3D10ResourceGetMappedSize", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                      // API_Driver ANALOGUE (cuD3D10ResourceGetMappedSize)
+    cuda2hipRename["cudaD3D10ResourceGetSurfaceDimensions"]     = {"hipD3D10ResourceGetSurfaceDimensions", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};               // API_Driver ANALOGUE (cuD3D10ResourceGetSurfaceDimensions)
+    cuda2hipRename["cudaD3D10ResourceSetMapFlags"]              = {"hipD3D10ResourceSetMapFlags", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                        // API_Driver ANALOGUE (cuD3D10ResourceSetMapFlags)
+    cuda2hipRename["cudaD3D10SetDirect3DDevice"]                = {"hipD3D10SetDirect3DDevice", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                          // no API_Driver ANALOGUE
+    cuda2hipRename["cudaD3D10UnmapResources"]                   = {"hipD3D10UnmapResources", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                             // API_Driver ANALOGUE (cuD3D10UnmapResources)
+    cuda2hipRename["cudaD3D10UnregisterResource"]               = {"hipD3D10UnregisterResource", CONV_D3D10, API_RUNTIME, HIP_UNSUPPORTED};                         // API_Driver ANALOGUE (cuD3D10UnregisterResource)
+
+    // Direct3D 11 Interoperability
+    // enum cudaD3D11DeviceList
+    cuda2hipRename["cudaD3D11DeviceList"]                       = {"hipd3d11DeviceList", CONV_D3D11, API_RUNTIME, HIP_UNSUPPORTED};                              // API_Driver ANALOGUE (CUd3d11DeviceList)
+    cuda2hipRename["cudaD3D11DeviceListAll"]                    = {"HIP_D3D11_DEVICE_LIST_ALL", CONV_D3D11, API_RUNTIME, HIP_UNSUPPORTED};                  // 1 // API_Driver ANALOGUE (CU_D3D11_DEVICE_LIST_ALL)
+    cuda2hipRename["cudaD3D11DeviceListCurrentFrame"]           = {"HIP_D3D11_DEVICE_LIST_CURRENT_FRAME", CONV_D3D11, API_RUNTIME, HIP_UNSUPPORTED};        // 2 // API_Driver ANALOGUE (CU_D3D11_DEVICE_LIST_CURRENT_FRAME)
+    cuda2hipRename["cudaD3D11DeviceListNextFrame"]              = {"HIP_D3D11_DEVICE_LIST_NEXT_FRAME", CONV_D3D11, API_RUNTIME, HIP_UNSUPPORTED};           // 3 // API_Driver ANALOGUE (CU_D3D11_DEVICE_LIST_NEXT_FRAME)
+
+    cuda2hipRename["cudaD3D11GetDevice"]                        = {"hipD3D11GetDevice", CONV_D3D11, API_RUNTIME, HIP_UNSUPPORTED};                               // API_Driver ANALOGUE (cuD3D11GetDevice)
+    cuda2hipRename["cudaD3D11GetDevices"]                       = {"hipD3D11GetDevices", CONV_D3D11, API_RUNTIME, HIP_UNSUPPORTED};                              // API_Driver ANALOGUE (cuD3D11GetDevices)
+    cuda2hipRename["cudaGraphicsD3D11RegisterResource"]         = {"hipGraphicsD3D11RegisterResource", CONV_D3D11, API_RUNTIME, HIP_UNSUPPORTED};                // API_Driver ANALOGUE (cuGraphicsD3D11RegisterResource)
+
+    // Direct3D 11 Interoperability [DEPRECATED]
+    cuda2hipRename["cudaD3D11GetDevice"]                        = {"hipD3D11GetDevice", CONV_D3D11, API_RUNTIME, HIP_UNSUPPORTED};                               // API_Driver ANALOGUE (cuD3D11GetDevice)
+    cuda2hipRename["cudaD3D11GetDevices"]                       = {"hipD3D11GetDevices", CONV_D3D11, API_RUNTIME, HIP_UNSUPPORTED};                              // API_Driver ANALOGUE (cuD3D11GetDevices)
+    cuda2hipRename["cudaGraphicsD3D11RegisterResource"]         = {"hipGraphicsD3D11RegisterResource", CONV_D3D11, API_RUNTIME, HIP_UNSUPPORTED};                // API_Driver ANALOGUE (cuGraphicsD3D11RegisterResource)
+
+    // VDPAU Interoperability
+    cuda2hipRename["cudaGraphicsVDPAURegisterOutputSurface"]    = {"hipGraphicsVDPAURegisterOutputSurface", CONV_VDPAU, API_RUNTIME, HIP_UNSUPPORTED};           // API_Driver ANALOGUE (cuGraphicsVDPAURegisterOutputSurface)
+    cuda2hipRename["cudaGraphicsVDPAURegisterVideoSurface"]     = {"hipGraphicsVDPAURegisterVideoSurface", CONV_VDPAU, API_RUNTIME, HIP_UNSUPPORTED};            // API_Driver ANALOGUE (cuGraphicsVDPAURegisterVideoSurface)
+    cuda2hipRename["cudaVDPAUGetDevice"]                        = {"hipVDPAUGetDevice", CONV_VDPAU, API_RUNTIME, HIP_UNSUPPORTED};                               // API_Driver ANALOGUE (cuVDPAUGetDevice)
+    cuda2hipRename["cudaVDPAUSetVDPAUDevice"]                   = {"hipVDPAUSetDevice", CONV_VDPAU, API_RUNTIME, HIP_UNSUPPORTED};                               // no API_Driver ANALOGUE
+
+    // EGL Interoperability
+    cuda2hipRename["cudaEglStreamConnection"]                   = {"hipEglStreamConnection", CONV_EGL, API_RUNTIME, HIP_UNSUPPORTED};                            // API_Driver ANALOGUE (CUeglStreamConnection)
+
+    cuda2hipRename["cudaEGLStreamConsumerAcquireFrame"]         = {"hipEGLStreamConsumerAcquireFrame", CONV_EGL, API_RUNTIME, HIP_UNSUPPORTED};                  // API_Driver ANALOGUE (cuEGLStreamConsumerAcquireFrame)
+    cuda2hipRename["cudaEGLStreamConsumerConnect"]              = {"hipEGLStreamConsumerConnect", CONV_EGL, API_RUNTIME, HIP_UNSUPPORTED};                       // API_Driver ANALOGUE (cuEGLStreamConsumerConnect)
+    cuda2hipRename["cudaEGLStreamConsumerConnectWithFlags"]     = {"hipEGLStreamConsumerConnectWithFlags", CONV_EGL, API_RUNTIME, HIP_UNSUPPORTED};              // API_Driver ANALOGUE (cuEGLStreamConsumerConnectWithFlags)
+    cuda2hipRename["cudaEGLStreamConsumerReleaseFrame"]         = {"hipEGLStreamConsumerReleaseFrame", CONV_EGL, API_RUNTIME, HIP_UNSUPPORTED};                  // API_Driver ANALOGUE (cuEGLStreamConsumerReleaseFrame)
+    cuda2hipRename["cudaEGLStreamProducerConnect"]              = {"hipEGLStreamProducerConnect", CONV_EGL, API_RUNTIME, HIP_UNSUPPORTED};                       // API_Driver ANALOGUE (cuEGLStreamProducerConnect)
+    cuda2hipRename["cudaEGLStreamProducerDisconnect"]           = {"hipEGLStreamProducerDisconnect", CONV_EGL, API_RUNTIME, HIP_UNSUPPORTED};                    // API_Driver ANALOGUE (cuEGLStreamProducerDisconnect)
+    cuda2hipRename["cudaEGLStreamProducerPresentFrame"]         = {"hipEGLStreamProducerPresentFrame", CONV_EGL, API_RUNTIME, HIP_UNSUPPORTED};                  // API_Driver ANALOGUE (cuEGLStreamProducerPresentFrame)
+    cuda2hipRename["cudaEGLStreamProducerReturnFrame"]          = {"hipEGLStreamProducerReturnFrame", CONV_EGL, API_RUNTIME, HIP_UNSUPPORTED};                   // API_Driver ANALOGUE (cuEGLStreamProducerReturnFrame)
+    cuda2hipRename["cudaGraphicsEGLRegisterImage"]              = {"hipGraphicsEGLRegisterImage", CONV_EGL, API_RUNTIME, HIP_UNSUPPORTED};                       // API_Driver ANALOGUE (cuGraphicsEGLRegisterImage)
+    cuda2hipRename["cudaGraphicsResourceGetMappedEglFrame"]     = {"hipGraphicsResourceGetMappedEglFrame", CONV_EGL, API_RUNTIME, HIP_UNSUPPORTED};              // API_Driver ANALOGUE (cuGraphicsResourceGetMappedEglFrame)
 
     //---------------------------------------BLAS-------------------------------------//
     // Blas types


### PR DESCRIPTION
… API (including missing data types, D3D, OpenGL, VDPAU and EGL interop).

    + All the Modules are supported now:
	1) 4.1 – 4.31 from CUDA 8.0.61 Driver API
	2) CUDA_Driver_API_functions_supported_by_HIP.md updated accordingly
	3) 4.1 – 4.31 from CUDA 8.0.61 Runtime API
	4) CUDA_Runtime_API_functions_supported_by_HIP.md updated accordingly
    + Typos fixing
    + Annotating