### PR TITLE
Adding long/float/double overloads for min and max.

### DIFF
--- a/include/hip/hcc_detail/hip_runtime.h
+++ b/include/hip/hcc_detail/hip_runtime.h
@@ -238,6 +238,21 @@ __device__ int __hip_move_dpp(int src, int dpp_ctrl, int row_mask, int bank_mask
 __host__ __device__ int min(int arg1, int arg2);
 __host__ __device__ int max(int arg1, int arg2);
 
+__host__ __device__ unsigned int min(unsigned int arg1, unsigned int arg2);
+__host__ __device__ unsigned int max(unsigned int arg1, unsigned int arg2);
+
+__host__ __device__ long min(long arg1, long arg2);
+__host__ __device__ long max(long arg1, long arg2);
+
+__host__ __device__ unsigned long min(unsigned long arg1, unsigned long arg2);
+__host__ __device__ unsigned long max(unsigned long arg1, unsigned long arg2);
+
+__host__ __device__ float min(float arg1, float arg2);
+__host__ __device__ float max(float arg1, float arg2);
+
+__host__ __device__ double min(double arg1, double arg2);
+__host__ __device__ double max(double arg1, double arg2);
+
 __device__ void* __get_dynamicgroupbaseptr();
 
 

--- a/include/hip/hcc_detail/hip_runtime.h
+++ b/include/hip/hcc_detail/hip_runtime.h
@@ -235,22 +235,42 @@ __device__ int __hip_move_dpp(int src, int dpp_ctrl, int row_mask, int bank_mask
 
 #endif  //__HIP_ARCH_GFX803__ == 1
 
-__host__ __device__ int min(int arg1, int arg2);
-__host__ __device__ int max(int arg1, int arg2);
-
+__host__ __device__ int          min(         int arg1,          int arg2);
+__host__ __device__ unsigned int min(         int arg1, unsigned int arg2);
+__host__ __device__ unsigned int min(unsigned int arg1,          int arg2);
 __host__ __device__ unsigned int min(unsigned int arg1, unsigned int arg2);
-__host__ __device__ unsigned int max(unsigned int arg1, unsigned int arg2);
 
-__host__ __device__ long min(long arg1, long arg2);
-__host__ __device__ long max(long arg1, long arg2);
-
+__host__ __device__          long min(         long arg1,          long arg2);
+__host__ __device__ unsigned long min(         long arg1, unsigned long arg2);
+__host__ __device__ unsigned long min(unsigned long arg1,          long arg2);
 __host__ __device__ unsigned long min(unsigned long arg1, unsigned long arg2);
-__host__ __device__ unsigned long max(unsigned long arg1, unsigned long arg2);
+
+__host__ __device__          long long min(         long long arg1,          long long arg2);
+__host__ __device__ unsigned long long min(         long long arg1, unsigned long long arg2);
+__host__ __device__ unsigned long long min(unsigned long long arg1,          long long arg2);
+__host__ __device__ unsigned long long min(unsigned long long arg1, unsigned long long arg2);
 
 __host__ __device__ float min(float arg1, float arg2);
-__host__ __device__ float max(float arg1, float arg2);
-
 __host__ __device__ double min(double arg1, double arg2);
+
+
+
+__host__ __device__ int          max(         int arg1,          int arg2);
+__host__ __device__ unsigned int max(         int arg1, unsigned int arg2);
+__host__ __device__ unsigned int max(unsigned int arg1,          int arg2);
+__host__ __device__ unsigned int max(unsigned int arg1, unsigned int arg2);
+
+__host__ __device__          long max(         long arg1,          long arg2);
+__host__ __device__ unsigned long max(         long arg1, unsigned long arg2);
+__host__ __device__ unsigned long max(unsigned long arg1,          long arg2);
+__host__ __device__ unsigned long max(unsigned long arg1, unsigned long arg2);
+
+__host__ __device__          long long max(         long long arg1,          long long arg2);
+__host__ __device__ unsigned long long max(         long long arg1, unsigned long long arg2);
+__host__ __device__ unsigned long long max(unsigned long long arg1,          long long arg2);
+__host__ __device__ unsigned long long max(unsigned long long arg1, unsigned long long arg2);
+
+__host__ __device__ float max(float arg1, float arg2);
 __host__ __device__ double max(double arg1, double arg2);
 
 __device__ void* __get_dynamicgroupbaseptr();

--- a/src/device_util.cpp
+++ b/src/device_util.cpp
@@ -203,55 +203,40 @@ __host__ __device__ int max(int arg1, int arg2) {
     return (int)(hc::precise_math::fmax((float)arg1, (float)arg2));
 }
 
-__host__ __device__ unsigned int min(unsigned int arg1, unsigned int arg2)
-{
-  return (arg1 < arg2) ? arg1 : arg2;
-}
+__host__ __device__ unsigned int min(         int arg1, unsigned int arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned int min(unsigned int arg1,          int arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned int min(unsigned int arg1, unsigned int arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
 
-__host__ __device__ unsigned int max(unsigned int arg1, unsigned int arg2)
-{
-  return (arg1 > arg2) ? arg1 : arg2;
-}
+__host__ __device__          long min(         long arg1,          long arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned long min(         long arg1, unsigned long arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned long min(unsigned long arg1,          long arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned long min(unsigned long arg1, unsigned long arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
 
-__host__ __device__  long min( long arg1,  long arg2)
-{
-  return (arg1 < arg2) ? arg1 : arg2;
-}
+__host__ __device__          long long min(         long long arg1,          long long arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned long long min(         long long arg1, unsigned long long arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned long long min(unsigned long long arg1,          long long arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned long long min(unsigned long long arg1, unsigned long long arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
 
-__host__ __device__  long max( long arg1,  long arg2)
-{
-  return (arg1 > arg2) ? arg1 : arg2;
-}
+__host__ __device__ float min(float arg1, float arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
+__host__ __device__ double min(double arg1, double arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
 
-__host__ __device__ unsigned long min(unsigned long arg1, unsigned long arg2)
-{
-  return (arg1 < arg2) ? arg1 : arg2;
-}
 
-__host__ __device__ unsigned long max(unsigned long arg1, unsigned long arg2)
-{
-  return (arg1 > arg2) ? arg1 : arg2;
-}
+__host__ __device__ unsigned int max(         int arg1, unsigned int arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned int max(unsigned int arg1,          int arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned int max(unsigned int arg1, unsigned int arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
 
-__host__ __device__ float min(float arg1, float arg2)
-{
-  return (arg1 < arg2) ? arg1 : arg2;
-}
+__host__ __device__          long max(         long arg1,          long arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned long max(         long arg1, unsigned long arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned long max(unsigned long arg1,          long arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned long max(unsigned long arg1, unsigned long arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
 
-__host__ __device__ float max(float arg1, float arg2)
-{
-  return (arg1 > arg2) ? arg1 : arg2;
-}
+__host__ __device__          long long max(         long long arg1,          long long arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned long long max(         long long arg1, unsigned long long arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned long long max(unsigned long long arg1,          long long arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
+__host__ __device__ unsigned long long max(unsigned long long arg1, unsigned long long arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
 
-__host__ __device__ double min(double arg1, double arg2)
-{
-  return (arg1 < arg2) ? arg1 : arg2;
-}
-
-__host__ __device__ double max(double arg1, double arg2)
-{
-  return (arg1 > arg2) ? arg1 : arg2;
-}
+__host__ __device__ float max(float arg1, float arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
+__host__ __device__ double max(double arg1, double arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
 
 __device__ void* __get_dynamicgroupbaseptr() {
     return hc::get_dynamic_group_segment_base_pointer();

--- a/src/device_util.cpp
+++ b/src/device_util.cpp
@@ -203,6 +203,56 @@ __host__ __device__ int max(int arg1, int arg2) {
     return (int)(hc::precise_math::fmax((float)arg1, (float)arg2));
 }
 
+__host__ __device__ unsigned int min(unsigned int arg1, unsigned int arg2)
+{
+  return (arg1 < arg2) ? arg1 : arg2;
+}
+
+__host__ __device__ unsigned int max(unsigned int arg1, unsigned int arg2)
+{
+  return (arg1 > arg2) ? arg1 : arg2;
+}
+
+__host__ __device__  long min( long arg1,  long arg2)
+{
+  return (arg1 < arg2) ? arg1 : arg2;
+}
+
+__host__ __device__  long max( long arg1,  long arg2)
+{
+  return (arg1 > arg2) ? arg1 : arg2;
+}
+
+__host__ __device__ unsigned long min(unsigned long arg1, unsigned long arg2)
+{
+  return (arg1 < arg2) ? arg1 : arg2;
+}
+
+__host__ __device__ unsigned long max(unsigned long arg1, unsigned long arg2)
+{
+  return (arg1 > arg2) ? arg1 : arg2;
+}
+
+__host__ __device__ float min(float arg1, float arg2)
+{
+  return (arg1 < arg2) ? arg1 : arg2;
+}
+
+__host__ __device__ float max(float arg1, float arg2)
+{
+  return (arg1 > arg2) ? arg1 : arg2;
+}
+
+__host__ __device__ double min(double arg1, double arg2)
+{
+  return (arg1 < arg2) ? arg1 : arg2;
+}
+
+__host__ __device__ double max(double arg1, double arg2)
+{
+  return (arg1 > arg2) ? arg1 : arg2;
+}
+
 __device__ void* __get_dynamicgroupbaseptr() {
     return hc::get_dynamic_group_segment_base_pointer();
 }

--- a/src/device_util.cpp
+++ b/src/device_util.cpp
@@ -196,13 +196,7 @@ __device__ float __shfl_xor(float input, int lane_mask, int width) {
     return hc::__shfl_xor(input, lane_mask, width);
 }
 
-__host__ __device__ int min(int arg1, int arg2) {
-    return (int)(hc::precise_math::fmin((float)arg1, (float)arg2));
-}
-__host__ __device__ int max(int arg1, int arg2) {
-    return (int)(hc::precise_math::fmax((float)arg1, (float)arg2));
-}
-
+__host__ __device__          int min(         int arg1,          int arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
 __host__ __device__ unsigned int min(         int arg1, unsigned int arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
 __host__ __device__ unsigned int min(unsigned int arg1,          int arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
 __host__ __device__ unsigned int min(unsigned int arg1, unsigned int arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
@@ -221,6 +215,7 @@ __host__ __device__ float min(float arg1, float arg2) { return ((arg1 < arg2) ? 
 __host__ __device__ double min(double arg1, double arg2) { return ((arg1 < arg2) ? arg1 : arg2 ); }
 
 
+__host__ __device__          int max(         int arg1,          int arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
 __host__ __device__ unsigned int max(         int arg1, unsigned int arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
 __host__ __device__ unsigned int max(unsigned int arg1,          int arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }
 __host__ __device__ unsigned int max(unsigned int arg1, unsigned int arg2) { return ((arg1 > arg2) ? arg1 : arg2 ); }


### PR DESCRIPTION
Tensorflow codebase expects the presence of float/double overloads for min/max. If not present, an implicit conversion from float/double to int occurs, leading to incorrect results, and hence this addition.

Thought about making this a templatized function, but decided against it because
1. a generic `template<typename T> __device__ T ...` would declare min/max overloads for all types, not sure that is what we want here. Also could not figure out a clean way of limiting the template instantiation to just the three types that we need for the time being.
2. did not want to change the existing implementation for the `int` type.