### PR TITLE
Enable hipStreamSync2 and record_event dtests

### DIFF
--- a/tests/src/runtimeApi/event/record_event.cpp
+++ b/tests/src/runtimeApi/event/record_event.cpp
@@ -19,7 +19,7 @@ THE SOFTWARE.
 
 /* HIT_START
  * BUILD: %t %s ../../test_common.cpp
- * RUN: %t EXCLUDE_HIP_PLATFORM hcc
+ * RUN: %t
  * HIT_END
  */
 

--- a/tests/src/runtimeApi/stream/hipStreamSync2.cpp
+++ b/tests/src/runtimeApi/stream/hipStreamSync2.cpp
@@ -19,7 +19,7 @@ THE SOFTWARE.
 
 /* HIT_START
  * BUILD: %t %s ../../test_common.cpp
- * RUN: %t EXCLUDE_HIP_PLATFORM hcc
+ * RUN: %t
  * HIT_END
  */
 


### PR DESCRIPTION
Enabled these tests since HIP_SYNC_NULL_STREAM=0 for __hcc_workweek__ >= 17300