### PR TITLE
[CentOS7] Fix HIP sample hipInfo and other tests

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -105,6 +105,7 @@ if ($HIP_PLATFORM eq "hcc") {
     $HIPLDFLAGS = `${HCC_HOME}/bin/hcc-config --ldflags`;
 
     #### GCC system includes workaround ####
+    $HOST_OSNAME= `cat /etc/os-release | grep "^ID\=" | cut -d= -f2 | tr -d '\n'`;
     $HCC_WA_FLAGS = " ";
     if ($HCC_VERSION_MAJOR eq 1) {
         my $GCC_CUR_VER = `gcc -dumpversion`;
@@ -116,7 +117,8 @@ if ($HIP_PLATFORM eq "hcc") {
 
         # Only include the libstdc++ headers and libraries flags explicitly if the g++ is older than version 5.
         # That's because HCC already uses libstdc++ by default if a newer g++/libstdc++ is available
-        if (${GCC_CUR_VER} eq ${GPP_CUR_VER} and $GPP_VER_FIELDS[0] < 5) {
+        # Cent OS 7 cannot use libstdc++ for compilation, defaults to libc++
+        if (${GCC_CUR_VER} eq ${GPP_CUR_VER} and $GPP_VER_FIELDS[0] < 5 and ($HOST_OSNAME ne "\"centos\"")) {
             $HCC_WA_FLAGS .= " -stdlib=libstdc++  -I/usr/include/x86_64-linux-gnu -I/usr/include/x86_64-linux-gnu/c++/${GCC_CUR_VER} -I/usr/include/c++/${GCC_CUR_VER} ";
             # Add C++ libs for GCC.
             $HIPLDFLAGS .= " -lstdc++";
@@ -124,7 +126,6 @@ if ($HIP_PLATFORM eq "hcc") {
     }
 
     # Force -stdlib=libc++ on UB14.04
-    $HOST_OSNAME= `cat /etc/os-release | grep "^ID\=" | cut -d= -f2 | tr -d '\n'`;
     $HOST_OSVER= `cat /etc/os-release | grep "^VERSION_ID\=" | cut -d= -f2 | tr -d '\n'`;
     if ($HOST_OSNAME eq "ubuntu" and $HOST_OSVER eq "\"14.04\"") {
         $HIPCXXFLAGS .= " -stdlib=libc++";


### PR DESCRIPTION
Cent OS 7 has conflicts between its libc++ and libstdc++. Seems that we cannot use libstdc++ on Cent OS. This is related to SWDEV-131972 [ROCm CQE][Cent OS 7][G] Building any HIP sample giving an fatal error: 'bits/c++config.h'.