### PR TITLE
[ci] Remove repo.radeon.com build-args; HiP CI unit tests running 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,10 +76,10 @@ def docker_build_image( String platform, String source_hip_rel, String from_imag
 
       // Docker 17.05 introduced the ability to use ARG values in FROM statements
       // Docker inspect failing on FROM statements with ARG https://issues.jenkins-ci.org/browse/JENKINS-44836
-      //build_image = docker.build( "${project}/${build_image_name}:latest", "--pull -f docker/${dockerfile_name} --build-arg REPO_RADEON=10.255.8.5 --build-arg user_uid=${user_uid} --build-arg base_image=${from_image} ." )
+      //build_image = docker.build( "${project}/${build_image_name}:latest", "--pull -f docker/${dockerfile_name} --build-arg user_uid=${user_uid} --build-arg base_image=${from_image} ." )
 
-      // JENKINS-44836 workaround
-      sh "docker build -t ${project}/${build_image_name}:latest --pull -f docker/${dockerfile_name} --build-arg REPO_RADEON=10.255.8.5 --build-arg user_uid=${user_uid} --build-arg base_image=${from_image} ."
+      // JENKINS-44836 workaround by using a bash script instead of docker.build()
+      sh "docker build -t ${project}/${build_image_name}:latest --pull -f docker/${dockerfile_name} --build-arg user_uid=${user_uid} --build-arg base_image=${from_image} ."
       build_image = docker.image( "${project}/${build_image_name}:latest" )
     }
   }
@@ -173,7 +173,8 @@ def docker_upload_artifactory( String hcc_ver, String from_image, String source_
     // Docker inspect failing on FROM statements with ARG https://issues.jenkins-ci.org/browse/JENKINS-44836
     // hip_install_image = docker.build( "${artifactory_org}/${image_name}:${env.BUILD_NUMBER}", "--pull -f ${build_dir_rel}/dockerfile-hip-ubuntu-16.04 --build-arg base_image=${from_image} ${build_dir_rel}" )
 
-    // JENKINS-44836 workaround
+    // The --build-arg REPO_RADEON= is a temporary fix to get around a DNS issue with our build machines
+    // JENKINS-44836 workaround by using a bash script instead of docker.build()
     sh "docker build -t ${artifactory_org}/${image_name}:${env.BUILD_NUMBER} --pull -f ${build_dir_rel}/dockerfile-hip-ubuntu-16.04 --build-arg base_image=${from_image} ${build_dir_rel}"
     hip_install_image = docker.image( "${artifactory_org}/${image_name}:${env.BUILD_NUMBER}" )
 

--- a/docker/dockerfile-build-ubuntu-16.04
+++ b/docker/dockerfile-build-ubuntu-16.04
@@ -18,7 +18,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-ins
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# docker pipeline runs containers with uid 1000
+# docker pipeline runs containers with particular uid
 # create a jenkins user with this specific uid so it can use sudo priviledges
 # Grant any member of sudo group password-less sudo privileges
 RUN useradd --create-home -u ${user_uid} -G sudo --shell /bin/bash jenkins && \

--- a/docker/dockerfile-hip-ubuntu-16.04
+++ b/docker/dockerfile-hip-ubuntu-16.04
@@ -1,6 +1,5 @@
 # Parameters related to building hip
 ARG base_image
-ARG REPO_RADEON=$REPO_RADEON
 
 FROM ${base_image}
 MAINTAINER Kent Knox <kent.knox@amd>
@@ -10,8 +9,6 @@ COPY *.deb /tmp/
 
 # Install the debian package
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y curl \
-  && curl -sL http://$REPO_RADEON/rocm/apt/debian/rocm.gpg.key | apt-key add - \
-  && echo deb [arch=amd64] http://$REPO_RADEON/rocm/apt/debian/ xenial main | tee /etc/apt/sources.list.d/rocm.list \
   && apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends --allow-unauthenticated -y \
     /tmp/hip_base-*.deb \
     /tmp/hip_hcc-*.deb \


### PR DESCRIPTION
HiP docker images should inherit the repo information from the hcc image,
so no need to duplicate in HiP again
