### PR TITLE
Migrate hipify-clang to a newer version of clang

### DIFF
--- a/hipify-clang/CMakeLists.txt
+++ b/hipify-clang/CMakeLists.txt
@@ -3,6 +3,13 @@ project(hipify-clang)
 
 option(HIPIFY_CLANG_TESTS "Build the tests for hipify-clang, if lit is installed" ON)
 
+# Disable the tests if `lit` is not installed.
+find_program(LIT_COMMAND lit)
+if (NOT LIT_COMMAND)
+    set(HIPIFY_CLANG_TESTS OFF CACHE INTERNAL "")
+    message(STATUS "hipify-clang's tests are not being built because `lit` is not installed.")
+endif()
+
 if (PARENT_SCOPE)
     set(BUILD_HIPIFY_CLANG 0 PARENT_SCOPE)
 endif()
@@ -67,20 +74,20 @@ install(TARGETS hipify-clang DESTINATION bin)
 if (HIPIFY_CLANG_TESTS)
     # tests
     find_package(PythonInterp 2.7 REQUIRED EXACT)
-    find_program(LIT_COMMAND lit)
 
     set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
     configure_file(
         ${CMAKE_SOURCE_DIR}/tests/hipify-clang/lit.site.cfg.in
         ${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
-        @ONLY)
+        @ONLY
+    )
 
     add_lit_testsuite(test-hipify "Running HIPify regression tests"
         ${CMAKE_SOURCE_DIR}/tests/hipify-clang
         PARAMS site_config=${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
         DEPENDS hipify-clang lit
-        )
+    )
 
     add_custom_target(test-hipify-clang)
     add_dependencies(test-hipify-clang test-hipify)

--- a/hipify-clang/CMakeLists.txt
+++ b/hipify-clang/CMakeLists.txt
@@ -13,6 +13,7 @@ if (NOT ${LLVM_FOUND})
         message(STATUS "hipify-clang will not be built. To build it please specify absolute path to LLVM 3.8 or LLVM 3.9 package/dist using -DHIPIFY_CLANG_LLVM_DIR")
     endif()
 endif()
+
 if (${LLVM_FOUND})
     list(APPEND CMAKE_MODULE_PATH ${LLVM_CMAKE_DIR})
     include(AddLLVM)
@@ -52,55 +53,54 @@ if (${LLVM_FOUND})
         LLVMOption
         LLVMCore)
 
-if(WIN32)
-    target_link_libraries(hipify-clang version)
-endif()
+    if(WIN32)
+        target_link_libraries(hipify-clang version)
+    endif()
 
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_CFLAGS}")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_CFLAGS}")
-if(MSVC)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR- /EHs- /EHc-")
-    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} /SUBSYSTEM:WINDOWS")
-else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -fno-rtti -fvisibility-inlines-hidden")
-endif()
+    if(MSVC)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR- /EHs- /EHc-")
+        set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} /SUBSYSTEM:WINDOWS")
+    else()
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -fno-rtti -fvisibility-inlines-hidden")
+    endif()
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHIPIFY_CLANG_RES=\\\"${LLVM_LIBRARY_DIRS}/clang/${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}\\\"")
 
     install(TARGETS hipify-clang DESTINATION bin)
 
-if (HIPIFY_CLANG_TESTS)
-    # tests
-    set(Python_ADDITIONAL_VERSIONS 2.7)
-    include(FindPythonInterp)
-    if(NOT PYTHONINTERP_FOUND)
-        message(FATAL_ERROR
-            "Unable to find Python interpreter, required for builds and testing.\n\n"
-            "Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
+    if (HIPIFY_CLANG_TESTS)
+        # tests
+        set(Python_ADDITIONAL_VERSIONS 2.7)
+        include(FindPythonInterp)
+        if(NOT PYTHONINTERP_FOUND)
+            message(FATAL_ERROR
+                "Unable to find Python interpreter, required for builds and testing.\n\n"
+                "Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
+        endif()
+
+        find_program(LIT_COMMAND lit)
+
+        set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
+
+        configure_file(
+            ${CMAKE_SOURCE_DIR}/tests/hipify-clang/lit.site.cfg.in
+            ${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
+            @ONLY)
+
+        add_lit_testsuite(test-hipify "Running HIPify regression tests"
+            ${CMAKE_SOURCE_DIR}/tests/hipify-clang
+            PARAMS site_config=${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
+            DEPENDS hipify-clang lit
+            )
+
+        add_custom_target(test-hipify-clang)
+        add_dependencies(test-hipify-clang test-hipify)
+        set_target_properties(test-hipify-clang PROPERTIES FOLDER "Tests")
     endif()
 
-    find_program(LIT_COMMAND lit)
-
-    set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
-
-    configure_file(
-        ${CMAKE_SOURCE_DIR}/tests/hipify-clang/lit.site.cfg.in
-        ${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
-        @ONLY)
-
-    add_lit_testsuite(test-hipify "Running HIPify regression tests"
-        ${CMAKE_SOURCE_DIR}/tests/hipify-clang
-        PARAMS site_config=${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
-        DEPENDS hipify-clang lit
-        )
-
-    add_custom_target(test-hipify-clang)
-    add_dependencies(test-hipify-clang test-hipify)
-    set_target_properties(test-hipify-clang PROPERTIES FOLDER "Tests")
-endif()
-
-if (PARENT_SCOPE)
-    set(BUILD_HIPIFY_CLANG 1 PARENT_SCOPE)
-endif()
-
+    if (PARENT_SCOPE)
+        set(BUILD_HIPIFY_CLANG 1 PARENT_SCOPE)
+    endif()
 endif()

--- a/hipify-clang/CMakeLists.txt
+++ b/hipify-clang/CMakeLists.txt
@@ -7,15 +7,7 @@ if (PARENT_SCOPE)
     set(BUILD_HIPIFY_CLANG 0 PARENT_SCOPE)
 endif()
 
-# Find LLVM package
-find_package(LLVM 3.8 QUIET PATHS ${HIPIFY_CLANG_LLVM_DIR} NO_DEFAULT_PATH)
-if (NOT ${LLVM_FOUND})
-    find_package(LLVM 3.9 QUIET PATHS ${HIPIFY_CLANG_LLVM_DIR} NO_DEFAULT_PATH)
-    if (NOT ${LLVM_FOUND})
-        message(STATUS "hipify-clang will not be built. To build it please specify absolute path to LLVM 3.8 or LLVM 3.9 package/dist using -DHIPIFY_CLANG_LLVM_DIR")
-        return()
-    endif()
-endif()
+find_package(LLVM PATHS ${HIPIFY_CLANG_LLVM_DIR} REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH ${LLVM_CMAKE_DIR})
 include(AddLLVM)

--- a/hipify-clang/CMakeLists.txt
+++ b/hipify-clang/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 2.8.8)
 project(hipify-clang)
 
+option(HIPIFY_CLANG_TESTS "Build the tests for hipify-clang, if lit is installed" ON)
+
 if (PARENT_SCOPE)
     set(BUILD_HIPIFY_CLANG 0 PARENT_SCOPE)
 endif()

--- a/hipify-clang/CMakeLists.txt
+++ b/hipify-clang/CMakeLists.txt
@@ -10,9 +10,7 @@ if (NOT LIT_COMMAND)
     message(STATUS "hipify-clang's tests are not being built because `lit` is not installed.")
 endif()
 
-if (PARENT_SCOPE)
-    set(BUILD_HIPIFY_CLANG 0 PARENT_SCOPE)
-endif()
+set(BUILD_HIPIFY_CLANG 0 CACHE INTERNAL "")
 
 find_package(LLVM PATHS ${HIPIFY_CLANG_LLVM_DIR} REQUIRED)
 
@@ -94,6 +92,4 @@ if (HIPIFY_CLANG_TESTS)
     set_target_properties(test-hipify-clang PROPERTIES FOLDER "Tests")
 endif()
 
-if (PARENT_SCOPE)
-    set(BUILD_HIPIFY_CLANG 1 PARENT_SCOPE)
-endif()
+set(BUILD_HIPIFY_CLANG 1 CACHE INTERNAL "")

--- a/hipify-clang/CMakeLists.txt
+++ b/hipify-clang/CMakeLists.txt
@@ -11,96 +11,95 @@ if (NOT ${LLVM_FOUND})
     find_package(LLVM 3.9 QUIET PATHS ${HIPIFY_CLANG_LLVM_DIR} NO_DEFAULT_PATH)
     if (NOT ${LLVM_FOUND})
         message(STATUS "hipify-clang will not be built. To build it please specify absolute path to LLVM 3.8 or LLVM 3.9 package/dist using -DHIPIFY_CLANG_LLVM_DIR")
+        return()
     endif()
 endif()
 
-if (${LLVM_FOUND})
-    list(APPEND CMAKE_MODULE_PATH ${LLVM_CMAKE_DIR})
-    include(AddLLVM)
+list(APPEND CMAKE_MODULE_PATH ${LLVM_CMAKE_DIR})
+include(AddLLVM)
 
-    message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
+message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 
-    include_directories(${LLVM_INCLUDE_DIRS})
-    link_directories(${LLVM_LIBRARY_DIRS})
-    add_definitions(${LLVM_DEFINITIONS})
-    add_llvm_executable(hipify-clang src/Cuda2Hip.cpp)
+include_directories(${LLVM_INCLUDE_DIRS})
+link_directories(${LLVM_LIBRARY_DIRS})
+add_definitions(${LLVM_DEFINITIONS})
+add_llvm_executable(hipify-clang src/Cuda2Hip.cpp)
 
-    set(CMAKE_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang++)
-    set(CMAKE_C_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
+set(CMAKE_CXX_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang++)
+set(CMAKE_C_COMPILER ${LLVM_TOOLS_BINARY_DIR}/clang)
 
-    # Link against LLVM and CLANG libraries
-    target_link_libraries(hipify-clang
-        clangASTMatchers
-        clangFrontend
-        clangTooling
-        clangParse
-        clangSerialization
-        clangSema
-        clangEdit
-        clangFormat
-        clangLex
-        clangAnalysis
-        clangDriver
-        clangAST
-        clangToolingCore
-        clangRewrite
-        clangBasic
-        LLVMProfileData
-        LLVMSupport
-        LLVMMCParser
-        LLVMMC
-        LLVMBitReader
-        LLVMOption
-        LLVMCore)
+# Link against LLVM and CLANG libraries
+target_link_libraries(hipify-clang
+    clangASTMatchers
+    clangFrontend
+    clangTooling
+    clangParse
+    clangSerialization
+    clangSema
+    clangEdit
+    clangFormat
+    clangLex
+    clangAnalysis
+    clangDriver
+    clangAST
+    clangToolingCore
+    clangRewrite
+    clangBasic
+    LLVMProfileData
+    LLVMSupport
+    LLVMMCParser
+    LLVMMC
+    LLVMBitReader
+    LLVMOption
+    LLVMCore)
 
-    if(WIN32)
-        target_link_libraries(hipify-clang version)
+if(WIN32)
+    target_link_libraries(hipify-clang version)
+endif()
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_CFLAGS}")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_CFLAGS}")
+if(MSVC)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR- /EHs- /EHc-")
+    set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} /SUBSYSTEM:WINDOWS")
+else()
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -fno-rtti -fvisibility-inlines-hidden")
+endif()
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHIPIFY_CLANG_RES=\\\"${LLVM_LIBRARY_DIRS}/clang/${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}\\\"")
+
+install(TARGETS hipify-clang DESTINATION bin)
+
+if (HIPIFY_CLANG_TESTS)
+    # tests
+    set(Python_ADDITIONAL_VERSIONS 2.7)
+    include(FindPythonInterp)
+    if(NOT PYTHONINTERP_FOUND)
+        message(FATAL_ERROR
+            "Unable to find Python interpreter, required for builds and testing.\n\n"
+            "Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
     endif()
 
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${EXTRA_CFLAGS}")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${EXTRA_CFLAGS}")
-    if(MSVC)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /GR- /EHs- /EHc-")
-        set(CMAKE_CXX_LINK_FLAGS "${CMAKE_CXX_LINK_FLAGS} /SUBSYSTEM:WINDOWS")
-    else()
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -pthread -fno-rtti -fvisibility-inlines-hidden")
-    endif()
+    find_program(LIT_COMMAND lit)
 
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHIPIFY_CLANG_RES=\\\"${LLVM_LIBRARY_DIRS}/clang/${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}.${LLVM_VERSION_PATCH}\\\"")
+    set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
-    install(TARGETS hipify-clang DESTINATION bin)
+    configure_file(
+        ${CMAKE_SOURCE_DIR}/tests/hipify-clang/lit.site.cfg.in
+        ${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
+        @ONLY)
 
-    if (HIPIFY_CLANG_TESTS)
-        # tests
-        set(Python_ADDITIONAL_VERSIONS 2.7)
-        include(FindPythonInterp)
-        if(NOT PYTHONINTERP_FOUND)
-            message(FATAL_ERROR
-                "Unable to find Python interpreter, required for builds and testing.\n\n"
-                "Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
-        endif()
+    add_lit_testsuite(test-hipify "Running HIPify regression tests"
+        ${CMAKE_SOURCE_DIR}/tests/hipify-clang
+        PARAMS site_config=${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
+        DEPENDS hipify-clang lit
+        )
 
-        find_program(LIT_COMMAND lit)
+    add_custom_target(test-hipify-clang)
+    add_dependencies(test-hipify-clang test-hipify)
+    set_target_properties(test-hipify-clang PROPERTIES FOLDER "Tests")
+endif()
 
-        set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
-
-        configure_file(
-            ${CMAKE_SOURCE_DIR}/tests/hipify-clang/lit.site.cfg.in
-            ${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
-            @ONLY)
-
-        add_lit_testsuite(test-hipify "Running HIPify regression tests"
-            ${CMAKE_SOURCE_DIR}/tests/hipify-clang
-            PARAMS site_config=${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
-            DEPENDS hipify-clang lit
-            )
-
-        add_custom_target(test-hipify-clang)
-        add_dependencies(test-hipify-clang test-hipify)
-        set_target_properties(test-hipify-clang PROPERTIES FOLDER "Tests")
-    endif()
-
-    if (PARENT_SCOPE)
-        set(BUILD_HIPIFY_CLANG 1 PARENT_SCOPE)
-    endif()
+if (PARENT_SCOPE)
+    set(BUILD_HIPIFY_CLANG 1 PARENT_SCOPE)
 endif()

--- a/hipify-clang/CMakeLists.txt
+++ b/hipify-clang/CMakeLists.txt
@@ -66,14 +66,7 @@ install(TARGETS hipify-clang DESTINATION bin)
 
 if (HIPIFY_CLANG_TESTS)
     # tests
-    set(Python_ADDITIONAL_VERSIONS 2.7)
-    include(FindPythonInterp)
-    if(NOT PYTHONINTERP_FOUND)
-        message(FATAL_ERROR
-            "Unable to find Python interpreter, required for builds and testing.\n\n"
-            "Please install Python or specify the PYTHON_EXECUTABLE CMake variable.")
-    endif()
-
+    find_package(PythonInterp 2.7 REQUIRED EXACT)
     find_program(LIT_COMMAND lit)
 
     set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})

--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -3799,7 +3799,7 @@ private:
   }
 
   bool stringLiteral(const MatchFinder::MatchResult &Result) {
-    if (const StringLiteral *sLiteral = Result.Nodes.getNodeAs<StringLiteral>("stringLiteral")) {
+    if (const clang::StringLiteral *sLiteral = Result.Nodes.getNodeAs<clang::StringLiteral>("stringLiteral")) {
       if (sLiteral->getCharByteWidth() == 1) {
         StringRef s = sLiteral->getString();
         SourceManager *SM = Result.SourceManager;

--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -3102,7 +3102,14 @@ public:
                             const MacroDefinition &MD, SourceRange Range,
                             const MacroArgs *Args) override {
     if (_sm->isWrittenInMainFile(MacroNameTok.getLocation())) {
-      for (unsigned int i = 0; Args && i < MD.getMacroInfo()->getNumArgs(); i++) {
+        // The getNumArgs function was rather unhelpfully renamed in clang 4.0. Its semantics
+        // remain unchanged.
+#if LLVM_VERSION_MAJOR > 3
+        #define GET_NUM_ARGS() getNumParams()
+#else
+        #define GET_NUM_ARGS() getNumArgs()
+#endif
+      for (unsigned int i = 0; Args && i < MD.getMacroInfo()->GET_NUM_ARGS(); i++) {
         std::vector<Token> toks;
         // Code below is a kind of stolen from 'MacroArgs::getPreExpArgument'
         // to workaround the 'const' MacroArgs passed into this hook.

--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -3030,7 +3030,11 @@ public:
   HipifyPPCallbacks(Replacements *R, const std::string &mainFileName)
     : Cuda2Hip(R, mainFileName), SeenEnd(false), _sm(nullptr), _pp(nullptr) {}
 
-  virtual bool handleBeginSource(CompilerInstance &CI, StringRef Filename) override {
+  virtual bool handleBeginSource(CompilerInstance &CI
+#if LLVM_VERSION_MAJOR < 4
+                                 , StringRef Filename
+#endif
+                                 ) override {
     Preprocessor &PP = CI.getPreprocessor();
     SourceManager &SM = CI.getSourceManager();
     setSourceManager(&SM);

--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -4300,12 +4300,12 @@ int main(int argc, const char **argv) {
     replacementsToUse = &Tool.getReplacements();
 #endif
 
-    HipifyPPCallbacks PPCallbacks(replacementsToUse, src);
-    Cuda2HipCallback Callback(replacementsToUse, &Finder, &PPCallbacks, src);
+    HipifyPPCallbacks* PPCallbacks = new HipifyPPCallbacks(replacementsToUse, src);
+    Cuda2HipCallback Callback(replacementsToUse, &Finder, PPCallbacks, src);
 
     addAllMatchers(Finder, &Callback);
 
-    auto action = newFrontendActionFactory(&Finder, &PPCallbacks);
+    auto action = newFrontendActionFactory(&Finder, PPCallbacks);
     std::vector<const char*> compilationStages;
     compilationStages.push_back("--cuda-host-only");
 
@@ -4367,13 +4367,13 @@ int main(int argc, const char **argv) {
         }
         std::remove(csv.c_str());
       }
-      if (0 == printStats(csv, src, PPCallbacks, Callback, repBytes, bytes, lines, start)) {
+      if (0 == printStats(csv, src, *PPCallbacks, Callback, repBytes, bytes, lines, start)) {
         filesTranslated--;
       }
       start = std::chrono::steady_clock::now();
       repBytesTotal += repBytes;
       bytesTotal += bytes;
-      changedLinesTotal += PPCallbacks.LOCs.size() + Callback.LOCs.size();
+      changedLinesTotal += PPCallbacks->LOCs.size() + Callback.LOCs.size();
       linesTotal += lines;
     }
     dst.clear();

--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -2928,7 +2928,13 @@ protected:
   std::string mainFileName;
 
   virtual void insertReplacement(const Replacement &rep, const FullSourceLoc &fullSL) {
+#if LLVM_VERSION_MAJOR > 3
+    // New clang added error checking to Replacements, and *insists* that you explicitly check it.
+    llvm::Error e = Replace->add(rep);
+#else
+    // In older versions, it's literally an std::set<Replacement>
     Replace->insert(rep);
+#endif
     if (PrintStats) {
       LOCs.insert(fullSL.getExpansionLineNumber());
     }

--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -4289,8 +4289,19 @@ int main(int argc, const char **argv) {
     }
     RefactoringTool Tool(OptionsParser.getCompilations(), dst);
     ast_matchers::MatchFinder Finder;
-    HipifyPPCallbacks PPCallbacks(&Tool.getReplacements(), src);
-    Cuda2HipCallback Callback(&Tool.getReplacements(), &Finder, &PPCallbacks, src);
+
+    // The Replacements to apply to the file `src`.
+    Replacements* replacementsToUse;
+#if LLVM_VERSION_MAJOR > 3
+    // getReplacements() now returns a map from filename to Replacements - so create an entry
+    // for this source file and return a pointer to it.
+    replacementsToUse = &(Tool.getReplacements()[src]);
+#else
+    replacementsToUse = &Tool.getReplacements();
+#endif
+
+    HipifyPPCallbacks PPCallbacks(replacementsToUse, src);
+    Cuda2HipCallback Callback(replacementsToUse, &Finder, &PPCallbacks, src);
 
     addAllMatchers(Finder, &Callback);
 
@@ -4318,9 +4329,14 @@ int main(int argc, const char **argv) {
     SourceManager SM(Diagnostics, Tool.getFiles());
     if (PrintStats) {
       DEBUG(dbgs() << "Replacements collected by the tool:\n");
-      for (const auto &r : Tool.getReplacements()) {
-        DEBUG(dbgs() << r.toString() << "\n");
-        repBytes += r.getLength();
+#if LLVM_VERSION_MAJOR > 3
+        Replacements& replacements = Tool.getReplacements().begin()->second;
+#else
+        Replacements& replacements = Tool.getReplacements();
+#endif
+      for (const auto &replacement : replacements) {
+        DEBUG(dbgs() << replacement.toString() << "\n");
+        repBytes += replacement.getLength();
       }
       std::ifstream src_file(dst, std::ios::binary | std::ios::ate);
       src_file.clear();

--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -3028,7 +3028,7 @@ class Cuda2HipCallback;
 class HipifyPPCallbacks : public PPCallbacks, public SourceFileCallbacks, public Cuda2Hip {
 public:
   HipifyPPCallbacks(Replacements *R, const std::string &mainFileName)
-    : Cuda2Hip(R, mainFileName), SeenEnd(false), _sm(nullptr), _pp(nullptr) {}
+    : Cuda2Hip(R, mainFileName) {}
 
   virtual bool handleBeginSource(CompilerInstance &CI
 #if LLVM_VERSION_MAJOR < 4
@@ -3201,15 +3201,15 @@ public:
 
   void EndOfMainFile() override {}
 
-  bool SeenEnd;
+  bool SeenEnd = false;
   void setSourceManager(SourceManager *sm) { _sm = sm; }
   void setPreprocessor(Preprocessor *pp) { _pp = pp; }
   void setMatch(Cuda2HipCallback *match) { Match = match; }
 
 private:
-  SourceManager *_sm;
-  Preprocessor *_pp;
-  Cuda2HipCallback *Match;
+  SourceManager *_sm = nullptr;
+  Preprocessor *_pp = nullptr;
+  Cuda2HipCallback *Match = nullptr;
 };
 
 class Cuda2HipCallback : public MatchFinder::MatchCallback, public Cuda2Hip {

--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -3109,10 +3109,10 @@ public:
         // to workaround the 'const' MacroArgs passed into this hook.
         const Token *start = Args->getUnexpArgument(i);
         size_t len = Args->getArgLength(start) + 1;
-#if (LLVM_VERSION_MAJOR >= 3) && (LLVM_VERSION_MINOR >= 9)
-        _pp->EnterTokenStream(ArrayRef<Token>(start, len), false);
-#else
+#if (LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR == 8)
         _pp->EnterTokenStream(start, len, false, false);
+#else
+        _pp->EnterTokenStream(ArrayRef<Token>(start, len), false);
 #endif
         do {
           toks.push_back(Token());
@@ -4201,11 +4201,15 @@ void printAllStats(const std::string &csvFile, int64_t totalFiles, int64_t conve
 int main(int argc, const char **argv) {
   auto start = std::chrono::steady_clock::now();
   auto begin = start;
-#if (LLVM_VERSION_MAJOR >= 3) && (LLVM_VERSION_MINOR >= 9)
-  llvm::sys::PrintStackTraceOnErrorSignal(StringRef());
-#else
+
+  // The signature of PrintStackTraceOnErrorSignal changed in llvm 3.9. We don't support
+  // anything older than 3.8, so let's specifically detect the one old version we support.
+#if (LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR == 8)
   llvm::sys::PrintStackTraceOnErrorSignal();
+#else
+  llvm::sys::PrintStackTraceOnErrorSignal(StringRef());
 #endif
+
   CommonOptionsParser OptionsParser(argc, argv, ToolTemplateCategory, llvm::cl::OneOrMore);
   std::vector<std::string> fileSources = OptionsParser.getSourcePathList();
   std::string dst = OutputFilename;

--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -3029,7 +3029,6 @@ public:
     SourceManager &SM = CI.getSourceManager();
     setSourceManager(&SM);
     PP.addPPCallbacks(std::unique_ptr<HipifyPPCallbacks>(this));
-    PP.Retain();
     setPreprocessor(&PP);
     return true;
   }

--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -4249,7 +4249,7 @@ int main(int argc, const char **argv) {
     if (dst.empty()) {
       dst = src;
       if (!Inplace) {
-        size_t pos = dst.rfind(".");
+        size_t pos = dst.rfind('.');
         if (pos != std::string::npos && pos + 1 < dst.size()) {
           dst = dst.substr(0, pos) + ".hip." + dst.substr(pos + 1, dst.size() - pos - 1);
         } else {
@@ -4320,7 +4320,7 @@ int main(int argc, const char **argv) {
       Result += Rewrite.overwriteChangedFiles();
     }
     if (!Inplace && !NoOutput) {
-      size_t pos = dst.rfind(".");
+      size_t pos = dst.rfind('.');
       if (pos != std::string::npos) {
         rename(dst.c_str(), dst.substr(0, pos).c_str());
       }


### PR DESCRIPTION
One obstacle to the use of CUDA 8/9 with `hipify-clang` is that `hipify-clang` was pinned to a fairly old version of clang (3.9.0), which itself does not support CUDA beyond 7.

It turns out to be relatively straightforward to migrate `hipify-clang` to be compatible with the APIs of clang 5.0, in a backward-compatible fashion. Some slight cleanup was done along the way, but nothing super invasive.

Each commit explains itself pretty well. Many of the API changes can be adapted to without having explicit version checks. The program also seems to compile very much faster now - although I would suggest future work might involve breaking it into multiple translation units. Single monolithic files make compilers sad.

So yeah. It now works with CUDA 8/9 (at least, with the features it understands), and you can build it with any version of clang/llvm between 3.8.0 and 5.0. With that in mind, it no longer seems to make sense to restrict the `find_package` used to locate LLVM to exclusively looking in the user-provided path.