### PR TITLE
[HIPIFY] cmake: fix standalone build

### DIFF
--- a/hipify-clang/CMakeLists.txt
+++ b/hipify-clang/CMakeLists.txt
@@ -73,23 +73,15 @@ if (HIPIFY_CLANG_TESTS)
     # tests
     find_package(PythonInterp 2.7 REQUIRED EXACT)
 
-    set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
-
-    if (CMAKE_CURRENT_SOURCE_DIR EQUAL CMAKE_SOURCE_DIR)
-        set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
-    else()
-        set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
-    endif()
-
     configure_file(
-        ${SOURCE_DIR}/tests/hipify-clang/lit.site.cfg.in
-        ${BINARY_DIR}/tests/hipify-clang/lit.site.cfg
+        $${CMAKE_CURRENT_LIST_DIR}/../tests/hipify-clang/lit.site.cfg.in
+        ${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
         @ONLY
     )
 
     add_lit_testsuite(test-hipify "Running HIPify regression tests"
-        ${SOURCE_DIR}/tests/hipify-clang
-        PARAMS site_config=${BINARY_DIR}/tests/hipify-clang/lit.site.cfg
+        ${CMAKE_CURRENT_LIST_DIR}/../tests/hipify-clang
+        PARAMS site_config=${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
         DEPENDS hipify-clang lit
     )
 

--- a/hipify-clang/CMakeLists.txt
+++ b/hipify-clang/CMakeLists.txt
@@ -75,15 +75,21 @@ if (HIPIFY_CLANG_TESTS)
 
     set(BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
 
+    if (CMAKE_CURRENT_SOURCE_DIR EQUAL CMAKE_SOURCE_DIR)
+        set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+    else()
+        set(SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/..)
+    endif()
+
     configure_file(
-        ${CMAKE_SOURCE_DIR}/tests/hipify-clang/lit.site.cfg.in
-        ${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
+        ${SOURCE_DIR}/tests/hipify-clang/lit.site.cfg.in
+        ${BINARY_DIR}/tests/hipify-clang/lit.site.cfg
         @ONLY
     )
 
     add_lit_testsuite(test-hipify "Running HIPify regression tests"
-        ${CMAKE_SOURCE_DIR}/tests/hipify-clang
-        PARAMS site_config=${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
+        ${SOURCE_DIR}/tests/hipify-clang
+        PARAMS site_config=${BINARY_DIR}/tests/hipify-clang/lit.site.cfg
         DEPENDS hipify-clang lit
     )
 

--- a/hipify-clang/CMakeLists.txt
+++ b/hipify-clang/CMakeLists.txt
@@ -1,6 +1,15 @@
 cmake_minimum_required(VERSION 2.8.8)
 project(hipify-clang)
 
+set(BUILD_HIPIFY_CLANG 0 CACHE INTERNAL "")
+
+if (HIPIFY_CLANG_LLVM_DIR)
+    find_package(LLVM PATHS ${HIPIFY_CLANG_LLVM_DIR} REQUIRED)
+else()
+    message(STATUS "hipify-clang will not be built. To build it please specify absolute path to LLVM 3.8 or higher using HIPIFY_CLANG_LLVM_DIR")
+    return()
+endif()
+
 option(HIPIFY_CLANG_TESTS "Build the tests for hipify-clang, if lit is installed" ON)
 
 # Disable the tests if `lit` is not installed.
@@ -9,10 +18,6 @@ if (NOT LIT_COMMAND)
     set(HIPIFY_CLANG_TESTS OFF CACHE INTERNAL "")
     message(STATUS "hipify-clang's tests are not being built because `lit` is not installed.")
 endif()
-
-set(BUILD_HIPIFY_CLANG 0 CACHE INTERNAL "")
-
-find_package(LLVM PATHS ${HIPIFY_CLANG_LLVM_DIR} REQUIRED)
 
 list(APPEND CMAKE_MODULE_PATH ${LLVM_CMAKE_DIR})
 include(AddLLVM)
@@ -74,7 +79,7 @@ if (HIPIFY_CLANG_TESTS)
     find_package(PythonInterp 2.7 REQUIRED EXACT)
 
     configure_file(
-        $${CMAKE_CURRENT_LIST_DIR}/../tests/hipify-clang/lit.site.cfg.in
+        ${CMAKE_CURRENT_LIST_DIR}/../tests/hipify-clang/lit.site.cfg.in
         ${CMAKE_CURRENT_BINARY_DIR}/tests/hipify-clang/lit.site.cfg
         @ONLY
     )


### PR DESCRIPTION
After switching HIPIFY_CLANG_TESTS on by default it turned out that standalone build is broken.
Change relies on an assumption that hipify-clang is in HIP folder as it is so for now, but it will be changed with moving of hipify-clang to a separate github repo.