### PR TITLE
correct use of constant address space as 2, it is 4

### DIFF
--- a/include/hip/hcc_detail/texture_functions.h
+++ b/include/hip/hcc_detail/texture_functions.h
@@ -34,14 +34,20 @@ union TData {
 };
 
 #define __TEXTURE_FUNCTIONS_DECL__ static __inline__ __device__
-#define ADDRESS_SPACE_4 __attribute__((address_space(4)))
+
+#if __hcc_workweek__ >= 18012
+#define ADDRESS_SPACE_CONST __attribute__((address_space(4)))
+#else
+#define ADDRESS_SPACE_CONST __attribute__((address_space(2)))
+#endif
+
 #define TEXTURE_PARAMETERS_INIT                                                                    \
-    unsigned int ADDRESS_SPACE_4* i = (unsigned int ADDRESS_SPACE_4*)textureObject;                \
-    unsigned int ADDRESS_SPACE_4* s = i + HIP_SAMPLER_OBJECT_OFFSET_DWORD;                         \
+    unsigned int ADDRESS_SPACE_CONST* i = (unsigned int ADDRESS_SPACE_CONST*)textureObject;                \
+    unsigned int ADDRESS_SPACE_CONST* s = i + HIP_SAMPLER_OBJECT_OFFSET_DWORD;                         \
     TData texel;
 #define TEXTURE_REF_PARAMETERS_INIT                                                                \
-    unsigned int ADDRESS_SPACE_4* i = (unsigned int ADDRESS_SPACE_4*)texRef.textureObject;         \
-    unsigned int ADDRESS_SPACE_4* s = i + HIP_SAMPLER_OBJECT_OFFSET_DWORD;                         \
+    unsigned int ADDRESS_SPACE_CONST* i = (unsigned int ADDRESS_SPACE_CONST*)texRef.textureObject;         \
+    unsigned int ADDRESS_SPACE_CONST* s = i + HIP_SAMPLER_OBJECT_OFFSET_DWORD;                         \
     TData texel;
 #define TEXTURE_SET_FLOAT *retVal = texel.f.x;
 
@@ -146,90 +152,90 @@ union TData {
 #define TEXTURE_RETURN_FLOAT_XYZW return float4(texel.f.x, texel.f.y, texel.f.z, texel.f.w);
 
 extern "C" {
-hc::short_vector::float4::vector_value_type __ockl_image_sample_1D(unsigned int ADDRESS_SPACE_4* i,
-                                                                   unsigned int ADDRESS_SPACE_4* s,
+hc::short_vector::float4::vector_value_type __ockl_image_sample_1D(unsigned int ADDRESS_SPACE_CONST* i,
+                                                                   unsigned int ADDRESS_SPACE_CONST* s,
                                                                    float c)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_1Da(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
     hc::short_vector::float2::vector_value_type c)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_2D(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
     hc::short_vector::float2::vector_value_type c)[[hc]];
 
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_2Da(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
     hc::short_vector::float4::vector_value_type c)[[hc]];
 
-float __ockl_image_sample_2Dad(unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+float __ockl_image_sample_2Dad(unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
                                hc::short_vector::float4::vector_value_type c)[[hc]];
 
-float __ockl_image_sample_2Dd(unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+float __ockl_image_sample_2Dd(unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
                               hc::short_vector::float2::vector_value_type c)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_3D(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
     hc::short_vector::float4::vector_value_type c)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_1D(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s, float c, float dx,
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s, float c, float dx,
     float dy)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_1Da(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
     hc::short_vector::float2::vector_value_type c, float dx, float dy)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_2D(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
     hc::short_vector::float2::vector_value_type c, hc::short_vector::float2::vector_value_type dx,
     hc::short_vector::float2::vector_value_type dy)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_2Da(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
     hc::short_vector::float4::vector_value_type c, hc::short_vector::float2::vector_value_type dx,
     hc::short_vector::float2::vector_value_type dy)[[hc]];
 
-float __ockl_image_sample_grad_2Dad(unsigned int ADDRESS_SPACE_4* i,
-                                    unsigned int ADDRESS_SPACE_4* s,
+float __ockl_image_sample_grad_2Dad(unsigned int ADDRESS_SPACE_CONST* i,
+                                    unsigned int ADDRESS_SPACE_CONST* s,
                                     hc::short_vector::float4::vector_value_type c,
                                     hc::short_vector::float2::vector_value_type dx,
                                     hc::short_vector::float2::vector_value_type dy)[[hc]];
 
-float __ockl_image_sample_grad_2Dd(unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+float __ockl_image_sample_grad_2Dd(unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
                                    hc::short_vector::float2::vector_value_type c,
                                    hc::short_vector::float2::vector_value_type dx,
                                    hc::short_vector::float2::vector_value_type dy)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_3D(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
     hc::short_vector::float4::vector_value_type c, hc::short_vector::float4::vector_value_type dx,
     hc::short_vector::float4::vector_value_type dy)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_1D(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s, float c, float l)[[hc]];
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s, float c, float l)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_1Da(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
     hc::short_vector::float2::vector_value_type c, float l)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_2D(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
     hc::short_vector::float2::vector_value_type c, float l)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_2Da(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
     hc::short_vector::float4::vector_value_type c, float l)[[hc]];
 
-float __ockl_image_sample_lod_2Dad(unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+float __ockl_image_sample_lod_2Dad(unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
                                    hc::short_vector::float4::vector_value_type c, float l)[[hc]];
 
-float __ockl_image_sample_lod_2Dd(unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+float __ockl_image_sample_lod_2Dd(unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
                                   hc::short_vector::float2::vector_value_type c, float l)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_3D(
-    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
+    unsigned int ADDRESS_SPACE_CONST* i, unsigned int ADDRESS_SPACE_CONST* s,
     hc::short_vector::float4::vector_value_type c, float l)[[hc]];
 }
 

--- a/include/hip/hcc_detail/texture_functions.h
+++ b/include/hip/hcc_detail/texture_functions.h
@@ -34,14 +34,14 @@ union TData {
 };
 
 #define __TEXTURE_FUNCTIONS_DECL__ static __inline__ __device__
-#define ADDRESS_SPACE_2 __attribute__((address_space(2)))
+#define ADDRESS_SPACE_4 __attribute__((address_space(4)))
 #define TEXTURE_PARAMETERS_INIT                                                                    \
-    unsigned int ADDRESS_SPACE_2* i = (unsigned int ADDRESS_SPACE_2*)textureObject;                \
-    unsigned int ADDRESS_SPACE_2* s = i + HIP_SAMPLER_OBJECT_OFFSET_DWORD;                         \
+    unsigned int ADDRESS_SPACE_4* i = (unsigned int ADDRESS_SPACE_4*)textureObject;                \
+    unsigned int ADDRESS_SPACE_4* s = i + HIP_SAMPLER_OBJECT_OFFSET_DWORD;                         \
     TData texel;
 #define TEXTURE_REF_PARAMETERS_INIT                                                                \
-    unsigned int ADDRESS_SPACE_2* i = (unsigned int ADDRESS_SPACE_2*)texRef.textureObject;         \
-    unsigned int ADDRESS_SPACE_2* s = i + HIP_SAMPLER_OBJECT_OFFSET_DWORD;                         \
+    unsigned int ADDRESS_SPACE_4* i = (unsigned int ADDRESS_SPACE_4*)texRef.textureObject;         \
+    unsigned int ADDRESS_SPACE_4* s = i + HIP_SAMPLER_OBJECT_OFFSET_DWORD;                         \
     TData texel;
 #define TEXTURE_SET_FLOAT *retVal = texel.f.x;
 
@@ -146,90 +146,90 @@ union TData {
 #define TEXTURE_RETURN_FLOAT_XYZW return float4(texel.f.x, texel.f.y, texel.f.z, texel.f.w);
 
 extern "C" {
-hc::short_vector::float4::vector_value_type __ockl_image_sample_1D(unsigned int ADDRESS_SPACE_2* i,
-                                                                   unsigned int ADDRESS_SPACE_2* s,
+hc::short_vector::float4::vector_value_type __ockl_image_sample_1D(unsigned int ADDRESS_SPACE_4* i,
+                                                                   unsigned int ADDRESS_SPACE_4* s,
                                                                    float c)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_1Da(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
     hc::short_vector::float2::vector_value_type c)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_2D(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
     hc::short_vector::float2::vector_value_type c)[[hc]];
 
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_2Da(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
     hc::short_vector::float4::vector_value_type c)[[hc]];
 
-float __ockl_image_sample_2Dad(unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+float __ockl_image_sample_2Dad(unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
                                hc::short_vector::float4::vector_value_type c)[[hc]];
 
-float __ockl_image_sample_2Dd(unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+float __ockl_image_sample_2Dd(unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
                               hc::short_vector::float2::vector_value_type c)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_3D(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
     hc::short_vector::float4::vector_value_type c)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_1D(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s, float c, float dx,
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s, float c, float dx,
     float dy)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_1Da(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
     hc::short_vector::float2::vector_value_type c, float dx, float dy)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_2D(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
     hc::short_vector::float2::vector_value_type c, hc::short_vector::float2::vector_value_type dx,
     hc::short_vector::float2::vector_value_type dy)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_2Da(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
     hc::short_vector::float4::vector_value_type c, hc::short_vector::float2::vector_value_type dx,
     hc::short_vector::float2::vector_value_type dy)[[hc]];
 
-float __ockl_image_sample_grad_2Dad(unsigned int ADDRESS_SPACE_2* i,
-                                    unsigned int ADDRESS_SPACE_2* s,
+float __ockl_image_sample_grad_2Dad(unsigned int ADDRESS_SPACE_4* i,
+                                    unsigned int ADDRESS_SPACE_4* s,
                                     hc::short_vector::float4::vector_value_type c,
                                     hc::short_vector::float2::vector_value_type dx,
                                     hc::short_vector::float2::vector_value_type dy)[[hc]];
 
-float __ockl_image_sample_grad_2Dd(unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+float __ockl_image_sample_grad_2Dd(unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
                                    hc::short_vector::float2::vector_value_type c,
                                    hc::short_vector::float2::vector_value_type dx,
                                    hc::short_vector::float2::vector_value_type dy)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_3D(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
     hc::short_vector::float4::vector_value_type c, hc::short_vector::float4::vector_value_type dx,
     hc::short_vector::float4::vector_value_type dy)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_1D(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s, float c, float l)[[hc]];
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s, float c, float l)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_1Da(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
     hc::short_vector::float2::vector_value_type c, float l)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_2D(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
     hc::short_vector::float2::vector_value_type c, float l)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_2Da(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
     hc::short_vector::float4::vector_value_type c, float l)[[hc]];
 
-float __ockl_image_sample_lod_2Dad(unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+float __ockl_image_sample_lod_2Dad(unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
                                    hc::short_vector::float4::vector_value_type c, float l)[[hc]];
 
-float __ockl_image_sample_lod_2Dd(unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+float __ockl_image_sample_lod_2Dd(unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
                                   hc::short_vector::float2::vector_value_type c, float l)[[hc]];
 
 hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_3D(
-    unsigned int ADDRESS_SPACE_2* i, unsigned int ADDRESS_SPACE_2* s,
+    unsigned int ADDRESS_SPACE_4* i, unsigned int ADDRESS_SPACE_4* s,
     hc::short_vector::float4::vector_value_type c, float l)[[hc]];
 }
 


### PR DESCRIPTION
With the latest upstream address space changes, the constant address space has change from 2 to 4.  The Texture tests have 2 hard coded.