### PR TITLE
[HIPIFY][tests] CUDA_SDK_samples adding to hipify-clang tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -449,7 +449,11 @@ nvcc:
     // Block of string constants customizing behavior for cuda
     String nvcc_ver = 'nvcc-9.0'
     String from_image = 'nvidia/cuda:9.0-devel'
-    String inside_args = '--runtime=nvidia';
+
+    // This unfortunately hardcodes the driver version nvidia_driver_384.90 in the volume mount.  Research if a way
+    // exists to get volume driver to customize the volume names to leave out driver version
+    String inside_args = '''--device=/dev/nvidiactl --device=/dev/nvidia0 --device=/dev/nvidia-uvm --device=/dev/nvidia-uvm-tools
+        --volume-driver=nvidia-docker --volume=nvidia_driver_384.90:/usr/local/nvidia:ro''';
 
     // Checkout source code, dependencies and version files
     String source_hip_rel = checkout_and_version( nvcc_ver )

--- a/hipify-clang/CMakeLists.txt
+++ b/hipify-clang/CMakeLists.txt
@@ -65,7 +65,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DHIPIFY_CLANG_RES=\\\"${LLVM_LIBRARY_DI
 install(TARGETS hipify-clang DESTINATION bin)
 
 if (HIPIFY_CLANG_TESTS)
-    find_package(PythonInterp 2.7 REQUIRED EXACT)
+    find_package(PythonInterp 2.7 REQUIRED)
 
     function (require_program PROGRAM_NAME)
         find_program(FOUND_${PROGRAM_NAME} ${PROGRAM_NAME})
@@ -78,11 +78,30 @@ if (HIPIFY_CLANG_TESTS)
 
     require_program(lit)
     require_program(FileCheck)
-    require_program(socat)
+    if(NOT WIN32)
+        require_program(socat)
+    endif()
 
     # Populates CUDA_TOOLKIT_ROOT_DIR, which is then applied to the lit config to give the
     # value of --cuda-path for the test runs.
     find_package(CUDA REQUIRED)
+    if ((CUDA_VERSION VERSION_LESS "7.0") OR (LLVM_PACKAGE_VERSION VERSION_LESS "3.8") OR
+        (CUDA_VERSION VERSION_GREATER "7.5" AND LLVM_PACKAGE_VERSION VERSION_LESS "4.0") OR
+        (CUDA_VERSION VERSION_GREATER "8.0" AND LLVM_PACKAGE_VERSION VERSION_LESS "6.0") OR
+        (CUDA_VERSION VERSION_GREATER "9.0" AND LLVM_PACKAGE_VERSION VERSION_LESS "7.0"))
+        message(SEND_ERROR "CUDA ${CUDA_VERSION} is not supported by clang ${LLVM_PACKAGE_VERSION}.")
+        if (CUDA_VERSION VERSION_LESS "7.0")
+            message(STATUS "Please install CUDA 7.0 or higher.")
+        elseif ((CUDA_VERSION VERSION_EQUAL "7.0") OR (CUDA_VERSION VERSION_EQUAL "7.5"))
+            message(STATUS "Please install clang 3.8 or higher.")
+        elseif (CUDA_VERSION VERSION_EQUAL "8.0")
+            message(STATUS "Please install clang 4.0 or higher.")
+        elseif (CUDA_VERSION VERSION_EQUAL "9.0")
+            message(STATUS "Please install clang 6.0 or higher.")
+        elseif (CUDA_VERSION VERSION_EQUAL "9.1")
+            message(STATUS "Please install clang 7.0 or higher.")
+        endif()
+    endif()
 
     configure_file(
         ${CMAKE_CURRENT_LIST_DIR}/../tests/hipify-clang/lit.site.cfg.in

--- a/hipify-clang/src/CUDA2HipMap.cpp
+++ b/hipify-clang/src/CUDA2HipMap.cpp
@@ -213,6 +213,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_TYPE_NAME_MAP{
     {"cudaMipmappedArray_t",       {"hipMipmappedArray_t",       CONV_MEM, API_RUNTIME}},
     {"cudaMipmappedArray_const_t", {"hipMipmappedArray_const_t", CONV_MEM, API_RUNTIME}},
 
+    // defines
+    {"cudaArrayDefault",           {"hipArrayDefault",          CONV_MEM, API_RUNTIME}},
+    {"cudaArrayLayered",           {"hipArrayLayered",          CONV_MEM, API_RUNTIME}},
+    {"cudaArraySurfaceLoadStore",  {"hipArraySurfaceLoadStore", CONV_MEM, API_RUNTIME}},
+    {"cudaArrayCubemap",           {"hipArrayCubemap",          CONV_MEM, API_RUNTIME}},
+    {"cudaArrayTextureGather",     {"hipArrayTextureGather",    CONV_MEM, API_RUNTIME}},
+
     {"cudaMemoryAdvise", {"hipMemAdvise", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED}},    // API_Driver ANALOGUE (CUmem_advise)
     {"cudaMemRangeAttribute", {"hipMemRangeAttribute", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED}},    // API_Driver ANALOGUE (CUmem_range_attribute)
     {"cudaMemcpyKind", {"hipMemcpyKind", CONV_MEM, API_RUNTIME}},
@@ -262,6 +269,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_TYPE_NAME_MAP{
     {"cudaSurfaceBoundaryMode", {"hipSurfaceBoundaryMode", CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED}},
 
     {"cudaSurfaceFormatMode", {"hipSurfaceFormatMode", CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED}},
+
+    // defines
+    {"cudaTextureType1D",             {"hipTextureType1D",             CONV_TEX, API_RUNTIME}},
+    {"cudaTextureType2D",             {"hipTextureType2D",             CONV_TEX, API_RUNTIME}},
+    {"cudaTextureType3D",             {"hipTextureType3D",             CONV_TEX, API_RUNTIME}},
+    {"cudaTextureTypeCubemap",        {"hipTextureTypeCubemap",        CONV_TEX, API_RUNTIME}},
+    {"cudaTextureType1DLayered",      {"hipTextureType1DLayered",      CONV_TEX, API_RUNTIME}},
+    {"cudaTextureType2DLayered",      {"hipTextureType2DLayered",      CONV_TEX, API_RUNTIME}},
+    {"cudaTextureTypeCubemapLayered", {"hipTextureTypeCubemapLayered", CONV_TEX, API_RUNTIME}},
 
     // Inter-Process Communication (IPC)
     {"cudaIpcEventHandle_t",  {"hipIpcEventHandle_t", CONV_TYPE, API_RUNTIME}},

--- a/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/matrixMulCUBLAS/matrixMulCUBLAS.cpp
+++ b/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/matrixMulCUBLAS/matrixMulCUBLAS.cpp
@@ -1,0 +1,385 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+/*
+* This software contains source code provided by NVIDIA Corporation.
+*/
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
+//
+// Please refer to the NVIDIA end user license agreement (EULA) associated
+// with this source code for terms and conditions that govern your use of
+// this software. Any use, reproduction, disclosure, or distribution of
+// this software and related documentation outside the terms of the EULA
+// is strictly prohibited.
+//
+////////////////////////////////////////////////////////////////////////////
+
+//
+// Matrix multiplication: C = A * B.
+// Host code.
+//
+// This sample implements matrix multiplication as described in Chapter 3
+// of the programming guide and uses the CUBLAS library to demonstrate
+// the best performance.
+
+// SOME PRECAUTIONS:
+// IF WE WANT TO CALCULATE ROW-MAJOR MATRIX MULTIPLY C = A * B,
+// WE JUST NEED CALL CUBLAS API IN A REVERSE ORDER: cublasSegemm(B, A)!
+// The reason is explained as follows:
+
+// CUBLAS library uses column-major storage, but C/C++ use row-major storage.
+// When passing the matrix pointer to CUBLAS, the memory layout alters from
+// row-major to column-major, which is equivalent to an implicit transpose.
+
+// In the case of row-major C/C++ matrix A, B, and a simple matrix multiplication
+// C = A * B, we can't use the input order like cublasSgemm(A, B)  because of
+// implicit transpose. The actual result of cublasSegemm(A, B) is A(T) * B(T).
+// If col(A(T)) != row(B(T)), equal to row(A) != col(B), A(T) and B(T) are not
+// multipliable. Moreover, even if A(T) and B(T) are multipliable, the result C
+// is a column-based cublas matrix, which means C(T) in C/C++, we need extra
+// transpose code to convert it to a row-based C/C++ matrix.
+
+// To solve the problem, let's consider our desired result C, a row-major matrix.
+// In cublas format, it is C(T) actually (because of the implicit transpose).
+// C = A * B, so C(T) = (A * B) (T) = B(T) * A(T). Cublas matrice B(T) and A(T)
+// happen to be C/C++ matrice B and A (still because of the implicit transpose)!
+// We don't need extra transpose code, we only need alter the input order!
+//
+// CUBLAS provides high-performance matrix multiplication.
+// See also:
+// V. Volkov and J. Demmel, "Benchmarking GPUs to tune dense linear algebra,"
+// in Proc. 2008 ACM/IEEE Conf. on Supercomputing (SC '08),
+// Piscataway, NJ: IEEE Press, 2008, pp. Art. 31:1-11.
+//
+
+// Utilities and system includes
+#include <assert.h>
+#include <helper_string.h>  // helper for shared functions common to CUDA Samples
+
+// CUDA runtime
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK: #include <hipblas.h>
+#include <cuda_runtime.h>
+#include <cublas_v2.h>
+
+// CUDA and CUBLAS functions
+#include <helper_functions.h>
+#include <helper_cuda.h>
+
+#ifndef min
+#define min(a,b) ((a < b) ? a : b)
+#endif
+#ifndef max
+#define max(a,b) ((a > b) ? a : b)
+#endif
+
+typedef struct _matrixSize      // Optional Command-line multiplier for matrix sizes
+{
+    unsigned int uiWA, uiHA, uiWB, uiHB, uiWC, uiHC;
+} sMatrixSize;
+
+////////////////////////////////////////////////////////////////////////////////
+//! Compute reference data set matrix multiply on CPU
+//! C = A * B
+//! @param C          reference data, computed but preallocated
+//! @param A          matrix A as provided to device
+//! @param B          matrix B as provided to device
+//! @param hA         height of matrix A
+//! @param wB         width of matrix B
+////////////////////////////////////////////////////////////////////////////////
+void
+matrixMulCPU(float *C, const float *A, const float *B, unsigned int hA, unsigned int wA, unsigned int wB)
+{
+    for (unsigned int i = 0; i < hA; ++i)
+        for (unsigned int j = 0; j < wB; ++j)
+        {
+            double sum = 0;
+
+            for (unsigned int k = 0; k < wA; ++k)
+            {
+                double a = A[i * wA + k];
+                double b = B[k * wB + j];
+                sum += a * b;
+            }
+
+            C[i * wB + j] = (float)sum;
+        }
+}
+
+// Allocates a matrix with random float entries.
+void randomInit(float *data, int size)
+{
+    for (int i = 0; i < size; ++i)
+        data[i] = rand() / (float)RAND_MAX;
+}
+
+void printDiff(float *data1, float *data2, int width, int height, int iListLength, float fListTol)
+{
+    printf("Listing first %d Differences > %.6f...\n", iListLength, fListTol);
+    int i,j,k;
+    int error_count=0;
+
+    for (j = 0; j < height; j++)
+    {
+        if (error_count < iListLength)
+        {
+            printf("\n  Row %d:\n", j);
+        }
+
+        for (i = 0; i < width; i++)
+        {
+            k = j * width + i;
+            float fDiff = fabs(data1[k] - data2[k]);
+
+            if (fDiff > fListTol)
+            {
+                if (error_count < iListLength)
+                {
+                    printf("    Loc(%d,%d)\tCPU=%.5f\tGPU=%.5f\tDiff=%.6f\n", i, j, data1[k], data2[k], fDiff);
+                }
+
+                error_count++;
+            }
+        }
+    }
+
+    printf(" \n  Total Errors = %d\n", error_count);
+}
+
+void initializeCUDA(int argc, char **argv, int &devID, int &iSizeMultiple, sMatrixSize &matrix_size)
+{
+    // By default, we use device 0, otherwise we override the device ID based on what is provided at the command line
+    // CHECK: hipError_t error;
+    cudaError_t error;
+    devID = 0;
+
+    devID = findCudaDevice(argc, (const char **)argv);
+
+    if (checkCmdLineFlag(argc, (const char **)argv, "sizemult"))
+    {
+        iSizeMultiple = getCmdLineArgumentInt(argc, (const char **)argv, "sizemult");
+    }
+
+    iSizeMultiple = min(iSizeMultiple, 10);
+    iSizeMultiple = max(iSizeMultiple, 1);
+    // CHECK: hipDeviceProp_t deviceProp;
+    cudaDeviceProp deviceProp;
+    // CHECK: error = hipGetDeviceProperties(&deviceProp, devID);
+    error = cudaGetDeviceProperties(&deviceProp, devID);
+    // CHECK: if (error != hipSuccess)
+    if (error != cudaSuccess)
+    {
+        // CHECK: printf("hipGetDeviceProperties returned error code %d, line(%d)\n", error, __LINE__);
+        printf("cudaGetDeviceProperties returned error code %d, line(%d)\n", error, __LINE__);
+        exit(EXIT_FAILURE);
+    }
+
+    printf("GPU Device %d: \"%s\" with compute capability %d.%d\n\n", devID, deviceProp.name, deviceProp.major, deviceProp.minor);
+
+    int block_size = 32;
+
+    matrix_size.uiWA = 3 * block_size * iSizeMultiple;
+    matrix_size.uiHA = 4 * block_size * iSizeMultiple;
+    matrix_size.uiWB = 2 * block_size * iSizeMultiple;
+    matrix_size.uiHB = 3 * block_size * iSizeMultiple;
+    matrix_size.uiWC = 2 * block_size * iSizeMultiple;
+    matrix_size.uiHC = 4 * block_size * iSizeMultiple;
+
+    printf("MatrixA(%u,%u), MatrixB(%u,%u), MatrixC(%u,%u)\n",
+           matrix_size.uiHA, matrix_size.uiWA,
+           matrix_size.uiHB, matrix_size.uiWB,
+           matrix_size.uiHC, matrix_size.uiWC);
+
+    if( matrix_size.uiWA != matrix_size.uiHB ||
+        matrix_size.uiHA != matrix_size.uiHC ||
+        matrix_size.uiWB != matrix_size.uiWC)
+    {
+       printf("ERROR: Matrix sizes do not match!\n");
+       exit(-1);
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//! Run a simple test matrix multiply using CUBLAS
+////////////////////////////////////////////////////////////////////////////////
+int matrixMultiply(int argc, char **argv, int devID, sMatrixSize &matrix_size)
+{
+    // CHECK: hipDeviceProp_t deviceProp;
+    cudaDeviceProp deviceProp;
+    // CHECK: checkCudaErrors(hipGetDeviceProperties(&deviceProp, devID));
+    checkCudaErrors(cudaGetDeviceProperties(&deviceProp, devID));
+
+    int block_size = 32;
+
+    // set seed for rand()
+    srand(2006);
+
+    // allocate host memory for matrices A and B
+    unsigned int size_A = matrix_size.uiWA * matrix_size.uiHA;
+    unsigned int mem_size_A = sizeof(float) * size_A;
+    float *h_A = (float *)malloc(mem_size_A);
+    unsigned int size_B = matrix_size.uiWB * matrix_size.uiHB;
+    unsigned int mem_size_B = sizeof(float) * size_B;
+    float *h_B = (float *)malloc(mem_size_B);
+
+    // set seed for rand()
+    srand(2006);
+
+    // initialize host memory
+    randomInit(h_A, size_A);
+    randomInit(h_B, size_B);
+
+    // allocate device memory
+    float *d_A, *d_B, *d_C;
+    unsigned int size_C = matrix_size.uiWC * matrix_size.uiHC;
+    unsigned int mem_size_C = sizeof(float) * size_C;
+
+    // allocate host memory for the result
+    float *h_C      = (float *) malloc(mem_size_C);
+    float *h_CUBLAS = (float *) malloc(mem_size_C);
+    // CHECK: checkCudaErrors(hipMalloc((void **) &d_A, mem_size_A));
+    // CHECK: checkCudaErrors(hipMalloc((void **) &d_B, mem_size_B));
+    // CHECK: checkCudaErrors(hipMemcpy(d_A, h_A, mem_size_A, hipMemcpyHostToDevice));
+    // CHECK: checkCudaErrors(hipMemcpy(d_B, h_B, mem_size_B, hipMemcpyHostToDevice));
+    // CHECK: checkCudaErrors(hipMalloc((void **) &d_C, mem_size_C));
+    checkCudaErrors(cudaMalloc((void **) &d_A, mem_size_A));
+    checkCudaErrors(cudaMalloc((void **) &d_B, mem_size_B));
+    checkCudaErrors(cudaMemcpy(d_A, h_A, mem_size_A, cudaMemcpyHostToDevice));
+    checkCudaErrors(cudaMemcpy(d_B, h_B, mem_size_B, cudaMemcpyHostToDevice));
+    checkCudaErrors(cudaMalloc((void **) &d_C, mem_size_C));
+
+    // setup execution parameters
+    dim3 threads(block_size, block_size);
+    dim3 grid(matrix_size.uiWC / threads.x, matrix_size.uiHC / threads.y);
+
+    // create and start timer
+    printf("Computing result using CUBLAS...");
+
+    // execute the kernel
+    int nIter = 30;
+
+    // CUBLAS version 2.0
+    {
+        const float alpha = 1.0f;
+        const float beta  = 0.0f;
+        // CHECK: hipblasHandle_t handle;
+        // CHECK: hipEvent_t start, stop;
+        cublasHandle_t handle;
+        cudaEvent_t start, stop;
+        // CHECK: checkCudaErrors(hipblasCreate(&handle));
+        checkCudaErrors(cublasCreate(&handle));
+
+        //Perform warmup operation with cublas
+        // CHECK: checkCudaErrors(hipblasSgemm(handle, HIPBLAS_OP_N, HIPBLAS_OP_N, matrix_size.uiWB, matrix_size.uiHA, matrix_size.uiWA, &alpha, d_B, matrix_size.uiWB, d_A, matrix_size.uiWA, &beta, d_C, matrix_size.uiWB));
+        checkCudaErrors(cublasSgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, matrix_size.uiWB, matrix_size.uiHA, matrix_size.uiWA, &alpha, d_B, matrix_size.uiWB, d_A, matrix_size.uiWA, &beta, d_C, matrix_size.uiWB));
+
+        // Allocate CUDA events that we'll use for timing
+        // CHECK: checkCudaErrors(hipEventCreate(&start));
+        // CHECK: checkCudaErrors(hipEventCreate(&stop));
+        checkCudaErrors(cudaEventCreate(&start));
+        checkCudaErrors(cudaEventCreate(&stop));
+
+        // Record the start event
+        // CHECK: checkCudaErrors(hipEventRecord(start, NULL));
+        checkCudaErrors(cudaEventRecord(start, NULL));
+
+        for (int j = 0; j < nIter; j++)
+        {
+            //note cublas is column primary!
+            //need to transpose the order
+            // CHECK: checkCudaErrors(hipblasSgemm(handle, HIPBLAS_OP_N, HIPBLAS_OP_N, matrix_size.uiWB, matrix_size.uiHA, matrix_size.uiWA, &alpha, d_B, matrix_size.uiWB, d_A, matrix_size.uiWA, &beta, d_C, matrix_size.uiWB));
+            checkCudaErrors(cublasSgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, matrix_size.uiWB, matrix_size.uiHA, matrix_size.uiWA, &alpha, d_B, matrix_size.uiWB, d_A, matrix_size.uiWA, &beta, d_C, matrix_size.uiWB));
+
+        }
+
+        printf("done.\n");
+
+        // Record the stop event
+        // CHECK: checkCudaErrors(hipEventRecord(stop, NULL));
+        checkCudaErrors(cudaEventRecord(stop, NULL));
+
+        // Wait for the stop event to complete
+        // CHECK: checkCudaErrors(hipEventSynchronize(stop));
+        checkCudaErrors(cudaEventSynchronize(stop));
+
+        float msecTotal = 0.0f;
+        // CHECK: checkCudaErrors(hipEventElapsedTime(&msecTotal, start, stop));
+        checkCudaErrors(cudaEventElapsedTime(&msecTotal, start, stop));
+
+        // Compute and print the performance
+        float msecPerMatrixMul = msecTotal / nIter;
+        double flopsPerMatrixMul = 2.0 * (double)matrix_size.uiHC * (double)matrix_size.uiWC * (double)matrix_size.uiHB;
+        double gigaFlops = (flopsPerMatrixMul * 1.0e-9f) / (msecPerMatrixMul / 1000.0f);
+        printf(
+            "Performance= %.2f GFlop/s, Time= %.3f msec, Size= %.0f Ops\n",
+            gigaFlops,
+            msecPerMatrixMul,
+            flopsPerMatrixMul);
+
+        // copy result from device to host
+        // CHECK: checkCudaErrors(hipMemcpy(h_CUBLAS, d_C, mem_size_C, hipMemcpyDeviceToHost));
+        checkCudaErrors(cudaMemcpy(h_CUBLAS, d_C, mem_size_C, cudaMemcpyDeviceToHost));
+
+        // Destroy the handle
+        // CHECK: checkCudaErrors(hipblasDestroy(handle));
+        checkCudaErrors(cublasDestroy(handle));
+    }
+
+    // compute reference solution
+    printf("Computing result using host CPU...");
+    float *reference = (float *)malloc(mem_size_C);
+    matrixMulCPU(reference, h_A, h_B, matrix_size.uiHA, matrix_size.uiWA, matrix_size.uiWB);
+    printf("done.\n");
+
+    // check result (CUBLAS)
+    bool resCUBLAS = sdkCompareL2fe(reference, h_CUBLAS, size_C, 1.0e-6f);
+
+    if (resCUBLAS != true)
+    {
+        printDiff(reference, h_CUBLAS, matrix_size.uiWC, matrix_size.uiHC, 100, 1.0e-5f);
+    }
+
+    printf("Comparing CUBLAS Matrix Multiply with CPU results: %s\n", (true == resCUBLAS) ? "PASS" : "FAIL");
+
+    printf("\nNOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.\n");
+
+    // clean up memory
+    free(h_A);
+    free(h_B);
+    free(h_C);
+    free(reference);
+    // CHECK: checkCudaErrors(hipFree(d_A));
+    // CHECK: checkCudaErrors(hipFree(d_B));
+    // CHECK: checkCudaErrors(hipFree(d_C));
+    checkCudaErrors(cudaFree(d_A));
+    checkCudaErrors(cudaFree(d_B));
+    checkCudaErrors(cudaFree(d_C));
+
+    if (resCUBLAS == true)
+    {
+        return EXIT_SUCCESS;    // return value = 1
+    }
+    else
+    {
+        return EXIT_FAILURE;     // return value = 0
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Program main
+////////////////////////////////////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+    printf("[Matrix Multiply CUBLAS] - Starting...\n");
+
+    int devID = 0, sizeMult = 5;
+    sMatrixSize matrix_size;
+
+    initializeCUDA(argc, argv, devID, sizeMult, matrix_size);
+
+    int matrix_result = matrixMultiply(argc, argv, devID, matrix_size);
+
+    return matrix_result;
+}

--- a/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/simpleLayeredTexture/simpleLayeredTexture.cu
+++ b/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/simpleLayeredTexture/simpleLayeredTexture.cu
@@ -1,0 +1,223 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+/*
+* This software contains source code provided by NVIDIA Corporation.
+*/
+
+/*
+* Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
+*
+* Please refer to the NVIDIA end user license agreement (EULA) associated
+* with this source code for terms and conditions that govern your use of
+* this software. Any use, reproduction, disclosure, or distribution of
+* this software and related documentation outside the terms of the EULA
+* is strictly prohibited.
+*
+*/
+
+/*
+* This sample demonstrates how to use texture fetches from layered 2D textures in CUDA C
+*
+* This sample first generates a 3D input data array for the layered texture
+* and the expected output. Then it starts CUDA C kernels, one for each layer,
+* which fetch their layer's texture data (using normalized texture coordinates)
+* transform it to the expected output, and write it to a 3D output data array.
+*/
+
+// includes, system
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+// includes, kernels
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+#include <texture_fetch_functions.h>
+
+// includes, project
+#include <helper_cuda.h>
+#include <helper_functions.h>  // helper for shared that are common to CUDA Samples
+
+static const char *sSDKname = "simpleLayeredTexture";
+
+// includes, kernels
+// declare texture reference for layered 2D float texture
+// Note: The "dim" field in the texture reference template is now deprecated.
+// Instead, please use a texture type macro such as cudaTextureType1D, etc.
+
+// CHECK: texture<float, hipTextureType2DLayered> tex;
+texture<float, cudaTextureType2DLayered> tex;
+
+////////////////////////////////////////////////////////////////////////////////
+//! Transform a layer of a layered 2D texture using texture lookups
+//! @param g_odata  output data in global memory
+////////////////////////////////////////////////////////////////////////////////
+__global__ void
+transformKernel(float *g_odata, int width, int height, int layer)
+{
+    // calculate this thread's data point
+    unsigned int x = blockIdx.x*blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y*blockDim.y + threadIdx.y;
+
+    // 0.5f offset and division are necessary to access the original data points
+    // in the texture (such that bilinear interpolation will not be activated).
+    // For details, see also CUDA Programming Guide, Appendix D
+    float u = (x+0.5f) / (float) width;
+    float v = (y+0.5f) / (float) height;
+
+    // read from texture, do expected transformation and write to global memory
+    g_odata[layer*width*height + y*width + x] = -tex2DLayered(tex, u, v, layer) + layer;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Program main
+////////////////////////////////////////////////////////////////////////////////
+int
+main(int argc, char **argv)
+{
+    printf("[%s] - Starting...\n", sSDKname);
+
+    // use command-line specified CUDA device, otherwise use device with highest Gflops/s
+    int devID = findCudaDevice(argc, (const char **)argv);
+
+    bool bResult = true;
+
+    // get number of SMs on this GPU
+    // CHECK: hipDeviceProp_t deviceProps;
+    cudaDeviceProp deviceProps;
+    // checkCudaErrors(hipGetDeviceProperties(&deviceProps, devID));
+    checkCudaErrors(cudaGetDeviceProperties(&deviceProps, devID));
+    printf("CUDA device [%s] has %d Multi-Processors ", deviceProps.name, deviceProps.multiProcessorCount);
+    printf("SM %d.%d\n", deviceProps.major, deviceProps.minor);
+
+    if (deviceProps.major < 2)
+    {
+        printf("%s requires SM >= 2.0 to support Texture Arrays.  Test will be waived... \n", sSDKname);
+        exit(EXIT_WAIVED);
+    }
+
+    // generate input data for layered texture
+    unsigned int width=512, height=512, num_layers = 5;
+    unsigned int size = width * height * num_layers * sizeof(float);
+    float *h_data = (float *) malloc(size);
+
+    for (unsigned int layer = 0; layer < num_layers; layer++)
+        for (int i = 0; i < (int)(width * height); i++)
+        {
+            h_data[layer*width*height + i] = (float)i;
+        }
+
+    // this is the expected transformation of the input data (the expected output)
+    float *h_data_ref = (float *) malloc(size);
+
+    for (unsigned int layer = 0; layer < num_layers; layer++)
+        for (int i = 0; i < (int)(width * height); i++)
+        {
+            h_data_ref[layer*width*height + i] = -h_data[layer*width*height + i] + layer;
+        }
+
+    // allocate device memory for result
+    float *d_data = NULL;
+    // CHECK: checkCudaErrors(hipMalloc((void **) &d_data, size));
+    checkCudaErrors(cudaMalloc((void **) &d_data, size));
+
+    // allocate array and copy image data
+    // CHECK: hipChannelFormatDesc channelDesc = hipCreateChannelDesc(32, 0, 0, 0, hipChannelFormatKindFloat);
+    cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc(32, 0, 0, 0, cudaChannelFormatKindFloat);
+    // CHECK: hipArray *cu_3darray;
+    cudaArray *cu_3darray;
+    // CHECK: checkCudaErrors(hipMalloc3DArray(&cu_3darray, &channelDesc, make_hipExtent(width, height, num_layers), hipArrayLayered));
+    checkCudaErrors(cudaMalloc3DArray(&cu_3darray, &channelDesc, make_cudaExtent(width, height, num_layers), cudaArrayLayered));
+    // CHECK: hipMemcpy3DParms myparms = {0};
+    // CHECK: myparms.srcPos = make_hipPos(0,0,0);
+    // CHECK: myparms.dstPos = make_hipPos(0,0,0);
+    // CHECK: myparms.srcPtr = make_hipPitchedPtr(h_data, width * sizeof(float), width, height);
+    cudaMemcpy3DParms myparms = {0};
+    myparms.srcPos = make_cudaPos(0,0,0);
+    myparms.dstPos = make_cudaPos(0,0,0);
+    myparms.srcPtr = make_cudaPitchedPtr(h_data, width * sizeof(float), width, height);
+    myparms.dstArray = cu_3darray;
+    // CHECK: myparms.extent = make_hipExtent(width, height, num_layers);
+    // CHECK: myparms.kind = hipMemcpyHostToDevice;
+    // CHECK: checkCudaErrors(hipMemcpy3D(&myparms));
+    myparms.extent = make_cudaExtent(width, height, num_layers);
+    myparms.kind = cudaMemcpyHostToDevice;
+    checkCudaErrors(cudaMemcpy3D(&myparms));
+
+    // set texture parameters
+    // CHECK: tex.addressMode[0] = hipAddressModeWrap;
+    // CHECK: tex.addressMode[1] = hipAddressModeWrap;
+    // CHECK: tex.filterMode = hipFilterModeLinear;
+    tex.addressMode[0] = cudaAddressModeWrap;
+    tex.addressMode[1] = cudaAddressModeWrap;
+    tex.filterMode = cudaFilterModeLinear;
+    tex.normalized = true;  // access with normalized texture coordinates
+
+    // Bind the array to the texture
+    // CHECK: checkCudaErrors(hipBindTextureToArray(tex, cu_3darray, channelDesc));
+    checkCudaErrors(cudaBindTextureToArray(tex, cu_3darray, channelDesc));
+
+    dim3 dimBlock(8, 8, 1);
+    dim3 dimGrid(width / dimBlock.x, height / dimBlock.y, 1);
+
+    printf("Covering 2D data array of %d x %d: Grid size is %d x %d, each block has 8 x 8 threads\n",
+           width, height, dimGrid.x, dimGrid.y);
+    // CHECK: hipLaunchKernelGGL(transformKernel, dim3(dimGrid), dim3(dimBlock), 0, 0, d_data, width, height, 0);
+    transformKernel<<< dimGrid, dimBlock >>>(d_data, width, height, 0);  // warmup (for better timing)
+
+    // check if kernel execution generated an error
+    getLastCudaError("warmup Kernel execution failed");
+    // CHECK: checkCudaErrors(hipDeviceSynchronize());
+    checkCudaErrors(cudaDeviceSynchronize());
+
+    StopWatchInterface *timer = NULL;
+    sdkCreateTimer(&timer);
+    sdkStartTimer(&timer);
+
+    // execute the kernel
+    for (unsigned int layer = 0; layer < num_layers; layer++)
+        // CHECK: hipLaunchKernelGGL(transformKernel, dim3(dimGrid), dim3(dimBlock), 0, 0, d_data, width, height, layer);
+        transformKernel<<< dimGrid, dimBlock, 0 >>>(d_data, width, height, layer);
+
+    // check if kernel execution generated an error
+    getLastCudaError("Kernel execution failed");
+    // CHECK: checkCudaErrors(hipDeviceSynchronize());
+    checkCudaErrors(cudaDeviceSynchronize());
+    sdkStopTimer(&timer);
+    printf("Processing time: %.3f msec\n", sdkGetTimerValue(&timer));
+    printf("%.2f Mtexlookups/sec\n", (width *height *num_layers / (sdkGetTimerValue(&timer) / 1000.0f) / 1e6));
+    sdkDeleteTimer(&timer);
+
+    // allocate mem for the result on host side
+    float *h_odata = (float *) malloc(size);
+    // copy result from device to host
+    // CHECK: checkCudaErrors(hipMemcpy(h_odata, d_data, size, hipMemcpyDeviceToHost));
+    checkCudaErrors(cudaMemcpy(h_odata, d_data, size, cudaMemcpyDeviceToHost));
+
+    // write regression file if necessary
+    if (checkCmdLineFlag(argc, (const char **)argv, "regression"))
+    {
+        // write file for regression test
+        sdkWriteFile<float>("./data/regression.dat", h_odata, width*height, 0.0f, false);
+    }
+    else
+    {
+        printf("Comparing kernel output to expected data\n");
+
+#define MIN_EPSILON_ERROR 5e-3f
+        bResult = compareData(h_odata, h_data_ref, width*height*num_layers, MIN_EPSILON_ERROR, 0.0f);
+    }
+
+    // cleanup memory
+    free(h_data);
+    free(h_data_ref);
+    free(h_odata);
+    // CHECK: checkCudaErrors(hipFree(d_data));
+    // CHECK: checkCudaErrors(hipFreeArray(cu_3darray));
+    checkCudaErrors(cudaFree(d_data));
+    checkCudaErrors(cudaFreeArray(cu_3darray));
+
+    exit(bResult ? EXIT_SUCCESS : EXIT_FAILURE);
+}

--- a/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/simpleOccupancy/simpleOccupancy.cu
+++ b/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/simpleOccupancy/simpleOccupancy.cu
@@ -1,0 +1,252 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+/*
+* This software contains source code provided by NVIDIA Corporation.
+*/
+
+/**
+ * Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
+ *
+ * Please refer to the NVIDIA end user license agreement (EULA) associated
+ * with this source code for terms and conditions that govern your use of
+ * this software. Any use, reproduction, disclosure, or distribution of
+ * this software and related documentation outside the terms of the EULA
+ * is strictly prohibited.
+ *
+ */
+
+#include <iostream>
+#include <helper_cuda.h>         // helper functions for CUDA error check
+
+const int manualBlockSize = 32;
+
+////////////////////////////////////////////////////////////////////////////////
+// Test kernel
+//
+// This kernel squares each array element. Each thread addresses
+// himself with threadIdx and blockIdx, so that it can handle any
+// execution configuration, including anything the launch configurator
+// API suggests.
+////////////////////////////////////////////////////////////////////////////////
+__global__ void square(int *array, int arrayCount)
+{
+    // CHECK: HIP_DYNAMIC_SHARED(int, dynamicSmem);
+    extern __shared__ int dynamicSmem[];
+    int idx = threadIdx.x + blockIdx.x * blockDim.x;
+    
+    if (idx < arrayCount) {
+        array[idx] *= array[idx];
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Potential occupancy calculator
+//
+// The potential occupancy is calculated according to the kernel and
+// execution configuration the user desires. Occupancy is defined in
+// terms of active blocks per multiprocessor, and the user can convert
+// it to other metrics.
+//
+// This wrapper routine computes the occupancy of kernel, and reports
+// it in terms of active warps / maximum warps per SM.
+////////////////////////////////////////////////////////////////////////////////
+static double reportPotentialOccupancy(void *kernel, int blockSize, size_t dynamicSMem)
+{
+    int device;
+    // CHECK: hipDeviceProp_t prop;
+    cudaDeviceProp prop;
+
+    int numBlocks;
+    int activeWarps;
+    int maxWarps;
+
+    double occupancy;
+
+    // CHECK: checkCudaErrors(hipGetDevice(&device));
+    // CHECK: checkCudaErrors(hipGetDeviceProperties(&prop, device));
+    // CHECK: checkCudaErrors(hipOccupancyMaxActiveBlocksPerMultiprocessor(
+    checkCudaErrors(cudaGetDevice(&device));
+    checkCudaErrors(cudaGetDeviceProperties(&prop, device));
+
+    checkCudaErrors(cudaOccupancyMaxActiveBlocksPerMultiprocessor(
+                        &numBlocks,
+                        kernel,
+                        blockSize,
+                        dynamicSMem));
+
+    // CHECK: activeWarps = numBlocks * blockSize / prop.hipWarpSize;
+    // CHECK: maxWarps = prop.maxThreadsPerMultiProcessor / prop.hipWarpSize;
+    activeWarps = numBlocks * blockSize / prop.warpSize;
+    maxWarps = prop.maxThreadsPerMultiProcessor / prop.warpSize;
+
+    occupancy = (double)activeWarps / maxWarps;
+
+    return occupancy;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Occupancy-based launch configurator
+//
+// The launch configurator, cudaOccupancyMaxPotentialBlockSize and
+// cudaOccupancyMaxPotentialBlockSizeVariableSMem, suggests a block
+// size that achieves the best theoretical occupancy. It also returns
+// the minimum number of blocks needed to achieve the occupancy on the
+// whole device.
+//
+// This launch configurator is purely occupancy-based. It doesn't
+// translate directly to performance, but the suggestion should
+// nevertheless be a good starting point for further optimizations.
+//
+// This function configures the launch based on the "automatic"
+// argument, records the runtime, and reports occupancy and runtime.
+////////////////////////////////////////////////////////////////////////////////
+static int launchConfig(int *array, int arrayCount, bool automatic)
+{
+    int blockSize;
+    int minGridSize;
+    int gridSize;
+    size_t dynamicSMemUsage = 0;
+    // CHECK: hipEvent_t start;
+    // CHECK: hipEvent_t end;
+    cudaEvent_t start;
+    cudaEvent_t end;
+
+    float elapsedTime;
+    
+    double potentialOccupancy;
+    // CHECK: checkCudaErrors(hipEventCreate(&start));
+    // CHECK: checkCudaErrors(hipEventCreate(&end));
+    checkCudaErrors(cudaEventCreate(&start));
+    checkCudaErrors(cudaEventCreate(&end));
+
+    if (automatic) {
+        // CHECK: checkCudaErrors(hipOccupancyMaxPotentialBlockSize(
+        checkCudaErrors(cudaOccupancyMaxPotentialBlockSize(
+                            &minGridSize,
+                            &blockSize,
+                            (void*)square,
+                            dynamicSMemUsage,
+                            arrayCount));
+
+        std::cout << "Suggested block size: " << blockSize << std::endl
+                  << "Minimum grid size for maximum occupancy: " << minGridSize << std::endl;
+    } else {
+        // This block size is too small. Given limited number of
+        // active blocks per multiprocessor, the number of active
+        // threads will be limited, and thus unable to achieve maximum
+        // occupancy.
+        //
+        blockSize = manualBlockSize;
+    }
+
+    // Round up
+    //
+    gridSize = (arrayCount + blockSize - 1) / blockSize;
+
+    // Launch and profile
+    //
+    // CHECK: checkCudaErrors(hipEventRecord(start));
+    // CHECK: hipLaunchKernelGGL(square, dim3(gridSize), dim3(blockSize), dynamicSMemUsage, 0, array, arrayCount);
+    // CHECK: checkCudaErrors(hipEventRecord(end));
+    checkCudaErrors(cudaEventRecord(start));
+    square<<<gridSize, blockSize, dynamicSMemUsage>>>(array, arrayCount);
+    checkCudaErrors(cudaEventRecord(end));
+    // CHECK: checkCudaErrors(hipDeviceSynchronize());
+    checkCudaErrors(cudaDeviceSynchronize());
+
+    // Calculate occupancy
+    //
+    potentialOccupancy = reportPotentialOccupancy((void*)square, blockSize, dynamicSMemUsage);
+
+    std::cout << "Potential occupancy: " << potentialOccupancy * 100 << "%" << std::endl;
+
+    // Report elapsed time
+    //
+    // CHECK: checkCudaErrors(hipEventElapsedTime(&elapsedTime, start, end));
+    checkCudaErrors(cudaEventElapsedTime(&elapsedTime, start, end));
+    std::cout << "Elapsed time: " << elapsedTime << "ms" << std::endl;
+    
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// The test
+//
+// The test generates an array and squares it with a CUDA kernel, then
+// verifies the result.
+////////////////////////////////////////////////////////////////////////////////
+static int test(bool automaticLaunchConfig, const int count = 1000000)
+{
+    int *array;
+    int *dArray;
+    int size = count * sizeof(int);
+
+    array = new int[count];
+
+    for (int i = 0; i < count; i += 1) {
+        array[i] = i;
+    }
+    // CHECK: checkCudaErrors(hipMalloc(&dArray, size));
+    // CHECK: checkCudaErrors(hipMemcpy(dArray, array, size, hipMemcpyHostToDevice));
+    checkCudaErrors(cudaMalloc(&dArray, size));
+    checkCudaErrors(cudaMemcpy(dArray, array, size, cudaMemcpyHostToDevice));
+
+    for (int i = 0; i < count; i += 1) {
+        array[i] = 0;
+    }
+
+    launchConfig(dArray, count, automaticLaunchConfig);
+    // CHECK: checkCudaErrors(hipMemcpy(array, dArray, size, hipMemcpyDeviceToHost));
+    // CHECK: checkCudaErrors(hipFree(dArray));
+    checkCudaErrors(cudaMemcpy(array, dArray, size, cudaMemcpyDeviceToHost));
+    checkCudaErrors(cudaFree(dArray));
+
+    // Verify the return data
+    //
+    for (int i = 0; i < count; i += 1) {
+        if (array[i] != i * i) {
+            std::cout << "element " << i << " expected " << i * i << " actual " << array[i] << std::endl;
+            return 1;
+        }
+    }
+    delete[] array;
+
+    return 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Sample Main
+//
+// The sample runs the test with manually configured launch and
+// automatically configured launch, and reports the occupancy and
+// performance.
+////////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    int status;
+
+    std::cout << "starting Simple Occupancy" << std::endl << std::endl;
+
+    std::cout << "[ Manual configuration with " << manualBlockSize
+              << " threads per block ]" << std::endl;
+
+    status = test(false);
+    if (status) {
+        std::cerr << "Test failed\n" << std::endl;
+        return -1;
+    }
+
+    std::cout << std::endl;
+
+    std::cout << "[ Automatic, occupancy-based configuration ]" << std::endl;
+    status = test(true);
+    if (status) {
+        std::cerr << "Test failed\n" << std::endl;
+        return -1;
+    }        
+
+    std::cout << std::endl;
+    std::cout << "Test PASSED\n" << std::endl;
+    
+    return 0;
+}

--- a/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/simpleP2P/simpleP2P.cu
+++ b/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/simpleP2P/simpleP2P.cu
@@ -1,0 +1,372 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+/*
+* This software contains source code provided by NVIDIA Corporation.
+*/
+
+/*
+ * Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
+ *
+ * Please refer to the NVIDIA end user license agreement (EULA) associated
+ * with this source code for terms and conditions that govern your use of
+ * this software. Any use, reproduction, disclosure, or distribution of
+ * this software and related documentation outside the terms of the EULA
+ * is strictly prohibited.
+ *
+ */
+
+/*
+ * This sample demonstrates a combination of Peer-to-Peer (P2P) and
+ * Unified Virtual Address Space (UVA) features new to SDK 4.0
+ */
+
+// includes, system
+#include <stdlib.h>
+#include <stdio.h>
+
+// CUDA includes
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+
+// includes, project
+#include <helper_cuda.h>
+#include <helper_functions.h>  // helper for shared that are common to CUDA Samples
+
+__global__ void SimpleKernel(float *src, float *dst)
+{
+    // Just a dummy kernel, doing enough for us to verify that everything
+    // worked
+    const int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    dst[idx] = src[idx] * 2.0f;
+}
+
+
+// CHECK: inline bool IsGPUCapableP2P(hipDeviceProp_t *pProp)
+inline bool IsGPUCapableP2P(cudaDeviceProp *pProp)
+{
+#ifdef _WIN32
+    return (bool)(pProp->tccDriver ? true : false);
+#else
+    return (bool)(pProp->major >= 2);
+#endif
+}
+
+inline bool IsAppBuiltAs64()
+{
+    return sizeof(void*) == 8;
+}
+
+int main(int argc, char **argv)
+{
+    printf("[%s] - Starting...\n", argv[0]);
+
+    if (!IsAppBuiltAs64())
+    {
+        printf("%s is only supported with on 64-bit OSs and the application must be built as a 64-bit target.  Test is being waived.\n", argv[0]);
+        exit(EXIT_WAIVED);
+    }
+
+    // Number of GPUs
+    printf("Checking for multiple GPUs...\n");
+    int gpu_n;
+    // CHECK: checkCudaErrors(hipGetDeviceCount(&gpu_n));
+    checkCudaErrors(cudaGetDeviceCount(&gpu_n));
+    printf("CUDA-capable device count: %i\n", gpu_n);
+
+    if (gpu_n < 2)
+    {
+        printf("Two or more GPUs with SM 2.0 or higher capability are required for %s.\n", argv[0]);
+        printf("Waiving test.\n");
+        exit(EXIT_WAIVED);
+    }
+
+    // Query device properties
+    // CHECK hipDeviceProp_t prop[64];
+    cudaDeviceProp prop[64];
+    int gpuid[64]; // we want to find the first two GPU's that can support P2P
+    int gpu_count = 0;   // GPUs that meet the criteria
+
+    for (int i=0; i < gpu_n; i++)
+    {
+        // CHECK: checkCudaErrors(hipGetDeviceProperties(&prop[i], i));
+        checkCudaErrors(cudaGetDeviceProperties(&prop[i], i));
+
+        // Only boards based on Fermi can support P2P
+        if ((prop[i].major >= 2)
+#ifdef _WIN32
+            // on Windows (64-bit), the Tesla Compute Cluster driver for windows must be enabled
+            && prop[i].tccDriver
+#endif
+           )
+        {
+            // This is an array of P2P capable GPUs
+            gpuid[gpu_count++] = i;
+        }
+
+        printf("> GPU%d = \"%15s\" %s capable of Peer-to-Peer (P2P)\n", i, prop[i].name, (IsGPUCapableP2P(&prop[i]) ? "IS " : "NOT"));
+    }
+
+    // Check for TCC for Windows
+    if (gpu_count < 2)
+    {
+        printf("\nTwo or more GPUs with SM 2.0 or higher capability are required for %s.\n", argv[0]);
+#ifdef _WIN32
+        printf("\nAlso, a TCC driver must be installed and enabled to run %s.\n", argv[0]);
+#endif
+        // CHECK: checkCudaErrors(hipSetDevice(0));
+        checkCudaErrors(cudaSetDevice(0));
+
+        exit(EXIT_WAIVED);
+    }
+
+#if CUDART_VERSION >= 4000
+    // Check possibility for peer access
+    printf("\nChecking GPU(s) for support of peer to peer memory access...\n");
+
+    int can_access_peer;
+    int p2pCapableGPUs[2]; // We take only 1 pair of P2P capable GPUs
+    p2pCapableGPUs[0] = p2pCapableGPUs[1] = -1;
+
+    // Show all the combinations of supported P2P GPUs
+    for (int i = 0; i < gpu_count; i++)
+    {
+        for (int j = 0; j < gpu_count; j++)
+        {
+            if (gpuid[i] == gpuid[j])
+            {
+                continue;
+            }
+            // CHECK: checkCudaErrors(hipDeviceCanAccessPeer(&can_access_peer, gpuid[i], gpuid[j]));
+            checkCudaErrors(cudaDeviceCanAccessPeer(&can_access_peer, gpuid[i], gpuid[j]));
+            printf("> Peer access from %s (GPU%d) -> %s (GPU%d) : %s\n", prop[gpuid[i]].name, gpuid[i],
+                           prop[gpuid[j]].name, gpuid[j] ,
+                           can_access_peer ? "Yes" : "No");
+            if (can_access_peer && p2pCapableGPUs[0] == -1)
+            {
+                    p2pCapableGPUs[0] = gpuid[i];
+                    p2pCapableGPUs[1] = gpuid[j];
+            }
+        }
+    }
+
+    if (p2pCapableGPUs[0] == -1 || p2pCapableGPUs[1] == -1)
+    {
+        printf("Two or more GPUs with SM 2.0 or higher capability are required for %s.\n", argv[0]);
+        printf("Peer to Peer access is not available amongst GPUs in the system, waiving test.\n");
+
+        for (int i=0; i < gpu_count; i++)
+        {
+            // CHECK: checkCudaErrors(hipSetDevice(gpuid[i]));
+            checkCudaErrors(cudaSetDevice(gpuid[i]));
+        }
+        exit(EXIT_WAIVED);
+    }
+
+    // Use first pair of p2p capable GPUs detected.
+    gpuid[0] = p2pCapableGPUs[0];
+    gpuid[1] = p2pCapableGPUs[1];
+
+    // Enable peer access
+    printf("Enabling peer access between GPU%d and GPU%d...\n", gpuid[0], gpuid[1]);
+
+    // CHECK: checkCudaErrors(hipSetDevice(gpuid[0]));
+    // CHECK: checkCudaErrors(hipDeviceEnablePeerAccess(gpuid[1], 0));
+    // CHECK: checkCudaErrors(hipSetDevice(gpuid[1]));
+    // CHECK: checkCudaErrors(hipDeviceEnablePeerAccess(gpuid[0], 0));
+    checkCudaErrors(cudaSetDevice(gpuid[0]));
+    checkCudaErrors(cudaDeviceEnablePeerAccess(gpuid[1], 0));
+    checkCudaErrors(cudaSetDevice(gpuid[1]));
+    checkCudaErrors(cudaDeviceEnablePeerAccess(gpuid[0], 0));
+
+    // Check that we got UVA on both devices
+    printf("Checking GPU%d and GPU%d for UVA capabilities...\n", gpuid[0], gpuid[1]);
+    const bool has_uva = (prop[gpuid[0]].unifiedAddressing && prop[gpuid[1]].unifiedAddressing);
+
+    printf("> %s (GPU%d) supports UVA: %s\n", prop[gpuid[0]].name, gpuid[0], (prop[gpuid[0]].unifiedAddressing ? "Yes" : "No"));
+    printf("> %s (GPU%d) supports UVA: %s\n", prop[gpuid[1]].name, gpuid[1], (prop[gpuid[1]].unifiedAddressing ? "Yes" : "No"));
+
+    if (has_uva)
+    {
+        printf("Both GPUs can support UVA, enabling...\n");
+    }
+    else
+    {
+        printf("At least one of the two GPUs does NOT support UVA, waiving test.\n");
+        exit(EXIT_WAIVED);
+    }
+
+    // Allocate buffers
+    const size_t buf_size = 1024 * 1024 * 16 * sizeof(float);
+    printf("Allocating buffers (%iMB on GPU%d, GPU%d and CPU Host)...\n", int(buf_size / 1024 / 1024), gpuid[0], gpuid[1]);
+    // CHECK: checkCudaErrors(hipSetDevice(gpuid[0]));
+    checkCudaErrors(cudaSetDevice(gpuid[0]));
+    float *g0;
+    // CHECK: checkCudaErrors(hipMalloc(&g0, buf_size));
+    // CHECK: checkCudaErrors(hipSetDevice(gpuid[1]));
+    checkCudaErrors(cudaMalloc(&g0, buf_size));
+    checkCudaErrors(cudaSetDevice(gpuid[1]));
+    float *g1;
+    // CHECK: checkCudaErrors(hipMalloc(&g1, buf_size));
+    checkCudaErrors(cudaMalloc(&g1, buf_size));
+    float *h0;
+    // CHECK: checkCudaErrors(hipHostMalloc(&h0, buf_size));
+    checkCudaErrors(cudaMallocHost(&h0, buf_size)); // Automatically portable with UVA
+
+    // Create CUDA event handles
+    printf("Creating event handles...\n");
+    // CHECK: hipEvent_t start_event, stop_event;
+    cudaEvent_t start_event, stop_event;
+    float time_memcpy;
+    // CHECK: int eventflags = hipEventBlockingSync;
+    int eventflags = cudaEventBlockingSync;
+    // CHECK: checkCudaErrors(hipEventCreateWithFlags(&start_event, eventflags));
+    // CHECK: checkCudaErrors(hipEventCreateWithFlags(&stop_event, eventflags));
+    checkCudaErrors(cudaEventCreateWithFlags(&start_event, eventflags));
+    checkCudaErrors(cudaEventCreateWithFlags(&stop_event, eventflags));
+
+    // P2P memcopy() benchmark
+    // CHECK: checkCudaErrors(hipEventRecord(start_event, 0));
+    checkCudaErrors(cudaEventRecord(start_event, 0));
+
+    for (int i=0; i<100; i++)
+    {
+        // With UVA we don't need to specify source and target devices, the
+        // runtime figures this out by itself from the pointers
+
+        // Ping-pong copy between GPUs
+        if (i % 2 == 0)
+        {
+            // CHECK: checkCudaErrors(hipMemcpy(g1, g0, buf_size, hipMemcpyDefault));
+            checkCudaErrors(cudaMemcpy(g1, g0, buf_size, cudaMemcpyDefault));
+        }
+        else
+        {
+            // CHECK: checkCudaErrors(hipMemcpy(g0, g1, buf_size, hipMemcpyDefault));
+            checkCudaErrors(cudaMemcpy(g0, g1, buf_size, cudaMemcpyDefault));
+        }
+    }
+
+    // CHECK: checkCudaErrors(hipEventRecord(stop_event, 0));
+    // CHECK: checkCudaErrors(hipEventSynchronize(stop_event));
+    // CHECK: checkCudaErrors(hipEventElapsedTime(&time_memcpy, start_event, stop_event));
+    // CHECK: printf("hipMemcpyPeer / hipMemcpy between GPU%d and GPU%d: %.2fGB/s\n", gpuid[0], gpuid[1],
+    checkCudaErrors(cudaEventRecord(stop_event, 0));
+    checkCudaErrors(cudaEventSynchronize(stop_event));
+    checkCudaErrors(cudaEventElapsedTime(&time_memcpy, start_event, stop_event));
+    printf("cudaMemcpyPeer / cudaMemcpy between GPU%d and GPU%d: %.2fGB/s\n", gpuid[0], gpuid[1],
+           (1.0f / (time_memcpy / 1000.0f)) * ((100.0f * buf_size)) / 1024.0f / 1024.0f / 1024.0f);
+
+    // Prepare host buffer and copy to GPU 0
+    printf("Preparing host buffer and memcpy to GPU%d...\n", gpuid[0]);
+
+    for (int i=0; i<buf_size / sizeof(float); i++)
+    {
+        h0[i] = float(i % 4096);
+    }
+
+    // CHECK: checkCudaErrors(hipSetDevice(gpuid[0]));
+    // CHECK: checkCudaErrors(hipMemcpy(g0, h0, buf_size, hipMemcpyDefault));
+    checkCudaErrors(cudaSetDevice(gpuid[0]));
+    checkCudaErrors(cudaMemcpy(g0, h0, buf_size, cudaMemcpyDefault));
+
+    // Kernel launch configuration
+    const dim3 threads(512, 1);
+    const dim3 blocks((buf_size / sizeof(float)) / threads.x, 1);
+
+    // Run kernel on GPU 1, reading input from the GPU 0 buffer, writing
+    // output to the GPU 1 buffer
+    printf("Run kernel on GPU%d, taking source data from GPU%d and writing to GPU%d...\n",
+           gpuid[1], gpuid[0], gpuid[1]);
+    // CHECK: checkCudaErrors(hipSetDevice(gpuid[1]));
+    checkCudaErrors(cudaSetDevice(gpuid[1]));
+    // CHECK: hipLaunchKernelGGL(SimpleKernel, dim3(blocks), dim3(threads), 0, 0, g0, g1);
+    SimpleKernel<<<blocks, threads>>>(g0, g1);
+
+    // CHECK: checkCudaErrors(hipDeviceSynchronize());
+    checkCudaErrors(cudaDeviceSynchronize());
+
+    // Run kernel on GPU 0, reading input from the GPU 1 buffer, writing
+    // output to the GPU 0 buffer
+    printf("Run kernel on GPU%d, taking source data from GPU%d and writing to GPU%d...\n",
+           gpuid[0], gpuid[1], gpuid[0]);
+    // CHECK: checkCudaErrors(hipSetDevice(gpuid[0]));
+    checkCudaErrors(cudaSetDevice(gpuid[0]));
+    // CHECK: hipLaunchKernelGGL(SimpleKernel, dim3(blocks), dim3(threads), 0, 0, g1, g0);
+    SimpleKernel<<<blocks, threads>>>(g1, g0);
+    // CHECK: checkCudaErrors(hipDeviceSynchronize());
+    checkCudaErrors(cudaDeviceSynchronize());
+
+    // Copy data back to host and verify
+    printf("Copy data back to host from GPU%d and verify results...\n", gpuid[0]);
+    // CHECK: checkCudaErrors(hipMemcpy(h0, g0, buf_size, hipMemcpyDefault));
+    checkCudaErrors(cudaMemcpy(h0, g0, buf_size, cudaMemcpyDefault));
+
+    int error_count = 0;
+
+    for (int i=0; i<buf_size / sizeof(float); i++)
+    {
+        // Re-generate input data and apply 2x '* 2.0f' computation of both
+        // kernel runs
+        if (h0[i] != float(i % 4096) * 2.0f * 2.0f)
+        {
+            printf("Verification error @ element %i: val = %f, ref = %f\n", i, h0[i], (float(i%4096)*2.0f*2.0f));
+
+            if (error_count++ > 10)
+            {
+                break;
+            }
+        }
+    }
+
+    // Disable peer access (also unregisters memory for non-UVA cases)
+    printf("Disabling peer access...\n");
+    // CHECK: checkCudaErrors(hipSetDevice(gpuid[0]));
+    // CHECK: checkCudaErrors(hipDeviceDisablePeerAccess(gpuid[1]));
+    // CHECK: checkCudaErrors(hipSetDevice(gpuid[1]));
+    // CHECK: checkCudaErrors(hipDeviceDisablePeerAccess(gpuid[0]));
+    checkCudaErrors(cudaSetDevice(gpuid[0]));
+    checkCudaErrors(cudaDeviceDisablePeerAccess(gpuid[1]));
+    checkCudaErrors(cudaSetDevice(gpuid[1]));
+    checkCudaErrors(cudaDeviceDisablePeerAccess(gpuid[0]));
+
+    // Cleanup and shutdown
+    printf("Shutting down...\n");
+    // CHECK: checkCudaErrors(hipEventDestroy(start_event));
+    // CHECK: checkCudaErrors(hipEventDestroy(stop_event));
+    // CHECK: checkCudaErrors(hipSetDevice(gpuid[0]));
+    // CHECK: checkCudaErrors(hipFree(g0));
+    // CHECK: checkCudaErrors(hipSetDevice(gpuid[1]));
+    // CHECK: checkCudaErrors(hipFree(g1));
+    // CHECK: checkCudaErrors(hipHostFree(h0));
+    checkCudaErrors(cudaEventDestroy(start_event));
+    checkCudaErrors(cudaEventDestroy(stop_event));
+    checkCudaErrors(cudaSetDevice(gpuid[0]));
+    checkCudaErrors(cudaFree(g0));
+    checkCudaErrors(cudaSetDevice(gpuid[1]));
+    checkCudaErrors(cudaFree(g1));
+    checkCudaErrors(cudaFreeHost(h0));
+
+    for (int i=0; i<gpu_n; i++)
+    {
+        // CHECK: checkCudaErrors(hipSetDevice(i));
+        checkCudaErrors(cudaSetDevice(i));
+    }
+
+    if (error_count != 0)
+    {
+        printf("Test failed!\n");
+        exit(EXIT_FAILURE);
+    }
+    else
+    {
+        printf("Test passed\n");
+        exit(EXIT_SUCCESS);
+    }
+
+#else // Using CUDA 3.2 or older
+    printf("simpleP2P requires CUDA 4.0 to build and run, waiving testing\n");
+    exit(EXIT_WAIVED);
+#endif
+
+}
+

--- a/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/simplePitchLinearTexture/simplePitchLinearTexture.cu
+++ b/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/simplePitchLinearTexture/simplePitchLinearTexture.cu
@@ -1,0 +1,392 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+/*
+* This software contains source code provided by NVIDIA Corporation.
+*/
+
+/*
+* Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
+*
+* Please refer to the NVIDIA end user license agreement (EULA) associated
+* with this source code for terms and conditions that govern your use of
+* this software. Any use, reproduction, disclosure, or distribution of
+* this software and related documentation outside the terms of the EULA
+* is strictly prohibited.
+*
+*/
+
+/* pitchLinearTexture
+*
+* This example demonstrates how to use textures bound to pitch linear memory.
+* It performs a shift of matrix elements using wrap addressing mode (aka
+* periodic boundary conditions) on two arrays, a pitch linear and a CUDA array,
+* in order to highlight the differences in using each.
+*
+* Textures binding to pitch linear memory is a new feature in CUDA 2.2,
+* and allows use of texture features such as wrap addressing mode and
+* filtering which are not possible with textures bound to regular linear memory
+*/
+
+// includes, system
+#include <stdio.h>
+
+#ifdef _WIN32
+#  define WINDOWS_LEAN_AND_MEAN
+#  define NOMINMAX
+#  include <windows.h>
+#endif
+
+// Includes CUDA
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+#include <texture_fetch_functions.h>
+
+// Utilities and timing functions
+#include <helper_functions.h>    // includes cuda.h and cuda_runtime_api.h
+
+// CUDA helper functions
+#include <helper_cuda.h>         // helper functions for CUDA error check
+
+#define NUM_REPS 100  // number of repetitions performed
+#define TILE_DIM 16   // tile/block size
+
+const char *sSDKsample = "simplePitchLinearTexture";
+
+////////////////////////////////////////////////////////////////////////////////
+// Texture references
+// CHECK: texture<float, 2, hipReadModeElementType> texRefPL;
+// CHECK: texture<float, 2, hipReadModeElementType> texRefArray;
+texture<float, 2, cudaReadModeElementType> texRefPL;
+texture<float, 2, cudaReadModeElementType> texRefArray;
+
+// Auto-Verification Code
+bool bTestResult = true;
+
+////////////////////////////////////////////////////////////////////////////////
+// NB: (1) The second argument "pitch" is in elements, not bytes
+//     (2) normalized coordinates are used (required for wrap address mode)
+////////////////////////////////////////////////////////////////////////////////
+//! Shifts matrix elements using pitch linear array
+//! @param odata  output data in global memory
+////////////////////////////////////////////////////////////////////////////////
+__global__ void shiftPitchLinear(float *odata,
+                                 int pitch,
+                                 int width,
+                                 int height,
+                                 int shiftX,
+                                 int shiftY)
+{
+    int xid = blockIdx.x * blockDim.x + threadIdx.x;
+    int yid = blockIdx.y * blockDim.y + threadIdx.y;
+
+    odata[yid * pitch + xid] = tex2D(texRefPL,
+                                     (xid + shiftX) / (float) width,
+                                     (yid + shiftY) / (float) height);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//! Shifts matrix elements using regular array
+//! @param odata  output data in global memory
+////////////////////////////////////////////////////////////////////////////////
+__global__ void shiftArray(float *odata,
+                           int pitch,
+                           int width,
+                           int height,
+                           int shiftX,
+                           int shiftY)
+{
+    int xid = blockIdx.x * blockDim.x + threadIdx.x;
+    int yid = blockIdx.y * blockDim.y + threadIdx.y;
+
+    odata[yid * pitch + xid] = tex2D(texRefArray,
+                                     (xid + shiftX) / (float) width,
+                                     (yid + shiftY) / (float) height);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Declaration, forward
+void runTest(int argc, char **argv);
+
+////////////////////////////////////////////////////////////////////////////////
+// Program main
+////////////////////////////////////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+    printf("%s starting...\n\n", sSDKsample);
+
+    runTest(argc, argv);
+
+    printf("%s completed, returned %s\n",
+           sSDKsample,
+           bTestResult ? "OK" : "ERROR!");
+    exit(bTestResult ? EXIT_SUCCESS : EXIT_FAILURE);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//! Run a simple test for CUDA
+////////////////////////////////////////////////////////////////////////////////
+void runTest(int argc, char **argv)
+{
+    // Set array size
+    const int nx = 2048;
+    const int ny = 2048;
+
+    // Setup shifts applied to x and y data
+    const int x_shift = 5;
+    const int y_shift = 7;
+
+    if ((nx % TILE_DIM != 0)  || (ny % TILE_DIM != 0))
+    {
+        printf("nx and ny must be multiples of TILE_DIM\n");
+        exit(EXIT_FAILURE);
+    }
+
+    // Setup execution configuration parameters
+    dim3 dimGrid(nx / TILE_DIM, ny / TILE_DIM), dimBlock(TILE_DIM, TILE_DIM);
+
+    // This will pick the best possible CUDA capable device
+    int devID = findCudaDevice(argc, (const char **)argv);
+
+    // CUDA events for timing
+    // CHECK: hipEvent_t start, stop;
+    // CHECK: hipEventCreate(&start);
+    // CHECK: hipEventCreate(&stop);
+    cudaEvent_t start, stop;
+    cudaEventCreate(&start);
+    cudaEventCreate(&stop);
+
+    // Host allocation and initialization
+    float *h_idata = (float *) malloc(sizeof(float) * nx * ny);
+    float *h_odata = (float *) malloc(sizeof(float) * nx * ny);
+    float *gold = (float *) malloc(sizeof(float) * nx * ny);
+
+    for (int i = 0; i < nx * ny; ++i)
+    {
+        h_idata[i] = (float) i;
+    }
+
+    // Device memory allocation
+    // Pitch linear input data
+    float *d_idataPL;
+    size_t d_pitchBytes;
+    // CHECK: checkCudaErrors(hipMallocPitch((void **) &d_idataPL,
+    checkCudaErrors(cudaMallocPitch((void **) &d_idataPL,
+                                    &d_pitchBytes,
+                                    nx * sizeof(float),
+                                    ny));
+
+    // Array input data
+    // CHECK: hipArray *d_idataArray;
+    // CHECK: hipChannelFormatDesc channelDesc = hipCreateChannelDesc<float>();
+    cudaArray *d_idataArray;
+    cudaChannelFormatDesc channelDesc = cudaCreateChannelDesc<float>();
+    // CHECK: checkCudaErrors(hipMallocArray(&d_idataArray, &channelDesc, nx, ny));
+    checkCudaErrors(cudaMallocArray(&d_idataArray, &channelDesc, nx, ny));
+
+    // Pitch linear output data
+    float *d_odata;
+    // CHECK: checkCudaErrors(hipMallocPitch((void **) &d_odata,
+    checkCudaErrors(cudaMallocPitch((void **) &d_odata,
+                                    &d_pitchBytes,
+                                    nx * sizeof(float),
+                                    ny));
+
+    // Copy host data to device
+    // Pitch linear
+    size_t h_pitchBytes = nx * sizeof(float);
+    // CHECK: checkCudaErrors(hipMemcpy2D(d_idataPL,
+    checkCudaErrors(cudaMemcpy2D(d_idataPL,
+                                 d_pitchBytes,
+                                 h_idata,
+                                 h_pitchBytes,
+                                 nx * sizeof(float),
+                                 ny,
+                                 // CHECK: hipMemcpyHostToDevice));
+                                 cudaMemcpyHostToDevice));
+
+    // Array
+    // CHECK: checkCudaErrors(hipMemcpyToArray(d_idataArray,
+    checkCudaErrors(cudaMemcpyToArray(d_idataArray,
+                                      0,
+                                      0,
+                                      h_idata,
+                                      nx * ny * sizeof(float),
+                                      // CHECK: hipMemcpyHostToDevice));
+                                      cudaMemcpyHostToDevice));
+
+    // Bind texture to memory
+    // Pitch linear
+    texRefPL.normalized = 1;
+    // CHECK: texRefPL.filterMode = hipFilterModePoint;
+    // CHECK: texRefPL.addressMode[0] = hipAddressModeWrap;
+    // CHECK: texRefPL.addressMode[1] = hipAddressModeWrap;
+    texRefPL.filterMode = cudaFilterModePoint;
+    texRefPL.addressMode[0] = cudaAddressModeWrap;
+    texRefPL.addressMode[1] = cudaAddressModeWrap;
+    // CHECK: checkCudaErrors(hipBindTexture2D(0,
+    checkCudaErrors(cudaBindTexture2D(0,
+                                      &texRefPL,
+                                      d_idataPL,
+                                      &channelDesc,
+                                      nx,
+                                      ny,
+                                      d_pitchBytes));
+
+    // Array
+    texRefArray.normalized = 1;
+    // CHECK: texRefArray.filterMode = hipFilterModePoint;
+    // CHECK: texRefArray.addressMode[0] = hipAddressModeWrap;
+    // CHECK: texRefArray.addressMode[1] = hipAddressModeWrap;
+    texRefArray.filterMode = cudaFilterModePoint;
+    texRefArray.addressMode[0] = cudaAddressModeWrap;
+    texRefArray.addressMode[1] = cudaAddressModeWrap;
+    // CHECK: checkCudaErrors(hipBindTextureToArray(texRefArray,
+    checkCudaErrors(cudaBindTextureToArray(texRefArray,
+                                           d_idataArray,
+                                           channelDesc));
+
+    // Reference calculation
+    for (int j = 0; j < ny; ++j)
+    {
+        int jshift = (j + y_shift) % ny;
+
+        for (int i = 0; i < nx; ++i)
+        {
+            int ishift = (i + x_shift) % nx;
+            gold[j * nx + i] = h_idata[jshift * nx + ishift];
+        }
+    }
+
+    // Run ShiftPitchLinear kernel
+    // CHECK: checkCudaErrors(hipMemset2D(d_odata,
+    checkCudaErrors(cudaMemset2D(d_odata,
+                                 d_pitchBytes,
+                                 0,
+                                 nx * sizeof(float),
+                                 ny));
+    // CHECK: checkCudaErrors(hipEventRecord(start, 0));
+    checkCudaErrors(cudaEventRecord(start, 0));
+
+    for (int i = 0; i < NUM_REPS; ++i)
+    {
+        // CHECK: hipLaunchKernelGGL(shiftPitchLinear, dim3(dimGrid), dim3(dimBlock), 0, 0, d_odata,
+        shiftPitchLinear<<<dimGrid, dimBlock>>>(d_odata,
+         (int)(d_pitchBytes / sizeof(float)),
+         nx,
+         ny,
+         x_shift,
+         y_shift);
+    }
+    // CHECK: checkCudaErrors(hipEventRecord(stop, 0));
+    // CHECK: checkCudaErrors(hipEventSynchronize(stop));
+    checkCudaErrors(cudaEventRecord(stop, 0));
+    checkCudaErrors(cudaEventSynchronize(stop));
+    float timePL;
+    // CHECK: checkCudaErrors(hipEventElapsedTime(&timePL, start, stop));
+    checkCudaErrors(cudaEventElapsedTime(&timePL, start, stop));
+
+    // Check results
+    // CHECK: checkCudaErrors(hipMemcpy2D(h_odata,
+    checkCudaErrors(cudaMemcpy2D(h_odata,
+                                 h_pitchBytes,
+                                 d_odata,
+                                 d_pitchBytes,
+                                 nx * sizeof(float),
+                                 ny,
+                                 // CHECK: hipMemcpyDeviceToHost));
+                                 cudaMemcpyDeviceToHost));
+
+    bool res = compareData(gold, h_odata, nx*ny, 0.0f, 0.15f);
+
+    bTestResult = true;
+
+    if (res == false)
+    {
+        printf("*** shiftPitchLinear failed ***\n");
+        bTestResult = false;
+    }
+
+    // Run ShiftArray kernel
+    // CHECK: checkCudaErrors(hipMemset2D(d_odata,
+    checkCudaErrors(cudaMemset2D(d_odata,
+                                 d_pitchBytes,
+                                 0,
+                                 nx * sizeof(float),
+                                 ny));
+    // CHECK: checkCudaErrors(hipEventRecord(start, 0));
+    checkCudaErrors(cudaEventRecord(start, 0));
+
+    for (int i = 0; i < NUM_REPS; ++i)
+    {
+        // CHECK: hipLaunchKernelGGL(shiftArray, dim3(dimGrid), dim3(dimBlock), 0, 0, d_odata,
+        shiftArray<<<dimGrid, dimBlock>>>(d_odata,
+         (int)(d_pitchBytes / sizeof(float)),
+         nx,
+         ny,
+         x_shift,
+         y_shift);
+    }
+    // CHECK: checkCudaErrors(hipEventRecord(stop, 0));
+    // CHECK: checkCudaErrors(hipEventSynchronize(stop));
+    checkCudaErrors(cudaEventRecord(stop, 0));
+    checkCudaErrors(cudaEventSynchronize(stop));
+    float timeArray;
+    // CHECK: checkCudaErrors(hipEventElapsedTime(&timeArray, start, stop));
+    checkCudaErrors(cudaEventElapsedTime(&timeArray, start, stop));
+
+    // Check results
+    // CHECK: checkCudaErrors(hipMemcpy2D(h_odata,
+    checkCudaErrors(cudaMemcpy2D(h_odata,
+                                 h_pitchBytes,
+                                 d_odata,
+                                 d_pitchBytes,
+                                 nx * sizeof(float),
+                                 ny,
+                                 // CHECK: hipMemcpyDeviceToHost));
+                                 cudaMemcpyDeviceToHost));
+    res = compareData(gold, h_odata, nx*ny, 0.0f, 0.15f);
+
+    if (res == false)
+    {
+        printf("*** shiftArray failed ***\n");
+        bTestResult = false;
+    }
+
+    float bandwidthPL =
+        2.f * 1000.f * nx * ny * sizeof(float) /
+        (1.e+9f) / (timePL / NUM_REPS);
+    float bandwidthArray =
+        2.f * 1000.f * nx * ny * sizeof(float) /
+        (1.e+9f) / (timeArray / NUM_REPS);
+
+    printf("\nBandwidth (GB/s) for pitch linear: %.2e; for array: %.2e\n",
+           bandwidthPL, bandwidthArray);
+
+    float fetchRatePL =
+        nx * ny / 1.e+6f / (timePL / (1000.0f * NUM_REPS));
+    float fetchRateArray =
+        nx * ny / 1.e+6f / (timeArray / (1000.0f * NUM_REPS));
+
+    printf("\nTexture fetch rate (Mpix/s) for pitch linear: "
+           "%.2e; for array: %.2e\n\n",
+           fetchRatePL, fetchRateArray);
+
+    // Cleanup
+    free(h_idata);
+    free(h_odata);
+    free(gold);
+    // CHECK: checkCudaErrors(hipUnbindTexture(texRefPL));
+    // CHECK: checkCudaErrors(hipUnbindTexture(texRefArray));
+    // CHECK: checkCudaErrors(hipFree(d_idataPL));
+    // CHECK: checkCudaErrors(hipFreeArray(d_idataArray));
+    // CHECK: checkCudaErrors(hipFree(d_odata));
+    checkCudaErrors(cudaUnbindTexture(texRefPL));
+    checkCudaErrors(cudaUnbindTexture(texRefArray));
+    checkCudaErrors(cudaFree(d_idataPL));
+    checkCudaErrors(cudaFreeArray(d_idataArray));
+    checkCudaErrors(cudaFree(d_odata));
+    // CHECK: checkCudaErrors(hipEventDestroy(start));
+    // CHECK: checkCudaErrors(hipEventDestroy(stop));
+    checkCudaErrors(cudaEventDestroy(start));
+    checkCudaErrors(cudaEventDestroy(stop));
+}

--- a/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/simplePrintf/simplePrintf.cu
+++ b/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/simplePrintf/simplePrintf.cu
@@ -1,0 +1,73 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+/*
+* This software contains source code provided by NVIDIA Corporation.
+*/
+
+/*
+ * Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
+ *
+ * Please refer to the NVIDIA end user license agreement (EULA) associated
+ * with this source code for terms and conditions that govern your use of
+ * this software. Any use, reproduction, disclosure, or distribution of
+ * this software and related documentation outside the terms of the EULA
+ * is strictly prohibited.
+ *
+ */
+
+
+// System includes
+#include <stdio.h>
+#include <assert.h>
+
+// CUDA runtime
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+
+// helper functions and utilities to work with CUDA
+#include <helper_functions.h>
+#include <helper_cuda.h>
+
+#ifndef MAX
+#define MAX(a,b) (a > b ? a : b)
+#endif
+
+__global__ void testKernel(int val)
+{
+    printf("[%d, %d]:\t\tValue is:%d\n",\
+            blockIdx.y*gridDim.x+blockIdx.x,\
+            threadIdx.z*blockDim.x*blockDim.y+threadIdx.y*blockDim.x+threadIdx.x,\
+            val);
+}
+
+int main(int argc, char **argv)
+{
+    int devID;
+    // CHECK: hipDeviceProp_t props;
+    cudaDeviceProp props;
+
+    // This will pick the best possible CUDA capable device
+    devID = findCudaDevice(argc, (const char **)argv);
+
+    //Get GPU information
+    // CHECK: checkCudaErrors(hipGetDevice(&devID));
+    // CHECK: checkCudaErrors(hipGetDeviceProperties(&props, devID));
+    checkCudaErrors(cudaGetDevice(&devID));
+    checkCudaErrors(cudaGetDeviceProperties(&props, devID));
+    printf("Device %d: \"%s\" with Compute %d.%d capability\n",
+           devID, props.name, props.major, props.minor);
+
+    printf("printf() is called. Output:\n\n");
+
+    //Kernel configuration, where a two-dimensional grid and
+    //three-dimensional blocks are configured.
+    dim3 dimGrid(2, 2);
+    dim3 dimBlock(2, 2, 2);
+    // CHECK: hipLaunchKernelGGL(testKernel, dim3(dimGrid), dim3(dimBlock), 0, 0, 10);
+    testKernel<<<dimGrid, dimBlock>>>(10);
+    // CHECK: hipDeviceSynchronize();
+    cudaDeviceSynchronize();
+
+    return EXIT_SUCCESS;
+}
+

--- a/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/simpleTexture/simpleTexture.cu
+++ b/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/simpleTexture/simpleTexture.cu
@@ -1,0 +1,291 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+/*
+ * This software contains source code provided by NVIDIA Corporation.
+*/
+
+/*
+ * Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
+ *
+ * Please refer to the NVIDIA end user license agreement (EULA) associated
+ * with this source code for terms and conditions that govern your use of
+ * this software. Any use, reproduction, disclosure, or distribution of
+ * this software and related documentation outside the terms of the EULA
+ * is strictly prohibited.
+ *
+ */
+
+/*
+ * This sample demonstrates how use texture fetches in CUDA
+ *
+ * This sample takes an input PGM image (image_filename) and generates
+ * an output PGM image (image_filename_out).  This CUDA kernel performs
+ * a simple 2D transform (rotation) on the texture coordinates (u,v).
+ */
+
+// Includes, system
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <math.h>
+
+#ifdef _WIN32
+#  define WINDOWS_LEAN_AND_MEAN
+#  define NOMINMAX
+#  include <windows.h>
+#endif
+
+// Includes CUDA
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+#include <texture_fetch_functions.h>
+
+// Utilities and timing functions
+#include <helper_functions.h>    // includes cuda.h and cuda_runtime_api.h
+
+// CUDA helper functions
+#include <helper_cuda.h>         // helper functions for CUDA error check
+
+#define MAX_EPSILON_ERROR 5e-3f
+
+// Define the files that are to be save and the reference images for validation
+const char *imageFilename = "lena_bw.pgm";
+const char *refFilename   = "ref_rotated.pgm";
+
+const char *sampleName = "simpleTexture";
+
+////////////////////////////////////////////////////////////////////////////////
+// Constants
+const float angle = 0.5f;        // angle to rotate image by (in radians)
+
+// Texture reference for 2D float texture
+// CHECK: texture<float, 2, hipReadModeElementType> tex;
+texture<float, 2, cudaReadModeElementType> tex;
+
+// Auto-Verification Code
+bool testResult = true;
+
+////////////////////////////////////////////////////////////////////////////////
+//! Transform an image using texture lookups
+//! @param outputData  output data in global memory
+////////////////////////////////////////////////////////////////////////////////
+__global__ void transformKernel(float *outputData,
+                                int width,
+                                int height,
+                                float theta)
+{
+    // calculate normalized texture coordinates
+    unsigned int x = blockIdx.x*blockDim.x + threadIdx.x;
+    unsigned int y = blockIdx.y*blockDim.y + threadIdx.y;
+
+    float u = (float)x - (float)width/2; 
+    float v = (float)y - (float)height/2; 
+    float tu = u*cosf(theta) - v*sinf(theta); 
+    float tv = v*cosf(theta) + u*sinf(theta); 
+
+    tu /= (float)width; 
+    tv /= (float)height; 
+
+    // read from texture and write to global memory
+    outputData[y*width + x] = tex2D(tex, tu+0.5f, tv+0.5f);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Declaration, forward
+void runTest(int argc, char **argv);
+
+////////////////////////////////////////////////////////////////////////////////
+// Program main
+////////////////////////////////////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+    printf("%s starting...\n", sampleName);
+
+    // Process command-line arguments
+    if (argc > 1)
+    {
+        if (checkCmdLineFlag(argc, (const char **) argv, "input"))
+        {
+            getCmdLineArgumentString(argc,
+                                     (const char **) argv,
+                                     "input",
+                                     (char **) &imageFilename);
+
+            if (checkCmdLineFlag(argc, (const char **) argv, "reference"))
+            {
+                getCmdLineArgumentString(argc,
+                                         (const char **) argv,
+                                         "reference",
+                                         (char **) &refFilename);
+            }
+            else
+            {
+                printf("-input flag should be used with -reference flag");
+                exit(EXIT_FAILURE);
+            }
+        }
+        else if (checkCmdLineFlag(argc, (const char **) argv, "reference"))
+        {
+            printf("-reference flag should be used with -input flag");
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    runTest(argc, argv);
+
+    printf("%s completed, returned %s\n",
+           sampleName,
+           testResult ? "OK" : "ERROR!");
+    exit(testResult ? EXIT_SUCCESS : EXIT_FAILURE);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+//! Run a simple test for CUDA
+////////////////////////////////////////////////////////////////////////////////
+void runTest(int argc, char **argv)
+{
+    int devID = findCudaDevice(argc, (const char **) argv);
+
+    // load image from disk
+    float *hData = NULL;
+    unsigned int width, height;
+    char *imagePath = sdkFindFilePath(imageFilename, argv[0]);
+
+    if (imagePath == NULL)
+    {
+        printf("Unable to source image file: %s\n", imageFilename);
+        exit(EXIT_FAILURE);
+    }
+
+    sdkLoadPGM(imagePath, &hData, &width, &height);
+
+    unsigned int size = width * height * sizeof(float);
+    printf("Loaded '%s', %d x %d pixels\n", imageFilename, width, height);
+
+    //Load reference image from image (output)
+    float *hDataRef = (float *) malloc(size);
+    char *refPath = sdkFindFilePath(refFilename, argv[0]);
+
+    if (refPath == NULL)
+    {
+        printf("Unable to find reference image file: %s\n", refFilename);
+        exit(EXIT_FAILURE);
+    }
+
+    sdkLoadPGM(refPath, &hDataRef, &width, &height);
+
+    // Allocate device memory for result
+    float *dData = NULL;
+    // CHECK: checkCudaErrors(hipMalloc((void **) &dData, size));
+    checkCudaErrors(cudaMalloc((void **) &dData, size));
+
+    // Allocate array and copy image data
+    // CHECK: hipChannelFormatDesc channelDesc =
+    cudaChannelFormatDesc channelDesc =
+    // CHECK: hipCreateChannelDesc(32, 0, 0, 0, hipChannelFormatKindFloat);
+        cudaCreateChannelDesc(32, 0, 0, 0, cudaChannelFormatKindFloat);
+    // CHECK: hipArray *cuArray;
+    cudaArray *cuArray;
+    // CHECK: checkCudaErrors(hipMallocArray(&cuArray,
+    checkCudaErrors(cudaMallocArray(&cuArray,
+                                    &channelDesc,
+                                    width,
+                                    height));
+    // CHECK: checkCudaErrors(hipMemcpyToArray(cuArray,
+    checkCudaErrors(cudaMemcpyToArray(cuArray,
+                                      0,
+                                      0,
+                                      hData,
+                                      size,
+                                      cudaMemcpyHostToDevice));
+
+    // Set texture parameters
+    // CHECK: tex.addressMode[0] = hipAddressModeWrap;
+    // CHECK: tex.addressMode[1] = hipAddressModeWrap;
+    // CHECK: tex.filterMode = hipFilterModeLinear;
+    tex.addressMode[0] = cudaAddressModeWrap;
+    tex.addressMode[1] = cudaAddressModeWrap;
+    tex.filterMode = cudaFilterModeLinear;
+    tex.normalized = true;    // access with normalized texture coordinates
+
+    // Bind the array to the texture
+    // CHECK: checkCudaErrors(hipBindTextureToArray(tex, cuArray, channelDesc));
+    checkCudaErrors(cudaBindTextureToArray(tex, cuArray, channelDesc));
+
+    dim3 dimBlock(8, 8, 1);
+    dim3 dimGrid(width / dimBlock.x, height / dimBlock.y, 1);
+
+    // Warmup
+    // CHECK: hipLaunchKernelGGL(transformKernel, dim3(dimGrid), dim3(dimBlock), 0, 0, dData, width, height, angle);
+    transformKernel<<<dimGrid, dimBlock, 0>>>(dData, width, height, angle);
+    // CHECK: checkCudaErrors(hipDeviceSynchronize());
+    checkCudaErrors(cudaDeviceSynchronize());
+    StopWatchInterface *timer = NULL;
+    sdkCreateTimer(&timer);
+    sdkStartTimer(&timer);
+
+    // Execute the kernel
+    // CHECK: hipLaunchKernelGGL(transformKernel, dim3(dimGrid), dim3(dimBlock), 0, 0, dData, width, height, angle);
+    transformKernel<<<dimGrid, dimBlock, 0>>>(dData, width, height, angle);
+
+    // Check if kernel execution generated an error
+    getLastCudaError("Kernel execution failed");
+    // CHECK: checkCudaErrors(hipDeviceSynchronize());
+    checkCudaErrors(cudaDeviceSynchronize());
+    sdkStopTimer(&timer);
+    printf("Processing time: %f (ms)\n", sdkGetTimerValue(&timer));
+    printf("%.2f Mpixels/sec\n",
+           (width *height / (sdkGetTimerValue(&timer) / 1000.0f)) / 1e6);
+    sdkDeleteTimer(&timer);
+
+    // Allocate mem for the result on host side
+    float *hOutputData = (float *) malloc(size);
+    // copy result from device to host
+    // CHECK: checkCudaErrors(hipMemcpy(hOutputData,
+    checkCudaErrors(cudaMemcpy(hOutputData,
+                               dData,
+                               size,
+    // CHECK: hipMemcpyDeviceToHost));
+                               cudaMemcpyDeviceToHost));
+
+    // Write result to file
+    char outputFilename[1024];
+    strcpy(outputFilename, imagePath);
+    strcpy(outputFilename + strlen(imagePath) - 4, "_out.pgm");
+    sdkSavePGM(outputFilename, hOutputData, width, height);
+    printf("Wrote '%s'\n", outputFilename);
+
+    // Write regression file if necessary
+    if (checkCmdLineFlag(argc, (const char **) argv, "regression"))
+    {
+        // Write file for regression test
+        sdkWriteFile<float>("./data/regression.dat",
+                            hOutputData,
+                            width*height,
+                            0.0f,
+                            false);
+    }
+    else
+    {
+        // We need to reload the data from disk,
+        // because it is inverted upon output
+        sdkLoadPGM(outputFilename, &hOutputData, &width, &height);
+
+        printf("Comparing files\n");
+        printf("\toutput:    <%s>\n", outputFilename);
+        printf("\treference: <%s>\n", refPath);
+
+        testResult = compareData(hOutputData,
+                                 hDataRef,
+                                 width*height,
+                                 MAX_EPSILON_ERROR,
+                                 0.15f);
+    }
+    // CHECK: checkCudaErrors(hipFree(dData));
+    // CHECK: checkCudaErrors(hipFreeArray(cuArray));
+    checkCudaErrors(cudaFree(dData));
+    checkCudaErrors(cudaFreeArray(cuArray));
+    free(imagePath);
+    free(refPath);
+}

--- a/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/vectorAdd/vectorAdd.cu
+++ b/tests/hipify-clang/CUDA_SDK_Samples/0_Simple/vectorAdd/vectorAdd.cu
@@ -1,0 +1,222 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+/*
+* This software contains source code provided by NVIDIA Corporation.
+*/
+
+/**
+ * Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
+ *
+ * Please refer to the NVIDIA end user license agreement (EULA) associated
+ * with this source code for terms and conditions that govern your use of
+ * this software. Any use, reproduction, disclosure, or distribution of
+ * this software and related documentation outside the terms of the EULA
+ * is strictly prohibited.
+ *
+ */
+
+/**
+ * Vector addition: C = A + B.
+ *
+ * This sample is a very basic sample that implements element by element
+ * vector addition. It is the same as the sample illustrating Chapter 2
+ * of the programming guide with some additions like error checking.
+ */
+
+#include <stdio.h>
+
+// For the CUDA runtime routines (prefixed with "cuda_")
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+
+#include <helper_cuda.h>
+/**
+ * CUDA Kernel Device code
+ *
+ * Computes the vector addition of A and B into C. The 3 vectors have the same
+ * number of elements numElements.
+ */
+__global__ void
+vectorAdd(const float *A, const float *B, float *C, int numElements)
+{
+    int i = blockDim.x * blockIdx.x + threadIdx.x;
+
+    if (i < numElements)
+    {
+        C[i] = A[i] + B[i];
+    }
+}
+
+/**
+ * Host main routine
+ */
+int
+main(void)
+{
+    // Error code to check return values for CUDA calls
+    // CHECK: hipError_t err = hipSuccess;
+    cudaError_t err = cudaSuccess;
+
+    // Print the vector length to be used, and compute its size
+    int numElements = 50000;
+    size_t size = numElements * sizeof(float);
+    printf("[Vector addition of %d elements]\n", numElements);
+
+    // Allocate the host input vector A
+    float *h_A = (float *)malloc(size);
+
+    // Allocate the host input vector B
+    float *h_B = (float *)malloc(size);
+
+    // Allocate the host output vector C
+    float *h_C = (float *)malloc(size);
+
+    // Verify that allocations succeeded
+    if (h_A == NULL || h_B == NULL || h_C == NULL)
+    {
+        fprintf(stderr, "Failed to allocate host vectors!\n");
+        exit(EXIT_FAILURE);
+    }
+
+    // Initialize the host input vectors
+    for (int i = 0; i < numElements; ++i)
+    {
+        h_A[i] = rand()/(float)RAND_MAX;
+        h_B[i] = rand()/(float)RAND_MAX;
+    }
+
+    // Allocate the device input vector A
+    float *d_A = NULL;
+    // CHECK: err = hipMalloc((void **)&d_A, size);
+    err = cudaMalloc((void **)&d_A, size);
+    // CHECK: if (err != hipSuccess)
+    if (err != cudaSuccess)
+    {
+        // CHECK: fprintf(stderr, "Failed to allocate device vector A (error code %s)!\n", hipGetErrorString(err));
+        fprintf(stderr, "Failed to allocate device vector A (error code %s)!\n", cudaGetErrorString(err));
+        exit(EXIT_FAILURE);
+    }
+
+    // Allocate the device input vector B
+    float *d_B = NULL;
+    // CHECK: err = hipMalloc((void **)&d_B, size);
+    err = cudaMalloc((void **)&d_B, size);
+    // CHECK: if (err != hipSuccess)
+    if (err != cudaSuccess)
+    {
+        // CHECK: fprintf(stderr, "Failed to allocate device vector B (error code %s)!\n", hipGetErrorString(err));
+        fprintf(stderr, "Failed to allocate device vector B (error code %s)!\n", cudaGetErrorString(err));
+        exit(EXIT_FAILURE);
+    }
+
+    // Allocate the device output vector C
+    float *d_C = NULL;
+    // CHECK: err = hipMalloc((void **)&d_C, size);
+    err = cudaMalloc((void **)&d_C, size);
+    // CHECK: if (err != hipSuccess)
+    if (err != cudaSuccess)
+    {
+        // CHECK: fprintf(stderr, "Failed to allocate device vector C (error code %s)!\n", hipGetErrorString(err));
+        fprintf(stderr, "Failed to allocate device vector C (error code %s)!\n", cudaGetErrorString(err));
+        exit(EXIT_FAILURE);
+    }
+
+    // Copy the host input vectors A and B in host memory to the device input vectors in
+    // device memory
+    printf("Copy input data from the host memory to the CUDA device\n");
+    // CHECK: err = hipMemcpy(d_A, h_A, size, hipMemcpyHostToDevice);
+    err = cudaMemcpy(d_A, h_A, size, cudaMemcpyHostToDevice);
+    // CHECK: if (err != hipSuccess)
+    if (err != cudaSuccess)
+    {
+        // CHECK: fprintf(stderr, "Failed to copy vector A from host to device (error code %s)!\n", hipGetErrorString(err));
+        fprintf(stderr, "Failed to copy vector A from host to device (error code %s)!\n", cudaGetErrorString(err));
+        exit(EXIT_FAILURE);
+    }
+
+    // CHECK: err = hipMemcpy(d_B, h_B, size, hipMemcpyHostToDevice);
+    err = cudaMemcpy(d_B, h_B, size, cudaMemcpyHostToDevice);
+    // CHECK: if (err != hipSuccess)
+    if (err != cudaSuccess)
+    {
+        // CHECK: fprintf(stderr, "Failed to copy vector B from host to device (error code %s)!\n", hipGetErrorString(err));
+        fprintf(stderr, "Failed to copy vector B from host to device (error code %s)!\n", cudaGetErrorString(err));
+        exit(EXIT_FAILURE);
+    }
+
+    // Launch the Vector Add CUDA Kernel
+    int threadsPerBlock = 256;
+    int blocksPerGrid =(numElements + threadsPerBlock - 1) / threadsPerBlock;
+    printf("CUDA kernel launch with %d blocks of %d threads\n", blocksPerGrid, threadsPerBlock);
+    // CHECK: hipLaunchKernelGGL(vectorAdd, dim3(blocksPerGrid), dim3(threadsPerBlock), 0, 0, d_A, d_B, d_C, numElements);
+    vectorAdd<<<blocksPerGrid, threadsPerBlock>>>(d_A, d_B, d_C, numElements);
+    // CHECK: err = hipGetLastError();
+    err = cudaGetLastError();
+    // CHECK: if (err != hipSuccess)
+    if (err != cudaSuccess)
+    {
+        // CHECK: fprintf(stderr, "Failed to launch vectorAdd kernel (error code %s)!\n", hipGetErrorString(err));
+        fprintf(stderr, "Failed to launch vectorAdd kernel (error code %s)!\n", cudaGetErrorString(err));
+        exit(EXIT_FAILURE);
+    }
+
+    // Copy the device result vector in device memory to the host result vector
+    // in host memory.
+    printf("Copy output data from the CUDA device to the host memory\n");
+    // CHECK: err = hipMemcpy(h_C, d_C, size, hipMemcpyDeviceToHost);
+    err = cudaMemcpy(h_C, d_C, size, cudaMemcpyDeviceToHost);
+    // CHECK: if (err != hipSuccess)
+    if (err != cudaSuccess)
+    {
+        // CHECK: fprintf(stderr, "Failed to copy vector C from device to host (error code %s)!\n", hipGetErrorString(err));
+        fprintf(stderr, "Failed to copy vector C from device to host (error code %s)!\n", cudaGetErrorString(err));
+        exit(EXIT_FAILURE);
+    }
+
+    // Verify that the result vector is correct
+    for (int i = 0; i < numElements; ++i)
+    {
+        if (fabs(h_A[i] + h_B[i] - h_C[i]) > 1e-5)
+        {
+            fprintf(stderr, "Result verification failed at element %d!\n", i);
+            exit(EXIT_FAILURE);
+        }
+    }
+
+    printf("Test PASSED\n");
+
+    // Free device global memory
+    // CHECK: err = hipFree(d_A);
+    err = cudaFree(d_A);
+    // CHECK: if (err != hipSuccess)
+    if (err != cudaSuccess)
+    {
+        fprintf(stderr, "Failed to free device vector A (error code %s)!\n", cudaGetErrorString(err));
+        exit(EXIT_FAILURE);
+    }
+    // CHECK: err = hipFree(d_B);
+    err = cudaFree(d_B);
+    // CHECK: if (err != hipSuccess)
+    if (err != cudaSuccess)
+    {
+        fprintf(stderr, "Failed to free device vector B (error code %s)!\n", cudaGetErrorString(err));
+        exit(EXIT_FAILURE);
+    }
+    // CHECK: err = hipFree(d_C);
+    err = cudaFree(d_C);
+    // CHECK: if (err != hipSuccess)
+    if (err != cudaSuccess)
+    {
+        fprintf(stderr, "Failed to free device vector C (error code %s)!\n", cudaGetErrorString(err));
+        exit(EXIT_FAILURE);
+    }
+
+    // Free host memory
+    free(h_A);
+    free(h_B);
+    free(h_C);
+
+    printf("Done\n");
+    return 0;
+}
+

--- a/tests/hipify-clang/CUDA_SDK_Samples/1_Utilities/p2pBandwidthLatencyTest/p2pBandwidthLatencyTest.cu
+++ b/tests/hipify-clang/CUDA_SDK_Samples/1_Utilities/p2pBandwidthLatencyTest/p2pBandwidthLatencyTest.cu
@@ -1,0 +1,603 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+/*
+* This software contains source code provided by NVIDIA Corporation.
+*/
+
+/*
+ * Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
+ *
+ * Please refer to the NVIDIA end user license agreement (EULA) associated
+ * with this source code for terms and conditions that govern your use of
+ * this software. Any use, reproduction, disclosure, or distribution of
+ * this software and related documentation outside the terms of the EULA
+ * is strictly prohibited.
+ *
+ */
+
+#include <cstdio>
+#include <vector>
+
+#include <helper_cuda.h>
+
+using namespace std;
+
+const char *sSampleName = "P2P (Peer-to-Peer) GPU Bandwidth Latency Test";
+
+//Macro for checking cuda errors following a cuda launch or api call
+
+// CHECK: #define cudaCheckError() {                                          \
+// CHECK: hipError_t e=hipGetLastError();                                 \
+// CHECK: if(e!=hipSuccess) {                                              \
+// CHECK: printf("Cuda failure %s:%d: '%s'\n",__FILE__,__LINE__,hipGetErrorString(e));           \
+// CHECK: exit(EXIT_FAILURE);                                           \
+// CHECK: }                                                                 \
+// CHECK: }
+#define cudaCheckError() {                                          \
+        cudaError_t e=cudaGetLastError();                                 \
+        if(e!=cudaSuccess) {                                              \
+            printf("Cuda failure %s:%d: '%s'\n",__FILE__,__LINE__,cudaGetErrorString(e));           \
+            exit(EXIT_FAILURE);                                           \
+        }                                                                 \
+    }
+__global__ void delay(int * null) {
+  float j=threadIdx.x;
+  for(int i=1;i<10000;i++)
+      j=(j+1)/j;
+
+  if(threadIdx.x == j) null[0] = j;
+}
+
+void checkP2Paccess(int numGPUs)
+{
+    for (int i=0; i<numGPUs; i++)
+    {
+        // CHECK: hipSetDevice(i);
+        cudaSetDevice(i);
+
+        for (int j=0; j<numGPUs; j++)
+        {
+            int access;
+            if (i!=j)
+            {
+                // CHECK: hipDeviceCanAccessPeer(&access,i,j);
+                cudaDeviceCanAccessPeer(&access,i,j);
+                printf("Device=%d %s Access Peer Device=%d\n", i, access ? "CAN" : "CANNOT", j);
+            }
+        }
+    }
+    printf("\n***NOTE: In case a device doesn't have P2P access to other one, it falls back to normal memcopy procedure.\nSo you can see lesser Bandwidth (GB/s) in those cases.\n\n");
+}
+
+void outputBandwidthMatrix(int numGPUs, bool p2p)
+{
+    int numElems=10000000;
+    int repeat=5;
+    vector<int *> buffers(numGPUs);
+    vector<int *> buffersD2D(numGPUs); // buffer for D2D, that is, intra-GPU copy
+    // CHECK: vector<hipEvent_t> start(numGPUs);
+    // CHECK: vector<hipEvent_t> stop(numGPUs);
+    vector<cudaEvent_t> start(numGPUs);
+    vector<cudaEvent_t> stop(numGPUs);
+
+    for (int d=0; d<numGPUs; d++)
+    {
+        // CHECK: hipSetDevice(d);
+        // CHECK: hipMalloc(&buffers[d],numElems*sizeof(int));
+        // CHECK: hipMalloc(&buffersD2D[d],numElems*sizeof(int));
+        cudaSetDevice(d);
+        cudaMalloc(&buffers[d],numElems*sizeof(int));
+        cudaMalloc(&buffersD2D[d],numElems*sizeof(int));
+        cudaCheckError();
+        // CHECK: hipEventCreate(&start[d]);
+        cudaEventCreate(&start[d]);
+        cudaCheckError();
+        // CHECK: hipEventCreate(&stop[d]);
+        cudaEventCreate(&stop[d]);
+        cudaCheckError();
+    }
+
+    vector<double> bandwidthMatrix(numGPUs*numGPUs);
+
+    for (int i=0; i<numGPUs; i++)
+    {
+        // CHECK: hipSetDevice(i);
+        cudaSetDevice(i);
+
+        for (int j=0; j<numGPUs; j++)
+        {
+            int access;
+            if(p2p) {
+                // CHECK: hipDeviceCanAccessPeer(&access,i,j);
+                cudaDeviceCanAccessPeer(&access,i,j);
+                if (access)
+                {
+                    // CHECK: hipDeviceEnablePeerAccess(j,0 );
+                    cudaDeviceEnablePeerAccess(j,0 );
+                    cudaCheckError();
+                    // CHECK: hipSetDevice(j);
+                    cudaSetDevice(j);
+                    // CHECK: hipDeviceEnablePeerAccess(i,0 );
+                    cudaDeviceEnablePeerAccess(i,0 );
+                    // CHECK: hipSetDevice(i);
+                    cudaSetDevice(i);
+                    cudaCheckError();
+                }
+            }
+            // CHECK: hipDeviceSynchronize();
+            cudaDeviceSynchronize();
+            cudaCheckError();
+            // CHECK: hipLaunchKernelGGL(delay, dim3(1), dim3(1), 0, 0, (int *)NULL);
+            delay<<<1,1>>>((int *)NULL);
+            // CHECK: hipEventRecord(start[i]);
+            cudaEventRecord(start[i]);
+
+            if (i==j)
+            {
+                // Perform intra-GPU, D2D copies
+                for (int r=0; r<repeat; r++)
+                {
+                    // CHECK: hipMemcpyPeerAsync(buffers[i],i,buffersD2D[i],i,sizeof(int)*numElems);
+                    cudaMemcpyPeerAsync(buffers[i],i,buffersD2D[i],i,sizeof(int)*numElems);
+                }
+            }
+            else
+            {
+                for (int r=0; r<repeat; r++)
+                {
+                    // CHECK: hipMemcpyPeerAsync(buffers[i],i,buffers[j],j,sizeof(int)*numElems);
+                    cudaMemcpyPeerAsync(buffers[i],i,buffers[j],j,sizeof(int)*numElems);
+                }
+            }
+            // CHECK: hipEventRecord(stop[i]);
+            // CHECK: hipDeviceSynchronize();
+            cudaEventRecord(stop[i]);
+            cudaDeviceSynchronize();
+            cudaCheckError();
+
+            float time_ms;
+            // CHECK: hipEventElapsedTime(&time_ms,start[i],stop[i]);
+            cudaEventElapsedTime(&time_ms,start[i],stop[i]);
+            double time_s=time_ms/1e3;
+
+            double gb=numElems*sizeof(int)*repeat/(double)1e9;
+            if(i==j) gb*=2;  //must count both the read and the write here
+            bandwidthMatrix[i*numGPUs+j]=gb/time_s;
+            if (p2p && access)
+            {
+                // CHECK: hipDeviceDisablePeerAccess(j);
+                // CHECK: hipSetDevice(j);
+                // CHECK: hipDeviceDisablePeerAccess(i);
+                // CHECK: hipSetDevice(i);
+                cudaDeviceDisablePeerAccess(j);
+                cudaSetDevice(j);
+                cudaDeviceDisablePeerAccess(i);
+                cudaSetDevice(i);
+                cudaCheckError();
+            }
+        }
+    }
+
+    printf("   D\\D");
+
+    for (int j=0; j<numGPUs; j++)
+    {
+        printf("%6d ", j);
+    }
+
+    printf("\n");
+
+    for (int i=0; i<numGPUs; i++)
+    {
+        printf("%6d ",i);
+
+        for (int j=0; j<numGPUs; j++)
+        {
+            printf("%6.02f ", bandwidthMatrix[i*numGPUs+j]);
+        }
+
+        printf("\n");
+    }
+
+    for (int d=0; d<numGPUs; d++)
+    {
+        // CHECK: hipSetDevice(d);
+        // CHECK: hipFree(buffers[d]);
+        // CHECK: hipFree(buffersD2D[d]);
+        cudaSetDevice(d);
+        cudaFree(buffers[d]);
+        cudaFree(buffersD2D[d]);
+        cudaCheckError();
+        // CHECK: hipEventDestroy(start[d]);
+        cudaEventDestroy(start[d]);
+        cudaCheckError();
+        // CHECK: hipEventDestroy(stop[d]);
+        cudaEventDestroy(stop[d]);
+        cudaCheckError();
+    }
+}
+
+void outputBidirectionalBandwidthMatrix(int numGPUs, bool p2p)
+{
+    int numElems=10000000;
+    int repeat=5;
+    vector<int *> buffers(numGPUs);
+    vector<int *> buffersD2D(numGPUs);
+    // CHECK: vector<hipEvent_t> start(numGPUs);
+    // CHECK: vector<hipEvent_t> stop(numGPUs);
+    // CHECK: vector<hipStream_t> stream0(numGPUs);
+    // CHECK: vector<hipStream_t> stream1(numGPUs);
+    vector<cudaEvent_t> start(numGPUs);
+    vector<cudaEvent_t> stop(numGPUs);
+    vector<cudaStream_t> stream0(numGPUs);
+    vector<cudaStream_t> stream1(numGPUs);
+
+    for (int d=0; d<numGPUs; d++)
+    {
+        // CHECK: hipSetDevice(d);
+        // CHECK: hipMalloc(&buffers[d],numElems*sizeof(int));
+        // CHECK: hipMalloc(&buffersD2D[d],numElems*sizeof(int));
+        cudaSetDevice(d);
+        cudaMalloc(&buffers[d],numElems*sizeof(int));
+        cudaMalloc(&buffersD2D[d],numElems*sizeof(int));
+        cudaCheckError();
+        // CHECK: hipEventCreate(&start[d]);
+        cudaEventCreate(&start[d]);
+        cudaCheckError();
+        // CHECK: hipEventCreate(&stop[d]);
+        cudaEventCreate(&stop[d]);
+        cudaCheckError();
+        // CHECK: hipStreamCreate(&stream0[d]);
+        cudaStreamCreate(&stream0[d]);
+        cudaCheckError();
+        // CHECK: hipStreamCreate(&stream1[d]);
+        cudaStreamCreate(&stream1[d]);
+        cudaCheckError();
+    }
+
+    vector<double> bandwidthMatrix(numGPUs*numGPUs);
+
+    for (int i=0; i<numGPUs; i++)
+    {
+        // CHECK: hipSetDevice(i);
+        cudaSetDevice(i);
+
+        for (int j=0; j<numGPUs; j++)
+        {
+            int access;
+            if(p2p) {
+                // CHECK: hipDeviceCanAccessPeer(&access,i,j);
+                cudaDeviceCanAccessPeer(&access,i,j);
+                if (access)
+                {
+                    // CHECK: hipSetDevice(i);
+                    // CHECK: hipDeviceEnablePeerAccess(j,0);
+                    cudaSetDevice(i);
+                    cudaDeviceEnablePeerAccess(j,0);
+                    cudaCheckError();
+                    // CHECK: hipSetDevice(j);
+                    // CHECK: hipDeviceEnablePeerAccess(i,0);
+                    cudaSetDevice(j);
+                    cudaDeviceEnablePeerAccess(i,0);
+                    cudaCheckError();
+                }
+            }
+            // CHECK: hipSetDevice(i);
+            // CHECK: hipDeviceSynchronize();
+            cudaSetDevice(i);
+            cudaDeviceSynchronize();
+            cudaCheckError();
+            // CHECK: hipLaunchKernelGGL(delay, dim3(1), dim3(1), 0, 0, (int *)NULL);
+            // CHECK: hipEventRecord(start[i]);
+            delay<<<1,1>>>((int *)NULL);
+            cudaEventRecord(start[i]);
+
+            if (i==j)
+            {
+                // For intra-GPU perform 2 memcopies buffersD2D <-> buffers
+                for (int r=0; r<repeat; r++)
+                {
+                    // CHECK: hipMemcpyPeerAsync(buffers[i], i, buffersD2D[i],i,sizeof(int)*numElems,stream0[i]);
+                    // CHECK: hipMemcpyPeerAsync(buffersD2D[i], i, buffers[i],i,sizeof(int)*numElems,stream1[i]);
+                    cudaMemcpyPeerAsync(buffers[i], i, buffersD2D[i],i,sizeof(int)*numElems,stream0[i]);
+                    cudaMemcpyPeerAsync(buffersD2D[i], i, buffers[i],i,sizeof(int)*numElems,stream1[i]);
+                }
+            }
+            else
+            {
+                for (int r=0; r<repeat; r++)
+                {
+                    // CHECK: hipMemcpyPeerAsync(buffers[i],i,buffers[j],j,sizeof(int)*numElems,stream0[i]);
+                    // CHECK: hipMemcpyPeerAsync(buffers[j],j,buffers[i],i,sizeof(int)*numElems,stream1[i]);
+                    cudaMemcpyPeerAsync(buffers[i],i,buffers[j],j,sizeof(int)*numElems,stream0[i]);
+                    cudaMemcpyPeerAsync(buffers[j],j,buffers[i],i,sizeof(int)*numElems,stream1[i]);
+                }
+            }
+            // CHECK: hipEventRecord(stop[i]);
+            // CHECK: hipDeviceSynchronize();
+            cudaEventRecord(stop[i]);
+            cudaDeviceSynchronize();
+            cudaCheckError();
+
+            float time_ms;
+            // CHECK: hipEventElapsedTime(&time_ms,start[i],stop[i]);
+            cudaEventElapsedTime(&time_ms,start[i],stop[i]);
+            double time_s=time_ms/1e3;
+
+            double gb=2.0*numElems*sizeof(int)*repeat/(double)1e9;
+            if(i==j) gb*=2;  //must count both the read and the write here
+            bandwidthMatrix[i*numGPUs+j]=gb/time_s;
+            if(p2p && access)
+            {
+                // CHECK: hipSetDevice(i);
+                // CHECK: hipDeviceDisablePeerAccess(j);
+                // CHECK: hipSetDevice(j);
+                // CHECK: hipDeviceDisablePeerAccess(i);
+                cudaSetDevice(i);
+                cudaDeviceDisablePeerAccess(j);
+                cudaSetDevice(j);
+                cudaDeviceDisablePeerAccess(i);
+            }
+        }
+    }
+
+    printf("   D\\D");
+
+    for (int j=0; j<numGPUs; j++)
+    {
+        printf("%6d ", j);
+    }
+
+    printf("\n");
+
+    for (int i=0; i<numGPUs; i++)
+    {
+        printf("%6d ",i);
+
+        for (int j=0; j<numGPUs; j++)
+        {
+            printf("%6.02f ", bandwidthMatrix[i*numGPUs+j]);
+        }
+
+        printf("\n");
+    }
+
+    for (int d=0; d<numGPUs; d++)
+    {
+        // CHECK: hipSetDevice(d);
+        // CHECK: hipFree(buffers[d]);
+        // CHECK: hipFree(buffersD2D[d]);
+        cudaSetDevice(d);
+        cudaFree(buffers[d]);
+        cudaFree(buffersD2D[d]);
+        cudaCheckError();
+        // CHECK: hipEventDestroy(start[d]);
+        cudaEventDestroy(start[d]);
+        cudaCheckError();
+        // CHECK: hipEventDestroy(stop[d]);
+        cudaEventDestroy(stop[d]);
+        cudaCheckError();
+        // CHECK: hipStreamDestroy(stream0[d]);
+        cudaStreamDestroy(stream0[d]);
+        cudaCheckError();
+        // CHECK: hipStreamDestroy(stream1[d]);
+        cudaStreamDestroy(stream1[d]);
+        cudaCheckError();
+    }
+}
+
+void outputLatencyMatrix(int numGPUs, bool p2p)
+{
+    int repeat=10000;
+    vector<int *> buffers(numGPUs);
+    vector<int *> buffersD2D(numGPUs);  // buffer for D2D, that is, intra-GPU copy
+    // CHECK: vector<hipEvent_t> start(numGPUs);
+    // CHECK: vector<hipEvent_t> stop(numGPUs);
+    vector<cudaEvent_t> start(numGPUs);
+    vector<cudaEvent_t> stop(numGPUs);
+
+    for (int d=0; d<numGPUs; d++)
+    {
+        // CHECK: hipSetDevice(d);
+        // CHECK: hipMalloc(&buffers[d],1);
+        // CHECK: hipMalloc(&buffersD2D[d],1);
+        cudaSetDevice(d);
+        cudaMalloc(&buffers[d],1);
+        cudaMalloc(&buffersD2D[d],1);
+        cudaCheckError();
+        // CHECK: hipEventCreate(&start[d]);
+        cudaEventCreate(&start[d]);
+        cudaCheckError();
+        // CHECK: hipEventCreate(&stop[d]);
+        cudaEventCreate(&stop[d]);
+        cudaCheckError();
+    }
+
+    vector<double> latencyMatrix(numGPUs*numGPUs);
+
+    for (int i=0; i<numGPUs; i++)
+    {
+        // CHECK: hipSetDevice(i);
+        cudaSetDevice(i);
+
+        for (int j=0; j<numGPUs; j++)
+        {
+            int access;
+            if(p2p) {
+                // CHECK: hipDeviceCanAccessPeer(&access,i,j);
+                cudaDeviceCanAccessPeer(&access,i,j);
+                if (access)
+                {
+                    // CHECK: hipDeviceEnablePeerAccess(j,0);
+                    cudaDeviceEnablePeerAccess(j,0);
+                    cudaCheckError();
+                    // CHECK: hipSetDevice(j);
+                    // CHECK: hipDeviceEnablePeerAccess(i,0 );
+                    // CHECK: hipSetDevice(i);
+                    cudaSetDevice(j);
+                    cudaDeviceEnablePeerAccess(i,0 );
+                    cudaSetDevice(i);
+                    cudaCheckError();
+                }
+            }
+            // CHECK: hipDeviceSynchronize();
+            cudaDeviceSynchronize();
+            cudaCheckError();
+            // CHECK: hipLaunchKernelGGL(delay, dim3(1), dim3(1), 0, 0, (int *)NULL);
+            delay<<<1,1>>>((int *)NULL);
+            // CHECK: hipEventRecord(start[i]);
+            cudaEventRecord(start[i]);
+
+            if (i==j)
+            {
+                // Perform intra-GPU, D2D copies
+                for (int r=0; r<repeat; r++)
+                {
+                    // CHECK: hipMemcpyPeerAsync(buffers[i],i,buffersD2D[i],i,1);
+                    cudaMemcpyPeerAsync(buffers[i],i,buffersD2D[i],i,1);
+                }
+            }
+            else
+            {
+                for (int r=0; r<repeat; r++)
+                {
+                    // CHECK: hipMemcpyPeerAsync(buffers[j],j,buffers[i],i,1);
+                    cudaMemcpyPeerAsync(buffers[j],j,buffers[i],i,1); // Peform P2P writes
+                }
+            }
+
+            // CHECK: hipEventRecord(stop[i]);
+            // CHECK: hipDeviceSynchronize();
+            cudaEventRecord(stop[i]);
+            cudaDeviceSynchronize();
+            cudaCheckError();
+
+            float time_ms;
+            // CHECK: hipEventElapsedTime(&time_ms,start[i],stop[i]);
+            cudaEventElapsedTime(&time_ms,start[i],stop[i]);
+
+            latencyMatrix[i*numGPUs+j]=time_ms*1e3/repeat;
+            if(p2p && access)
+            {
+                // CHECK: hipDeviceDisablePeerAccess(j);
+                // CHECK: hipSetDevice(j);
+                // CHECK: hipDeviceDisablePeerAccess(i);
+                // CHECK: hipSetDevice(i);
+                cudaDeviceDisablePeerAccess(j);
+                cudaSetDevice(j);
+                cudaDeviceDisablePeerAccess(i);
+                cudaSetDevice(i);
+                cudaCheckError();
+            }
+        }
+    }
+
+    printf("   D\\D");
+
+    for (int j=0; j<numGPUs; j++)
+    {
+        printf("%6d ", j);
+    }
+
+    printf("\n");
+
+    for (int i=0; i<numGPUs; i++)
+    {
+        printf("%6d ",i);
+
+        for (int j=0; j<numGPUs; j++)
+        {
+            printf("%6.02f ", latencyMatrix[i*numGPUs+j]);
+        }
+
+        printf("\n");
+    }
+
+    for (int d=0; d<numGPUs; d++)
+    {
+        // CHECK: hipSetDevice(d);
+        // CHECK: hipFree(buffers[d]);
+        // CHECK: hipFree(buffersD2D[d]);
+        cudaSetDevice(d);
+        cudaFree(buffers[d]);
+        cudaFree(buffersD2D[d]);
+        cudaCheckError();
+        // CHECK: hipEventDestroy(start[d]);
+        cudaEventDestroy(start[d]);
+        cudaCheckError();
+        // CHECK: hipEventDestroy(stop[d]);
+        cudaEventDestroy(stop[d]);
+        cudaCheckError();
+    }
+}
+
+int main(int argc, char **argv)
+{
+
+    int numGPUs;
+    // CHECK: hipGetDeviceCount(&numGPUs);
+    cudaGetDeviceCount(&numGPUs);
+
+    printf("[%s]\n", sSampleName);
+
+    //output devices
+    for (int i=0; i<numGPUs; i++)
+    {
+        // CHECK: hipDeviceProp_t prop;
+        // CHECK: hipGetDeviceProperties(&prop,i);
+        cudaDeviceProp prop;
+        cudaGetDeviceProperties(&prop,i);
+        printf("Device: %d, %s, pciBusID: %x, pciDeviceID: %x, pciDomainID:%x\n",i,prop.name, prop.pciBusID, prop.pciDeviceID, prop.pciDomainID);
+    }
+
+    checkP2Paccess(numGPUs);
+
+    //Check peer-to-peer connectivity
+    printf("P2P Connectivity Matrix\n");
+    printf("     D\\D");
+
+    for (int j=0; j<numGPUs; j++)
+    {
+        printf("%6d", j);
+    }
+    printf("\n");
+
+    for (int i=0; i<numGPUs; i++)
+    {
+        printf("%6d\t", i);
+        for (int j=0; j<numGPUs; j++)
+        {
+            if (i!=j)
+            {
+               int access;
+               // CHECK: hipDeviceCanAccessPeer(&access,i,j);
+               cudaDeviceCanAccessPeer(&access,i,j);
+               printf("%6d", (access) ? 1 : 0);
+            }
+            else
+            {
+                printf("%6d", 1);
+            }
+        }
+        printf("\n");
+    }
+
+    printf("Unidirectional P2P=Disabled Bandwidth Matrix (GB/s)\n");
+    outputBandwidthMatrix(numGPUs, false);
+    printf("Unidirectional P2P=Enabled Bandwidth Matrix (GB/s)\n");
+    outputBandwidthMatrix(numGPUs, true);
+    printf("Bidirectional P2P=Disabled Bandwidth Matrix (GB/s)\n");
+    outputBidirectionalBandwidthMatrix(numGPUs, false);
+    printf("Bidirectional P2P=Enabled Bandwidth Matrix (GB/s)\n");
+    outputBidirectionalBandwidthMatrix(numGPUs, true);
+
+
+    printf("P2P=Disabled Latency Matrix (us)\n");
+    outputLatencyMatrix(numGPUs, false);
+    printf("P2P=Enabled Latency Matrix (us)\n");
+    outputLatencyMatrix(numGPUs, true);
+
+    printf("\nNOTE: The CUDA Samples are not meant for performance measurements. Results may vary when GPU Boost is enabled.\n");
+
+    exit(EXIT_SUCCESS);
+}

--- a/tests/hipify-clang/CUDA_SDK_Samples/6_Advanced/concurrentKernels/concurentKernels.cu
+++ b/tests/hipify-clang/CUDA_SDK_Samples/6_Advanced/concurrentKernels/concurentKernels.cu
@@ -1,4 +1,9 @@
 // RUN: %run_test hipify "%s" "%t" %cuda_args
+
+/*
+* This software contains source code provided by NVIDIA Corporation.
+*/
+
 /*
  * Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
  *

--- a/tests/hipify-clang/CUDA_SDK_Samples/7_CUDALibraries/simpleCUBLAS/simpleCUBLAS.cpp
+++ b/tests/hipify-clang/CUDA_SDK_Samples/7_CUDALibraries/simpleCUBLAS/simpleCUBLAS.cpp
@@ -1,0 +1,303 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+/*
+* This software contains source code provided by NVIDIA Corporation.
+*/
+
+/*
+ * Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
+ *
+ * NOTICE TO USER:
+ *
+ * This source code is subject to NVIDIA ownership rights under U.S. and
+ * international Copyright laws.  Users and possessors of this source code
+ * are hereby granted a nonexclusive, royalty-free license to use this code
+ * in individual and commercial software.
+ *
+ * NVIDIA MAKES NO REPRESENTATION ABOUT THE SUITABILITY OF THIS SOURCE
+ * CODE FOR ANY PURPOSE.  IT IS PROVIDED "AS IS" WITHOUT EXPRESS OR
+ * IMPLIED WARRANTY OF ANY KIND.  NVIDIA DISCLAIMS ALL WARRANTIES WITH
+ * REGARD TO THIS SOURCE CODE, INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY, NONINFRINGEMENT, AND FITNESS FOR A PARTICULAR PURPOSE.
+ * IN NO EVENT SHALL NVIDIA BE LIABLE FOR ANY SPECIAL, INDIRECT, INCIDENTAL,
+ * OR CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+ * OF USE, DATA OR PROFITS,  WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+ * OR OTHER TORTIOUS ACTION,  ARISING OUT OF OR IN CONNECTION WITH THE USE
+ * OR PERFORMANCE OF THIS SOURCE CODE.
+ *
+ * U.S. Government End Users.   This source code is a "commercial item" as
+ * that term is defined at  48 C.F.R. 2.101 (OCT 1995), consisting  of
+ * "commercial computer  software"  and "commercial computer software
+ * documentation" as such terms are  used in 48 C.F.R. 12.212 (SEPT 1995)
+ * and is provided to the U.S. Government only as a commercial end item.
+ * Consistent with 48 C.F.R.12.212 and 48 C.F.R. 227.7202-1 through
+ * 227.7202-4 (JUNE 1995), all U.S. Government End Users acquire the
+ * source code with only those rights set forth herein.
+ *
+ * Any use of this source code in individual and commercial software must
+ * include, in the user documentation and internal comments to the code,
+ * the above Disclaimer and U.S. Government End Users Notice.
+ */
+
+/* This example demonstrates how to use the CUBLAS library
+ * by scaling an array of floating-point values on the device
+ * and comparing the result to the same operation performed
+ * on the host.
+ */
+
+/* Includes, system */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Includes, cuda */
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK: #include <hipblas.h>
+#include <cuda_runtime.h>
+#include <cublas_v2.h>
+#include <helper_cuda.h>
+
+/* Matrix size */
+#define N  (275)
+
+/* Host implementation of a simple version of sgemm */
+static void simple_sgemm(int n, float alpha, const float *A, const float *B,
+                         float beta, float *C)
+{
+    int i;
+    int j;
+    int k;
+
+    for (i = 0; i < n; ++i)
+    {
+        for (j = 0; j < n; ++j)
+        {
+            float prod = 0;
+
+            for (k = 0; k < n; ++k)
+            {
+                prod += A[k * n + i] * B[j * n + k];
+            }
+
+            C[j * n + i] = alpha * prod + beta * C[j * n + i];
+        }
+    }
+}
+
+/* Main */
+int main(int argc, char **argv)
+{
+    // CHECK: hipblasStatus_t status;
+    cublasStatus_t status;
+    float *h_A;
+    float *h_B;
+    float *h_C;
+    float *h_C_ref;
+    float *d_A = 0;
+    float *d_B = 0;
+    float *d_C = 0;
+    float alpha = 1.0f;
+    float beta = 0.0f;
+    int n2 = N * N;
+    int i;
+    float error_norm;
+    float ref_norm;
+    float diff;
+    // CHECK: hipblasHandle_t handle;
+    cublasHandle_t handle;
+
+    int dev = findCudaDevice(argc, (const char **) argv);
+
+    if (dev == -1)
+    {
+        return EXIT_FAILURE;
+    }
+
+    /* Initialize CUBLAS */
+    printf("simpleCUBLAS test running..\n");
+    // CHECK: status = hipblasCreate(&handle);
+    status = cublasCreate(&handle);
+    // CHECK: if (status != HIPBLAS_STATUS_SUCCESS)
+    if (status != CUBLAS_STATUS_SUCCESS)
+    {
+        fprintf(stderr, "!!!! CUBLAS initialization error\n");
+        return EXIT_FAILURE;
+    }
+
+    /* Allocate host memory for the matrices */
+    h_A = (float *)malloc(n2 * sizeof(h_A[0]));
+
+    if (h_A == 0)
+    {
+        fprintf(stderr, "!!!! host memory allocation error (A)\n");
+        return EXIT_FAILURE;
+    }
+
+    h_B = (float *)malloc(n2 * sizeof(h_B[0]));
+
+    if (h_B == 0)
+    {
+        fprintf(stderr, "!!!! host memory allocation error (B)\n");
+        return EXIT_FAILURE;
+    }
+
+    h_C = (float *)malloc(n2 * sizeof(h_C[0]));
+
+    if (h_C == 0)
+    {
+        fprintf(stderr, "!!!! host memory allocation error (C)\n");
+        return EXIT_FAILURE;
+    }
+
+    /* Fill the matrices with test data */
+    for (i = 0; i < n2; i++)
+    {
+        h_A[i] = rand() / (float)RAND_MAX;
+        h_B[i] = rand() / (float)RAND_MAX;
+        h_C[i] = rand() / (float)RAND_MAX;
+    }
+
+    /* Allocate device memory for the matrices */
+    // CHECK: if (hipMalloc((void **)&d_A, n2 * sizeof(d_A[0])) != hipSuccess)
+    if (cudaMalloc((void **)&d_A, n2 * sizeof(d_A[0])) != cudaSuccess)
+    {
+        fprintf(stderr, "!!!! device memory allocation error (allocate A)\n");
+        return EXIT_FAILURE;
+    }
+    // CHECK: if (hipMalloc((void **)&d_B, n2 * sizeof(d_B[0])) != hipSuccess)
+    if (cudaMalloc((void **)&d_B, n2 * sizeof(d_B[0])) != cudaSuccess)
+    {
+        fprintf(stderr, "!!!! device memory allocation error (allocate B)\n");
+        return EXIT_FAILURE;
+    }
+    // CHECK: if (hipMalloc((void **)&d_C, n2 * sizeof(d_C[0])) != hipSuccess)
+    if (cudaMalloc((void **)&d_C, n2 * sizeof(d_C[0])) != cudaSuccess)
+    {
+        fprintf(stderr, "!!!! device memory allocation error (allocate C)\n");
+        return EXIT_FAILURE;
+    }
+
+    /* Initialize the device matrices with the host matrices */
+    // CHECK: status = hipblasSetVector(n2, sizeof(h_A[0]), h_A, 1, d_A, 1);
+    status = cublasSetVector(n2, sizeof(h_A[0]), h_A, 1, d_A, 1);
+    // CHECK: if (status != HIPBLAS_STATUS_SUCCESS)
+    if (status != CUBLAS_STATUS_SUCCESS)
+    {
+        fprintf(stderr, "!!!! device access error (write A)\n");
+        return EXIT_FAILURE;
+    }
+    // CHECK: status = hipblasSetVector(n2, sizeof(h_B[0]), h_B, 1, d_B, 1);
+    status = cublasSetVector(n2, sizeof(h_B[0]), h_B, 1, d_B, 1);
+    // CHECK: if (status != HIPBLAS_STATUS_SUCCESS)
+    if (status != CUBLAS_STATUS_SUCCESS)
+    {
+        fprintf(stderr, "!!!! device access error (write B)\n");
+        return EXIT_FAILURE;
+    }
+    // CHECK: status = hipblasSetVector(n2, sizeof(h_C[0]), h_C, 1, d_C, 1);
+    status = cublasSetVector(n2, sizeof(h_C[0]), h_C, 1, d_C, 1);
+    // CHECK: if (status != HIPBLAS_STATUS_SUCCESS)
+    if (status != CUBLAS_STATUS_SUCCESS)
+    {
+        fprintf(stderr, "!!!! device access error (write C)\n");
+        return EXIT_FAILURE;
+    }
+
+    /* Performs operation using plain C code */
+    simple_sgemm(N, alpha, h_A, h_B, beta, h_C);
+    h_C_ref = h_C;
+
+    /* Performs operation using cublas */
+    // CHECK: status = hipblasSgemm(handle, HIPBLAS_OP_N, HIPBLAS_OP_N, N, N, N, &alpha, d_A, N, d_B, N, &beta, d_C, N);
+    status = cublasSgemm(handle, CUBLAS_OP_N, CUBLAS_OP_N, N, N, N, &alpha, d_A, N, d_B, N, &beta, d_C, N);
+    // CHECK: if (status != HIPBLAS_STATUS_SUCCESS)
+    if (status != CUBLAS_STATUS_SUCCESS)
+    {
+        fprintf(stderr, "!!!! kernel execution error.\n");
+        return EXIT_FAILURE;
+    }
+
+    /* Allocate host memory for reading back the result from device memory */
+    h_C = (float *)malloc(n2 * sizeof(h_C[0]));
+
+    if (h_C == 0)
+    {
+        fprintf(stderr, "!!!! host memory allocation error (C)\n");
+        return EXIT_FAILURE;
+    }
+
+    /* Read the result back */
+    // CHECK: status = hipblasGetVector(n2, sizeof(h_C[0]), d_C, 1, h_C, 1);
+    status = cublasGetVector(n2, sizeof(h_C[0]), d_C, 1, h_C, 1);
+    // CHECK: if (status != HIPBLAS_STATUS_SUCCESS)
+    if (status != CUBLAS_STATUS_SUCCESS)
+    {
+        fprintf(stderr, "!!!! device access error (read C)\n");
+        return EXIT_FAILURE;
+    }
+
+    /* Check result against reference */
+    error_norm = 0;
+    ref_norm = 0;
+
+    for (i = 0; i < n2; ++i)
+    {
+        diff = h_C_ref[i] - h_C[i];
+        error_norm += diff * diff;
+        ref_norm += h_C_ref[i] * h_C_ref[i];
+    }
+
+    error_norm = (float)sqrt((double)error_norm);
+    ref_norm = (float)sqrt((double)ref_norm);
+
+    if (fabs(ref_norm) < 1e-7)
+    {
+        fprintf(stderr, "!!!! reference norm is 0\n");
+        return EXIT_FAILURE;
+    }
+
+    /* Memory clean up */
+    free(h_A);
+    free(h_B);
+    free(h_C);
+    free(h_C_ref);
+    // CHECK: if (hipFree(d_A) != hipSuccess)
+    if (cudaFree(d_A) != cudaSuccess)
+    {
+        fprintf(stderr, "!!!! memory free error (A)\n");
+        return EXIT_FAILURE;
+    }
+    // CHECK: if (hipFree(d_B) != hipSuccess)
+    if (cudaFree(d_B) != cudaSuccess)
+    {
+        fprintf(stderr, "!!!! memory free error (B)\n");
+        return EXIT_FAILURE;
+    }
+    // CHECK: if (hipFree(d_C) != hipSuccess)
+    if (cudaFree(d_C) != cudaSuccess)
+    {
+        fprintf(stderr, "!!!! memory free error (C)\n");
+        return EXIT_FAILURE;
+    }
+
+    /* Shutdown */
+    // CHECK: status = hipblasDestroy(handle);
+    status = cublasDestroy(handle);
+    // CHECK: if (status != HIPBLAS_STATUS_SUCCESS)
+    if (status != CUBLAS_STATUS_SUCCESS)
+    {
+        fprintf(stderr, "!!!! shutdown error (A)\n");
+        return EXIT_FAILURE;
+    }
+
+    if (error_norm / ref_norm < 1e-6f)
+    {
+        printf("simpleCUBLAS test passed.\n");
+        exit(EXIT_SUCCESS);
+    }
+    else
+    {
+        printf("simpleCUBLAS test failed.\n");
+        exit(EXIT_FAILURE);
+    }
+}

--- a/tests/hipify-clang/axpy.cu
+++ b/tests/hipify-clang/axpy.cu
@@ -16,7 +16,6 @@
 
 template<typename T>
 __global__ void axpy(T a, T *x, T *y) {
-  // CHECK: y[hipThreadIdx_x] = a * x[hipThreadIdx_x];
   y[threadIdx.x] = a * x[threadIdx.x];
 }
 

--- a/tests/hipify-clang/cudaRegister.cu
+++ b/tests/hipify-clang/cudaRegister.cu
@@ -38,7 +38,6 @@ if(status != cudaSuccess) { \
 }
 
 __global__ void Inc1(float *Ad, float *Bd){
-  // CHECK: int tx = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
 	int tx = threadIdx.x + blockIdx.x * blockDim.x;
 	if(tx < 1 ){
 		for(int i=0;i<ITER;i++){
@@ -51,7 +50,6 @@ __global__ void Inc1(float *Ad, float *Bd){
 }
 
 __global__ void Inc2(float *Ad, float *Bd){
-  // CHECK: int tx = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
 	int tx = threadIdx.x + blockIdx.x * blockDim.x;
 	if(tx < 1024){
 		for(int i=0;i<ITER;i++){

--- a/tests/hipify-clang/lit.cfg
+++ b/tests/hipify-clang/lit.cfg
@@ -13,7 +13,7 @@ import lit.util
 config.name = 'hipify'
 
 # suffixes: CUDA source is only supported
-config.suffixes = ['.cu']
+config.suffixes = ['.cu', '.cpp']
 
 # testFormat: The test format to use to interpret tests.
 config.test_format = lit.formats.ShTest()

--- a/tests/hipify-clang/square.cu
+++ b/tests/hipify-clang/square.cu
@@ -41,8 +41,6 @@ template <typename T>
 __global__ void
 vector_square(T *C_d, const T *A_d, size_t N)
 {
-    // CHECK: size_t offset = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x);
-    // CHECK: size_t stride = hipBlockDim_x * hipGridDim_x;
     size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
     size_t stride = blockDim.x * gridDim.x;
 


### PR DESCRIPTION
As HIP has started to support vanilla CUDA syntax for threadIdx, blockIdx, blockDim and gridDim.
Other CUDA builtins are not tracked for now.