### PR TITLE
Fix hipEnvVar test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,6 +119,7 @@ def docker_build_inside_image( def build_image, String inside_args, String platf
             cd ${build_dir_rel}
             make install -j\$(nproc)
             make build_tests -j\$(nproc)
+            make test 
           """
         // If unit tests output a junit or xunit file in the future, jenkins can parse that file
         // to display test results on the dashboard

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -119,7 +119,6 @@ def docker_build_inside_image( def build_image, String inside_args, String platf
             cd ${build_dir_rel}
             make install -j\$(nproc)
             make build_tests -j\$(nproc)
-            ctest -E hipEnvVarDriver
           """
         // If unit tests output a junit or xunit file in the future, jenkins can parse that file
         // to display test results on the dashboard

--- a/tests/src/hipEnvVar.cpp
+++ b/tests/src/hipEnvVar.cpp
@@ -109,15 +109,14 @@ int main(int argc, char **argv)
         std::cout << devCount  << std::endl;
     }
     if (retDevInfo) {
-        hipSetDevice(device);
-        hipDeviceProp_t devProp;
+	hipDevice_t deviceT;
+	hipDeviceGet(&deviceT, device);
 
-        hipGetDeviceProperties(&devProp, device);
-        if (devProp.major < 1) {
-            printf("%d does not support HIP\n", device);
-            return -1;
-        }
-        std::cout << devProp.pciBusID << std::endl;
+        char pciBusId[100];
+        memset(pciBusId,0,100);
+        hipDeviceGetPCIBusId(pciBusId,100,deviceT);
+
+        cout<<pciBusId<<endl;
     }
     exit(0);
 }

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -28,16 +28,21 @@ THE USE OR OTHER DEALINGS IN THE SOFTWARE. */
 #include <assert.h>
 #include <string>
 #include "hip/hip_runtime.h"
+#include <chrono>
+#include <thread>
 using namespace std;
 
 int getDeviceNumber(){
-   FILE *in;
-   char buff[512];
-   string str;
-   if(!(in = popen("./hipEnvVar -c", "r"))){
-        return 1;
+    FILE *in;
+    char buff[512];
+    string str;
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    if(!(in = popen("./directed_tests/hipEnvVar -c", "r"))){
+         return 1;
+     }
+    while(fgets(buff, sizeof(buff), in)!=NULL){
+         cout << buff;
     }
-    fgets(buff, sizeof(buff), in);
     pclose(in);
     return atoi(buff);
 }
@@ -46,12 +51,15 @@ int getDeviceNumber(){
 int getDevicePCIBusNumRemote(int deviceID){
     FILE *in;
     char buff[512];
-    string str = "./hipEnvVar -d ";
+    string str = "./directed_tests/hipEnvVar -d ";
     str += std::to_string(deviceID);
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
     if(!(in = popen(str.c_str(), "r"))){
         return 1;
     }
-    fgets(buff, sizeof(buff), in);
+    while(fgets(buff, sizeof(buff), in)!=NULL){
+        cout << buff;
+    }
     pclose(in);
     return atoi(buff);
 }


### PR DESCRIPTION
This PR fixes indentation, binary path and adding wait on popen calls for the hipEnvVarDriver test. 