### PR TITLE
Fixing a HIP bug that causes DEBUG symbols to be dropped.

### DIFF
--- a/cmake/FindHIP.cmake
+++ b/cmake/FindHIP.cmake
@@ -380,7 +380,7 @@ endmacro()
 ###############################################################################
 macro(HIP_PREPARE_TARGET_COMMANDS _target _format _generated_files _source_files)
     set(_hip_flags "")
-    set(_hip_build_configuration "${CMAKE_BUILD_TYPE}")
+    string(TOUPPER _hip_build_configuration "${CMAKE_BUILD_TYPE}")
     if(HIP_HOST_COMPILATION_CPP)
         set(HIP_C_OR_CXX CXX)
     else()


### PR DESCRIPTION
I've noticed that in the generated makefiles, we'd have 

if(NOT build_configuration)
    set(build_configuration Debug)
endif()

However, only definitions with all capitals are provided. 

e.g.

set(HIP_HCC_FLAGS_DEBUG -g)

This is because of lines 442 to 448. We capitalize the configuration ${config_upper}.

This PR fixes this bug.