### PR TITLE
[nvccTests] Enable hipPeerToPeer_simple on nvcc

### DIFF
--- a/tests/src/p2p/hipPeerToPeer_simple.cpp
+++ b/tests/src/p2p/hipPeerToPeer_simple.cpp
@@ -23,10 +23,10 @@ THE SOFTWARE.
 // Also serves as a template for other tests.
 
 /* HIT_START
- * BUILD: %t %s ../test_common.cpp
- * RUN: %t EXCLUDE_HIP_PLATFORM all
- * RUN: %t --memcpyWithPeer EXCLUDE_HIP_PLATFORM all
- * RUN: %t --mirrorPeers EXCLUDE_HIP_PLATFORM all
+ * BUILD: %t %s ../test_common.cpp 
+ * RUN: %t EXCLUDE_HIP_PLATFORM hipcc 
+ * RUN: %t --memcpyWithPeer EXCLUDE_HIP_PLATFORM hipcc
+ * RUN: %t --mirrorPeers EXCLUDE_HIP_PLATFORM hipcc
  * HIT_END
  */
 

--- a/tests/src/p2p/hipPeerToPeer_simple.cpp
+++ b/tests/src/p2p/hipPeerToPeer_simple.cpp
@@ -23,10 +23,10 @@ THE SOFTWARE.
 // Also serves as a template for other tests.
 
 /* HIT_START
- * BUILD: %t %s ../test_common.cpp 
- * RUN: %t EXCLUDE_HIP_PLATFORM hipcc 
- * RUN: %t --memcpyWithPeer EXCLUDE_HIP_PLATFORM hipcc
- * RUN: %t --mirrorPeers EXCLUDE_HIP_PLATFORM hipcc
+ * BUILD: %t %s ../test_common.cpp
+ * RUN: %t EXCLUDE_HIP_PLATFORM hcc 
+ * RUN: %t --memcpyWithPeer EXCLUDE_HIP_PLATFORM hcc
+ * RUN: %t --mirrorPeers EXCLUDE_HIP_PLATFORM hcc
  * HIT_END
  */
 

--- a/tests/src/runtimeApi/device/hipGetDeviceAttribute.cpp
+++ b/tests/src/runtimeApi/device/hipGetDeviceAttribute.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 /* HIT_START
  * BUILD: %t %s ../../test_common.cpp
- * RUN: %t EXCLUDE_HIP_PLATFORM nvcc
+ * RUN: %t
  * HIT_END
  */
 


### PR DESCRIPTION
Enable this on on nvcc. on hipcc it is crashing in a mGPU, non-peer scenario. Looks like that needs to be fixed. 