### PR TITLE
SWDEV-141618

### DIFF
--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -339,6 +339,12 @@ hipError_t hipHostAlloc(void** ptr, size_t sizeBytes, unsigned int flags) {
 // width in bytes
 hipError_t ihipMallocPitch(void** ptr, size_t* pitch, size_t width, size_t height, size_t depth) {
     hipError_t hip_status = hipSuccess;
+	if(ptr==NULL || ptr==0)
+	{
+	hip_status=hipErrorInvalidValue;
+	return hip_status;
+	}
+	
     // hardcoded 128 bytes
     *pitch = ((((int)width - 1) / 128) + 1) * 128;
     const size_t sizeBytes = (*pitch) * height;


### PR DESCRIPTION
Fixed issue for :::hipMallocPitch() gives seg. fault when NULL or zero is provided for any of four parameter.
Verified the fix in my local machine also found that fix has no impact on memory related tests under directed tests.