### PR TITLE
Fix missing MARKER_END

### DIFF
--- a/src/grid_launch.cpp
+++ b/src/grid_launch.cpp
@@ -92,5 +92,8 @@ namespace hip_impl
 
         delete static_cast<L*>(locked_stream);
         locked_stream = nullptr;
+        if(HIP_PROFILE_API) {
+            MARKER_END();
+        }
     }
 }

--- a/src/hip_context.cpp
+++ b/src/hip_context.cpp
@@ -269,7 +269,7 @@ hipError_t hipCtxGetSharedMemConfig ( hipSharedMemConfig * pConfig )
 hipError_t hipCtxSynchronize ( void )
 {
     HIP_INIT_API(1);
-    return ihipSynchronize(); //TODP Shall check validity of ctx?
+    return ihipLogStatus(ihipSynchronize()); //TODP Shall check validity of ctx?
 }
 
 hipError_t hipCtxGetFlags ( unsigned int* flags )

--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -1592,7 +1592,9 @@ void ihipPostLaunchKernel(const char *kernelName, hipStream_t stream, grid_launc
     tprintf(DB_SYNC, "ihipPostLaunchKernel, unlocking stream\n");
 
     stream->lockclose_postKernelCommand(kernelName, lp.av);
-    MARKER_END();
+    if(HIP_PROFILE_API) {
+        MARKER_END();
+    }
 }
 
 //=================================================================================================


### PR DESCRIPTION
Logging status of hipCtxSynchronize was missing
Test if hip profiling is active for MARKER_END in ihipPostLaunchKernel
Add MARKER_END after the completion of a kernel launched through
the "grid launch"