### PR TITLE
SWDEV-141024

### DIFF
--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -766,10 +766,18 @@ hipError_t hipArray3DCreate(hipArray_t* array, const HIP_ARRAY_DESCRIPTOR* pAllo
 
 hipError_t hipMalloc3DArray(hipArray_t* array, const struct hipChannelFormatDesc* desc,
                             struct hipExtent extent, unsigned int flags) {
+
+
+
     HIP_INIT_API(array, desc, &extent, flags);
     HIP_SET_DEVICE();
     hipError_t hip_status = hipSuccess;
 
+        if(array==NULL )
+        {
+         hip_status=hipErrorInvalidValue;
+        return ihipLogStatus(hip_status);
+        }
     auto ctx = ihipGetTlsDefaultCtx();
 
     *array = (hipArray*)malloc(sizeof(hipArray));


### PR DESCRIPTION
Fixed the issue for ::hipMalloc3DArray.cpp gives seg. fault when NULL or 0 is passed as first parameter.
Verified the case in my local machine and also observed that directed tests have no impact with this fix.