### PR TITLE
Add workaround to hipcc for build failure in tensorflow due to missin…

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -601,6 +601,9 @@ if ($needLDFLAGS and not $compileOnly) {
     $CMD .= " $HIPLDFLAGS";
 }
 $CMD .= " $toolArgs";
+if ($needLDFLAGS and not $compileOnly and $HIP_PLATFORM eq "clang") {
+    $CMD .= " -lgcc_s -lgcc";
+}
 
 if ($verbose & 0x1) {
     print "hipcc-cmd: ", $CMD, "\n";


### PR DESCRIPTION
…g symbol __cpu_model

https://github.com/tensorflow/tensorflow/issues/9593