### PR TITLE
[HIPIFY][tests][win] CUDA samples root env. var is changed

### DIFF
--- a/tests/hipify-clang/lit.site.cfg.in
+++ b/tests/hipify-clang/lit.site.cfg.in
@@ -7,8 +7,10 @@ config.cuda_root = "@CUDA_TOOLKIT_ROOT_DIR@"
 if sys.platform in ['win32']:
     config.cuda_sdk_root = "@CUDA_SDK_ROOT_DIR@"
     if not config.cuda_sdk_root or config.cuda_sdk_root == "CUDA_SDK_ROOT_DIR-NOTFOUND":
-        config.cuda_samples_root = os.environ.get('NVCUDASAMPLES_ROOT')
-        if not config.cuda_samples_root or config.cuda_samples_root == "NVCUDASAMPLES_ROOT-NOTFOUND":
+        cuda_version = "@CUDA_VERSION@"
+        cuda_version = cuda_version.replace('.','_')
+        config.cuda_samples_root = os.environ.get('NVCUDASAMPLES' + cuda_version + '_ROOT')
+        if not config.cuda_samples_root:
             lit_config.fatal('No CUDA Samples dir set! Please set CUDA_SDK_ROOT_DIR.')
         config.cuda_sdk_root = config.cuda_samples_root
     config.build_type = "@CMAKE_BUILD_TYPE@"


### PR DESCRIPTION
Env. var NVCUDASAMPLES_ROOT is changed to NVCUDASAMPLESX_Y_ROOT where X - major ver, Y - minor ver.

Reason: NVCUDASAMPLES_ROOT contains path to CUDA SDK installed last, while NVCUDASAMPLESX_Y_ROOT contains samples of the same version as of CUDA_TOOLKIT_ROOT_DIR.