### PR TITLE
Use memcpy kernel for all pinned memory cases in hipMemcpy2DAsync

### DIFF
--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1680,9 +1680,12 @@ hipError_t hipMemcpy2DAsync(void* dst, size_t dpitch, const void* src, size_t sp
             actualDest = pinnedPtr;
           }
     }
+#if 0
     if((width == dpitch) && (width == spitch)) {
             hip_internal::memcpyAsync(dst, src, width*height, kind, stream);
-    } else {
+    } else
+#endif
+   {
         try {
             if(!isLocked){
                 for (int i = 0; i < height; ++i) 


### PR DESCRIPTION
Temporary PR for now, to test dtrsm issues seen while using hipMemcpy2DAsync