### PR TITLE
[nvcc] Enable hipGetDeviceAttribute

### DIFF
--- a/tests/src/runtimeApi/device/hipGetDeviceAttribute.cpp
+++ b/tests/src/runtimeApi/device/hipGetDeviceAttribute.cpp
@@ -23,7 +23,7 @@ THE SOFTWARE.
 
 /* HIT_START
  * BUILD: %t %s ../../test_common.cpp
- * RUN: %t EXCLUDE_HIP_PLATFORM nvcc
+ * RUN: %t
  * HIT_END
  */
 


### PR DESCRIPTION
Enable hipGetDeviceAttribute on nvcc since the issue reported earlier is now fixed