### PR TITLE
[nvccWarnings] Fix warnings seen with dtests on nvcc path

### DIFF
--- a/tests/src/deviceLib/hipDeviceMemcpy.cpp
+++ b/tests/src/deviceLib/hipDeviceMemcpy.cpp
@@ -29,7 +29,7 @@ __global__ void set(hipLaunchParm lp, uint32_t *ptr, uint8_t val, size_t size)
 int main()
 {
     uint32_t *A, *Ad, *B, *Bd;
-    uint32_t *Val, *Vald;
+    uint32_t *Val;
     A = new uint32_t[LEN];
     B = new uint32_t[LEN];
     Val = new uint32_t;

--- a/tests/src/deviceLib/hipFloatMath.cpp
+++ b/tests/src/deviceLib/hipFloatMath.cpp
@@ -55,7 +55,7 @@ __global__ void floatMath(hipLaunchParm lp, float *In, float *Out) {
 }
 
 int main(){
-  float *Inh, *Outh, *Ind, *Outd;
+  float  *Ind, *Outd;
   hipMalloc((void**)&Ind, SIZE);
   hipMalloc((void**)&Outd, SIZE);
   hipLaunchKernel(floatMath, dim3(LEN,1,1), dim3(1,1,1), 0, 0, Ind, Outd);

--- a/tests/src/deviceLib/hipFloatMathPrecise.cpp
+++ b/tests/src/deviceLib/hipFloatMathPrecise.cpp
@@ -32,7 +32,7 @@ THE SOFTWARE.
 
 __global__ void FloatMathPrecise(hipLaunchParm lp)
 {
-    int iX;
+    //int iX; //uncomment this when remqouf() is enabled again
     float fX, fY;
 
     acosf(1.0f);

--- a/tests/src/deviceLib/hipSimpleAtomicsTest.cpp
+++ b/tests/src/deviceLib/hipSimpleAtomicsTest.cpp
@@ -287,7 +287,7 @@ void runTest(int argc, char **argv)
            "SM %d.%d compute capabilities\n\n",
            deviceProp.multiProcessorCount, deviceProp.major, deviceProp.minor);
 
-    int version = (deviceProp.major * 0x10 + deviceProp.minor);
+
 
     unsigned int numThreads = 256;
     unsigned int numBlocks = 64;

--- a/tests/src/deviceLib/hipTestDevice.cpp
+++ b/tests/src/deviceLib/hipTestDevice.cpp
@@ -249,7 +249,6 @@ hipMemcpy(B, Bd, N*sizeof(long long int), hipMemcpyDeviceToHost);
 int passed = 0;
 for(int i=0;i<512;i++){
     int x = roundf(A[i]);
-    long long int y = x;
     if(B[i] == x){
         passed = 1;
     }
@@ -283,7 +282,6 @@ hipMemcpy(B, Bd, N*sizeof(long int), hipMemcpyDeviceToHost);
 int passed = 0;
 for(int i=0;i<512;i++){
     int x = roundf(A[i]);
-    long int y = x;
     if(B[i] == x){
         passed = 1;
     }
@@ -351,7 +349,6 @@ hipMemcpy(B, Bd, N*sizeof(long long int), hipMemcpyDeviceToHost);
 int passed = 0;
 for(int i=0;i<512;i++){
     int x = roundf(A[i]);
-    long long int y = x;
     if(B[i] == x){
         passed = 1;
     }
@@ -385,7 +382,6 @@ hipMemcpy(B, Bd, N*sizeof(long int), hipMemcpyDeviceToHost);
 int passed = 0;
 for(int i=0;i<512;i++){
     int x = roundf(A[i]);
-    long int y = x;
     if(B[i] == x){
         passed = 1;
     }

--- a/tests/src/deviceLib/hip_anyall.cpp
+++ b/tests/src/deviceLib/hip_anyall.cpp
@@ -21,7 +21,7 @@ THE SOFTWARE.
 */
 
 /* HIT_START
- * BUILD: %t %s ../test_common.cpp
+ * BUILD: %t %s ../test_common.cpp 
  * RUN: %t
  * HIT_END
  */

--- a/tests/src/kernel/hipLanguageExtensions.cpp
+++ b/tests/src/kernel/hipLanguageExtensions.cpp
@@ -90,14 +90,6 @@ vectorADD(const hipLaunchParm lp,
           size_t N)
 {
 //    KERNELBEGIN;
-    int ws = warpSize;
-
-
-    int zuzu = deviceVar + 1;
-
-
-    int b = threadIdx.x;
-    int c;
 #ifdef NOT_YET
     int a = __shfl_up(x, 1);
 #endif
@@ -109,6 +101,10 @@ vectorADD(const hipLaunchParm lp,
 #endif
 
 #ifdef __HCC__
+
+   int b = threadIdx.x;
+   int c;
+
 	// TODO - move to HIP atomics when ready.
     concurrency :: atomic_fetch_add(&c, b);
     //Concurrency::atomic_add_unsigned (&x, a);

--- a/tests/src/runtimeApi/memory/hipMemcpy.cpp
+++ b/tests/src/runtimeApi/memory/hipMemcpy.cpp
@@ -192,8 +192,6 @@ HostMemory<T>::~HostMemory ()
         free(A_hh);
         free(B_hh);
     }
-    T *A_hh = NULL;
-    T *B_hh = NULL;
 
 };
 

--- a/tests/src/runtimeApi/memory/hipMemcpyPeer.cpp
+++ b/tests/src/runtimeApi/memory/hipMemcpyPeer.cpp
@@ -32,7 +32,6 @@ THE SOFTWARE.
 
 int main()
 {
-    hipDevice_t device;
     size_t Nbytes = N*sizeof(int);
     int numDevices = 0;
     int *A_d, *B_d, *C_d, *X_d, *Y_d, *Z_d;

--- a/tests/src/runtimeApi/memory/p2p_copy_coherency.cpp
+++ b/tests/src/runtimeApi/memory/p2p_copy_coherency.cpp
@@ -188,7 +188,6 @@ int main(int argc, char *argv[])
 {
     HipTest::parseStandardArguments(argc, argv, true);
 
-    int numElements = N;
 
     int dev0 = 0;
     int dev1 = 1;

--- a/tests/src/runtimeApi/stream/hipStreamAddCallback.cpp
+++ b/tests/src/runtimeApi/stream/hipStreamAddCallback.cpp
@@ -27,7 +27,10 @@ THE SOFTWARE.
 
 #include "hip/hip_runtime.h"
 #include "test_common.h"
+
+#ifdef __HIP_PLATFORM_HCC__ 
 #define HIPRT_CB
+#endif
 
 class CallbackClass
 {


### PR DESCRIPTION
Fix warnings (related to unused variables and like) in these tests:
tests/src/deviceLib/hipDeviceMemcpy.cpp              | 2 +-
 tests/src/deviceLib/hipFloatMath.cpp                 | 2 +-
 tests/src/deviceLib/hipFloatMathPrecise.cpp          | 2 +-
 tests/src/deviceLib/hipSimpleAtomicsTest.cpp         | 2 +-
 tests/src/deviceLib/hipTestDevice.cpp                | 4 ----
 tests/src/deviceLib/hip_anyall.cpp                   | 2 +-
 tests/src/kernel/hipLanguageExtensions.cpp           | 8 --------
 tests/src/runtimeApi/memory/hipMemcpy.cpp            | 2 --
 tests/src/runtimeApi/memory/hipMemcpyPeer.cpp        | 1 -
 tests/src/runtimeApi/memory/p2p_copy_coherency.cpp   | 1 -
 tests/src/runtimeApi/stream/hipStreamAddCallback.cpp | 3 +++
