### PR TITLE
adjust the hcc work week for the texture fix

### DIFF
--- a/include/hip/hcc_detail/texture_functions.h
+++ b/include/hip/hcc_detail/texture_functions.h
@@ -36,7 +36,7 @@ union TData {
 #define __TEXTURE_FUNCTIONS_DECL__ static __inline__ __device__
 
 
-#if (__hcc_workweek__ >= 18115)
+#if (__hcc_workweek__ >= 18114)
 #define ADDRESS_SPACE_CONSTANT __attribute__((address_space(4)))
 #else
 #define ADDRESS_SPACE_CONSTANT __attribute__((address_space(2)))


### PR DESCRIPTION
This adjustment is necessary for the 1.8 release, which implies that this fix would also need to be cherry-pick into 1.8