### PR TITLE
[hit] Add support for cmake commands as part of test infra

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -75,6 +75,18 @@ RUN: %t CMAKE_TEST_NAME <arguments_to_test_executable> EXCLUDE_HIP_PLATFORM <hcc
 ```
 
 
+#### CMAKECMD command
+
+The supported syntax for the CMAKECMD command is:
+```
+CMAKECMD: <cmake_command> <options_to_cmake_command>
+```
+cmake_command: refers to any of the commands supported by ```cmake -E``` as specified in the [cmake documentation](https://cmake.org/cmake/help/latest/manual/cmake.1.html#command-line-tool-mode). Note that the commands are limited by the version of cmake the user is running.
+options_to_cmake_command: refers to the arguments supported by the specific cmake_command. The arguments are parsed by HIT to replace special markers. The markers supported by HIT are:
+%S: Refers to the source directory containing the current source file.
+%B: Refers to the build directory for the current cmake project i.e. CMAKE_CURRENT_BINARY_DIR.
+
+
 ### Running tests:
 ```
 ctest

--- a/tests/hit/HIT.cmake
+++ b/tests/hit/HIT.cmake
@@ -155,6 +155,20 @@ macro(HIT_ADD_FILES _dir _label _parent)
             endif()
         endforeach()
 
+        # Run cmake commands
+        execute_process(COMMAND ${HIP_SRC_PATH}/tests/hit/parser --cmakeCMDs ${file}
+            OUTPUT_VARIABLE _contents
+            ERROR_QUIET
+            WORKING_DIRECTORY ${_dir}
+            OUTPUT_STRIP_TRAILING_WHITESPACE)
+        string(REGEX REPLACE "\n" ";" _contents "${_contents}")
+        string(REGEX REPLACE "%S" ${_dir} _contents "${_contents}")
+        string(REGEX REPLACE "%B" ${CMAKE_CURRENT_BINARY_DIR} _contents "${_contents}")
+        foreach(_cmd ${_contents})
+            string(REGEX REPLACE " " ";" _cmd "${_cmd}")
+            execute_process(COMMAND ${CMAKE_COMMAND} -E ${_cmd})
+        endforeach()
+
         # Add tests
         execute_process(COMMAND ${HIP_SRC_PATH}/tests/hit/parser --runCMDs ${file}
             OUTPUT_VARIABLE _contents

--- a/tests/hit/parser
+++ b/tests/hit/parser
@@ -8,7 +8,7 @@ use File::Spec;
 sub parse_file {
     my $file = shift;
     (my $exe = $file) =~ s/\.[^.]+$//g;
-    my (@buildCMDs, @runCMDs, @runNamedCMDs);
+    my (@buildCMDs, @runCMDs, @runNamedCMDs, @cmakeCMDs);
     if (open (SOURCE, '<:encoding(UTF-8)', "$file")) {
         while (<SOURCE>) {
             my $line=$_;
@@ -36,10 +36,17 @@ sub parse_file {
                 $line =~ s/\R//g;               # Remove line endings
                 push @runNamedCMDs, $line;
             }
+            # Look for CMAKECMD instructions
+            if ($line =~ /^ \* CMAKECMD:/) {
+                $line =~ s/^ \* CMAKECMD: //g;  # Remove " * CMAKECMD: "
+                # Substitute %S -> srcdir and %B -> builddir happens in cmake
+                $line =~ s/\R//g;               # Remove line endings
+                push @cmakeCMDs, $line;
+            }
         }
         close(SOURCE);
     }
-    return (\@buildCMDs, \@runCMDs, \@runNamedCMDs);
+    return (\@buildCMDs, \@runCMDs, \@runNamedCMDs, \@cmakeCMDs);
 }
 
 # Exit if no arguments specified
@@ -53,8 +60,9 @@ my @options = ();
 my $retBuildCMDs = 0;
 my $retRunCMDs = 0;
 my $retRunNamedCMDs = 0;
+my $retCmakeCMDs = 0;
 foreach $arg (@ARGV) {
-    if ($retBuildCMDs or $retRunCMDs or $retRunNamedCMDs) {
+    if ($retBuildCMDs or $retRunCMDs or $retRunNamedCMDs or $retCmakeCMDs) {
         push (@options, $arg);
     }
     if ($arg eq '--buildCMDs') {
@@ -66,18 +74,21 @@ foreach $arg (@ARGV) {
     if ($arg eq '--runNamedCMDs') {
         $retRunNamedCMDs = 1;
     }
+    if ($arg eq '--cmakeCMDs') {
+        $retCmakeCMDs = 1;
+    }
 }
 
 # Atleast one command needs to be specified
-if (($retBuildCMDs eq 0) and ($retRunCMDs eq 0) and ($retRunNamedCMDs eq 0)) {
-    die "Usage: $0 <--buildCMDs|--runCMDs|--runNamedCMDs> FILENAMEs\n";
+if (($retBuildCMDs eq 0) and ($retRunCMDs eq 0) and ($retRunNamedCMDs eq 0) and ($retCmakeCMDs eq 0)) {
+    die "Usage: $0 <--buildCMDs|--runCMDs|--runNamedCMDs|--cmakeCMDs> FILENAMEs\n";
 }
 
 # Iterate over input files
 foreach $file (@options) {
     # Convert absolute path to path relative to working directory
     my $relfile = File::Spec->abs2rel($file);
-    my ($buildCMDs, $runCMDs, $runNamedCMDs) = parse_file("$relfile");
+    my ($buildCMDs, $runCMDs, $runNamedCMDs, $cmakeCMDs) = parse_file("$relfile");
     if ($retBuildCMDs) {
         # print "BuildCMDs:\n";
         print "$_\n" for @$buildCMDs;
@@ -89,6 +100,10 @@ foreach $file (@options) {
     if ($retRunNamedCMDs) {
         # print "RunNamedCMDs:\n";
         print "$_\n" for @$runNamedCMDs;
+    }
+    if ($retCmakeCMDs) {
+        # print "CmakeCMDs:\n";
+        print "$_\n" for @$cmakeCMDs;
     }
 }
 


### PR DESCRIPTION
Cmake supports several builtin command-line tools. These tools can
now be specified as part of the HIT block. These commands will be
run during cmake configure step.