### PR TITLE
[HIPIFY][FIX][#306] Eliminate second cuda main include directive

### DIFF
--- a/hipify-clang/src/HipifyAction.cpp
+++ b/hipify-clang/src/HipifyAction.cpp
@@ -157,11 +157,11 @@ void HipifyAction::InclusionDirective(clang::SourceLocation hash_loc,
     }
 
     // Special-casing to avoid duplication of the hip_runtime include.
+    bool secondMainInclude = false;
     if (found->second.hipName == "hip/hip_runtime.h") {
         if (insertedRuntimeHeader) {
-            return;
+          secondMainInclude = true;
         }
-
         insertedRuntimeHeader = true;
     }
 
@@ -169,22 +169,28 @@ void HipifyAction::InclusionDirective(clang::SourceLocation hash_loc,
 
     clang::SourceLocation sl = filename_range.getBegin();
     if (found->second.unsupported) {
-        // An unsupported CUDA header? Oh dear. Print a warning.
         clang::DiagnosticsEngine& DE = getCompilerInstance().getDiagnostics();
         DE.Report(sl, DE.getCustomDiagID(clang::DiagnosticsEngine::Warning, "Unsupported CUDA header"));
         return;
     }
 
-    const char *B = SM.getCharacterData(sl);
+    char *B = nullptr;
     const char *E = SM.getCharacterData(filename_range.getEnd());
-    clang::SmallString<128> includeBuffer;
     clang::StringRef newInclude;
 
     // Keep the same include type that the user gave.
-    if (is_angled) {
-        newInclude = llvm::Twine("<" + found->second.hipName + ">").toStringRef(includeBuffer);
+    if (!secondMainInclude) {
+      B = const_cast<char*>(SM.getCharacterData(sl));
+      clang::SmallString<128> includeBuffer;
+      if (is_angled) {
+          newInclude = llvm::Twine("<" + found->second.hipName + ">").toStringRef(includeBuffer);
+      } else {
+          newInclude = llvm::Twine("\"" + found->second.hipName + "\"").toStringRef(includeBuffer);
+      }
     } else {
-        newInclude = llvm::Twine("\"" + found->second.hipName + "\"").toStringRef(includeBuffer);
+      // hashLoc is location of the '#', thus replacing the whole include directive by empty newInclude starting with '#'.
+      B = const_cast<char*>(SM.getCharacterData(hash_loc));
+      sl = hash_loc;
     }
 
     ct::Replacement Rep(SM, sl, E - B, newInclude);

--- a/hipify-clang/src/HipifyAction.cpp
+++ b/hipify-clang/src/HipifyAction.cpp
@@ -174,13 +174,10 @@ void HipifyAction::InclusionDirective(clang::SourceLocation hash_loc,
         return;
     }
 
-    char *B = nullptr;
-    const char *E = SM.getCharacterData(filename_range.getEnd());
     clang::StringRef newInclude;
 
     // Keep the same include type that the user gave.
     if (!secondMainInclude) {
-      B = const_cast<char*>(SM.getCharacterData(sl));
       clang::SmallString<128> includeBuffer;
       if (is_angled) {
           newInclude = llvm::Twine("<" + found->second.hipName + ">").toStringRef(includeBuffer);
@@ -189,10 +186,10 @@ void HipifyAction::InclusionDirective(clang::SourceLocation hash_loc,
       }
     } else {
       // hashLoc is location of the '#', thus replacing the whole include directive by empty newInclude starting with '#'.
-      B = const_cast<char*>(SM.getCharacterData(hash_loc));
       sl = hash_loc;
     }
-
+    const char *B = SM.getCharacterData(sl);
+    const char *E = SM.getCharacterData(filename_range.getEnd());
     ct::Replacement Rep(SM, sl, E - B, newInclude);
     insertReplacement(Rep, clang::FullSourceLoc{sl, SM});
 }

--- a/tests/hipify-clang/headers_test_01.cu
+++ b/tests/hipify-clang/headers_test_01.cu
@@ -1,0 +1,6 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda.h>
+// CHECK-NOT: #include<cuda_runtime.h>
+#include <cuda_runtime.h>

--- a/tests/hipify-clang/headers_test_02.cu
+++ b/tests/hipify-clang/headers_test_02.cu
@@ -1,0 +1,6 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+// CHECK-NOT: #include<cuda.h>
+#include <cuda.h>


### PR DESCRIPTION
// hipified to #include<hip/hip_runtime.h>
#include<cuda.h> // 1st cuda main include (Driver API)
// to eliminate
#include<cuda_runtime.h> // 2nd cuda main include (Runtime API)

HIP has one header hip_runtime.h for both CUDA APIs, thus second cuda main include directive is eliminated entirely.