### PR TITLE
Adding double/long int signatures for abs

### DIFF
--- a/include/hip/hcc_detail/math_functions.h
+++ b/include/hip/hcc_detail/math_functions.h
@@ -60,6 +60,7 @@ __device__ int abs(int x);
 __device__ long long abs(long long x);
 __device__ double abs(double x);
 __device__ long int abs(long int x);
+__device__ long long int labs(long long int x);
 __device__ float fabsf(float x);
 __device__ float fdimf(float x, float y);
 __device__ float fdividef(float x, float y);

--- a/include/hip/hcc_detail/math_functions.h
+++ b/include/hip/hcc_detail/math_functions.h
@@ -58,6 +58,8 @@ __device__ float expf(float x);
 __device__ float expm1f(float x);
 __device__ int abs(int x);
 __device__ long long abs(long long x);
+__device__ double abs(double x);
+__device__ long int abs(long int x);
 __device__ float fabsf(float x);
 __device__ float fdimf(float x, float y);
 __device__ float fdividef(float x, float y);


### PR DESCRIPTION
Adding overloads for abs that are found in cuda's math_functions.

Changes to cpp source here: https://github.com/ROCm-Developer-Tools/HIP/pull/472