### PR TITLE
Add __assert_fail, __device_trap and hipErrorAssert for clang

### DIFF
--- a/include/hip/hcc_detail/hip_runtime.h
+++ b/include/hip/hcc_detail/hip_runtime.h
@@ -613,15 +613,15 @@ extern const __device__ __attribute__((weak)) __hip_builtin_gridDim_t gridDim;
 #define hipGridDim_z gridDim.z
 
 #pragma push_macro("__DEVICE__")
-#define __DEVICE__ extern "C" __device__ inline __attribute__((always_inline)) \
+#define __DEVICE__ extern "C" __device__ __attribute__((always_inline)) \
   __attribute__((weak))
 
 __DEVICE__ void __device_trap() __asm("llvm.trap");
 
-__DEVICE__ void __assert_fail(const char * __assertion,
-                              const char *__file,
-                              unsigned int __line,
-                              const char *__function)
+__DEVICE__ void inline __assert_fail(const char * __assertion,
+                                     const char *__file,
+                                     unsigned int __line,
+                                     const char *__function)
 {
     // Ignore all the args for now.
     __device_trap();

--- a/include/hip/hcc_detail/hip_runtime.h
+++ b/include/hip/hcc_detail/hip_runtime.h
@@ -612,6 +612,22 @@ extern const __device__ __attribute__((weak)) __hip_builtin_gridDim_t gridDim;
 #define hipGridDim_y gridDim.y
 #define hipGridDim_z gridDim.z
 
+#pragma push_macro("__DEVICE__")
+#define __DEVICE__ extern "C" __device__ inline __attribute__((always_inline)) \
+  __attribute__((weak))
+
+__DEVICE__ void __device_trap() __asm("llvm.trap");
+
+__DEVICE__ void __assert_fail(const char * __assertion,
+                              const char *__file,
+                              unsigned int __line,
+                              const char *__function)
+{
+    // Ignore all the args for now.
+    __device_trap();
+}
+#pragma push_macro("__DEVICE__")
+
 #endif
 
 #endif  // HIP_HCC_DETAIL_RUNTIME_H

--- a/include/hip/hip_runtime_api.h
+++ b/include/hip/hip_runtime_api.h
@@ -243,6 +243,8 @@ typedef enum __HIP_NODISCARD hipError_t {
         1062,  ///< Produced when trying to unlock a non-page-locked memory.
     hipErrorMapBufferObjectFailed =
         1071,    ///< Produced when the IPC memory attach failed from ROCr.
+    hipErrorAssert =
+        1081,    ///< Produced when the kernel calls assert.
     hipErrorTbd  ///< Marker that more error codes are needed.
 } hipError_t;
 


### PR DESCRIPTION
This is to fix the compilation failure for the following test:

```
#include "hip/hip_runtime.h"
#include <assert.h>
#include <stdio.h>

// Use fixed value for __FILE__ so assert message does not depend on
// the actual path to the file during compilation..
#define __FILE__ "assert.cu"

__global__ void kernel() {
  // Our reference output contains the line number of this assert() call; be
  // careful when modifying the parts of this file above this line.
  assert(false);
}

int main() {
  hipLaunchKernelGGL((kernel), dim3(1), dim3(1), 0, 0, );
  hipError_t err = hipDeviceSynchronize();
  if (err != hipErrorAssert)
    return err;
  return 0;
}


```