### PR TITLE
use assign rather than insert

### DIFF
--- a/include/hip/hcc_detail/code_object_bundle.hpp
+++ b/include/hip/hcc_detail/code_object_bundle.hpp
@@ -88,7 +88,7 @@ namespace hip_impl
                     std::copy_n(it, sizeof(y.cbuf), y.cbuf);
                     it += sizeof(y.cbuf);
 
-                    y.triple.insert(y.triple.cend(), it, it + y.triple_sz);
+                    y.triple.assign(it, it + y.triple_sz);
 
                     std::copy_n(
                         f + y.offset, y.bundle_sz, std::back_inserter(y.blob));


### PR DESCRIPTION
originally a patch to fix a build issue on RHEL 7 but actually replacing `insert` with `assign` here makes the code a bit more concise, see HCC PR  https://github.com/RadeonOpenCompute/hcc/pull/608