### PR TITLE
Fix new gfx target naming convention

### DIFF
--- a/src/code_object_bundle.cpp
+++ b/src/code_object_bundle.cpp
@@ -7,22 +7,21 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <iostream>
 
 using namespace std;
 
 hsa_isa_t hip_impl::triple_to_hsa_isa(const std::string& triple) {
-    static constexpr const char prefix[] = "hcc-amdgcn--amdhsa-gfx";
+    static constexpr const char prefix[] = "amdgcn-amd-amdhsa--gfx";
     static constexpr size_t prefix_sz = sizeof(prefix) - 1;
-
     hsa_isa_t r = {};
 
     auto idx = triple.find(prefix);
 
     if (idx != string::npos) {
         idx += prefix_sz;
-        string tmp = "AMD:AMDGPU";
+        string tmp = "amdgcn-amd-amdhsa--gfx";
         while (idx != triple.size()) {
-            tmp.push_back(':');
             tmp.push_back(triple[idx++]);
         }
 

--- a/src/code_object_bundle.cpp
+++ b/src/code_object_bundle.cpp
@@ -7,28 +7,31 @@
 #include <cstdint>
 #include <string>
 #include <vector>
-#include <iostream>
 
 using namespace std;
 
 hsa_isa_t hip_impl::triple_to_hsa_isa(const std::string& triple) {
-    static constexpr const char prefix[] = "amdgcn-amd-amdhsa--gfx";
-    static constexpr size_t prefix_sz = sizeof(prefix) - 1;
-    hsa_isa_t r = {};
+    static constexpr const char OffloadKind[] = "hcc-";
+    hsa_isa_t Isa = {0};
 
-    auto idx = triple.find(prefix);
-
-    if (idx != string::npos) {
-        idx += prefix_sz;
-        string tmp = "amdgcn-amd-amdhsa--gfx";
-        while (idx != triple.size()) {
-            tmp.push_back(triple[idx++]);
-        }
-
-        hsa_isa_from_name(tmp.c_str(), &r);
+    if ((triple.size() < sizeof(OffloadKind) - 1) || !std::equal(triple.c_str(),  triple.c_str() + sizeof(OffloadKind) - 1, triple.c_str())) {
+        return Isa;
     }
 
-    return r;
+    std::string validatedTriple = triple.substr(sizeof(OffloadKind) - 1);
+    static constexpr const char oldPrefix[] = "amdgcn--amdhsa-gfx";
+    static constexpr const char newPrefix[] = "amdgcn-amd-amdhsa--gfx";
+
+    if ((triple.size() >= sizeof(oldPrefix) - 1) && std::equal(oldPrefix, oldPrefix + sizeof(oldPrefix) - 1, triple.c_str())) {
+        // Support backwards compatibility with old naming.
+        validatedTriple = newPrefix + triple.substr(sizeof(oldPrefix) - 1);
+    }
+
+    if (HSA_STATUS_SUCCESS != hsa_isa_from_name(validatedTriple.c_str(), &Isa)) {
+        Isa.handle = 0;
+    }
+
+    return Isa;
 }
 
 // DATA - STATICS

--- a/src/code_object_bundle.cpp
+++ b/src/code_object_bundle.cpp
@@ -7,25 +7,28 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <iostream>
 
 using namespace std;
 
 hsa_isa_t hip_impl::triple_to_hsa_isa(const std::string& triple) {
-    static constexpr const char oldPrefix[] = "hcc-amdgcn--amdhsa-gfx";
-    static constexpr const char newPrefix[] = "amdgcn-amd-amdhsa--gfx";
+    static constexpr const char prefix[] = "amdgcn-amd-amdhsa--gfx";
+    static constexpr size_t prefix_sz = sizeof(prefix) - 1;
+    hsa_isa_t r = {};
 
-    std::string validatedTriple = triple;
-    if ((triple.size() >= sizeof(oldPrefix) - 1) && std::equal(oldPrefix, oldPrefix + sizeof(oldPrefix) - 1, triple.c_str())) {
-        // Support backwards compatibility with old naming.
-        validatedTriple = newPrefix + triple.substr(sizeof(oldPrefix) - 1);
+    auto idx = triple.find(prefix);
+
+    if (idx != string::npos) {
+        idx += prefix_sz;
+        string tmp = "amdgcn-amd-amdhsa--gfx";
+        while (idx != triple.size()) {
+            tmp.push_back(triple[idx++]);
+        }
+
+        hsa_isa_from_name(tmp.c_str(), &r);
     }
 
-    hsa_isa_t Isa = {0};
-    if (HSA_STATUS_SUCCESS != hsa_isa_from_name(validatedTriple.c_str(), &Isa)) {
-        Isa.handle = 0;
-    }
-
-    return Isa;
+    return r;
 }
 
 // DATA - STATICS


### PR DESCRIPTION
This was introduced in recent xnack changes naming changes which affected our offload bundler. This patch will fix issues in HIP samples, ROCR tests, and others. Related to internal issues SWDEV-150756, SWDEV-149306. Also requires HCC PR https://github.com/RadeonOpenCompute/hcc/pull/692