### PR TITLE
Fix null check in hipMemsetAsync API

### DIFF
--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1551,6 +1551,11 @@ typedef enum ihipMemsetDataType {
 hipError_t ihipMemset(void* dst, int  value, size_t sizeBytes, hipStream_t stream, enum ihipMemsetDataType copyDataType  )
 {
     hipError_t e = hipSuccess;
+	if(dst==NULL || dst==0)
+        {
+         e=hipErrorInvalidValue;
+        return ihipLogStatus(e);
+        }
 
     if (stream) {
         if(copyDataType == ihipMemsetDataTypeChar){


### PR DESCRIPTION
hipMemsetAsync() gives hipSuccess and also Aborted(core dumped) when the first parameter is passed as NULL or 0. Ran all the tests in memory module under directed tests in my local machine and found no issues.

As suggested earlier, I made changes in ihipMemset().