### PR TITLE
Support ccache/sccache for hcc.

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -144,6 +144,8 @@ if ($HIP_PLATFORM eq "clang") {
     $marker_path = "$ROCM_PATH/profiler/CXLActivityLogger";
 
     # HCC* may be used to compile src/hip_hcc.o (and also feed the HIPCXXFLAGS below)
+    # Here, we'll search for hcc inside the path first instead of setting the direct path.
+    # This is helpful in cases when we're using ccache for caching compiler invocations.
     if [[ -n "$(which hcc)" ]]; then
         $HCC = "$(which hcc)";
     else

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -146,11 +146,10 @@ if ($HIP_PLATFORM eq "clang") {
     # HCC* may be used to compile src/hip_hcc.o (and also feed the HIPCXXFLAGS below)
     # Here, we'll search for hcc inside the path first instead of setting the direct path.
     # This is helpful in cases when we're using ccache for caching compiler invocations.
-    if [[ -n "$(which hcc)" ]]; then
-        $HCC = "$(which hcc)";
-    else
+    $HCC = `"$(which hcc)"`
+    if ($HCC eq ""){
         $HCC = "$HCC_HOME/bin/hcc"
-    fi
+    }
 
     $HCCFLAGS = "-hc  -D__HIPCC__ -I$HCC_HOME/include ";
 

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -147,6 +147,7 @@ if ($HIP_PLATFORM eq "clang") {
     # Here, we'll search for hcc inside the path first instead of setting the direct path.
     # This is helpful in cases when we're using ccache for caching compiler invocations.
     $HCC = `which hcc`;
+    chomp $HCC;
     if ($HCC eq ""){
         $HCC = "$HCC_HOME/bin/hcc"
     }

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -146,7 +146,7 @@ if ($HIP_PLATFORM eq "clang") {
     # HCC* may be used to compile src/hip_hcc.o (and also feed the HIPCXXFLAGS below)
     # Here, we'll search for hcc inside the path first instead of setting the direct path.
     # This is helpful in cases when we're using ccache for caching compiler invocations.
-    $HCC = `"$(which hcc)"`
+    $HCC = `which hcc`
     if ($HCC eq ""){
         $HCC = "$HCC_HOME/bin/hcc"
     }

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -144,7 +144,12 @@ if ($HIP_PLATFORM eq "clang") {
     $marker_path = "$ROCM_PATH/profiler/CXLActivityLogger";
 
     # HCC* may be used to compile src/hip_hcc.o (and also feed the HIPCXXFLAGS below)
-    $HCC = "$HCC_HOME/bin/hcc";
+    if [[ -n "$(which hcc)" ]]; then
+        $HCC = "$(which hcc)";
+    else
+        $HCC = "$HCC_HOME/bin/hcc"
+    fi
+
     $HCCFLAGS = "-hc  -D__HIPCC__ -I$HCC_HOME/include ";
 
     $HIPCC=$HCC;

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -146,7 +146,7 @@ if ($HIP_PLATFORM eq "clang") {
     # HCC* may be used to compile src/hip_hcc.o (and also feed the HIPCXXFLAGS below)
     # Here, we'll search for hcc inside the path first instead of setting the direct path.
     # This is helpful in cases when we're using ccache for caching compiler invocations.
-    $HCC = `which hcc`
+    $HCC = `which hcc`;
     if ($HCC eq ""){
         $HCC = "$HCC_HOME/bin/hcc"
     }


### PR DESCRIPTION
In order to use compiler caching tools such as ccache for local caching or sccache for caching via the cloud, HIPCC needs to select the HCC given from the path. This is necessary because a wrapper hcc file will be created (e.g. /root/sccache/hcc) that gets executed with the commands that would have been invoked into hcc, and passed them into sccache, which will then create a 1 to 1 mapping between the input arguments and the built object ("-o built_object.o....").  In general, the $PATH is updated in order to have this wrapper script (/root/sccache/hcc) execute when "hcc" is invoked standalone. 