### PR TITLE
[HIPIFY] Add DEBUG(X) macro compatibility

### DIFF
--- a/hipify-clang/src/LLVMCompat.h
+++ b/hipify-clang/src/LLVMCompat.h
@@ -23,6 +23,10 @@ namespace llcompat {
     #define GET_NUM_ARGS() getNumArgs()
 #endif
 
+#if LLVM_VERSION_MAJOR < 7
+    #define LLVM_DEBUG(X) DEBUG(X)
+#endif
+
 void PrintStackTraceOnErrorSignal();
 
 /**

--- a/hipify-clang/src/main.cpp
+++ b/hipify-clang/src/main.cpp
@@ -132,7 +132,7 @@ int main(int argc, const char **argv) {
 
     // Hipify _all_ the things!
     if (Tool.runAndSave(&actionFactory)) {
-      DEBUG(llvm::dbgs() << "Skipped some replacements.\n");
+      LLVM_DEBUG(llvm::dbgs() << "Skipped some replacements.\n");
     }
 
     // Either move the tmpfile to the output, or remove it.


### PR DESCRIPTION
In LLVM 7.0 DEBUG(X) was deleted, LLVM_DEBUG(X) should be used instead.