### PR TITLE
temporarily disable the printf test

### DIFF
--- a/tests/src/kernel/hipPrintfKernel.cpp
+++ b/tests/src/kernel/hipPrintfKernel.cpp
@@ -18,7 +18,7 @@ THE SOFTWARE.
 */
 
 /* HIT_START
- * BUILD: %t %s ../test_common.cpp 
+ * BUILD: %t %s ../test_common.cpp EXCLUDE_HIP_PLATFORM all
  * RUN: %t
  * HIT_END
  */


### PR DESCRIPTION
until stability issue has been resolved