### PR TITLE
Test cleanup

### DIFF
--- a/tests/src/context/hipMemsetD8.cpp
+++ b/tests/src/context/hipMemsetD8.cpp
@@ -46,7 +46,6 @@ int main(int argc, char *argv[])
 	A_h = new char[Nbytes];
 
     HIPCHECK ( hipMalloc((void **) &A_d, Nbytes) );
-    A_h = (char*)malloc(Nbytes);
 
 	printf ("Size=%zu  memsetval=%2x \n", Nbytes, memsetval);
     HIPCHECK ( hipMemsetD8(A_d, memsetval, Nbytes) );
@@ -61,7 +60,7 @@ int main(int argc, char *argv[])
     }
 
     hipFree((void *) A_d);
-    free(A_h);
+    delete [] A_h;
     passed();
 
 }

--- a/tests/src/deviceLib/hipTestDevice.cpp
+++ b/tests/src/deviceLib/hipTestDevice.cpp
@@ -139,7 +139,14 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+
 if(passed == 1){
     return true;
 }
@@ -174,7 +181,14 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+
 if(passed == 1){
     return true;
 }
@@ -205,7 +219,13 @@ for(int i=0;i<512;i++){
     }
 }
 
-free(A);
+delete [] A;
+delete [] B;
+delete [] C;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+
 if(passed == 1){
     return true;
 }
@@ -234,7 +254,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -263,7 +288,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -291,7 +321,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -321,7 +356,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -350,7 +390,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -387,7 +432,16 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+delete [] D;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+hipFree(Dd);
+
 if(passed == 1){
     return true;
 }
@@ -427,7 +481,18 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+delete [] D;
+delete [] E;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+hipFree(Dd);
+hipFree(Ed);
+
 if(passed == 1){
     return true;
 }
@@ -457,7 +522,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -489,7 +559,14 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+
 if(passed == 1){
     return true;
 }
@@ -525,7 +602,16 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+delete [] D;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+hipFree(Dd);
+
 if(passed == 1){
     return true;
 }
@@ -565,7 +651,18 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+delete [] D;
+delete [] E;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+hipFree(Dd);
+hipFree(Ed);
+
 if(passed == 1){
     return true;
 }
@@ -595,7 +692,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -622,7 +724,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -631,7 +738,7 @@ return false;
 }
 
 int main(){
-if(run_sincosf() && run_sincospif() && run_fdividef() && 
+if(run_sincosf() && run_sincospif() && run_fdividef() &&
    run_llrintf() && run_norm3df() && run_norm4df() &&
    run_normf() && run_rnorm3df() && run_rnorm4df() &&
    run_rnormf() && run_lroundf() && run_llroundf() &&

--- a/tests/src/deviceLib/hipTestDeviceDouble.cpp
+++ b/tests/src/deviceLib/hipTestDeviceDouble.cpp
@@ -128,7 +128,14 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+
 if(passed == 1){
     return true;
 }
@@ -163,7 +170,14 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+
 if(passed == 1){
     return true;
 }
@@ -193,7 +207,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -221,7 +240,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -249,7 +273,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -278,7 +307,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -306,7 +340,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -343,7 +382,16 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+delete [] D;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+hipFree(Dd);
+
 if(passed == 1){
     return true;
 }
@@ -383,7 +431,18 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+delete [] D;
+delete [] E;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+hipFree(Dd);
+hipFree(Ed);
+
 if(passed == 1){
     return true;
 }
@@ -416,7 +475,14 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+
 if(passed == 1){
     return true;
 }
@@ -452,7 +518,16 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+delete [] D;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+hipFree(Dd);
+
 if(passed == 1){
     return true;
 }
@@ -492,7 +567,18 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+delete [] C;
+delete [] D;
+delete [] E;
+hipFree(Ad);
+hipFree(Bd);
+hipFree(Cd);
+hipFree(Dd);
+hipFree(Ed);
+
 if(passed == 1){
     return true;
 }
@@ -522,7 +608,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }
@@ -549,7 +640,12 @@ for(int i=0;i<512;i++){
         passed = 1;
     }
 }
-free(A);
+
+delete [] A;
+delete [] B;
+hipFree(Ad);
+hipFree(Bd);
+
 if(passed == 1){
     return true;
 }

--- a/tests/src/experimental/xcompile/hipxxKer.cpp
+++ b/tests/src/experimental/xcompile/hipxxKer.cpp
@@ -36,17 +36,23 @@ __global__ void Kern(hipLaunchParm lp, float *A)
 
 int main()
 {
-	float *A, *Ad;
+	float A[len];
+	float *Ad;
+
 	for(int i=0;i<len;i++)
 	{
 		A[i] = 1.0f;
 	}
+
 	Ad = (float*)mallocHip(size);
 	memcpyHipH2D(Ad, A, size);
-	hipLaunchKernel(HIP_KERNEL_NAME(Kern), dim3(len/1024), dim3(1024), 0, 0, A);
+	hipLaunchKernel(
+		HIP_KERNEL_NAME(Kern), dim3(len/1024), dim3(1024), 0, 0, Ad);
 	memcpyHipD2H(A, Ad, size);
 	for(int i=0;i<len;i++)
 	{
 		assert(A[i] == 2.0f);
 	}
+
+	hipFree(Ad);
 }

--- a/tests/src/kernel/hipLanguageExtensions.cpp
+++ b/tests/src/kernel/hipLanguageExtensions.cpp
@@ -74,8 +74,8 @@ __global__ void MyKernel (const hipLaunchParm lp, const float *a, const float *b
 void callMyKernel()
 {
     float *a, *b, *c;
-    unsigned N;
     const unsigned blockSize = 256;
+    unsigned N = blockSize;
 
     hipLaunchKernel(MyKernel, dim3(N/blockSize), dim3(blockSize), 0, 0, a,b,c,N);
 }
@@ -102,7 +102,7 @@ vectorADD(const hipLaunchParm lp,
     int a = __shfl_up(x, 1);
 #endif
 
-    float x;
+    float x = 1.0;
     float z = sin(x);
 #ifdef NOT_YET
     float fastZ = __sin(x);

--- a/tests/src/kernel/hipTestMemKernel.cpp
+++ b/tests/src/kernel/hipTestMemKernel.cpp
@@ -107,9 +107,12 @@ int main(){
         assert(C[i] == 1);
     }
 
-    delete A;
-    delete B;
-    delete C;
+    delete [] A;
+    delete [] B;
+    delete [] C;
+    hipFree(Ad);
+    hipFree(Bd);
+    hipFree(Cd);
 
     A = new uint8_t[LEN9];
     B = new uint8_t[LEN9];
@@ -132,9 +135,12 @@ int main(){
         assert(C[i] == 1);
     }
 
-    delete A;
-    delete B;
-    delete C;
+    delete [] A;
+    delete [] B;
+    delete [] C;
+    hipFree(Ad);
+    hipFree(Bd);
+    hipFree(Cd);
 
     A = new uint8_t[LEN10];
     B = new uint8_t[LEN10];
@@ -157,9 +163,12 @@ int main(){
         assert(C[i] == 1);
     }
 
-    delete A;
-    delete B;
-    delete C;
+    delete [] A;
+    delete [] B;
+    delete [] C;
+    hipFree(Ad);
+    hipFree(Bd);
+    hipFree(Cd);
 
     A = new uint8_t[LEN11];
     B = new uint8_t[LEN11];
@@ -182,9 +191,12 @@ int main(){
         assert(C[i] == 1);
     }
 
-    delete A;
-    delete B;
-    delete C;
+    delete [] A;
+    delete [] B;
+    delete [] C;
+    hipFree(Ad);
+    hipFree(Bd);
+    hipFree(Cd);
 
     A = new uint8_t[LEN12];
     B = new uint8_t[LEN12];
@@ -207,9 +219,12 @@ int main(){
         assert(C[i] == 1);
     }
 
-    delete A;
-    delete B;
-    delete C;
+    delete [] A;
+    delete [] B;
+    delete [] C;
+    hipFree(Ad);
+    hipFree(Bd);
+    hipFree(Cd);
 
     passed();
 }

--- a/tests/src/stress/hipStressKernel.cpp
+++ b/tests/src/stress/hipStressKernel.cpp
@@ -57,5 +57,8 @@ int main(){
 		}
         std::cout<<std::endl;
 		hipDeviceSynchronize();
+
+		free(A);
+		hipFree(Ad);
 	}
 }


### PR DESCRIPTION
This corrects some interesting choices that were present in the HIP unit 
tests such as e.g. de-allocating memory allocated with new[] using free. 
All of these were identified via cppcheck.