### PR TITLE
various fixes for centos/rhel

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -127,7 +127,9 @@ if ($HIP_PLATFORM eq "hcc") {
 
     # Force -stdlib=libc++ on UB14.04
     $HOST_OSVER= `cat /etc/os-release | grep "^VERSION_ID\=" | cut -d= -f2 | tr -d '\n'`;
-    if ($HOST_OSNAME eq "ubuntu" and $HOST_OSVER eq "\"14.04\"") {
+    if (($HOST_OSNAME eq "ubuntu" and $HOST_OSVER eq "\"14.04\"")
+         or ($HOST_OSNAME eq "\"centos\"" and $HOST_OSVER eq "\"7\"") 
+         or ($HOST_OSNAME eq "\"rhel\"" and $HOST_OSVER eq "\"7.4\"")) {
         $HIPCXXFLAGS .= " -stdlib=libc++";
         $setStdLib = 1;
     }

--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -217,7 +217,7 @@ namespace
         using namespace ELFIO;
         using namespace std;
 
-        static constexpr pair<Elf64_Addr, Elf_Xword> r{0, 0};
+        static const pair<Elf64_Addr, Elf_Xword> r{0, 0};
 
         for (auto i = 0u; i != section.get_symbols_num(); ++i) {
             // TODO: this is boyscout code, caching the temporaries


### PR DESCRIPTION
- hipcc has to pass the -stdlib=libc++ to hcc
- remove usage of constexpr pair ctor since libc++ doesn't enable it under C++11 