### PR TITLE
[HIPIFY][fix] Build against llvm 3.8.0 fixed - missing include

### DIFF
--- a/hipify-clang/src/main.cpp
+++ b/hipify-clang/src/main.cpp
@@ -36,6 +36,7 @@ THE SOFTWARE.
 #include "LLVMCompat.h"
 #include "HipifyAction.h"
 #include "ArgParse.h"
+#include "llvm/Support/Debug.h"
 
 #define DEBUG_TYPE "cuda2hip"
 


### PR DESCRIPTION
/srv/HIP/hipify-clang/src/main.cpp:134:19: error: no member named 'dbgs' in namespace 'llvm'
      DEBUG(llvm::dbgs() << "Skipped some replacements.\n");
            ~~~~~~^