### PR TITLE
__CUDA__ and __HIP__ are both defined when compiling with 'clang -x h…

### DIFF
--- a/include/hip/hip_common.h
+++ b/include/hip/hip_common.h
@@ -31,7 +31,7 @@ THE SOFTWARE.
 #endif //__HCC__
 
 // Auto enable __HIP_PLATFORM_NVCC__ if compiling with NVCC
-#if defined(__NVCC__) || (defined(__clang__) && defined(__CUDA__))
+#if defined(__NVCC__) || (defined(__clang__) && defined(__CUDA__) && !defined(__HIP__))
 #define __HIP_PLATFORM_NVCC__
 #ifdef __CUDACC__
 #define __HIPCC__


### PR DESCRIPTION
…ip', so make sure __HIP__ is not defined in the case of __HIP_PLATFORM_NVCC__.