### PR TITLE
SWDEV-141661

### DIFF
--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1125,6 +1125,14 @@ hipError_t hipMemcpy(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind
 
     hipError_t e = hipSuccess;
 
+    if(dst==NULL || dst==0 || src==NULL || src==0)
+        {
+         e=hipErrorInvalidValue;
+        return ihipLogStatus(e);
+        }
+
+    
+    
     try {
         stream->locked_copySync(dst, src, sizeBytes, kind);
     } catch (ihipException& ex) {


### PR DESCRIPTION
Added a fix for the issue ::hipMemcpy() gives seg. fault when the first or second parameter is passed as NULL or zero. Verified in the local machine the fail scenario and also ran the directed tests. Things are fine.