### PR TITLE
hipDeviceReset(): make sure to reinitialize the printf buffer in hcc RT

### DIFF
--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -614,6 +614,11 @@ void ihipDevice_t::locked_reset()
     _state = 0;
     am_memtracker_reset(_acc);
 
+    //FIXME - Calling am_memtracker_reset is really bad since it destroyed all buffers allocated by the HCC runtime as well
+    //such as the printf buffer.  Re-initialze the printf buffer as a workaround for now.
+#if (__hcc_workweek__ >= 17423)
+    Kalmar::getContext()->initPrintfBuffer();
+#endif
 };
 
 #define ErrorCheck(x) error_check(x, __LINE__, __FILE__)


### PR DESCRIPTION
- re-initialize the printf buffer in HCC RT after resetting the am memory tracker
- this will fix several HIP directed test failures observed with a recent HCC compiler
- this PR depends on  https://github.com/RadeonOpenCompute/hcc/pull/508