### PR TITLE
[nvccTests]Enabling hipTestMallocTest for both nvcc and hipcc

### DIFF
--- a/tests/src/kernel/hipTestMallocKernel.cpp
+++ b/tests/src/kernel/hipTestMallocKernel.cpp
@@ -18,7 +18,7 @@ THE SOFTWARE.
 */
 
 /* HIT_START
- * BUILD: %t %s ../test_common.cpp EXCLUDE_HIP_PLATFORM all
+ * BUILD: %t %s ../test_common.cpp 
  * RUN: %t
  * HIT_END
  */
@@ -26,18 +26,18 @@ THE SOFTWARE.
 #include<hip/hip_runtime.h>
 #include<hip/hip_runtime_api.h>
 #include<iostream>
+#include "test_common.h"
 
-#define HIP_ASSERT(status) assert(hipSuccess == status);
 
 #define NUM  1024
 #define SIZE NUM * 8
 
-__global__ void Alloc(hipLaunchParm lp, uint64_t *Ptr) {
+__global__ void Alloc(uint64_t *Ptr) {
     int tid = threadIdx.x + blockIdx.x * blockDim.x;
     Ptr[tid] = (uint64_t)malloc(128);
 }
 
-__global__ void Free(hipLaunchParm lp, uint64_t *Ptr) {
+__global__ void Free(uint64_t *Ptr) {
     int tid = threadIdx.x + blockIdx.x * blockDim.x;
     free((void*)Ptr[tid]);
 }
@@ -49,19 +49,20 @@ int main()
     for(uint32_t i=0;i<NUM;i++) {
         hPtr[i] = 1;
     }
-    int devCnt;
+    int devCnt = 0;
     hipGetDeviceCount(&devCnt);
-    for(uint32_t i=0;i<devCnt;i++){
-        HIP_ASSERT(hipSetDevice(i));
-        HIP_ASSERT(hipMalloc((void**)&dPtr, SIZE));
-        HIP_ASSERT(hipMemcpy(dPtr, hPtr, SIZE, hipMemcpyHostToDevice));
-        hipLaunchKernel(Alloc, dim3(1,1,1), dim3(NUM,1,1), 0, 0, dPtr);
-        HIP_ASSERT(hipMemcpy(hPtr, dPtr, SIZE, hipMemcpyDeviceToHost));
-        assert(hPtr[0] != 0);
-        hipLaunchKernel(Free, dim3(1,1,1), dim3(NUM,1,1), 0, 0, dPtr);
-        HIP_ASSERT(hipFree(dPtr));
+    for(int i=0;i<devCnt;i++){
+        HIPCHECK(hipSetDevice(i));
+        HIPCHECK(hipMalloc((void**)&dPtr, SIZE));
+        HIPCHECK(hipMemcpy(dPtr, hPtr, SIZE, hipMemcpyHostToDevice));
+        hipLaunchKernelGGL(Alloc, dim3(1,1,1), dim3(NUM,1,1), 0, 0, dPtr);
+        HIPCHECK(hipMemcpy(hPtr, dPtr, SIZE, hipMemcpyDeviceToHost));
+        HIPASSERT(hPtr[0] != 0);
+        hipLaunchKernelGGL(Free, dim3(1,1,1), dim3(NUM,1,1), 0, 0, dPtr);
+        HIPCHECK(hipFree(dPtr));
         for(uint32_t i=1;i<NUM;i++) {
-            assert(hPtr[i] == hPtr[i-1] + 4096);
+            HIPASSERT(hPtr[i] == hPtr[i-1] + 4096);
         }
     }
+  passed();
 }


### PR DESCRIPTION
Modified & Enabled hipTestMallocKernel for both nvcc & hipcc platforms.It worked fine in my test setups. 