### PR TITLE
[HIPIFY] Alter output file behaviour slightly

### DIFF
--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -4239,7 +4239,6 @@ int main(int argc, const char **argv) {
         llvm::errs() << "[HIPIFY] conflict: both -o and -inplace options are specified.\n";
         return 1;
       }
-      dst += ".hip";
     }
 
     std::string tmpFile = src + ".hipify-tmp";

--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -4225,20 +4225,14 @@ int main(int argc, const char **argv) {
   }
   for (const auto & src : fileSources) {
     if (dst.empty()) {
-      dst = src;
-      if (!Inplace) {
-        size_t pos = dst.rfind(".");
-        if (pos != std::string::npos && pos + 1 < dst.size()) {
-          dst = dst.substr(0, pos) + ".hip." + dst.substr(pos + 1, dst.size() - pos - 1);
-        } else {
-          dst += ".hip.cu";
-        }
-      }
-    } else {
       if (Inplace) {
-        llvm::errs() << "[HIPIFY] conflict: both -o and -inplace options are specified.\n";
-        return 1;
+        dst = src;
+      } else {
+        dst = src + ".hip";
       }
+    } else if (Inplace) {
+      llvm::errs() << "[HIPIFY] conflict: both -o and -inplace options are specified.\n";
+      return 1;
     }
 
     std::string tmpFile = src + ".hipify-tmp";


### PR DESCRIPTION
The LLVM APIs modify the input file in-place. To avoid overwriting the input file,
the original implementation was therefore copying the input to the output and
operating on the output. This fails, however, because it means relative includes
are being resolved relative to the output path.

To resolve this, I here change the behaviour to:
- Copy the input file to `<src>.hipify-tmp`
- Operate on that temporary file
- Move the temporary file to the output (which will overwrite the input if we're
  in in-place mode).

This strategy has the added advantage that you won't corrupt the input source file
if the program crashes while operating in in-place mode.