### PR TITLE
[HIPIFY][fix][#211] Algorithm for explicit insert of hip include directive

### DIFF
--- a/hipify-clang/src/HipifyAction.cpp
+++ b/hipify-clang/src/HipifyAction.cpp
@@ -202,7 +202,6 @@ void HipifyAction::PragmaDirective(clang::SourceLocation Loc, clang::PragmaIntro
     clang::SourceManager& SM = getCompilerInstance().getSourceManager();
     clang::Preprocessor& PP = getCompilerInstance().getPreprocessor();
     const clang::Token tok = PP.LookAhead(0);
-    clang::LangOptions DefaultLangOptions;
     StringRef Text(SM.getCharacterData(tok.getLocation()), tok.getLength());
     if (Text == "once") {
         pragmaOnce = true;

--- a/hipify-clang/src/HipifyAction.h
+++ b/hipify-clang/src/HipifyAction.h
@@ -23,6 +23,10 @@ private:
     // not, we insert it at the top of the file when we finish processing it.
     // This approach means we do the best it's possible to do w.r.t preserving the user's include order.
     bool insertedRuntimeHeader = false;
+    bool firstNotMainHeader = false;
+    bool pragmaOnce = false;
+    clang::SourceLocation firstNotMainHeaderLoc;
+    clang::SourceLocation pragmaOnceLoc;
 
     /**
      * Rewrite a string literal to refer to hip, not CUDA.
@@ -56,6 +60,11 @@ public:
                             StringRef search_path,
                             StringRef relative_path,
                             const clang::Module *imported);
+
+    /**
+    * Called by the preprocessor for each pragma directive during the non-raw lexing pass.
+    */
+    void PragmaDirective(clang::SourceLocation Loc, clang::PragmaIntroducerKind Introducer);
 
 protected:
     /**

--- a/tests/hipify-clang/headers_test_03.cu
+++ b/tests/hipify-clang/headers_test_03.cu
@@ -1,0 +1,10 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+// CHECK: #pragma once
+// CHECK-NEXT: #include <hip/hip_runtime.h>
+#pragma once
+// CHECK-NOT: #include<hip/hip_runtime.h>
+int main(int argc, char* argv[]) {
+  return 0;
+}
+

--- a/tests/hipify-clang/headers_test_03.cu
+++ b/tests/hipify-clang/headers_test_03.cu
@@ -3,7 +3,7 @@
 // CHECK: #pragma once
 // CHECK-NEXT: #include <hip/hip_runtime.h>
 #pragma once
-// CHECK-NOT: #include<hip/hip_runtime.h>
+// CHECK-NOT: #include <hip/hip_runtime.h>
 int main(int argc, char* argv[]) {
   return 0;
 }

--- a/tests/hipify-clang/headers_test_04.cu
+++ b/tests/hipify-clang/headers_test_04.cu
@@ -1,0 +1,12 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+// CHECK: #include <hip/hip_runtime.h>
+// CHECK-NEXT: #include <stdio.h>
+// CHECK-NEXT: #include <iostream>
+#include <stdio.h>
+#include <iostream>
+// CHECK-NOT: #include<hip/hip_runtime.h>
+int main(int argc, char* argv[]) {
+  return 0;
+}
+

--- a/tests/hipify-clang/headers_test_04.cu
+++ b/tests/hipify-clang/headers_test_04.cu
@@ -5,7 +5,7 @@
 // CHECK-NEXT: #include <iostream>
 #include <stdio.h>
 #include <iostream>
-// CHECK-NOT: #include<hip/hip_runtime.h>
+// CHECK-NOT: #include <hip/hip_runtime.h>
 int main(int argc, char* argv[]) {
   return 0;
 }

--- a/tests/hipify-clang/headers_test_05.cu
+++ b/tests/hipify-clang/headers_test_05.cu
@@ -1,0 +1,12 @@
+// RUN: %run_test hipify "%s" "%t" %cuda_args
+
+// CHECK: #pragma once
+// CHECK-NEXT: #include <hip/hip_runtime.h>
+#pragma once
+// CHECK-NOT: #include <hip/hip_runtime.h>
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+  return 0;
+}
+


### PR DESCRIPTION
If in source CUDA file main header (cuda_runtime.h or cuda.h) is not presented, corresponding HIP main header (hip_runtime.h) should be explicitly included in output hipified file.

[Algorithm]
1. If #pragma once is presented, HIP main header should be placed just after it;
2. Otherwise if any other (not CUDA main) header is presented, HIP main header should be placed just before it;
3. Otherwise HIP main header should be placed in the beginning of output file.

P.S.
There might be one more situation when #ifndef #define ... #endif guard for the entire file is presented (make sense for *.h, *.hpp, *.cuh files). In this case HIP main include should be placed just after such #ifdef, or after #pragma once, if it is also presented. This situation will be handled in a separate change.