### PR TITLE
Fix return EXIT_FAILURE if ballot or anyall fails

### DIFF
--- a/tests/src/deviceLib/hip_anyall.cpp
+++ b/tests/src/deviceLib/hip_anyall.cpp
@@ -96,13 +96,17 @@ int main(int argc, char* argv[]) {
 #if defined(__HIP_PLATFORM_HCC__) && !defined(NVCC_COMPAT)
     if (anycount == 1 && allcount == 1)
         printf("PASSED\n");
-    else
+    else {
         printf("FAILED\n");
+        return EXIT_FAILURE;
+    }
 #else
     if (anycount == 0 && allcount == 1)
         printf("PASSED\n");
-    else
+    else {
         printf("FAILED\n");
+        return EXIT_FAILURE;
+    }
 #endif
 
     return EXIT_SUCCESS;

--- a/tests/src/deviceLib/hip_ballot.cpp
+++ b/tests/src/deviceLib/hip_ballot.cpp
@@ -89,7 +89,9 @@ int main(int argc, char* argv[]) {
 
     if (divergent_count == 1)
         printf("PASSED\n");
-    else
+    else {
         printf("FAILED\n");
+        return EXIT_FAILURE;
+    }
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
I'm not sure why hip_anyall and hip_ballot returned success in failed cases. It should return failure when it fails.