### PR TITLE
Let hipcc use proper include and lib path for HIP/VDI

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -24,6 +24,7 @@ use Cwd 'abs_path';
 # CUDA_PATH : Path to CUDA SDK (default /usr/local/cuda). Used on NVIDIA platforms only.
 # HCC_HOME  : Path to HCC SDK (default /opt/rocm/hcc).  Used on AMD platforms only.
 # HSA_PATH  : Path to HSA dir (default /opt/rocm/hsa).  Used on AMD platforms only.
+# HIP_VDI_HOME : Path to HIP/VDI directory. Used on AMD platforms only.
 
 if(scalar @ARGV == 0){
     print "No Arguments passed, exiting ...\n";
@@ -53,6 +54,7 @@ $verbose = $ENV{'HIPCC_VERBOSE'} // 0;
 # Verbose: 0x1=commands, 0x2=paths, 0x4=hipcc args
 
 $HIP_PATH=$ENV{'HIP_PATH'} // dirname (dirname $0); # use parent directory of hipcc
+$HIP_VDI_HOME=$ENV{'HIP_VDI_HOME'};
 $HIP_CLANG_PATH=$ENV{'HIP_CLANG_PATH'};
 $DEVICE_LIB_PATH=$ENV{'DEVICE_LIB_PATH'};
 
@@ -88,6 +90,18 @@ $HIP_PLATFORM= `$HIP_PATH/bin/hipconfig --platform` // "hcc";
 $HIP_VERSION= `$HIP_PATH/bin/hipconfig --version`;
 ($HIP_VERSION_MAJOR, $HIP_VERSION_MINOR, $HIP_VERSION_PATCH) = split(/\./, $HIP_VERSION);
 
+if (defined $HIP_VDI_HOME) {
+    if (!defined $HIP_CLANG_PATH) {
+        $HIP_CLANG_PATH = "$HIP_VDI_HOME/bin/x86_64";
+    }
+    if (!defined $DEVICE_LIB_PATH) {
+        $DEVICE_LIB_PATH = "$HIP_VDI_HOME/lib/x86_64/bitcode";
+    }
+    $HIP_CLANG_INCLUDE_PATH = "$HIP_VDI_HOME/include/clang";
+    $HIP_INCLUDE_PATH = "$HIP_VDI_HOME/include";
+    $HIP_LIB_PATH = "$HIP_VDI_HOME/lib/x86_64";
+}
+
 if (defined $HIP_CLANG_PATH) {
   $HIP_PLATFORM = "clang"
 }
@@ -109,9 +123,6 @@ $target_gfx906 = 0;
 $default_amdgpu_target = 1;
 
 if ($HIP_PLATFORM eq "clang") {
-    if ($verbose & 0x2) {
-        print ("HIP_CLANG_PATH=$HIP_CLANG_PATH\n");
-    }
     $ROCM_PATH=$ENV{'ROCM_PATH'} // "/opt/rocm";
     $HIPCC="$HIP_CLANG_PATH/clang++";
 
@@ -125,9 +136,30 @@ if ($HIP_PLATFORM eq "clang") {
     $HIP_CLANG_VERSION=~/.*clang version ([^ ]+).*/;
     $HIP_CLANG_VERSION=$1;
 
-    $HIPCXXFLAGS .= " -std=c++11 -isystem $HIP_CLANG_PATH/../lib/clang/$HIP_CLANG_VERSION/include -I$HIP_PATH/include";
-    $HIPLDFLAGS .= " --hip-link --hip-device-lib-path=$DEVICE_LIB_PATH -L$HIP_PATH/lib -lhip_hcc";
+    if (! defined $HIP_CLANG_INCLUDE_PATH) {
+        $HIP_CLANG_INCLUDE_PATH = "$HIP_CLANG_PATH/../lib/clang/$HIP_CLANG_VERSION/include";
+    }
+    if (! defined $HIP_INCLUDE_PATH) {
+        $HIP_INCLUDE_PATH = "$HIP_PATH/include";
+    }
+    if (! defined $HIP_LIB_PATH) {
+        $HIP_LIB_PATH = "$HIP_PATH/lib";
+    }
+    if ($verbose & 0x2) {
+        if (defined $HIP_VDI_HOME) {
+            print ("HIP_VDI_HOME=$HIP_VDI_HOME\n");
+        }
+        print ("HIP_CLANG_PATH=$HIP_CLANG_PATH\n");
+        print ("HIP_CLANG_INCLUDE_PATH=$HIP_CLANG_INCLUDE_PATH\n");
+        print ("HIP_INCLUDE_PATH=$HIP_INCLUDE_PATH\n");
+        print ("HIP_LIB_PATH=$HIP_LIB_PATH\n");
+        print ("DEVICE_LIB_PATH=$DEVICE_LIB_PATH\n");
+    }
+
+    $HIPCXXFLAGS .= " -std=c++11 -isystem $HIP_CLANG_INCLUDE_PATH";
+    $HIPLDFLAGS .= " --hip-link --hip-device-lib-path=$DEVICE_LIB_PATH -L$HIP_LIB_PATH -lhip_hcc";
 } elsif ($HIP_PLATFORM eq "hcc") {
+    $HIP_INCLUDE_PATH = "$HIP_PATH/include";
     $HSA_PATH=$ENV{'HSA_PATH'} // "/opt/rocm/hsa";
 
     $HCC_HOME=$ENV{'HCC_HOME'} // $hipConfig{'HCC_HOME'} // "/opt/rocm/hcc";
@@ -209,6 +241,7 @@ if ($HIP_PLATFORM eq "clang") {
     }
 
 } elsif ($HIP_PLATFORM eq "nvcc") {
+    $HIP_INCLUDE_PATH = "$HIP_PATH/include";
     if ($verbose & 0x2) {
         print ("CUDA_PATH=$CUDA_PATH\n");
     }
@@ -225,7 +258,7 @@ if ($HIP_PLATFORM eq "clang") {
 }
 
 # Add paths to common HIP includes:
-$HIPCXXFLAGS .= " -I$HIP_PATH/include -DHIP_VERSION_MAJOR=$HIP_VERSION_MAJOR -DHIP_VERSION_MINOR=$HIP_VERSION_MINOR -DHIP_VERSION_PATCH=$HIP_VERSION_PATCH" ;
+$HIPCXXFLAGS .= " -I$HIP_INCLUDE_PATH -DHIP_VERSION_MAJOR=$HIP_VERSION_MAJOR -DHIP_VERSION_MINOR=$HIP_VERSION_MINOR -DHIP_VERSION_PATCH=$HIP_VERSION_PATCH" ;
 
 my $compileOnly = 0;
 my $needCXXFLAGS = 0;  # need to add CXX flags to compile step

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -635,6 +635,10 @@ if ($buildDeps and $HIP_PLATFORM eq 'nvcc') {
     $HIPCXXFLAGS .= " -M -D__CUDACC__";
 }
 
+if ($buildDeps and $HIP_PLATFORM eq 'clang') {
+    $HIPCXXFLAGS .= " --cuda-host-only";
+}
+
 if ($setStdLib eq 0 and $HIP_PLATFORM eq 'hcc')
 {
     $HIPCXXFLAGS .= $HCC_WA_FLAGS;

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -157,7 +157,7 @@ if ($HIP_PLATFORM eq "clang") {
     }
 
     $HIPCXXFLAGS .= " -std=c++11 -isystem $HIP_CLANG_INCLUDE_PATH";
-    $HIPLDFLAGS .= " --hip-link --hip-device-lib-path=$DEVICE_LIB_PATH -L$HIP_LIB_PATH -lhip_hcc";
+    $HIPLDFLAGS .= " --hip-device-lib-path=$DEVICE_LIB_PATH -L$HIP_LIB_PATH -Wl,--rpath=$HIP_LIB_PATH -lhip_hcc";
 } elsif ($HIP_PLATFORM eq "hcc") {
     $HIP_INCLUDE_PATH = "$HIP_PATH/include";
     $HSA_PATH=$ENV{'HSA_PATH'} // "/opt/rocm/hsa";
@@ -637,6 +637,11 @@ if ($buildDeps and $HIP_PLATFORM eq 'nvcc') {
 
 if ($buildDeps and $HIP_PLATFORM eq 'clang') {
     $HIPCXXFLAGS .= " --cuda-host-only";
+}
+
+# Add --hip-link only if there are no source files.
+if (!$needCXXFLAGS and $HIP_PLATFORM eq 'clang') {
+    $HIPLDFLAGS .= " --hip-link";
 }
 
 if ($setStdLib eq 0 and $HIP_PLATFORM eq 'hcc')


### PR DESCRIPTION
Add support of environment variable HIP_VDI_HOME.

By setting environment variable HIP_VDI_HOME to the distribution directory of HIP/VDI, hipcc
will choose proper include and lib path for hip-clang.