### PR TITLE
[HIPClang] Fix icmp asm and attributes

### DIFF
--- a/include/hip/hcc_detail/device_functions.h
+++ b/include/hip/hcc_detail/device_functions.h
@@ -689,13 +689,13 @@ int __any(int predicate) {
 __device__
 inline
 unsigned long long int __ballot(int predicate) {
-    return __llvm_amdgcn_icmp_i32(predicate, 0, ICMP_NE);
+    return __llvm_amdgcn_icmp_i64_i32(predicate, 0, ICMP_NE);
 }
 
 __device__
 inline
 unsigned long long int __ballot64(int predicate) {
-    return __llvm_amdgcn_icmp_i32(predicate, 0, ICMP_NE);
+    return __llvm_amdgcn_icmp_i64_i32(predicate, 0, ICMP_NE);
 }
 
 // hip.amdgcn.bc - lanemask

--- a/include/hip/hcc_detail/llvm_intrinsics.h
+++ b/include/hip/hcc_detail/llvm_intrinsics.h
@@ -32,8 +32,8 @@ THE SOFTWARE.
 #include "hip/hcc_detail/host_defines.h"
 
 __device__
-__attribute__((convergent))
-ulong __llvm_amdgcn_icmp_i32(uint x, uint y, uint z) __asm("llvm.amdgcn.icmp.i32");
+__attribute__((const, convergent))
+ulong __llvm_amdgcn_icmp_i64_i32(uint x, uint y, uint z) __asm("llvm.amdgcn.icmp.i64.i32");
 
 __device__
 unsigned __llvm_amdgcn_groupstaticsize() __asm("llvm.amdgcn.groupstaticsize");


### PR DESCRIPTION
HIP llvm.amdgcn.icmp needs i64 return. This should fix recent llvm trunk changes causing this issue:

Intrinsic name not mangled correctly for type arguments! Should be: llvm.amdgcn.icmp.i64.i32
i64 (i32, i32, i32)* @llvm.amdgcn.icmp.i32
fatal error: error in backend: Broken function found, compilation aborted!
clang: error: clang frontend command failed with exit code 70 (use -v to see invocation)
clang version 4.0
Target: x86_64-unknown-linux-gnu
Thread model: posix
