### PR TITLE
Fixed offset null check in bind texture functions

### DIFF
--- a/src/hip_texture.cpp
+++ b/src/hip_texture.cpp
@@ -389,7 +389,8 @@ hipError_t ihipBindTextureImpl(int dim, enum hipTextureReadMode readMode, size_t
     enum hipTextureFilterMode filterMode = tex->filterMode;
     int normalizedCoords = tex->normalized;
     hipTextureObject_t& textureObject = tex->textureObject;
-    *offset = 0;
+    if(offset != nullptr)
+        *offset = 0;
     auto ctx = ihipGetTlsDefaultCtx();
     if (ctx) {
         hc::accelerator acc = ctx->getDevice()->_acc;
@@ -459,7 +460,8 @@ hipError_t ihipBindTexture2DImpl(int dim, enum hipTextureReadMode readMode, size
     enum hipTextureFilterMode filterMode = tex->filterMode;
     int normalizedCoords = tex->normalized;
     hipTextureObject_t& textureObject = tex->textureObject;
-    *offset = 0;
+    if(offset != nullptr)
+        *offset = 0;
     auto ctx = ihipGetTlsDefaultCtx();
     if (ctx) {
         hc::accelerator acc = ctx->getDevice()->_acc;


### PR DESCRIPTION
Fixed offset null check in bind texture functions. Fixes SWDEV-155872.