### PR TITLE
[HIPIFY] Sync with HIP (Execution Control, Surfaces, Memory)

### DIFF
--- a/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -102,9 +102,9 @@
 
 |   **CUDA**                                                |   **HIP**                     |
 |-----------------------------------------------------------|-------------------------------|
-| `cudaConfigureCall`                                       |                               |
-| `cudaLaunch`                                              |                               |
-| `cudaSetupArgument`                                       |                               |
+| `cudaConfigureCall`                                       | `hipConfigureCall`            |
+| `cudaLaunch`                                              | `hipLaunchByPtr`              |
+| `cudaSetupArgument`                                       | `hipSetupArgument`            |
 
 ## **9. Memory Management**
 
@@ -158,7 +158,7 @@
 | `cudaMemcpyToSymbolAsync`                                 | `hipMemcpyToSymbolAsync`      |
 | `cudaMemset`                                              | `hipMemset`                   |
 | `cudaMemset2D`                                            | `hipMemset2D`                 |
-| `cudaMemset2DAsync`                                       |                               |
+| `cudaMemset2DAsync`                                       | `hipMemset2DAsync`            |
 | `cudaMemset3D`                                            |                               |
 | `cudaMemset3DAsync`                                       |                               |
 | `cudaMemsetAsync`                                         | `hipMemsetAsync`              |
@@ -338,8 +338,8 @@
 
 |   **CUDA**                                                |   **HIP**                     |
 |-----------------------------------------------------------|-------------------------------|
-| `cudaCreateSurfaceObject`                                 |                               |
-| `cudaDestroySurfaceObject`                                |                               |
+| `cudaCreateSurfaceObject`                                 | `hipCreateSurfaceObject`      |
+| `cudaDestroySurfaceObject`                                | `hipDestroySurfaceObject`     |
 | `cudaGetSurfaceObjectResourceDesc`                        |                               |
 
 ## **27. Version Management**
@@ -675,10 +675,10 @@
 |            0 |*`cudaSharedMemBankSizeDefault`*               |*`hipSharedMemBankSizeDefault`*                       |
 |            1 |*`cudaSharedMemBankSizeFourByte`*              |*`hipSharedMemBankSizeFourByte`*                      |
 |            2 |*`cudaSharedMemBankSizeEightByte`*             |*`hipSharedMemBankSizeEightByte`*                     |
-| enum         |***`cudaSurfaceBoundaryMode`***                |                                                      |
-|            0 |*`cudaBoundaryModeZero`*                       |                                                      |
-|            1 |*`cudaBoundaryModeClamp`*                      |                                                      |
-|            2 |*`cudaBoundaryModeTrap`*                       |                                                      |
+| enum         |***`cudaSurfaceBoundaryMode`***                |***`hipSurfaceBoundaryMode`***                        |
+|            0 |*`cudaBoundaryModeZero`*                       |*`hipBoundaryModeZero`*                               |
+|            1 |*`cudaBoundaryModeClamp`*                      |*`hipBoundaryModeClamp`*                              |
+|            2 |*`cudaBoundaryModeTrap`*                       |*`hipBoundaryModeTrap`*                               |
 | enum         |***`cudaSurfaceFormatMode`***                  |                                                      |
 |            0 |*`cudaFormatModeForced`*                       |                                                      |
 |            1 |*`cudaFormatModeAuto`*                         |                                                      |
@@ -742,7 +742,7 @@
 | typedef      | `cudaOutputMode_t`                            |                                                      |
 | typedef      | `cudaStream_t`                                | `hipStream_t`                                        |
 | typedef      | `cudaStreamCallback_t`                        | `hipStreamCallback_t`                                |
-| typedef      | `cudaSurfaceObject_t`                         |                                                      |
+| typedef      | `cudaSurfaceObject_t`                         | `hipSurfaceObject_t`                                 |
 | typedef      | `cudaTextureObject_t`                         | `hipTextureObject_t`                                 |
 | typedef      | `CUuuid_stcudaUUID_t`                         |                                                      |
 | define       | `CUDA_IPC_HANDLE_SIZE`                        |                                                      |

--- a/hipify-clang/src/CUDA2HipMap.cpp
+++ b/hipify-clang/src/CUDA2HipMap.cpp
@@ -261,12 +261,13 @@ const std::map<llvm::StringRef, hipCounter> CUDA_TYPE_NAME_MAP{
 
     // typedefs
     {"cudaTextureObject_t",  {"hipTextureObject_t",  CONV_TEX,     API_RUNTIME}},
+    {"cudaSurfaceObject_t",  {"hipSurfaceObject_t",  CONV_SURFACE, API_RUNTIME}},
 
     // enums
     {"cudaResourceType",        {"hipResourceType",        CONV_TEX,     API_RUNTIME}},    // API_Driver ANALOGUE (CUresourcetype)
     {"cudaResourceViewFormat",  {"hipResourceViewFormat",  CONV_TEX,     API_RUNTIME}},    // API_Driver ANALOGUE (CUresourceViewFormat)
     {"cudaTextureAddressMode",  {"hipTextureAddressMode",  CONV_TEX,     API_RUNTIME}},
-    {"cudaSurfaceBoundaryMode", {"hipSurfaceBoundaryMode", CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED}},
+    {"cudaSurfaceBoundaryMode", {"hipSurfaceBoundaryMode", CONV_SURFACE, API_RUNTIME}},
 
     {"cudaSurfaceFormatMode", {"hipSurfaceFormatMode", CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED}},
 
@@ -1484,7 +1485,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_IDENTIFIER_MAP{
     {"cudaMemset",        {"hipMemset",        CONV_MEM, API_RUNTIME}},
     {"cudaMemsetAsync",   {"hipMemsetAsync",   CONV_MEM, API_RUNTIME}},
     {"cudaMemset2D",      {"hipMemset2D",      CONV_MEM, API_RUNTIME}},
-    {"cudaMemset2DAsync", {"hipMemset2DAsync", CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED}},
+    {"cudaMemset2DAsync", {"hipMemset2DAsync", CONV_MEM, API_RUNTIME}},
     {"cudaMemset3D",      {"hipMemset3D",      CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED}},
     {"cudaMemset3DAsync", {"hipMemset3DAsync", CONV_MEM, API_RUNTIME, HIP_UNSUPPORTED}},
 
@@ -1745,9 +1746,9 @@ const std::map<llvm::StringRef, hipCounter> CUDA_IDENTIFIER_MAP{
     {"cudaSetDoubleForHost",       {"hipSetDoubleForHost",       CONV_EXEC, API_RUNTIME, HIP_UNSUPPORTED}},
 
     // Execution Control [deprecated since 7.0]
-    {"cudaConfigureCall", {"hipConfigureCall", CONV_EXEC, API_RUNTIME, HIP_UNSUPPORTED}},
-    {"cudaLaunch",        {"hipLaunch",        CONV_EXEC, API_RUNTIME, HIP_UNSUPPORTED}},
-    {"cudaSetupArgument", {"hipSetupArgument", CONV_EXEC, API_RUNTIME, HIP_UNSUPPORTED}},
+    {"cudaConfigureCall", {"hipConfigureCall", CONV_EXEC, API_RUNTIME}},
+    {"cudaLaunch",        {"hipLaunchByPtr",   CONV_EXEC, API_RUNTIME}},
+    {"cudaSetupArgument", {"hipSetupArgument", CONV_EXEC, API_RUNTIME}},
 
     // Version Management
     {"cudaDriverGetVersion",  {"hipDriverGetVersion",  CONV_VERSION, API_RUNTIME}},
@@ -1889,17 +1890,17 @@ const std::map<llvm::StringRef, hipCounter> CUDA_IDENTIFIER_MAP{
     {"cudaGetSurfaceReference", {"hipGetSurfaceReference", CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED}},
 
     // enum cudaSurfaceBoundaryMode
-    {"cudaBoundaryModeZero",    {"hipBoundaryModeZero",    CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED}},
-    {"cudaBoundaryModeClamp",   {"hipBoundaryModeClamp",   CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED}},
-    {"cudaBoundaryModeTrap",    {"hipBoundaryModeTrap",    CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED}},
+    {"cudaBoundaryModeZero",    {"hipBoundaryModeZero",    CONV_SURFACE, API_RUNTIME}},
+    {"cudaBoundaryModeClamp",   {"hipBoundaryModeClamp",   CONV_SURFACE, API_RUNTIME}},
+    {"cudaBoundaryModeTrap",    {"hipBoundaryModeTrap",    CONV_SURFACE, API_RUNTIME}},
 
     // enum cudaSurfaceFormatMode
     {"cudaFormatModeForced",    {"hipFormatModeForced",    CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED}},
     {"cudaFormatModeAuto",      {"hipFormatModeAuto",      CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED}},
 
     // Surface Object Management
-    {"cudaCreateSurfaceObject",          {"hipCreateSurfaceObject",          CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED}},
-    {"cudaDestroySurfaceObject",         {"hipDestroySurfaceObject",         CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED}},
+    {"cudaCreateSurfaceObject",          {"hipCreateSurfaceObject",          CONV_SURFACE, API_RUNTIME}},
+    {"cudaDestroySurfaceObject",         {"hipDestroySurfaceObject",         CONV_SURFACE, API_RUNTIME}},
     {"cudaGetSurfaceObjectResourceDesc", {"hipGetSurfaceObjectResourceDesc", CONV_SURFACE, API_RUNTIME, HIP_UNSUPPORTED}},
 
     // Inter-Process Communications (IPC)


### PR DESCRIPTION
Execution Control [deprecated since 7.0]:
cudaConfigureCall -> hipConfigureCall
cudaLaunch -> hipLaunchByPtr
cudaSetupArgument -> hipSetupArgument

Surfaces (partially):
cudaSurfaceObject_t -> hipSurfaceObject_t
cudaSurfaceBoundaryMode -> hipSurfaceBoundaryMode
cudaCreateSurfaceObject -> hipCreateSurfaceObject
cudaDestroySurfaceObject -> hipDestroySurfaceObject

Memory Management:
cudaMemset2DAsync -> hipMemset2DAsync