### PR TITLE
Include host_defines.h in hip_fp16.h since it uses __host__ __device_…

### DIFF
--- a/include/hip/hcc_detail/hip_fp16.h
+++ b/include/hip/hcc_detail/hip_fp16.h
@@ -21,7 +21,7 @@ THE SOFTWARE.
 */
 
 #pragma once
-
+#include "hip/hcc_detail/host_defines.h"
 #include <assert.h>
 #if defined(__cplusplus)
     #include <algorithm>


### PR DESCRIPTION
…_ attributes