### PR TITLE
Add [[nodiscard]] attribute to hipError_t in C++17 mode

### DIFF
--- a/include/hip/hip_runtime_api.h
+++ b/include/hip/hip_runtime_api.h
@@ -143,6 +143,13 @@ typedef struct hipPointerAttribute_t {
  *
  */
 
+// Ignoring error-code return values from hip APIs is discouraged. On C++17,
+// we can make that yield a warning
+#if __cplusplus >= 201703L
+#define __HIP_NODISCARD [[nodiscard]]
+#else
+#define __HIP_NODISCARD
+#endif
 
 /*
  * @brief hipError_t
@@ -152,7 +159,7 @@ typedef struct hipPointerAttribute_t {
 // Developer note - when updating these, update the hipErrorName and hipErrorString functions in NVCC and HCC paths
 // Also update the hipCUDAErrorTohipError function in NVCC path.
 
-typedef enum hipError_t {
+typedef enum __HIP_NODISCARD hipError_t {
     hipSuccess                      = 0,    ///< Successful completion.
     hipErrorOutOfMemory             = 2,
     hipErrorNotInitialized          = 3,
@@ -218,6 +225,8 @@ typedef enum hipError_t {
     hipErrorMapBufferObjectFailed = 1071,   ///< Produced when the IPC memory attach failed from ROCr.
     hipErrorTbd                             ///< Marker that more error codes are needed.
 } hipError_t;
+
+#undef __HIP_NODISCARD
 
 /*
  * @brief hipDeviceAttribute_t


### PR DESCRIPTION
This will yield a compiler warning any time you discard an error
return value from an API call.

Some thoughts:
- Should we move the definition of `__HIP_NODISCARD` into `hip_common.h` - it
  might well prove useful elsewhere, after all.
- A very common pattern (at least in CUDA code) is to wrap every API call in
  a macro that implements some flavour of "If exception, crash". Perhaps hip
  could provide one of those out of the box as a convenience?
- Perhaps there could be a macro that, when set, causes hip errors to propagate
  as exceptions instead of this C-style API? I guess that would be part of a
  more general C++ API for hip (which would, admittedly, slightly defeat the
  point of being a close match to CUDA. But CUDA is very much clunky to use in
  some situations)...