### PR TITLE
Change hipconfig to adopt new location of llc

### DIFF
--- a/bin/hipconfig
+++ b/bin/hipconfig
@@ -129,7 +129,7 @@ if (!$printed or $p_full) {
         print ("HSA_PATH     : $HSA_PATH\n");
         print ("HCC_HOME     : $HCC_HOME\n");
         system("$HCC_HOME/bin/hcc --version");
-        system("$HCC_HOME/compiler/bin/llc --version");
+        system("$HCC_HOME/bin/llc --version");
         print ("HCC-cxxflags : ");
         system("$HCC_HOME/bin/hcc-config --cxxflags");
         print ("HCC-ldflags  : ");


### PR DESCRIPTION
llc is now placed under $HCC_HOME/bin, instead of $HCC_HOME/compiler/bin.