### PR TITLE
[HIPIFY] Handle unconditional preprocessor directives far better

### DIFF
--- a/hipify-clang/src/Cuda2Hip.cpp
+++ b/hipify-clang/src/Cuda2Hip.cpp
@@ -531,28 +531,10 @@ private:
     }
 
     size_t length = name.size();
-    bool bReplace = true;
-    if (SM->isMacroArgExpansion(sl)) {
-      sl = SM->getImmediateSpellingLoc(sl);
-    } else if (SM->isMacroBodyExpansion(sl)) {
-      LangOptions DefaultLangOptions;
-      SourceLocation sl_macro = SM->getExpansionLoc(sl);
-      SourceLocation sl_end = Lexer::getLocForEndOfToken(sl_macro, 0, *SM, DefaultLangOptions);
-      length = SM->getCharacterData(sl_end) - SM->getCharacterData(sl_macro);
-      StringRef macroName = StringRef(SM->getCharacterData(sl_macro), length);
-      if (CUDA_EXCLUDES.end() != CUDA_EXCLUDES.find(macroName)) {
-        bReplace = false;
-      } else {
-        sl = sl_macro;
-      }
-    }
-
-    if (bReplace) {
-      updateCounters(found->second, name);
-      Replacement Rep(*SM, sl, length, hipCtr.hipName);
-      FullSourceLoc fullSL(sl, *SM);
-      insertReplacement(Rep, fullSL);
-    }
+    updateCounters(found->second, name);
+    Replacement Rep(*SM, sl, length, hipCtr.hipName);
+    FullSourceLoc fullSL(sl, *SM);
+    insertReplacement(Rep, fullSL);
 
     return true;
   }


### PR DESCRIPTION
See commit messages for detailled explanations. This partially fixes #207,
effectively allowing hipify to handle all preprocessor interactions
except false conditionals correctly.

It will still be forced to inline macros in silly cases, but this should
handle anything you're likely to get in sane code. It won't cope with,
for example:
```c++
#define silly x)
kernelCall<<<1, 1>>>(silly
```


... But if you write code like that, I think you deserve to have hipify
shout at you ;)