### PR TITLE
[CentOS7] Fix HIP sample hipInfo and other tests

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -117,8 +117,8 @@ if ($HIP_PLATFORM eq "hcc") {
 
         # Only include the libstdc++ headers and libraries flags explicitly if the g++ is older than version 5.
         # That's because HCC already uses libstdc++ by default if a newer g++/libstdc++ is available
-        # Cent OS 7 cannot use libstdc++ for compilation, defaults to libc++
-        if (${GCC_CUR_VER} eq ${GPP_CUR_VER} and $GPP_VER_FIELDS[0] < 5 and ($HOST_OSNAME ne "\"centos\"")) {
+        # Cent OS 7 and RHEL 7.4 cannot use libstdc++ for compilation, default to libc++
+        if (${GCC_CUR_VER} eq ${GPP_CUR_VER} and $GPP_VER_FIELDS[0] < 5 and ($HOST_OSNAME ne "\"centos\"") and ($HOST_OSNAME ne "\"rhel\"")) {
             $HCC_WA_FLAGS .= " -stdlib=libstdc++  -I/usr/include/x86_64-linux-gnu -I/usr/include/x86_64-linux-gnu/c++/${GCC_CUR_VER} -I/usr/include/c++/${GCC_CUR_VER} ";
             # Add C++ libs for GCC.
             $HIPLDFLAGS .= " -lstdc++";
@@ -131,8 +131,8 @@ if ($HIP_PLATFORM eq "hcc") {
         $HIPCXXFLAGS .= " -stdlib=libc++";
         $setStdLib = 1;
     }
-    # Force -stdlib=libc++ on Cent OS 7
-    if ($HOST_OSNAME eq "\"centos\"" and $HOST_OSVER eq "\"7\"") {
+    # Force -stdlib=libc++ on Cent OS 7 and RHEL 7.4
+    if (($HOST_OSNAME eq "\"centos\"" and $HOST_OSVER eq "\"7\"") or ($HOST_OSNAME eq "\"rhel\"" and $HOST_OSVER eq "\"7.4\"")) {
         $HIPCXXFLAGS .= " -stdlib=libc++";
         $HIPLDFLAGS .= " -lc++ -lc++abi";
         $setStdLib = 1;

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -131,6 +131,11 @@ if ($HIP_PLATFORM eq "hcc") {
         $HIPCXXFLAGS .= " -stdlib=libc++";
         $setStdLib = 1;
     }
+    if ($HOST_OSNAME eq "\"centos\"" and $HOST_OSVER eq "\"7\"") {
+        $HIPCXXFLAGS .= " -stdlib=libc++";
+        $HIPLDFLAGS .= " -lc++ -lc++abi";
+        $setStdLib = 1;
+    }
 
     $HIPCXXFLAGS .= " -I$HIP_PATH/include/hip/hcc_detail/cuda";
     $HIPCXXFLAGS .= " -I$HSA_PATH/include";

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -106,6 +106,7 @@ if ($HIP_PLATFORM eq "hcc") {
 
     #### GCC system includes workaround ####
     $HCC_WA_FLAGS = " ";
+    $HOST_OSNAME= `cat /etc/os-release | grep "^ID\=" | cut -d= -f2 | tr -d '\n'`;
     if ($HCC_VERSION_MAJOR eq 1) {
         my $GCC_CUR_VER = `gcc -dumpversion`;
         my $GPP_CUR_VER = `g++ -dumpversion`;
@@ -116,7 +117,8 @@ if ($HIP_PLATFORM eq "hcc") {
 
         # Only include the libstdc++ headers and libraries flags explicitly if the g++ is older than version 5.
         # That's because HCC already uses libstdc++ by default if a newer g++/libstdc++ is available
-        if (${GCC_CUR_VER} eq ${GPP_CUR_VER} and $GPP_VER_FIELDS[0] < 5) {
+        # Cent OS 7 cannot use libstdc++ for compilation, defaults to libc++
+        if (${GCC_CUR_VER} eq ${GPP_CUR_VER} and $GPP_VER_FIELDS[0] < 5 and ($HOST_OSNAME ne "\"centos\"")) {
             $HCC_WA_FLAGS .= " -stdlib=libstdc++  -I/usr/include/x86_64-linux-gnu -I/usr/include/x86_64-linux-gnu/c++/${GCC_CUR_VER} -I/usr/include/c++/${GCC_CUR_VER} ";
             # Add C++ libs for GCC.
             $HIPLDFLAGS .= " -lstdc++";
@@ -124,7 +126,6 @@ if ($HIP_PLATFORM eq "hcc") {
     }
 
     # Force -stdlib=libc++ on UB14.04
-    $HOST_OSNAME= `cat /etc/os-release | grep "^ID\=" | cut -d= -f2 | tr -d '\n'`;
     $HOST_OSVER= `cat /etc/os-release | grep "^VERSION_ID\=" | cut -d= -f2 | tr -d '\n'`;
     if ($HOST_OSNAME eq "ubuntu" and $HOST_OSVER eq "\"14.04\"") {
         $HIPCXXFLAGS .= " -stdlib=libc++";

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -131,12 +131,6 @@ if ($HIP_PLATFORM eq "hcc") {
         $HIPCXXFLAGS .= " -stdlib=libc++";
         $setStdLib = 1;
     }
-    # Force -stdlib=libc++ on Cent OS 7 and RHEL 7.4
-    if (($HOST_OSNAME eq "\"centos\"" and $HOST_OSVER eq "\"7\"") or ($HOST_OSNAME eq "\"rhel\"" and $HOST_OSVER eq "\"7.4\"")) {
-        $HIPCXXFLAGS .= " -stdlib=libc++";
-        $HIPLDFLAGS .= " -lc++ -lc++abi";
-        $setStdLib = 1;
-    }
 
     $HIPCXXFLAGS .= " -I$HIP_PATH/include/hip/hcc_detail/cuda";
     $HIPCXXFLAGS .= " -I$HSA_PATH/include";

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -131,6 +131,7 @@ if ($HIP_PLATFORM eq "hcc") {
         $HIPCXXFLAGS .= " -stdlib=libc++";
         $setStdLib = 1;
     }
+    # Force -stdlib=libc++ on Cent OS 7
     if ($HOST_OSNAME eq "\"centos\"" and $HOST_OSVER eq "\"7\"") {
         $HIPCXXFLAGS .= " -stdlib=libc++";
         $HIPLDFLAGS .= " -lc++ -lc++abi";


### PR DESCRIPTION
Cent OS 7 has conflicts between its libc++ and libstdc++. Seems that we cannot use libstdc++ on Cent OS. This is related to SWDEV-131972 [ROCm CQE][Cent OS 7][G] Building any HIP sample giving an fatal error: 'bits/c++config.h'.