### PR TITLE
[HIPIFY][tests] Remove checks on cudaBuiltins

### DIFF
--- a/tests/hipify-clang/axpy.cu
+++ b/tests/hipify-clang/axpy.cu
@@ -16,7 +16,6 @@
 
 template<typename T>
 __global__ void axpy(T a, T *x, T *y) {
-  // CHECK: y[hipThreadIdx_x] = a * x[hipThreadIdx_x];
   y[threadIdx.x] = a * x[threadIdx.x];
 }
 

--- a/tests/hipify-clang/cudaRegister.cu
+++ b/tests/hipify-clang/cudaRegister.cu
@@ -38,7 +38,6 @@ if(status != cudaSuccess) { \
 }
 
 __global__ void Inc1(float *Ad, float *Bd){
-  // CHECK: int tx = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
 	int tx = threadIdx.x + blockIdx.x * blockDim.x;
 	if(tx < 1 ){
 		for(int i=0;i<ITER;i++){
@@ -51,7 +50,6 @@ __global__ void Inc1(float *Ad, float *Bd){
 }
 
 __global__ void Inc2(float *Ad, float *Bd){
-  // CHECK: int tx = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
 	int tx = threadIdx.x + blockIdx.x * blockDim.x;
 	if(tx < 1024){
 		for(int i=0;i<ITER;i++){

--- a/tests/hipify-clang/square.cu
+++ b/tests/hipify-clang/square.cu
@@ -41,8 +41,6 @@ template <typename T>
 __global__ void
 vector_square(T *C_d, const T *A_d, size_t N)
 {
-    // CHECK: size_t offset = (hipBlockIdx_x * hipBlockDim_x + hipThreadIdx_x);
-    // CHECK: size_t stride = hipBlockDim_x * hipGridDim_x;
     size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
     size_t stride = blockDim.x * gridDim.x;
 


### PR DESCRIPTION
As HIP has started to support vanilla CUDA syntax for threadIdx, blockIdx, blockDim and gridDim.
Other CUDA builtins are not tracked for now.