### PR TITLE
[HIPIFY][fix] cmake: NO_DEFAULT_PATH is strongly needed in find_package for LLVM

### DIFF
--- a/hipify-clang/CMakeLists.txt
+++ b/hipify-clang/CMakeLists.txt
@@ -4,7 +4,7 @@ project(hipify-clang)
 set(BUILD_HIPIFY_CLANG 0 CACHE INTERNAL "")
 
 if (HIPIFY_CLANG_LLVM_DIR)
-    find_package(LLVM PATHS ${HIPIFY_CLANG_LLVM_DIR} REQUIRED)
+    find_package(LLVM PATHS ${HIPIFY_CLANG_LLVM_DIR} REQUIRED NO_DEFAULT_PATH)
 else()
     message(STATUS "hipify-clang will not be built. To build it please specify absolute path to LLVM 3.8 or higher using HIPIFY_CLANG_LLVM_DIR")
     return()


### PR DESCRIPTION
Otherwise LLVM will be searched in system folders.