### PR TITLE
Placeholder PR for HIP program state re-initialization logic

### DIFF
--- a/include/hip/hcc_detail/program_state.hpp
+++ b/include/hip/hcc_detail/program_state.hpp
@@ -75,7 +75,7 @@ namespace hip_impl
         std::uintptr_t,
         std::vector<std::pair<hsa_agent_t, Kernel_descriptor>>>& functions(bool rebuild = false);
     const std::unordered_map<std::uintptr_t, std::string>& function_names(bool rebuild = false);
-    std::unordered_map<std::string, void*>& globals();
+    std::unordered_map<std::string, void*>& globals(bool rebuild = false);
 
     hsa_executable_t load_executable(
         const std::string& file,

--- a/include/hip/hcc_detail/program_state.hpp
+++ b/include/hip/hcc_detail/program_state.hpp
@@ -70,11 +70,11 @@ namespace hip_impl
     };
 
     const std::unordered_map<
-        hsa_agent_t, std::vector<hsa_executable_t>>& executables();
+        hsa_agent_t, std::vector<hsa_executable_t>>& executables(bool rebuild = false);
     const std::unordered_map<
         std::uintptr_t,
-        std::vector<std::pair<hsa_agent_t, Kernel_descriptor>>>& functions();
-    const std::unordered_map<std::uintptr_t, std::string>& function_names();
+        std::vector<std::pair<hsa_agent_t, Kernel_descriptor>>>& functions(bool rebuild = false);
+    const std::unordered_map<std::uintptr_t, std::string>& function_names(bool rebuild = false);
     std::unordered_map<std::string, void*>& globals();
 
     hsa_executable_t load_executable(

--- a/src/functional_grid_launch.inl
+++ b/src/functional_grid_launch.inl
@@ -92,13 +92,19 @@ namespace hip_impl
         hipStream_t stream,
         void** kernarg)
     {
-        const auto it0 = functions().find(function_address);
+        auto it0 = functions().find(function_address);
 
         if (it0 == functions().cend()) {
-            throw runtime_error{
-                "No device code available for function: " +
-                name(function_address)
-            };
+            // Re-init device code maps once again to help locate kernels
+            // loaded after HIP runtime initialization via means such as
+            // dlopen().
+            it0 = functions(true).find(function_address);
+            if (it0 == functions().cend()) {   
+                throw runtime_error{
+                    "No device code available for function: " +
+                    name(function_address)
+                };
+            }
         }
 
         auto agent = target_agent(stream);

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -102,12 +102,16 @@ namespace
 
     const std::unordered_map<
         std::string,
-        std::pair<ELFIO::Elf64_Addr, ELFIO::Elf_Xword>>& symbol_addresses()
+        std::pair<ELFIO::Elf64_Addr, ELFIO::Elf_Xword>>& symbol_addresses(bool rebuild = false)
     {
         static unordered_map<string, pair<Elf64_Addr, Elf_Xword>> r;
         static once_flag f;
 
-        call_once(f, []() {
+        auto cons = [rebuild]() {
+            if (rebuild) {
+                r.clear();
+            }
+
             dl_iterate_phdr([](dl_phdr_info* info, size_t, void*) {
                 static constexpr const char self[] = "/proc/self/exe";
                 elfio reader;
@@ -140,7 +144,12 @@ namespace
 
                 return 0;
             }, nullptr);
-        });
+        };
+
+        call_once(f, cons);
+        if (rebuild) {
+            cons();
+        }
 
         return r;
     }
@@ -493,6 +502,7 @@ namespace hip_impl
                 r.clear();
                 function_names(rebuild);
                 kernels(rebuild);
+                globals(rebuild);
             }
             for (auto&& function : function_names()) {
                 const auto it = kernels().find(function.second);
@@ -521,11 +531,22 @@ namespace hip_impl
         return r;
     }
 
-    unordered_map<string, void*>& globals()
+    unordered_map<string, void*>& globals(bool rebuild)
     {
         static unordered_map<string, void*> r;
         static once_flag f;
-        call_once(f, []() { r.reserve(symbol_addresses().size()); });
+        auto cons = [rebuild]() {
+            if (rebuild) {
+                r.clear();
+                symbol_addresses(rebuild);
+            }
+            r.reserve(symbol_addresses().size());
+        };
+
+        call_once(f, cons);
+        if (rebuild) {
+            cons();
+        }
 
         return r;
     }

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -210,14 +210,19 @@ namespace
         return r;
     }
 
-    const unordered_map<hsa_isa_t, vector<vector<uint8_t>>>& code_object_blobs()
+    const unordered_map<hsa_isa_t, vector<vector<uint8_t>>>& code_object_blobs(bool rebuild = false)
     {
         static unordered_map<hsa_isa_t, vector<vector<uint8_t>>> r;
         static once_flag f;
 
-        call_once(f, []() {
+        auto cons = [rebuild]() {
             static vector<vector<uint8_t>> blobs{
                 code_object_blob_for_process()};
+
+            if (rebuild) {
+                blobs.clear();
+                blobs.push_back(code_object_blob_for_process());
+            }
 
             dl_iterate_phdr([](dl_phdr_info* info, std::size_t, void*) {
                 elfio tmp;
@@ -241,7 +246,12 @@ namespace
                     }
                 }
             }
-        });
+        };
+
+        call_once(f, cons);
+        if (rebuild) {
+            cons();
+        }
 
         return r;
     }
@@ -267,14 +277,14 @@ namespace
         return r;
     }
 
-    const vector<pair<uintptr_t, string>>& function_names_for_process()
+    const vector<pair<uintptr_t, string>>& function_names_for_process(bool rebuild = false)
     {
         static constexpr const char self[] = "/proc/self/exe";
 
         static vector<pair<uintptr_t, string>> r;
         static once_flag f;
 
-        call_once(f, []() {
+        auto cons = []() {
             elfio reader;
 
             if (!reader.load(self)) {
@@ -287,17 +297,27 @@ namespace
             });
 
             if (symtab) r = function_names_for(reader, symtab);
-        });
+        };
+
+        call_once(f, cons);
+        if (rebuild) {
+            cons();
+        }
 
         return r;
     }
 
-    const unordered_map<string, vector<hsa_executable_symbol_t>>& kernels()
+    const unordered_map<string, vector<hsa_executable_symbol_t>>& kernels(bool rebuild = false)
     {
         static unordered_map<string, vector<hsa_executable_symbol_t>> r;
         static once_flag f;
 
-        call_once(f, []() {
+        auto cons = [rebuild]() {
+            if (rebuild) {
+                r.clear();
+                executables(rebuild);
+            }
+
             static const auto copy_kernels = [](
                 hsa_executable_t, hsa_agent_t, hsa_executable_symbol_t s, void*) {
                 if (type(s) == HSA_SYMBOL_KIND_KERNEL) r[name(s)].push_back(s);
@@ -314,7 +334,12 @@ namespace
                         nullptr);
                 }
             }
-        });
+        };
+
+        call_once(f, cons);
+        if (rebuild) {
+            cons();
+        }
 
         return r;
     }
@@ -355,13 +380,18 @@ namespace
 
 namespace hip_impl
 {
-    const unordered_map<hsa_agent_t, vector<hsa_executable_t>>& executables()
+    const unordered_map<hsa_agent_t, vector<hsa_executable_t>>& executables(bool rebuild)
     {   // TODO: This leaks the hsa_executable_ts, it should use RAII.
         static unordered_map<hsa_agent_t, vector<hsa_executable_t>> r;
         static once_flag f;
 
-        call_once(f, []() {
+        auto cons = [rebuild]() {
             static const auto accelerators = hc::accelerator::get_all();
+
+            if (rebuild) {
+                r.clear();
+                code_object_blobs(rebuild);
+            }
 
             for (auto&& acc : accelerators) {
                 auto agent = static_cast<hsa_agent_t*>(acc.get_hsa_agent());
@@ -395,19 +425,30 @@ namespace hip_impl
                     return HSA_STATUS_SUCCESS;
                 }, agent);
             }
-        });
+        };
+
+        call_once(f, cons);
+        if (rebuild) {
+            cons();
+        }
 
         return r;
     }
 
-    const unordered_map<uintptr_t, string>& function_names()
+    const unordered_map<uintptr_t, string>& function_names(bool rebuild)
     {
         static unordered_map<uintptr_t, string> r{
             function_names_for_process().cbegin(),
             function_names_for_process().cend()};
         static once_flag f;
 
-        call_once(f, []() {
+        auto cons = [rebuild]() {
+            if (rebuild) {
+                r.clear();
+                function_names_for_process(rebuild);
+                r.insert(function_names_for_process().cbegin(),
+                         function_names_for_process().cend());
+            }
             dl_iterate_phdr([](dl_phdr_info* info, size_t, void*) {
                 elfio tmp;
                 if (tmp.load(info->dlpi_name)) {
@@ -428,19 +469,31 @@ namespace hip_impl
 
                 return 0;
             }, nullptr);
-        });
+        };
+
+        call_once(f, cons);
+        if (rebuild) {
+            static mutex mtx;
+            lock_guard<mutex> lck{mtx};
+            cons();
+        }
 
         return r;
     }
 
     const unordered_map<
-        uintptr_t, vector<pair<hsa_agent_t, Kernel_descriptor>>>& functions()
+        uintptr_t, vector<pair<hsa_agent_t, Kernel_descriptor>>>& functions(bool rebuild)
     {
         static unordered_map<
             uintptr_t, vector<pair<hsa_agent_t, Kernel_descriptor>>> r;
         static once_flag f;
 
-        call_once(f, []() {
+        auto cons = [rebuild]() {
+            if (rebuild) {
+                r.clear();
+                function_names(rebuild);
+                kernels(rebuild);
+            }
             for (auto&& function : function_names()) {
                 const auto it = kernels().find(function.second);
 
@@ -456,7 +509,14 @@ namespace hip_impl
                     }
                 }
             }
-        });
+        };
+
+        call_once(f, cons);
+        if (rebuild) {
+            static mutex mtx;
+            lock_guard<mutex> lck{mtx};
+            cons();
+        }
 
         return r;
     }


### PR DESCRIPTION
Please do NOT merge this PR yet as it shall it be amended, and perhaps rebased to target `master` branch.

This PR tries to re-initialize HIP runtime data structures in `program_state.cpp`. In applications such as TensorFlow it was evident that HIP kernels within shared libraries may not be identified if they are loaded later after initialization by `dlopen()`. Instead of raising an exception immediately we re-initialize data structures within `program_state.cpp` with a `rebuild` flag.

The current implementation may deserve to be amended so that:

- rebase to target `master` branch.
- maps / vectors are stored in TLS so we don't need mutex to guard `function()`.
