### PR TITLE
Enable HIP texture functions with HIP vector types

### DIFF
--- a/include/hip/hcc_detail/hip_runtime.h
+++ b/include/hip/hcc_detail/hip_runtime.h
@@ -110,9 +110,9 @@ extern int HIP_TRACE_API;
 #include <hip/hcc_detail/host_defines.h>
 #include <hip/hcc_detail/device_functions.h>
 #include <hip/hcc_detail/surface_functions.h>
+#include <hip/hcc_detail/texture_functions.h>
 #if __HCC__
 #include <hip/hcc_detail/math_functions.h>
-#include <hip/hcc_detail/texture_functions.h>
 #endif // __HCC__
 
 // TODO-HCC remove old definitions ; ~1602 hcc supports __HCC_ACCELERATOR__ define.

--- a/include/hip/hcc_detail/texture_functions.h
+++ b/include/hip/hcc_detail/texture_functions.h
@@ -26,21 +26,25 @@ THE SOFTWARE.
 #include <hip/hcc_detail/hip_vector_types.h>
 #include <hip/hcc_detail/hip_texture_types.h>
 
+#pragma push_macro("TYPEDEF_VECTOR_VALUE_TYPE")
 #define TYPEDEF_VECTOR_VALUE_TYPE(SCALAR_TYPE) \
-typedef SCALAR_TYPE SCALAR_TYPE##2_vector_value_type __attribute__((ext_vector_type(2))); \
-typedef SCALAR_TYPE SCALAR_TYPE##3_vector_value_type __attribute__((ext_vector_type(3))); \
-typedef SCALAR_TYPE SCALAR_TYPE##4_vector_value_type __attribute__((ext_vector_type(4))); \
-typedef SCALAR_TYPE SCALAR_TYPE##8_vector_value_type __attribute__((ext_vector_type(8))); \
-typedef SCALAR_TYPE SCALAR_TYPE##16_vector_value_type __attribute__((ext_vector_type(16)));
+typedef SCALAR_TYPE __hip_##SCALAR_TYPE##2_vector_value_type __attribute__((ext_vector_type(2))); \
+typedef SCALAR_TYPE __hip_##SCALAR_TYPE##3_vector_value_type __attribute__((ext_vector_type(3))); \
+typedef SCALAR_TYPE __hip_##SCALAR_TYPE##4_vector_value_type __attribute__((ext_vector_type(4))); \
+typedef SCALAR_TYPE __hip_##SCALAR_TYPE##8_vector_value_type __attribute__((ext_vector_type(8))); \
+typedef SCALAR_TYPE __hip_##SCALAR_TYPE##16_vector_value_type __attribute__((ext_vector_type(16)));
 
 TYPEDEF_VECTOR_VALUE_TYPE(float);
 TYPEDEF_VECTOR_VALUE_TYPE(int);
 TYPEDEF_VECTOR_VALUE_TYPE(uint);
 
+#undef TYPEDEF_VECTOR_VALUE_TYPE
+#pragma pop_macro("TYPEDEF_VECTOR_VALUE_TYPE")
+
 union TData {
-    float4_vector_value_type f;
-    int4_vector_value_type i;
-    uint4_vector_value_type u;
+    __hip_float4_vector_value_type f;
+    __hip_int4_vector_value_type i;
+    __hip_uint4_vector_value_type u;
 };
 
 #define __TEXTURE_FUNCTIONS_DECL__ static __inline__ __device__
@@ -165,110 +169,110 @@ union TData {
 extern "C" {
 
 __device__
-float4_vector_value_type __ockl_image_sample_1D(
+__hip_float4_vector_value_type __ockl_image_sample_1D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
     float c);
 
 __device__
-float4_vector_value_type __ockl_image_sample_1Da(
+__hip_float4_vector_value_type __ockl_image_sample_1Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2_vector_value_type c);
+    __hip_float2_vector_value_type c);
 
 __device__
-float4_vector_value_type __ockl_image_sample_2D(
+__hip_float4_vector_value_type __ockl_image_sample_2D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2_vector_value_type c);
+    __hip_float2_vector_value_type c);
 
 
 __device__
-float4_vector_value_type __ockl_image_sample_2Da(
+__hip_float4_vector_value_type __ockl_image_sample_2Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4_vector_value_type c);
+    __hip_float4_vector_value_type c);
 
 __device__
 float __ockl_image_sample_2Dad(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4_vector_value_type c);
+    __hip_float4_vector_value_type c);
 
 __device__
 float __ockl_image_sample_2Dd(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2_vector_value_type c);
+    __hip_float2_vector_value_type c);
 
 __device__
-float4_vector_value_type __ockl_image_sample_3D(
+__hip_float4_vector_value_type __ockl_image_sample_3D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4_vector_value_type c);
+    __hip_float4_vector_value_type c);
 
 __device__
-float4_vector_value_type __ockl_image_sample_grad_1D(
+__hip_float4_vector_value_type __ockl_image_sample_grad_1D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
     float c, float dx, float dy);
 
 __device__
-float4_vector_value_type __ockl_image_sample_grad_1Da(
+__hip_float4_vector_value_type __ockl_image_sample_grad_1Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2_vector_value_type c, float dx, float dy);
+    __hip_float2_vector_value_type c, float dx, float dy);
 
 __device__
-float4_vector_value_type __ockl_image_sample_grad_2D(
+__hip_float4_vector_value_type __ockl_image_sample_grad_2D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2_vector_value_type c, float2_vector_value_type dx, float2_vector_value_type dy);
+    __hip_float2_vector_value_type c, __hip_float2_vector_value_type dx, __hip_float2_vector_value_type dy);
 
 __device__
-float4_vector_value_type __ockl_image_sample_grad_2Da(
+__hip_float4_vector_value_type __ockl_image_sample_grad_2Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4_vector_value_type c, float2_vector_value_type dx, float2_vector_value_type dy);
+    __hip_float4_vector_value_type c, __hip_float2_vector_value_type dx, __hip_float2_vector_value_type dy);
 
 __device__
 float __ockl_image_sample_grad_2Dad(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4_vector_value_type c, float2_vector_value_type dx, float2_vector_value_type dy);
+    __hip_float4_vector_value_type c, __hip_float2_vector_value_type dx, __hip_float2_vector_value_type dy);
 
 __device__
 float __ockl_image_sample_grad_2Dd(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2_vector_value_type c, float2_vector_value_type dx, float2_vector_value_type dy);
+    __hip_float2_vector_value_type c, __hip_float2_vector_value_type dx, __hip_float2_vector_value_type dy);
 
 __device__
-float4_vector_value_type __ockl_image_sample_grad_3D(
+__hip_float4_vector_value_type __ockl_image_sample_grad_3D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4_vector_value_type c, float4_vector_value_type dx, float4_vector_value_type dy);
+    __hip_float4_vector_value_type c, __hip_float4_vector_value_type dx, __hip_float4_vector_value_type dy);
 
 __device__
-float4_vector_value_type __ockl_image_sample_lod_1D(
+__hip_float4_vector_value_type __ockl_image_sample_lod_1D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
     float c, float l);
 
 __device__
-float4_vector_value_type __ockl_image_sample_lod_1Da(
+__hip_float4_vector_value_type __ockl_image_sample_lod_1Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2_vector_value_type c, float l);
+    __hip_float2_vector_value_type c, float l);
 
 __device__
-float4_vector_value_type __ockl_image_sample_lod_2D(
+__hip_float4_vector_value_type __ockl_image_sample_lod_2D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2_vector_value_type c, float l);
+    __hip_float2_vector_value_type c, float l);
 
 __device__
-float4_vector_value_type __ockl_image_sample_lod_2Da(
+__hip_float4_vector_value_type __ockl_image_sample_lod_2Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4_vector_value_type c, float l);
+    __hip_float4_vector_value_type c, float l);
 
 __device__
 float __ockl_image_sample_lod_2Dad(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4_vector_value_type c, float l);
+    __hip_float4_vector_value_type c, float l);
 
 __device__
 float __ockl_image_sample_lod_2Dd(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2_vector_value_type c, float l);
+    __hip_float2_vector_value_type c, float l);
 
 __device__
-float4_vector_value_type __ockl_image_sample_lod_3D(
+__hip_float4_vector_value_type __ockl_image_sample_lod_3D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4_vector_value_type c, float l);
+    __hip_float4_vector_value_type c, float l);
 }
 
 ////////////////////////////////////////////////////////////

--- a/include/hip/hcc_detail/texture_functions.h
+++ b/include/hip/hcc_detail/texture_functions.h
@@ -26,10 +26,21 @@ THE SOFTWARE.
 #include <hip/hcc_detail/hip_vector_types.h>
 #include <hip/hcc_detail/hip_texture_types.h>
 
+#define TYPEDEF_VECTOR_VALUE_TYPE(SCALAR_TYPE) \
+typedef SCALAR_TYPE SCALAR_TYPE##2_vector_value_type __attribute__((ext_vector_type(2))); \
+typedef SCALAR_TYPE SCALAR_TYPE##3_vector_value_type __attribute__((ext_vector_type(3))); \
+typedef SCALAR_TYPE SCALAR_TYPE##4_vector_value_type __attribute__((ext_vector_type(4))); \
+typedef SCALAR_TYPE SCALAR_TYPE##8_vector_value_type __attribute__((ext_vector_type(8))); \
+typedef SCALAR_TYPE SCALAR_TYPE##16_vector_value_type __attribute__((ext_vector_type(16)));
+
+TYPEDEF_VECTOR_VALUE_TYPE(float);
+TYPEDEF_VECTOR_VALUE_TYPE(int);
+TYPEDEF_VECTOR_VALUE_TYPE(uint);
+
 union TData {
-    float4 f;
-    int4 i;
-    uint4 u;
+    float4_vector_value_type f;
+    int4_vector_value_type i;
+    uint4_vector_value_type u;
 };
 
 #define __TEXTURE_FUNCTIONS_DECL__ static __inline__ __device__
@@ -154,110 +165,110 @@ union TData {
 extern "C" {
 
 __device__
-float4 __ockl_image_sample_1D(
+float4_vector_value_type __ockl_image_sample_1D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
     float c);
 
 __device__
-float4 __ockl_image_sample_1Da(
+float4_vector_value_type __ockl_image_sample_1Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2 c);
+    float2_vector_value_type c);
 
 __device__
-float4 __ockl_image_sample_2D(
+float4_vector_value_type __ockl_image_sample_2D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2 c);
+    float2_vector_value_type c);
 
 
 __device__
-float4 __ockl_image_sample_2Da(
+float4_vector_value_type __ockl_image_sample_2Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4 c);
+    float4_vector_value_type c);
 
 __device__
 float __ockl_image_sample_2Dad(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4 c);
+    float4_vector_value_type c);
 
 __device__
 float __ockl_image_sample_2Dd(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2 c);
+    float2_vector_value_type c);
 
 __device__
-float4 __ockl_image_sample_3D(
+float4_vector_value_type __ockl_image_sample_3D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4 c);
+    float4_vector_value_type c);
 
 __device__
-float4 __ockl_image_sample_grad_1D(
+float4_vector_value_type __ockl_image_sample_grad_1D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
     float c, float dx, float dy);
 
 __device__
-float4 __ockl_image_sample_grad_1Da(
+float4_vector_value_type __ockl_image_sample_grad_1Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2 c, float dx, float dy);
+    float2_vector_value_type c, float dx, float dy);
 
 __device__
-float4 __ockl_image_sample_grad_2D(
+float4_vector_value_type __ockl_image_sample_grad_2D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2 c, float2 dx, float2 dy);
+    float2_vector_value_type c, float2_vector_value_type dx, float2_vector_value_type dy);
 
 __device__
-float4 __ockl_image_sample_grad_2Da(
+float4_vector_value_type __ockl_image_sample_grad_2Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4 c, float2 dx, float2 dy);
+    float4_vector_value_type c, float2_vector_value_type dx, float2_vector_value_type dy);
 
 __device__
 float __ockl_image_sample_grad_2Dad(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4 c, float2 dx, float2 dy);
+    float4_vector_value_type c, float2_vector_value_type dx, float2_vector_value_type dy);
 
 __device__
 float __ockl_image_sample_grad_2Dd(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2 c, float2 dx, float2 dy);
+    float2_vector_value_type c, float2_vector_value_type dx, float2_vector_value_type dy);
 
 __device__
-float4 __ockl_image_sample_grad_3D(
+float4_vector_value_type __ockl_image_sample_grad_3D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4 c, float4 dx, float4 dy);
+    float4_vector_value_type c, float4_vector_value_type dx, float4_vector_value_type dy);
 
 __device__
-float4 __ockl_image_sample_lod_1D(
+float4_vector_value_type __ockl_image_sample_lod_1D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
     float c, float l);
 
 __device__
-float4 __ockl_image_sample_lod_1Da(
+float4_vector_value_type __ockl_image_sample_lod_1Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2 c, float l);
+    float2_vector_value_type c, float l);
 
 __device__
-float4 __ockl_image_sample_lod_2D(
+float4_vector_value_type __ockl_image_sample_lod_2D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2 c, float l);
+    float2_vector_value_type c, float l);
 
 __device__
-float4 __ockl_image_sample_lod_2Da(
+float4_vector_value_type __ockl_image_sample_lod_2Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4 c, float l);
+    float4_vector_value_type c, float l);
 
 __device__
 float __ockl_image_sample_lod_2Dad(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4 c, float l);
+    float4_vector_value_type c, float l);
 
 __device__
 float __ockl_image_sample_lod_2Dd(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float2 c, float l);
+    float2_vector_value_type c, float l);
 
 __device__
-float4 __ockl_image_sample_lod_3D(
+float4_vector_value_type __ockl_image_sample_lod_3D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    float4 c, float l);
+    float4_vector_value_type c, float l);
 }
 
 ////////////////////////////////////////////////////////////
@@ -1045,196 +1056,196 @@ __TEXTURE_FUNCTIONS_DECL__ T tex1DGrad(hipTextureObject_t textureObject, float x
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(char* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(char1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(char2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(char4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(unsigned char* retVal, hipTextureObject_t textureObject,
                                       float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(uchar1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(uchar2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(uchar4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(short* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(short1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(short2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(short4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(unsigned short* retVal, hipTextureObject_t textureObject,
                                       float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(ushort1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(ushort2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(ushort4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(int* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(int1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(int2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(int4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(unsigned int* retVal, hipTextureObject_t textureObject,
                                       float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(uint1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(uint2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(uint4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(float* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_FLOAT;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(float1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_FLOAT_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(float2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_FLOAT_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(float4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -1249,196 +1260,196 @@ __TEXTURE_FUNCTIONS_DECL__ T tex2D(hipTextureObject_t textureObject, float x, fl
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(char* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(char1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(char2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(char4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(unsigned char* retVal, hipTextureObject_t textureObject,
                                          float x, float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(uchar1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(uchar2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(uchar4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(short* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(short1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(short2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(short4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(unsigned short* retVal, hipTextureObject_t textureObject,
                                          float x, float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(ushort1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(ushort2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(ushort4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(int* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(int1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(int2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(int4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(unsigned int* retVal, hipTextureObject_t textureObject,
                                          float x, float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(uint1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(uint2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(uint4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(float* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_FLOAT;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(float1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_FLOAT_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(float2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_FLOAT_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(float4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -1454,196 +1465,196 @@ __TEXTURE_FUNCTIONS_DECL__ T tex2DLod(hipTextureObject_t textureObject, float x,
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(char* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(char1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(char2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(char4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(unsigned char* retVal, hipTextureObject_t textureObject,
                                       float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(uchar1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(uchar2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(uchar4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(short* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(short1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(short2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(short4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(unsigned short* retVal, hipTextureObject_t textureObject,
                                       float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(ushort1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(ushort2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(ushort4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(int* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(int1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(int2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(int4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(unsigned int* retVal, hipTextureObject_t textureObject,
                                       float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(uint1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(uint2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(uint4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(float* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_FLOAT;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(float1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_FLOAT_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(float2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_FLOAT_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(float4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -1658,7 +1669,7 @@ __TEXTURE_FUNCTIONS_DECL__ T tex3D(hipTextureObject_t textureObject, float x, fl
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_SIGNED;
 }
@@ -1666,7 +1677,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char* retVal, hipTextureObject_t textur
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_SIGNED_X;
 }
@@ -1674,7 +1685,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char1* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_SIGNED_XY;
 }
@@ -1682,7 +1693,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char2* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_SIGNED_XYZW;
 }
@@ -1690,7 +1701,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char4* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(unsigned char* retVal, hipTextureObject_t textureObject,
                                          float x, float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_UNSIGNED;
 }
@@ -1698,7 +1709,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(unsigned char* retVal, hipTextureObject
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uchar1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_UNSIGNED_X;
 }
@@ -1706,7 +1717,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uchar1* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uchar2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_UNSIGNED_XY;
 }
@@ -1714,7 +1725,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uchar2* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uchar4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
@@ -1722,7 +1733,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uchar4* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_SIGNED;
 }
@@ -1730,7 +1741,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_SIGNED_X;
 }
@@ -1738,7 +1749,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short1* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_SIGNED_XY;
 }
@@ -1746,7 +1757,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short2* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_SIGNED_XYZW;
 }
@@ -1754,7 +1765,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short4* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(unsigned short* retVal, hipTextureObject_t textureObject,
                                          float x, float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_UNSIGNED;
 }
@@ -1762,7 +1773,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(unsigned short* retVal, hipTextureObjec
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(ushort1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_UNSIGNED_X;
 }
@@ -1770,7 +1781,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(ushort1* retVal, hipTextureObject_t tex
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(ushort2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_UNSIGNED_XY;
 }
@@ -1778,7 +1789,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(ushort2* retVal, hipTextureObject_t tex
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(ushort4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
@@ -1786,7 +1797,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(ushort4* retVal, hipTextureObject_t tex
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_SIGNED;
 }
@@ -1794,7 +1805,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int* retVal, hipTextureObject_t texture
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_SIGNED_X;
 }
@@ -1802,7 +1813,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int1* retVal, hipTextureObject_t textur
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_SIGNED_XY;
 }
@@ -1810,7 +1821,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int2* retVal, hipTextureObject_t textur
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_SIGNED_XYZW;
 }
@@ -1818,7 +1829,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int4* retVal, hipTextureObject_t textur
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(unsigned int* retVal, hipTextureObject_t textureObject,
                                          float x, float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_UNSIGNED;
 }
@@ -1826,7 +1837,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(unsigned int* retVal, hipTextureObject_
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uint1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_UNSIGNED_X;
 }
@@ -1834,7 +1845,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uint1* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uint2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_UNSIGNED_XY;
 }
@@ -1842,7 +1853,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uint2* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uint4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
@@ -1850,7 +1861,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uint4* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_FLOAT;
 }
@@ -1858,7 +1869,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_FLOAT_X;
 }
@@ -1866,7 +1877,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float1* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_FLOAT_XY;
 }
@@ -1874,7 +1885,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float2* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_SET_FLOAT_XYZW;
 }
@@ -1891,189 +1902,189 @@ __TEXTURE_FUNCTIONS_DECL__ T tex3DLod(hipTextureObject_t textureObject, float x,
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(char* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(char1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(char2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_SIGNED_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(char4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(unsigned char* retVal,
                                              hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(uchar1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(uchar2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_UNSIGNED_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(uchar4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(short* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(short1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(short2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_SIGNED_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(short4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(unsigned short* retVal,
                                              hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(ushort1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(ushort2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_UNSIGNED_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(ushort4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(int* retVal, hipTextureObject_t textureObject, float x,
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(int1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(int2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_SIGNED_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(int4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(unsigned int* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(uint1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(uint2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_UNSIGNED_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(uint4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(float* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_FLOAT;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(float1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_FLOAT_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(float2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_FLOAT_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(float4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -2089,7 +2100,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(char* retVal, hipTextureObject_t
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2097,7 +2108,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(char1* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2105,7 +2116,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(char2* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2113,7 +2124,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(char4* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2122,7 +2133,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(unsigned char* retVal,
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2130,7 +2141,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(uchar1* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2138,7 +2149,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(uchar2* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2146,7 +2157,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(uchar4* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2154,7 +2165,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(short* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2162,7 +2173,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(short1* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2170,7 +2181,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(short2* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2178,7 +2189,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(short4* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2187,7 +2198,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(unsigned short* retVal,
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2195,7 +2206,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(ushort1* retVal, hipTextureObjec
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2203,7 +2214,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(ushort2* retVal, hipTextureObjec
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2211,7 +2222,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(ushort4* retVal, hipTextureObjec
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2219,7 +2230,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(int* retVal, hipTextureObject_t 
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2227,7 +2238,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(int1* retVal, hipTextureObject_t
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2235,7 +2246,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(int2* retVal, hipTextureObject_t
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2243,7 +2254,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(int4* retVal, hipTextureObject_t
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2252,7 +2263,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(unsigned int* retVal,
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2260,7 +2271,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(uint1* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2268,7 +2279,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(uint2* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2276,7 +2287,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(uint4* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2284,7 +2295,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(float* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_FLOAT;
 }
 
@@ -2292,7 +2303,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(float1* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_FLOAT_X;
 }
 
@@ -2300,7 +2311,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(float2* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_FLOAT_XY;
 }
 
@@ -2308,7 +2319,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(float4* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -2325,7 +2336,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(char* retVal, hipTextureObject_
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2333,7 +2344,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(char1* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2341,7 +2352,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(char2* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2349,7 +2360,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(char4* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2358,7 +2369,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(unsigned char* retVal,
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2366,7 +2377,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(uchar1* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2374,7 +2385,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(uchar2* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2382,7 +2393,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(uchar4* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2390,7 +2401,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(short* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2398,7 +2409,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(short1* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2406,7 +2417,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(short2* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2414,7 +2425,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(short4* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2423,7 +2434,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(unsigned short* retVal,
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2431,7 +2442,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(ushort1* retVal, hipTextureObje
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2439,7 +2450,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(ushort2* retVal, hipTextureObje
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2447,7 +2458,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(ushort4* retVal, hipTextureObje
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2455,7 +2466,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(int* retVal, hipTextureObject_t
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2463,7 +2474,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(int1* retVal, hipTextureObject_
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2471,7 +2482,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(int2* retVal, hipTextureObject_
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2479,7 +2490,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(int4* retVal, hipTextureObject_
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2488,7 +2499,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(unsigned int* retVal,
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2496,7 +2507,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(uint1* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2504,7 +2515,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(uint2* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2512,7 +2523,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(uint4* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2520,7 +2531,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(float* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_FLOAT;
 }
 
@@ -2528,7 +2539,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(float1* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_FLOAT_X;
 }
 
@@ -2536,7 +2547,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(float2* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_FLOAT_XY;
 }
 
@@ -2544,7 +2555,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(float4* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -2561,7 +2572,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(char* retVal, hipTextureObject_t te
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2569,7 +2580,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(char1* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2577,7 +2588,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(char2* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2585,7 +2596,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(char4* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2594,7 +2605,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(unsigned char* retVal,
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2602,7 +2613,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(uchar1* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2610,7 +2621,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(uchar2* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2618,7 +2629,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(uchar4* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2626,7 +2637,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(short* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2634,7 +2645,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(short1* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2642,7 +2653,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(short2* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2650,7 +2661,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(short4* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2659,7 +2670,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(unsigned short* retVal,
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2667,7 +2678,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(ushort1* retVal, hipTextureObject_t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2675,7 +2686,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(ushort2* retVal, hipTextureObject_t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2683,7 +2694,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(ushort4* retVal, hipTextureObject_t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2691,7 +2702,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(int* retVal, hipTextureObject_t tex
                                              float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2699,7 +2710,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(int1* retVal, hipTextureObject_t te
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2707,7 +2718,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(int2* retVal, hipTextureObject_t te
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2715,7 +2726,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(int4* retVal, hipTextureObject_t te
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2723,7 +2734,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(unsigned int* retVal, hipTextureObj
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2731,7 +2742,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(uint1* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2739,7 +2750,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(uint2* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2747,7 +2758,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(uint4* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2755,7 +2766,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(float* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_FLOAT;
 }
 
@@ -2763,7 +2774,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(float1* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_FLOAT_X;
 }
 
@@ -2771,7 +2782,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(float2* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_FLOAT_XY;
 }
 
@@ -2779,7 +2790,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(float4* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -2796,7 +2807,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(char* retVal, hipTextureObject_t
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2804,7 +2815,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(char1* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2812,7 +2823,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(char2* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2820,7 +2831,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(char4* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2829,7 +2840,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(unsigned char* retVal,
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2837,7 +2848,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(uchar1* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2845,7 +2856,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(uchar2* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2853,7 +2864,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(uchar4* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2861,7 +2872,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(short* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2869,7 +2880,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(short1* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2877,7 +2888,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(short2* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2885,7 +2896,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(short4* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2894,7 +2905,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(unsigned short* retVal,
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2902,7 +2913,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(ushort1* retVal, hipTextureObjec
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2910,7 +2921,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(ushort2* retVal, hipTextureObjec
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2918,7 +2929,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(ushort4* retVal, hipTextureObjec
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2926,7 +2937,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(int* retVal, hipTextureObject_t 
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2934,7 +2945,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(int1* retVal, hipTextureObject_t
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2942,7 +2953,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(int2* retVal, hipTextureObject_t
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2950,7 +2961,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(int4* retVal, hipTextureObject_t
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2959,7 +2970,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(unsigned int* retVal,
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2967,7 +2978,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(uint1* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2975,7 +2986,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(uint2* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2983,7 +2994,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(uint4* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2991,7 +3002,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(float* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_FLOAT;
 }
 
@@ -2999,7 +3010,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(float1* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_FLOAT_X;
 }
 
@@ -3007,7 +3018,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(float2* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_FLOAT_XY;
 }
 
@@ -3015,7 +3026,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(float4* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -4819,28 +4830,28 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex1DGrad(texture<float4, texType, mode> texRe
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex2D(texture<char, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_CHAR;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex2D(texture<char1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex2D(texture<char2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex2D(texture<char4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -4848,56 +4859,56 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2D(texture<unsigned char, texType, mode> texRef,
                                                float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UCHAR;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2D(texture<uchar1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2D(texture<uchar2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2D(texture<uchar4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short tex2D(texture<short, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_SHORT;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short1 tex2D(texture<short1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short2 tex2D(texture<short2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short4 tex2D(texture<short4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -4905,56 +4916,56 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2D(texture<unsigned short, texType, mode> texRef,
                                                 float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_USHORT;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2D(texture<ushort1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2D(texture<ushort2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2D(texture<ushort4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex2D(texture<int, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_INT;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex2D(texture<int1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_INT_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex2D(texture<int2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_INT_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex2D(texture<int4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -4962,28 +4973,28 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2D(texture<unsigned int, texType, mode> texRef, float x,
                                               float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UINT;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex2D(texture<uint1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UINT_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex2D(texture<uint2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex2D(texture<uint4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -4994,7 +5005,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex2D(texture<char, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -5002,7 +5013,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex2D(texture<char1, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -5010,7 +5021,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex2D(texture<char2, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -5018,7 +5029,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex2D(texture<char4, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -5026,7 +5037,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2D(texture<unsigned char, texType, mode> texRef,
                                                hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -5034,7 +5045,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2D(texture<uchar1, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -5042,7 +5053,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2D(texture<uchar2, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -5050,7 +5061,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2D(texture<uchar4, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -5058,7 +5069,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short tex2D(texture<short, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -5066,7 +5077,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short1 tex2D(texture<short1, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -5074,7 +5085,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short2 tex2D(texture<short2, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -5082,7 +5093,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short4 tex2D(texture<short4, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -5091,7 +5102,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2D(texture<unsigned short, texType,
                                                 hipTextureObject_t textureObject, float x,
                                                 float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -5099,7 +5110,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2D(texture<ushort1, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -5107,7 +5118,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2D(texture<ushort2, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -5115,7 +5126,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2D(texture<ushort4, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -5123,7 +5134,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex2D(texture<int, texType, mode> texRef,
                                      hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_INT;
 }
 
@@ -5131,7 +5142,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex2D(texture<int1, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -5139,7 +5150,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex2D(texture<int2, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -5147,7 +5158,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex2D(texture<int4, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -5155,7 +5166,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2D(texture<unsigned int, texType, mode> texRef,
                                               hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UINT;
 }
 
@@ -5163,7 +5174,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex2D(texture<uint1, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -5171,7 +5182,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex2D(texture<uint2, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -5179,7 +5190,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex2D(texture<uint4, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -5187,21 +5198,21 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex2D(texture<float, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_FLOAT;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex2D(texture<float, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_FLOAT;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex2D(texture<float1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -5209,14 +5220,14 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex2D(texture<float1, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex2D(texture<float2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -5224,14 +5235,14 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex2D(texture<float2, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex2D(texture<float4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -5239,7 +5250,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex2D(texture<float4, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -5249,7 +5260,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex2DLod(texture<char, texType, mode> texRef, float x, float y,
                                          float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -5257,7 +5268,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLod(texture<char1, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -5265,7 +5276,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLod(texture<char2, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -5273,7 +5284,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLod(texture<char4, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -5281,7 +5292,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLod(texture<unsigned char, texType, mode> texRef,
                                                   float x, float y, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -5289,7 +5300,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLod(texture<uchar1, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -5297,7 +5308,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLod(texture<uchar2, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -5305,7 +5316,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLod(texture<uchar4, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -5313,7 +5324,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short tex2DLod(texture<short, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -5321,7 +5332,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLod(texture<short1, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -5329,7 +5340,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLod(texture<short2, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -5337,7 +5348,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLod(texture<short4, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -5345,7 +5356,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLod(texture<unsigned short, texType, mode> texRef,
                                                    float x, float y, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -5353,7 +5364,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLod(texture<ushort1, texType, mode> texRef, float x,
                                             float y, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -5361,7 +5372,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLod(texture<ushort2, texType, mode> texRef, float x,
                                             float y, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -5369,7 +5380,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLod(texture<ushort4, texType, mode> texRef, float x,
                                             float y, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -5377,7 +5388,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex2DLod(texture<int, texType, mode> texRef, float x, float y,
                                         float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_INT;
 }
 
@@ -5385,7 +5396,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLod(texture<int1, texType, mode> texRef, float x, float y,
                                          float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -5393,7 +5404,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLod(texture<int2, texType, mode> texRef, float x, float y,
                                          float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -5401,7 +5412,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLod(texture<int4, texType, mode> texRef, float x, float y,
                                          float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -5409,7 +5420,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLod(texture<unsigned int, texType, mode> texRef,
                                                  float x, float y, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UINT;
 }
 
@@ -5417,7 +5428,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLod(texture<uint1, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -5425,7 +5436,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLod(texture<uint2, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -5433,7 +5444,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLod(texture<uint4, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -5441,7 +5452,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex2DLod(texture<float, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -5449,7 +5460,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLod(texture<float1, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -5457,7 +5468,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLod(texture<float2, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -5465,7 +5476,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLod(texture<float4, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -5476,7 +5487,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLod(texture<char, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -5485,7 +5496,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLod(texture<char1, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -5494,7 +5505,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLod(texture<char2, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -5503,7 +5514,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLod(texture<char4, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -5512,7 +5523,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLod(texture<unsigned char, texType
                                                   hipTextureObject_t textureObject, float x,
                                                   float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -5521,7 +5532,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLod(texture<uchar1, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -5530,7 +5541,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLod(texture<uchar2, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -5539,7 +5550,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLod(texture<uchar4, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -5548,7 +5559,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLod(texture<short, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -5557,7 +5568,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLod(texture<short1, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -5566,7 +5577,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLod(texture<short2, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -5575,7 +5586,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLod(texture<short4, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -5584,7 +5595,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLod(texture<unsigned short, texTy
                                                    hipTextureObject_t textureObject, float x,
                                                    float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -5593,7 +5604,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLod(texture<ushort1, texType, mode> texR
                                             hipTextureObject_t textureObject, float x, float y,
                                             float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -5602,7 +5613,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLod(texture<ushort2, texType, mode> texR
                                             hipTextureObject_t textureObject, float x, float y,
                                             float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -5611,7 +5622,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLod(texture<ushort4, texType, mode> texR
                                             hipTextureObject_t textureObject, float x, float y,
                                             float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -5620,7 +5631,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLod(texture<int, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_INT;
 }
 
@@ -5629,7 +5640,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLod(texture<int1, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -5638,7 +5649,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLod(texture<int2, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -5647,7 +5658,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLod(texture<int4, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -5656,7 +5667,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLod(texture<unsigned int, texType, 
                                                  hipTextureObject_t textureObject, float x, float y,
                                                  float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UINT;
 }
 
@@ -5665,7 +5676,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLod(texture<uint1, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -5674,7 +5685,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLod(texture<uint2, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -5683,7 +5694,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLod(texture<uint4, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -5692,7 +5703,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLod(texture<float, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -5701,7 +5712,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLod(texture<float1, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -5710,7 +5721,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLod(texture<float2, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -5719,7 +5730,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLod(texture<float4, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y).data, level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -5729,9 +5740,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex2DGrad(texture<char, texType, mode> texRef, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -5739,9 +5750,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex2DGrad(texture<char1, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -5749,9 +5760,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex2DGrad(texture<char2, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -5759,9 +5770,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex2DGrad(texture<char4, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -5769,9 +5780,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DGrad(texture<unsigned char, texType, mode> texRef,
                                                    float x, float y, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -5779,9 +5790,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DGrad(texture<uchar1, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -5789,9 +5800,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DGrad(texture<uchar2, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -5799,9 +5810,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DGrad(texture<uchar4, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -5809,9 +5820,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short tex2DGrad(texture<short, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -5819,9 +5830,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short1 tex2DGrad(texture<short1, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -5829,9 +5840,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short2 tex2DGrad(texture<short2, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -5839,9 +5850,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short4 tex2DGrad(texture<short4, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -5849,9 +5860,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DGrad(texture<unsigned short, texType, mode> texRef,
                                                     float x, float y, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -5859,9 +5870,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DGrad(texture<ushort1, texType, mode> texRef, float x,
                                              float y, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -5869,9 +5880,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DGrad(texture<ushort2, texType, mode> texRef, float x,
                                              float y, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -5879,9 +5890,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DGrad(texture<ushort4, texType, mode> texRef, float x,
                                              float y, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -5889,9 +5900,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex2DGrad(texture<int, texType, mode> texRef, float x, float y,
                                          float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT;
 }
 
@@ -5899,9 +5910,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex2DGrad(texture<int1, texType, mode> texRef, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -5909,9 +5920,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex2DGrad(texture<int2, texType, mode> texRef, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -5919,9 +5930,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex2DGrad(texture<int4, texType, mode> texRef, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -5929,9 +5940,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DGrad(texture<unsigned int, texType, mode> texRef,
                                                   float x, float y, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT;
 }
 
@@ -5939,9 +5950,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DGrad(texture<uint1, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -5949,9 +5960,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DGrad(texture<uint2, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -5959,9 +5970,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DGrad(texture<uint4, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -5969,9 +5980,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex2DGrad(texture<float, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -5979,9 +5990,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex2DGrad(texture<float1, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -5989,9 +6000,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex2DGrad(texture<float2, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -5999,9 +6010,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex2DGrad(texture<float4, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -6012,9 +6023,9 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DGrad(texture<char, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -6023,9 +6034,9 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DGrad(texture<char1, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -6034,9 +6045,9 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DGrad(texture<char2, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -6045,9 +6056,9 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DGrad(texture<char4, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -6056,9 +6067,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DGrad(texture<unsigned char, texTyp
                                                    hipTextureObject_t textureObject, float x,
                                                    float y, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -6067,9 +6078,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DGrad(texture<uchar1, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -6078,9 +6089,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DGrad(texture<uchar2, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -6089,9 +6100,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DGrad(texture<uchar4, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -6100,9 +6111,9 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DGrad(texture<short, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -6111,9 +6122,9 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DGrad(texture<short1, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -6122,9 +6133,9 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DGrad(texture<short2, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -6133,9 +6144,9 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DGrad(texture<short4, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -6144,9 +6155,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DGrad(texture<unsigned short, texT
                                                     hipTextureObject_t textureObject, float x,
                                                     float y, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -6155,9 +6166,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DGrad(texture<ushort1, texType, mode> tex
                                              hipTextureObject_t textureObject, float x, float y,
                                              float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -6166,9 +6177,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DGrad(texture<ushort2, texType, mode> tex
                                              hipTextureObject_t textureObject, float x, float y,
                                              float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -6177,9 +6188,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DGrad(texture<ushort4, texType, mode> tex
                                              hipTextureObject_t textureObject, float x, float y,
                                              float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -6188,9 +6199,9 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DGrad(texture<int, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT;
 }
 
@@ -6199,9 +6210,9 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DGrad(texture<int1, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -6210,9 +6221,9 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DGrad(texture<int2, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -6221,9 +6232,9 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DGrad(texture<int4, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -6232,9 +6243,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DGrad(texture<unsigned int, texType,
                                                   hipTextureObject_t textureObject, float x,
                                                   float y, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT;
 }
 
@@ -6243,9 +6254,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DGrad(texture<uint1, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -6254,9 +6265,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DGrad(texture<uint2, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -6265,9 +6276,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DGrad(texture<uint4, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -6276,9 +6287,9 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DGrad(texture<float, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -6287,9 +6298,9 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DGrad(texture<float1, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -6298,9 +6309,9 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DGrad(texture<float2, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -6309,9 +6320,9 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DGrad(texture<float4, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
-                                          float2(dx.x, dx.y),
-                                          float2(dy.x, dy.y));
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y).data,
+                                          float2(dx.x, dx.y).data,
+                                          float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -6321,7 +6332,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex3D(texture<char, texType, mode> texRef, float x, float y,
                                       float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -6329,7 +6340,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex3D(texture<char1, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -6337,7 +6348,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex3D(texture<char2, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -6345,7 +6356,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex3D(texture<char4, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -6353,7 +6364,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex3D(texture<unsigned char, texType, mode> texRef,
                                                float x, float y, float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -6361,7 +6372,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex3D(texture<uchar1, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -6369,7 +6380,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex3D(texture<uchar2, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -6377,7 +6388,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex3D(texture<uchar4, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -6385,7 +6396,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short tex3D(texture<short, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -6393,7 +6404,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short1 tex3D(texture<short1, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -6401,7 +6412,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short2 tex3D(texture<short2, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -6409,7 +6420,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short4 tex3D(texture<short4, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -6417,7 +6428,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned short tex3D(texture<unsigned short, texType, mode> texRef,
                                                 float x, float y, float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -6425,7 +6436,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort1 tex3D(texture<ushort1, texType, mode> texRef, float x, float y,
                                          float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -6433,7 +6444,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort2 tex3D(texture<ushort2, texType, mode> texRef, float x, float y,
                                          float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -6441,7 +6452,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort4 tex3D(texture<ushort4, texType, mode> texRef, float x, float y,
                                          float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -6449,7 +6460,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex3D(texture<int, texType, mode> texRef, float x, float y,
                                      float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_INT;
 }
 
@@ -6457,7 +6468,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex3D(texture<int1, texType, mode> texRef, float x, float y,
                                       float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -6465,7 +6476,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex3D(texture<int2, texType, mode> texRef, float x, float y,
                                       float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -6473,7 +6484,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex3D(texture<int4, texType, mode> texRef, float x, float y,
                                       float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -6481,7 +6492,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex3D(texture<unsigned int, texType, mode> texRef, float x,
                                               float y, float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UINT;
 }
 
@@ -6489,7 +6500,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex3D(texture<uint1, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -6497,7 +6508,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex3D(texture<uint2, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -6505,7 +6516,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex3D(texture<uint4, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -6513,7 +6524,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex3D(texture<float, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -6521,7 +6532,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex3D(texture<float1, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -6529,7 +6540,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex3D(texture<float2, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -6537,7 +6548,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex3D(texture<float4, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -6547,7 +6558,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex3D(texture<char, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -6556,7 +6567,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex3D(texture<char1, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -6565,7 +6576,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex3D(texture<char2, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -6574,7 +6585,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex3D(texture<char4, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -6583,7 +6594,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex3D(texture<unsigned char, texType, m
                                                hipTextureObject_t textureObject, float x, float y,
                                                float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -6592,7 +6603,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex3D(texture<uchar1, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -6601,7 +6612,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex3D(texture<uchar2, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -6610,7 +6621,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex3D(texture<uchar4, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -6619,7 +6630,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex3D(texture<short, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -6628,7 +6639,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex3D(texture<short1, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -6637,7 +6648,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex3D(texture<short2, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -6646,7 +6657,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex3D(texture<short4, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -6655,7 +6666,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex3D(texture<unsigned short, texType,
                                                 hipTextureObject_t textureObject, float x, float y,
                                                 float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -6664,7 +6675,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex3D(texture<ushort1, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -6673,7 +6684,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex3D(texture<ushort2, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -6682,7 +6693,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex3D(texture<ushort4, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -6690,7 +6701,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex3D(texture<int, texType, mode> texRef,
                                      hipTextureObject_t textureObject, float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_INT;
 }
 
@@ -6698,7 +6709,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex3D(texture<int1, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -6706,7 +6717,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex3D(texture<int2, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -6714,7 +6725,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex3D(texture<int4, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -6723,7 +6734,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex3D(texture<unsigned int, texType, mod
                                               hipTextureObject_t textureObject, float x, float y,
                                               float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UINT;
 }
 
@@ -6732,7 +6743,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex3D(texture<uint1, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -6741,7 +6752,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex3D(texture<uint2, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -6750,7 +6761,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex3D(texture<uint4, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -6759,7 +6770,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex3D(texture<float, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -6768,7 +6779,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex3D(texture<float1, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -6777,7 +6788,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex3D(texture<float2, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -6786,7 +6797,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex3D(texture<float4, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -6796,7 +6807,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex3DLod(texture<char, texType, mode> texRef, float x, float y,
                                          float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_CHAR;
 }
@@ -6805,7 +6816,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex3DLod(texture<char1, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_CHAR_X;
 }
@@ -6814,7 +6825,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex3DLod(texture<char2, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_CHAR_XY;
 }
@@ -6823,7 +6834,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex3DLod(texture<char4, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
@@ -6832,7 +6843,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex3DLod(texture<unsigned char, texType, mode> texRef,
                                                   float x, float y, float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UCHAR;
 }
@@ -6841,7 +6852,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex3DLod(texture<uchar1, texType, mode> texRef, float x, float y,
                                            float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UCHAR_X;
 }
@@ -6850,7 +6861,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex3DLod(texture<uchar2, texType, mode> texRef, float x, float y,
                                            float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UCHAR_XY;
 }
@@ -6859,7 +6870,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex3DLod(texture<uchar4, texType, mode> texRef, float x, float y,
                                            float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
@@ -6868,7 +6879,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex3DLod(texture<int, texType, mode> texRef, float x, float y,
                                         float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_INT;
 }
@@ -6877,7 +6888,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex3DLod(texture<int1, texType, mode> texRef, float x, float y,
                                          float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_INT_X;
 }
@@ -6886,7 +6897,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex3DLod(texture<int2, texType, mode> texRef, float x, float y,
                                          float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_INT_XY;
 }
@@ -6895,7 +6906,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex3DLod(texture<int4, texType, mode> texRef, float x, float y,
                                          float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_INT_XYZW;
 }
@@ -6904,7 +6915,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex3DLod(texture<unsigned int, texType, mode> texRef,
                                                  float x, float y, float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UINT;
 }
@@ -6913,7 +6924,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex3DLod(texture<uint1, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UINT_X;
 }
@@ -6922,7 +6933,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex3DLod(texture<uint2, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UINT_XY;
 }
@@ -6931,7 +6942,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex3DLod(texture<uint4, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UINT_XYZW;
 }
@@ -6940,7 +6951,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex3DLod(texture<float, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_FLOAT;
 }
@@ -6949,7 +6960,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex3DLod(texture<float1, texType, mode> texRef, float x, float y,
                                            float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_FLOAT_X;
 }
@@ -6958,7 +6969,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex3DLod(texture<float2, texType, mode> texRef, float x, float y,
                                            float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_FLOAT_XY;
 }
@@ -6967,7 +6978,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex3DLod(texture<float4, texType, mode> texRef, float x, float y,
                                            float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
@@ -6979,7 +6990,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex3DLod(texture<char, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_CHAR;
 }
@@ -6989,7 +7000,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex3DLod(texture<char1, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_CHAR_X;
 }
@@ -6999,7 +7010,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex3DLod(texture<char2, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_CHAR_XY;
 }
@@ -7009,7 +7020,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex3DLod(texture<char4, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
@@ -7019,7 +7030,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex3DLod(texture<unsigned char, texType
                                                   hipTextureObject_t textureObject, float x,
                                                   float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UCHAR;
 }
@@ -7029,7 +7040,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex3DLod(texture<uchar1, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UCHAR_X;
 }
@@ -7039,7 +7050,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex3DLod(texture<uchar2, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UCHAR_XY;
 }
@@ -7049,7 +7060,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex3DLod(texture<uchar4, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
@@ -7059,7 +7070,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex3DLod(texture<int, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y, float z,
                                         float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_INT;
 }
@@ -7069,7 +7080,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex3DLod(texture<int1, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_INT_X;
 }
@@ -7079,7 +7090,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex3DLod(texture<int2, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_INT_XY;
 }
@@ -7089,7 +7100,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex3DLod(texture<int4, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_INT_XYZW;
 }
@@ -7099,7 +7110,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex3DLod(texture<unsigned int, texType, 
                                                  hipTextureObject_t textureObject, float x, float y,
                                                  float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UINT;
 }
@@ -7109,7 +7120,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex3DLod(texture<uint1, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UINT_X;
 }
@@ -7119,7 +7130,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex3DLod(texture<uint2, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UINT_XY;
 }
@@ -7129,7 +7140,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex3DLod(texture<uint4, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_UINT_XYZW;
 }
@@ -7139,7 +7150,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex3DLod(texture<float, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_FLOAT;
 }
@@ -7149,7 +7160,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex3DLod(texture<float1, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_FLOAT_X;
 }
@@ -7159,7 +7170,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex3DLod(texture<float2, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_FLOAT_XY;
 }
@@ -7169,7 +7180,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex3DLod(texture<float4, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f).data,
                                          level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
@@ -7181,9 +7192,9 @@ __TEXTURE_FUNCTIONS_DECL__ char tex3DGrad(texture<char, texType, mode> texRef, f
                                           float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -7192,9 +7203,9 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex3DGrad(texture<char1, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -7203,9 +7214,9 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex3DGrad(texture<char2, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -7214,9 +7225,9 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex3DGrad(texture<char4, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -7226,9 +7237,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex3DGrad(texture<unsigned char, texTyp
                                                    float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -7237,9 +7248,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex3DGrad(texture<uchar1, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -7248,9 +7259,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex3DGrad(texture<uchar2, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -7259,9 +7270,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex3DGrad(texture<uchar4, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -7270,9 +7281,9 @@ __TEXTURE_FUNCTIONS_DECL__ short tex3DGrad(texture<short, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -7281,9 +7292,9 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex3DGrad(texture<short1, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -7292,9 +7303,9 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex3DGrad(texture<short2, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -7303,9 +7314,9 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex3DGrad(texture<short4, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -7315,9 +7326,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex3DGrad(texture<unsigned short, texT
                                                     float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -7326,9 +7337,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex3DGrad(texture<ushort1, texType, mode> tex
                                              float y, float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -7337,9 +7348,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex3DGrad(texture<ushort2, texType, mode> tex
                                              float y, float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -7348,9 +7359,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex3DGrad(texture<ushort4, texType, mode> tex
                                              float y, float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -7359,9 +7370,9 @@ __TEXTURE_FUNCTIONS_DECL__ int tex3DGrad(texture<int, texType, mode> texRef, flo
                                          float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_INT;
 }
 
@@ -7370,9 +7381,9 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex3DGrad(texture<int1, texType, mode> texRef, f
                                           float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -7381,9 +7392,9 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex3DGrad(texture<int2, texType, mode> texRef, f
                                           float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -7392,9 +7403,9 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex3DGrad(texture<int4, texType, mode> texRef, f
                                           float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -7403,9 +7414,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex3DGrad(texture<unsigned int, texType,
                                                   float x, float y, float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UINT;
 }
 
@@ -7414,9 +7425,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex3DGrad(texture<uint1, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -7425,9 +7436,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex3DGrad(texture<uint2, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -7436,9 +7447,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex3DGrad(texture<uint4, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -7447,9 +7458,9 @@ __TEXTURE_FUNCTIONS_DECL__ float tex3DGrad(texture<float, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -7458,9 +7469,9 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex3DGrad(texture<float1, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -7469,9 +7480,9 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex3DGrad(texture<float2, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -7480,9 +7491,9 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex3DGrad(texture<float4, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -7493,9 +7504,9 @@ __TEXTURE_FUNCTIONS_DECL__ char tex3DGrad(texture<char, texType, mode> texRef,
                                           float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -7505,9 +7516,9 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex3DGrad(texture<char1, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -7517,9 +7528,9 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex3DGrad(texture<char2, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -7529,9 +7540,9 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex3DGrad(texture<char4, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -7541,9 +7552,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex3DGrad(texture<unsigned char, texTyp
                                                    float y, float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -7553,9 +7564,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex3DGrad(texture<uchar1, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -7565,9 +7576,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex3DGrad(texture<uchar2, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -7577,9 +7588,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex3DGrad(texture<uchar4, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -7589,9 +7600,9 @@ __TEXTURE_FUNCTIONS_DECL__ short tex3DGrad(texture<short, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -7601,9 +7612,9 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex3DGrad(texture<short1, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -7613,9 +7624,9 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex3DGrad(texture<short2, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -7625,9 +7636,9 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex3DGrad(texture<short4, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -7637,9 +7648,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex3DGrad(texture<unsigned short, texT
                                                     float y, float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -7649,9 +7660,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex3DGrad(texture<ushort1, texType, mode> tex
                                              float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -7661,9 +7672,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex3DGrad(texture<ushort2, texType, mode> tex
                                              float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -7673,9 +7684,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex3DGrad(texture<ushort4, texType, mode> tex
                                              float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -7685,9 +7696,9 @@ __TEXTURE_FUNCTIONS_DECL__ int tex3DGrad(texture<int, texType, mode> texRef,
                                          float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_INT;
 }
 
@@ -7697,9 +7708,9 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex3DGrad(texture<int1, texType, mode> texRef,
                                           float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -7709,9 +7720,9 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex3DGrad(texture<int2, texType, mode> texRef,
                                           float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -7721,9 +7732,9 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex3DGrad(texture<int4, texType, mode> texRef,
                                           float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -7733,9 +7744,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex3DGrad(texture<unsigned int, texType,
                                                   float y, float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UINT;
 }
 
@@ -7745,9 +7756,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex3DGrad(texture<uint1, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -7757,9 +7768,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex3DGrad(texture<uint2, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -7769,9 +7780,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex3DGrad(texture<uint4, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -7781,9 +7792,9 @@ __TEXTURE_FUNCTIONS_DECL__ float tex3DGrad(texture<float, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -7793,9 +7804,9 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex3DGrad(texture<float1, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -7805,9 +7816,9 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex3DGrad(texture<float2, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -7817,9 +7828,9 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex3DGrad(texture<float4, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
-                                    float4(dx.x, dx.y, dx.z, dx.w),
-                                    float4(dy.x, dy.y, dy.z, dy.w));
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f).data,
+                                    float4(dx.x, dx.y, dx.z, dx.w).data,
+                                    float4(dy.x, dy.y, dy.z, dy.w).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -7829,7 +7840,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex1DLayered(texture<char, texType, mode> texRef, float x,
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -7837,7 +7848,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex1DLayered(texture<char1, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -7845,7 +7856,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex1DLayered(texture<char2, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -7853,7 +7864,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex1DLayered(texture<char4, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -7861,7 +7872,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex1DLayered(texture<unsigned char, texType, mode> texRef,
                                                       float x, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -7869,7 +7880,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex1DLayered(texture<uchar1, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -7877,7 +7888,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex1DLayered(texture<uchar2, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -7885,7 +7896,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex1DLayered(texture<uchar4, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -7893,7 +7904,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short tex1DLayered(texture<short, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -7901,7 +7912,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short1 tex1DLayered(texture<short1, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -7909,7 +7920,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short2 tex1DLayered(texture<short2, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -7917,7 +7928,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short4 tex1DLayered(texture<short4, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -7925,7 +7936,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned short tex1DLayered(
     texture<unsigned short, texType, mode> texRef, float x, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -7933,7 +7944,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort1 tex1DLayered(texture<ushort1, texType, mode> texRef, float x,
                                                 int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -7941,7 +7952,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort2 tex1DLayered(texture<ushort2, texType, mode> texRef, float x,
                                                 int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -7949,7 +7960,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort4 tex1DLayered(texture<ushort4, texType, mode> texRef, float x,
                                                 int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -7957,7 +7968,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex1DLayered(texture<int, texType, mode> texRef, float x,
                                             int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_INT;
 }
 
@@ -7965,7 +7976,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex1DLayered(texture<int1, texType, mode> texRef, float x,
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -7973,7 +7984,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex1DLayered(texture<int2, texType, mode> texRef, float x,
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -7981,7 +7992,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex1DLayered(texture<int4, texType, mode> texRef, float x,
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -7989,7 +8000,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex1DLayered(texture<unsigned int, texType, mode> texRef,
                                                      float x, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UINT;
 }
 
@@ -7997,7 +8008,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex1DLayered(texture<uint1, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -8005,7 +8016,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex1DLayered(texture<uint2, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -8013,7 +8024,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex1DLayered(texture<uint4, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -8021,7 +8032,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex1DLayered(texture<float, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -8029,7 +8040,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex1DLayered(texture<float1, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -8037,7 +8048,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex1DLayered(texture<float2, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -8045,7 +8056,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex1DLayered(texture<float4, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -8055,7 +8066,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex1DLayered(texture<char, texType, mode> texRef,
                                              hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -8064,7 +8075,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex1DLayered(texture<char1, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -8073,7 +8084,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex1DLayered(texture<char2, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -8082,7 +8093,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex1DLayered(texture<char4, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -8091,7 +8102,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex1DLayered(texture<unsigned char, tex
                                                       hipTextureObject_t textureObject, float x,
                                                       int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -8100,7 +8111,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex1DLayered(texture<uchar1, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -8109,7 +8120,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex1DLayered(texture<uchar2, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -8118,7 +8129,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex1DLayered(texture<uchar4, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -8127,7 +8138,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex1DLayered(texture<short, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -8136,7 +8147,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex1DLayered(texture<short1, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -8145,7 +8156,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex1DLayered(texture<short2, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -8154,7 +8165,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex1DLayered(texture<short4, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -8163,7 +8174,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex1DLayered(
     texture<unsigned short, texType, mode> texRef, hipTextureObject_t textureObject, float x,
     int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -8172,7 +8183,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex1DLayered(texture<ushort1, texType, mode> 
                                                 hipTextureObject_t textureObject, float x,
                                                 int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -8181,7 +8192,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex1DLayered(texture<ushort2, texType, mode> 
                                                 hipTextureObject_t textureObject, float x,
                                                 int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -8190,7 +8201,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex1DLayered(texture<ushort4, texType, mode> 
                                                 hipTextureObject_t textureObject, float x,
                                                 int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -8198,7 +8209,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex1DLayered(texture<int, texType, mode> texRef,
                                             hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_INT;
 }
 
@@ -8206,7 +8217,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex1DLayered(texture<int1, texType, mode> texRef,
                                              hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -8214,7 +8225,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex1DLayered(texture<int2, texType, mode> texRef,
                                              hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -8222,7 +8233,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex1DLayered(texture<int4, texType, mode> texRef,
                                              hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -8231,7 +8242,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex1DLayered(texture<unsigned int, texTy
                                                      hipTextureObject_t textureObject, float x,
                                                      int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UINT;
 }
 
@@ -8240,7 +8251,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex1DLayered(texture<uint1, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -8249,7 +8260,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex1DLayered(texture<uint2, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -8258,7 +8269,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex1DLayered(texture<uint4, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -8267,7 +8278,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex1DLayered(texture<float, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -8276,7 +8287,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex1DLayered(texture<float1, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -8285,7 +8296,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex1DLayered(texture<float2, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -8294,7 +8305,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex1DLayered(texture<float4, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -8305,7 +8316,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex1DLayeredLod(texture<char, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -8314,7 +8325,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex1DLayeredLod(texture<char1, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -8323,7 +8334,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex1DLayeredLod(texture<char2, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -8332,7 +8343,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex1DLayeredLod(texture<char4, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -8341,7 +8352,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex1DLayeredLod(
     texture<unsigned char, texType, mode> texRef, float x, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -8350,7 +8361,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex1DLayeredLod(texture<uchar1, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -8359,7 +8370,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex1DLayeredLod(texture<uchar2, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -8368,7 +8379,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex1DLayeredLod(texture<uchar4, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -8377,7 +8388,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex1DLayeredLod(texture<short, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -8386,7 +8397,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex1DLayeredLod(texture<short1, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -8395,7 +8406,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex1DLayeredLod(texture<short2, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -8404,7 +8415,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex1DLayeredLod(texture<short4, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -8413,7 +8424,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex1DLayeredLod(
     texture<unsigned short, texType, mode> texRef, float x, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -8422,7 +8433,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex1DLayeredLod(texture<ushort1, texType, mod
                                                    int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -8431,7 +8442,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex1DLayeredLod(texture<ushort2, texType, mod
                                                    int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -8440,7 +8451,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex1DLayeredLod(texture<ushort4, texType, mod
                                                    int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -8449,7 +8460,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex1DLayeredLod(texture<int, texType, mode> texRe
                                                int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_INT;
 }
 
@@ -8458,7 +8469,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex1DLayeredLod(texture<int1, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -8467,7 +8478,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex1DLayeredLod(texture<int2, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -8476,7 +8487,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex1DLayeredLod(texture<int4, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -8485,7 +8496,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex1DLayeredLod(texture<unsigned int, te
                                                         float x, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UINT;
 }
 
@@ -8494,7 +8505,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex1DLayeredLod(texture<uint1, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -8503,7 +8514,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex1DLayeredLod(texture<uint2, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -8512,7 +8523,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex1DLayeredLod(texture<uint4, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -8521,7 +8532,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex1DLayeredLod(texture<float, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -8530,7 +8541,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex1DLayeredLod(texture<float1, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -8539,7 +8550,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex1DLayeredLod(texture<float2, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -8548,7 +8559,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex1DLayeredLod(texture<float4, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -8560,7 +8571,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex1DLayeredLod(texture<char, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -8570,7 +8581,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex1DLayeredLod(texture<char1, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -8580,7 +8591,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex1DLayeredLod(texture<char2, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -8590,7 +8601,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex1DLayeredLod(texture<char4, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -8600,7 +8611,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex1DLayeredLod(
     int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -8610,7 +8621,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex1DLayeredLod(texture<uchar1, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -8620,7 +8631,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex1DLayeredLod(texture<uchar2, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -8630,7 +8641,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex1DLayeredLod(texture<uchar4, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -8640,7 +8651,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex1DLayeredLod(texture<short, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -8650,7 +8661,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex1DLayeredLod(texture<short1, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -8660,7 +8671,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex1DLayeredLod(texture<short2, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -8670,7 +8681,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex1DLayeredLod(texture<short4, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -8680,7 +8691,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex1DLayeredLod(
     int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -8690,7 +8701,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex1DLayeredLod(texture<ushort1, texType, mod
                                                    int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -8700,7 +8711,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex1DLayeredLod(texture<ushort2, texType, mod
                                                    int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -8710,7 +8721,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex1DLayeredLod(texture<ushort4, texType, mod
                                                    int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -8720,7 +8731,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex1DLayeredLod(texture<int, texType, mode> texRe
                                                float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_INT;
 }
 
@@ -8730,7 +8741,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex1DLayeredLod(texture<int1, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -8740,7 +8751,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex1DLayeredLod(texture<int2, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -8750,7 +8761,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex1DLayeredLod(texture<int4, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -8760,7 +8771,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex1DLayeredLod(texture<unsigned int, te
                                                         int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UINT;
 }
 
@@ -8770,7 +8781,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex1DLayeredLod(texture<uint1, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -8780,7 +8791,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex1DLayeredLod(texture<uint2, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -8790,7 +8801,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex1DLayeredLod(texture<uint4, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -8800,7 +8811,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex1DLayeredLod(texture<float, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -8810,7 +8821,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex1DLayeredLod(texture<float1, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -8820,7 +8831,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex1DLayeredLod(texture<float2, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -8830,7 +8841,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex1DLayeredLod(texture<float4, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer).data, level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -8841,7 +8852,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex1DLayeredGrad(texture<char, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -8851,7 +8862,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex1DLayeredGrad(texture<char, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -8860,7 +8871,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex1DLayeredGrad(texture<char1, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -8870,7 +8881,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex1DLayeredGrad(texture<char1, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -8879,7 +8890,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex1DLayeredGrad(texture<char2, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -8889,7 +8900,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex1DLayeredGrad(texture<char2, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -8898,7 +8909,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex1DLayeredGrad(texture<char4, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -8908,7 +8919,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex1DLayeredGrad(texture<char4, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -8917,7 +8928,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex1DLayeredGrad(
     texture<unsigned char, texType, mode> texRef, float x, int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -8927,7 +8938,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex1DLayeredGrad(
     int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -8936,7 +8947,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex1DLayeredGrad(texture<uchar1, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -8946,7 +8957,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex1DLayeredGrad(texture<uchar1, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -8955,7 +8966,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex1DLayeredGrad(texture<uchar2, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -8965,7 +8976,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex1DLayeredGrad(texture<uchar2, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -8974,7 +8985,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex1DLayeredGrad(texture<uchar4, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -8984,7 +8995,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex1DLayeredGrad(texture<uchar4, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -8993,7 +9004,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex1DLayeredGrad(texture<short, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -9003,7 +9014,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex1DLayeredGrad(texture<short, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -9012,7 +9023,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex1DLayeredGrad(texture<short1, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -9022,7 +9033,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex1DLayeredGrad(texture<short1, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -9031,7 +9042,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex1DLayeredGrad(texture<short2, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -9041,7 +9052,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex1DLayeredGrad(texture<short2, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -9050,7 +9061,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex1DLayeredGrad(texture<short4, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -9060,7 +9071,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex1DLayeredGrad(texture<short4, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -9069,7 +9080,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex1DLayeredGrad(
     texture<unsigned short, texType, mode> texRef, float x, int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -9079,7 +9090,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex1DLayeredGrad(
     int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -9088,7 +9099,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex1DLayeredGrad(texture<ushort1, texType, mo
                                                     int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -9098,7 +9109,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex1DLayeredGrad(texture<ushort1, texType, mo
                                                     int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -9107,7 +9118,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex1DLayeredGrad(texture<ushort2, texType, mo
                                                     int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -9117,7 +9128,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex1DLayeredGrad(texture<ushort2, texType, mo
                                                     int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -9126,7 +9137,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex1DLayeredGrad(texture<ushort4, texType, mo
                                                     int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -9136,7 +9147,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex1DLayeredGrad(texture<ushort4, texType, mo
                                                     int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -9145,7 +9156,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex1DLayeredGrad(texture<int, texType, mode> texR
                                                 int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_INT;
 }
 
@@ -9155,7 +9166,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex1DLayeredGrad(texture<int, texType, mode> texR
                                                 int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_INT;
 }
 
@@ -9164,7 +9175,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex1DLayeredGrad(texture<int1, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -9174,7 +9185,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex1DLayeredGrad(texture<int1, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -9183,7 +9194,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex1DLayeredGrad(texture<int2, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -9193,7 +9204,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex1DLayeredGrad(texture<int2, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -9202,7 +9213,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex1DLayeredGrad(texture<int4, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -9212,7 +9223,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex1DLayeredGrad(texture<int4, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -9221,7 +9232,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex1DLayeredGrad(
     texture<unsigned int, texType, mode> texRef, float x, int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UINT;
 }
 
@@ -9231,7 +9242,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex1DLayeredGrad(
     int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UINT;
 }
 
@@ -9240,7 +9251,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex1DLayeredGrad(texture<uint1, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -9250,7 +9261,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex1DLayeredGrad(texture<uint1, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -9259,7 +9270,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex1DLayeredGrad(texture<uint2, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -9269,7 +9280,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex1DLayeredGrad(texture<uint2, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -9278,7 +9289,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex1DLayeredGrad(texture<uint4, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -9288,7 +9299,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex1DLayeredGrad(texture<uint4, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -9297,7 +9308,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex1DLayeredGrad(texture<float, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -9307,7 +9318,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex1DLayeredGrad(texture<float, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -9316,7 +9327,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex1DLayeredGrad(texture<float1, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -9326,7 +9337,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex1DLayeredGrad(texture<float1, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -9335,7 +9346,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex1DLayeredGrad(texture<float2, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -9345,7 +9356,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex1DLayeredGrad(texture<float2, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -9354,7 +9365,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex1DLayeredGrad(texture<float4, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -9364,7 +9375,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex1DLayeredGrad(texture<float4, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer).data, dx, dy);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -9375,7 +9386,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLayered(texture<char, texType, mode> texRef
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -9385,7 +9396,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLayered(texture<char, texType, mode> texRef
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -9394,7 +9405,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLayered(texture<char1, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -9404,7 +9415,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLayered(texture<char1, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -9413,7 +9424,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLayered(texture<char2, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -9423,7 +9434,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLayered(texture<char2, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -9432,7 +9443,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLayered(texture<char4, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -9442,7 +9453,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLayered(texture<char4, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -9451,7 +9462,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLayered(texture<unsigned char, tex
                                                       float x, float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -9461,7 +9472,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLayered(texture<unsigned char, tex
                                                       float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -9470,7 +9481,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLayered(texture<uchar1, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -9480,7 +9491,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLayered(texture<uchar1, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -9489,7 +9500,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLayered(texture<uchar2, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -9499,7 +9510,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLayered(texture<uchar2, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -9508,7 +9519,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLayered(texture<uchar4, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -9518,7 +9529,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLayered(texture<uchar4, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -9527,7 +9538,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLayered(texture<short, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -9537,7 +9548,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLayered(texture<short, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -9546,7 +9557,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLayered(texture<short1, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -9556,7 +9567,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLayered(texture<short1, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -9565,7 +9576,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLayered(texture<short2, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -9575,7 +9586,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLayered(texture<short2, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -9584,7 +9595,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLayered(texture<short4, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -9594,7 +9605,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLayered(texture<short4, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -9603,7 +9614,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLayered(
     texture<unsigned short, texType, mode> texRef, float x, float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -9613,7 +9624,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLayered(
     float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -9622,7 +9633,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLayered(texture<ushort1, texType, mode> 
                                                 float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -9632,7 +9643,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLayered(texture<ushort1, texType, mode> 
                                                 int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -9641,7 +9652,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLayered(texture<ushort2, texType, mode> 
                                                 float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -9651,7 +9662,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLayered(texture<ushort2, texType, mode> 
                                                 int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -9660,7 +9671,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLayered(texture<ushort4, texType, mode> 
                                                 float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -9670,7 +9681,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLayered(texture<ushort4, texType, mode> 
                                                 int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -9679,7 +9690,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLayered(texture<int, texType, mode> texRef, 
                                             int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_INT;
 }
 
@@ -9689,7 +9700,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLayered(texture<int, texType, mode> texRef,
                                             int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_INT;
 }
 
@@ -9698,7 +9709,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLayered(texture<int1, texType, mode> texRef
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -9708,7 +9719,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLayered(texture<int1, texType, mode> texRef
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -9717,7 +9728,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLayered(texture<int2, texType, mode> texRef
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -9727,7 +9738,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLayered(texture<int2, texType, mode> texRef
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -9736,7 +9747,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLayered(texture<int4, texType, mode> texRef
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -9746,7 +9757,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLayered(texture<int4, texType, mode> texRef
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -9755,7 +9766,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLayered(texture<unsigned int, texTy
                                                      float x, float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UINT;
 }
 
@@ -9765,7 +9776,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLayered(texture<unsigned int, texTy
                                                      float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UINT;
 }
 
@@ -9774,7 +9785,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLayered(texture<uint1, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -9784,7 +9795,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLayered(texture<uint1, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -9793,7 +9804,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLayered(texture<uint2, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -9803,7 +9814,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLayered(texture<uint2, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -9812,7 +9823,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLayered(texture<uint4, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -9822,7 +9833,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLayered(texture<uint4, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -9831,7 +9842,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLayered(texture<float, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -9841,7 +9852,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLayered(texture<float, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -9850,7 +9861,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLayered(texture<float1, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -9860,7 +9871,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLayered(texture<float1, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -9869,7 +9880,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLayered(texture<float2, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -9879,7 +9890,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLayered(texture<float2, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -9888,7 +9899,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLayered(texture<float4, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -9898,7 +9909,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLayered(texture<float4, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -9909,7 +9920,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLayeredLod(texture<char, texType, mode> tex
                                                 float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -9919,7 +9930,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLayeredLod(texture<char, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -9928,7 +9939,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLayeredLod(texture<char1, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -9938,7 +9949,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLayeredLod(texture<char1, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -9947,7 +9958,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLayeredLod(texture<char2, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -9957,7 +9968,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLayeredLod(texture<char2, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -9966,7 +9977,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLayeredLod(texture<char4, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -9976,7 +9987,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLayeredLod(texture<char4, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -9985,7 +9996,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLayeredLod(
     texture<unsigned char, texType, mode> texRef, float x, float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -9995,7 +10006,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLayeredLod(
     float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -10004,7 +10015,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLayeredLod(texture<uchar1, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -10014,7 +10025,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLayeredLod(texture<uchar1, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -10023,7 +10034,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLayeredLod(texture<uchar2, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -10033,7 +10044,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLayeredLod(texture<uchar2, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -10042,7 +10053,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLayeredLod(texture<uchar4, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -10052,7 +10063,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLayeredLod(texture<uchar4, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -10061,7 +10072,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLayeredLod(texture<short, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -10071,7 +10082,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLayeredLod(texture<short, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -10080,7 +10091,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLayeredLod(texture<short1, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -10090,7 +10101,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLayeredLod(texture<short1, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -10099,7 +10110,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLayeredLod(texture<short2, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -10109,7 +10120,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLayeredLod(texture<short2, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -10118,7 +10129,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLayeredLod(texture<short4, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -10128,7 +10139,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLayeredLod(texture<short4, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -10137,7 +10148,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLayeredLod(
     texture<unsigned short, texType, mode> texRef, float x, float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -10147,7 +10158,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLayeredLod(
     float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -10156,7 +10167,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLayeredLod(texture<ushort1, texType, mod
                                                    float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -10166,7 +10177,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLayeredLod(texture<ushort1, texType, mod
                                                    float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -10175,7 +10186,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLayeredLod(texture<ushort2, texType, mod
                                                    float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -10185,7 +10196,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLayeredLod(texture<ushort2, texType, mod
                                                    float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -10194,7 +10205,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLayeredLod(texture<ushort4, texType, mod
                                                    float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -10204,7 +10215,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLayeredLod(texture<ushort4, texType, mod
                                                    float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -10213,7 +10224,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLayeredLod(texture<int, texType, mode> texRe
                                                int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_INT;
 }
 
@@ -10223,7 +10234,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLayeredLod(texture<int, texType, mode> texRe
                                                int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_INT;
 }
 
@@ -10232,7 +10243,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLayeredLod(texture<int1, texType, mode> tex
                                                 float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -10242,7 +10253,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLayeredLod(texture<int1, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -10251,7 +10262,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLayeredLod(texture<int2, texType, mode> tex
                                                 float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -10261,7 +10272,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLayeredLod(texture<int2, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -10270,7 +10281,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLayeredLod(texture<int4, texType, mode> tex
                                                 float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -10280,7 +10291,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLayeredLod(texture<int4, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -10289,7 +10300,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLayeredLod(texture<unsigned int, te
                                                         float x, float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UINT;
 }
 
@@ -10299,7 +10310,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLayeredLod(texture<unsigned int, te
                                                         float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UINT;
 }
 
@@ -10308,7 +10319,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLayeredLod(texture<uint1, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -10318,7 +10329,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLayeredLod(texture<uint1, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -10327,7 +10338,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLayeredLod(texture<uint2, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -10337,7 +10348,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLayeredLod(texture<uint2, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -10346,7 +10357,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLayeredLod(texture<uint4, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -10356,7 +10367,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLayeredLod(texture<uint4, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -10365,7 +10376,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLayeredLod(texture<float, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -10375,7 +10386,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLayeredLod(texture<float, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -10384,7 +10395,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLayeredLod(texture<float1, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -10394,7 +10405,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLayeredLod(texture<float1, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -10403,7 +10414,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLayeredLod(texture<float2, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -10413,7 +10424,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLayeredLod(texture<float2, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -10422,7 +10433,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLayeredLod(texture<float4, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -10432,7 +10443,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLayeredLod(texture<float4, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, float4(x, y, layer, 0.0f), level);
+        i, s, float4(x, y, layer, 0.0f).data, level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -10443,9 +10454,9 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLayeredGrad(texture<char, texType, mode> te
                                                  float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -10455,9 +10466,9 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLayeredGrad(texture<char, texType, mode> te
                                                  int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -10466,9 +10477,9 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLayeredGrad(texture<char1, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -10478,9 +10489,9 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLayeredGrad(texture<char1, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -10489,9 +10500,9 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLayeredGrad(texture<char2, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -10501,9 +10512,9 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLayeredGrad(texture<char2, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -10512,9 +10523,9 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLayeredGrad(texture<char4, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -10524,9 +10535,9 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLayeredGrad(texture<char4, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -10536,9 +10547,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLayeredGrad(
     float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -10548,9 +10559,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLayeredGrad(
     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -10559,9 +10570,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLayeredGrad(texture<uchar1, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -10571,9 +10582,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLayeredGrad(texture<uchar1, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -10582,9 +10593,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLayeredGrad(texture<uchar2, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -10594,9 +10605,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLayeredGrad(texture<uchar2, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -10605,9 +10616,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLayeredGrad(texture<uchar4, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -10617,9 +10628,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLayeredGrad(texture<uchar4, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -10628,9 +10639,9 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLayeredGrad(texture<short, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -10640,9 +10651,9 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLayeredGrad(texture<short, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -10651,9 +10662,9 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLayeredGrad(texture<short1, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -10663,9 +10674,9 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLayeredGrad(texture<short1, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -10674,9 +10685,9 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLayeredGrad(texture<short2, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -10686,9 +10697,9 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLayeredGrad(texture<short2, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -10697,9 +10708,9 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLayeredGrad(texture<short4, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -10709,9 +10720,9 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLayeredGrad(texture<short4, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -10721,9 +10732,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLayeredGrad(
     float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -10733,9 +10744,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLayeredGrad(
     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -10744,9 +10755,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLayeredGrad(texture<ushort1, texType, mo
                                                     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -10756,9 +10767,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLayeredGrad(texture<ushort1, texType, mo
                                                     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -10767,9 +10778,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLayeredGrad(texture<ushort2, texType, mo
                                                     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -10779,9 +10790,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLayeredGrad(texture<ushort2, texType, mo
                                                     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -10790,9 +10801,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLayeredGrad(texture<ushort4, texType, mo
                                                     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -10802,9 +10813,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLayeredGrad(texture<ushort4, texType, mo
                                                     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -10813,9 +10824,9 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLayeredGrad(texture<int, texType, mode> texR
                                                 float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT;
 }
 
@@ -10825,9 +10836,9 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLayeredGrad(texture<int, texType, mode> texR
                                                 int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT;
 }
 
@@ -10836,9 +10847,9 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLayeredGrad(texture<int1, texType, mode> te
                                                  float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -10848,9 +10859,9 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLayeredGrad(texture<int1, texType, mode> te
                                                  int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -10859,9 +10870,9 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLayeredGrad(texture<int2, texType, mode> te
                                                  float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -10871,9 +10882,9 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLayeredGrad(texture<int2, texType, mode> te
                                                  int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -10882,9 +10893,9 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLayeredGrad(texture<int4, texType, mode> te
                                                  float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -10894,9 +10905,9 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLayeredGrad(texture<int4, texType, mode> te
                                                  int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -10906,9 +10917,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLayeredGrad(
     float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT;
 }
 
@@ -10918,9 +10929,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLayeredGrad(
     int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT;
 }
 
@@ -10929,9 +10940,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLayeredGrad(texture<uint1, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -10941,9 +10952,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLayeredGrad(texture<uint1, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -10952,9 +10963,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLayeredGrad(texture<uint2, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -10964,9 +10975,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLayeredGrad(texture<uint2, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -10975,9 +10986,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLayeredGrad(texture<uint4, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -10987,9 +10998,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLayeredGrad(texture<uint4, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -10998,9 +11009,9 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLayeredGrad(texture<float, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -11010,9 +11021,9 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLayeredGrad(texture<float, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -11021,9 +11032,9 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLayeredGrad(texture<float1, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -11033,9 +11044,9 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLayeredGrad(texture<float1, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -11044,9 +11055,9 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLayeredGrad(texture<float2, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -11056,9 +11067,9 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLayeredGrad(texture<float2, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -11067,9 +11078,9 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLayeredGrad(texture<float4, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -11079,9 +11090,9 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLayeredGrad(texture<float4, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
-                                     float2(dx.x, dx.y),
-                                     float2(dy.x, dy.y));
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f).data,
+                                     float2(dx.x, dx.y).data,
+                                     float2(dy.x, dy.y).data);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 #endif

--- a/include/hip/hcc_detail/texture_functions.h
+++ b/include/hip/hcc_detail/texture_functions.h
@@ -23,14 +23,13 @@ THE SOFTWARE.
 #ifndef HIP_INCLUDE_HIP_HCC_DETAIL_TEXTURE_FUNCTIONS_H
 #define HIP_INCLUDE_HIP_HCC_DETAIL_TEXTURE_FUNCTIONS_H
 
-#include <hc.hpp>
-#include <hc_short_vector.hpp>
+#include <hip/hcc_detail/hip_vector_types.h>
 #include <hip/hcc_detail/hip_texture_types.h>
 
 union TData {
-    hc::short_vector::float4::vector_value_type f;
-    hc::short_vector::int4::vector_value_type i;
-    hc::short_vector::uint4::vector_value_type u;
+    float4 f;
+    int4 i;
+    uint4 u;
 };
 
 #define __TEXTURE_FUNCTIONS_DECL__ static __inline__ __device__
@@ -153,91 +152,112 @@ union TData {
 #define TEXTURE_RETURN_FLOAT_XYZW return make_float4(texel.f.x, texel.f.y, texel.f.z, texel.f.w);
 
 extern "C" {
-hc::short_vector::float4::vector_value_type __ockl_image_sample_1D(unsigned int ADDRESS_SPACE_CONSTANT* i,
-                                                                   unsigned int ADDRESS_SPACE_CONSTANT* s,
-                                                                   float c)[[hc]];
 
-hc::short_vector::float4::vector_value_type __ockl_image_sample_1Da(
+__device__
+float4 __ockl_image_sample_1D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    hc::short_vector::float2::vector_value_type c)[[hc]];
+    float c);
 
-hc::short_vector::float4::vector_value_type __ockl_image_sample_2D(
+__device__
+float4 __ockl_image_sample_1Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    hc::short_vector::float2::vector_value_type c)[[hc]];
+    float2 c);
 
-
-hc::short_vector::float4::vector_value_type __ockl_image_sample_2Da(
+__device__
+float4 __ockl_image_sample_2D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    hc::short_vector::float4::vector_value_type c)[[hc]];
+    float2 c);
 
-float __ockl_image_sample_2Dad(unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-                               hc::short_vector::float4::vector_value_type c)[[hc]];
 
-float __ockl_image_sample_2Dd(unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-                              hc::short_vector::float2::vector_value_type c)[[hc]];
-
-hc::short_vector::float4::vector_value_type __ockl_image_sample_3D(
+__device__
+float4 __ockl_image_sample_2Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    hc::short_vector::float4::vector_value_type c)[[hc]];
+    float4 c);
 
-hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_1D(
-    unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s, float c, float dx,
-    float dy)[[hc]];
-
-hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_1Da(
+__device__
+float __ockl_image_sample_2Dad(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    hc::short_vector::float2::vector_value_type c, float dx, float dy)[[hc]];
+    float4 c);
 
-hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_2D(
+__device__
+float __ockl_image_sample_2Dd(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    hc::short_vector::float2::vector_value_type c, hc::short_vector::float2::vector_value_type dx,
-    hc::short_vector::float2::vector_value_type dy)[[hc]];
+    float2 c);
 
-hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_2Da(
+__device__
+float4 __ockl_image_sample_3D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    hc::short_vector::float4::vector_value_type c, hc::short_vector::float2::vector_value_type dx,
-    hc::short_vector::float2::vector_value_type dy)[[hc]];
+    float4 c);
 
-float __ockl_image_sample_grad_2Dad(unsigned int ADDRESS_SPACE_CONSTANT* i,
-                                    unsigned int ADDRESS_SPACE_CONSTANT* s,
-                                    hc::short_vector::float4::vector_value_type c,
-                                    hc::short_vector::float2::vector_value_type dx,
-                                    hc::short_vector::float2::vector_value_type dy)[[hc]];
-
-float __ockl_image_sample_grad_2Dd(unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-                                   hc::short_vector::float2::vector_value_type c,
-                                   hc::short_vector::float2::vector_value_type dx,
-                                   hc::short_vector::float2::vector_value_type dy)[[hc]];
-
-hc::short_vector::float4::vector_value_type __ockl_image_sample_grad_3D(
+__device__
+float4 __ockl_image_sample_grad_1D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    hc::short_vector::float4::vector_value_type c, hc::short_vector::float4::vector_value_type dx,
-    hc::short_vector::float4::vector_value_type dy)[[hc]];
+    float c, float dx, float dy);
 
-hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_1D(
-    unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s, float c, float l)[[hc]];
-
-hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_1Da(
+__device__
+float4 __ockl_image_sample_grad_1Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    hc::short_vector::float2::vector_value_type c, float l)[[hc]];
+    float2 c, float dx, float dy);
 
-hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_2D(
+__device__
+float4 __ockl_image_sample_grad_2D(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    hc::short_vector::float2::vector_value_type c, float l)[[hc]];
+    float2 c, float2 dx, float2 dy);
 
-hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_2Da(
+__device__
+float4 __ockl_image_sample_grad_2Da(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    hc::short_vector::float4::vector_value_type c, float l)[[hc]];
+    float4 c, float2 dx, float2 dy);
 
-float __ockl_image_sample_lod_2Dad(unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-                                   hc::short_vector::float4::vector_value_type c, float l)[[hc]];
-
-float __ockl_image_sample_lod_2Dd(unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-                                  hc::short_vector::float2::vector_value_type c, float l)[[hc]];
-
-hc::short_vector::float4::vector_value_type __ockl_image_sample_lod_3D(
+__device__
+float __ockl_image_sample_grad_2Dad(
     unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
-    hc::short_vector::float4::vector_value_type c, float l)[[hc]];
+    float4 c, float2 dx, float2 dy);
+
+__device__
+float __ockl_image_sample_grad_2Dd(
+    unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
+    float2 c, float2 dx, float2 dy);
+
+__device__
+float4 __ockl_image_sample_grad_3D(
+    unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
+    float4 c, float4 dx, float4 dy);
+
+__device__
+float4 __ockl_image_sample_lod_1D(
+    unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
+    float c, float l);
+
+__device__
+float4 __ockl_image_sample_lod_1Da(
+    unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
+    float2 c, float l);
+
+__device__
+float4 __ockl_image_sample_lod_2D(
+    unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
+    float2 c, float l);
+
+__device__
+float4 __ockl_image_sample_lod_2Da(
+    unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
+    float4 c, float l);
+
+__device__
+float __ockl_image_sample_lod_2Dad(
+    unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
+    float4 c, float l);
+
+__device__
+float __ockl_image_sample_lod_2Dd(
+    unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
+    float2 c, float l);
+
+__device__
+float4 __ockl_image_sample_lod_3D(
+    unsigned int ADDRESS_SPACE_CONSTANT* i, unsigned int ADDRESS_SPACE_CONSTANT* s,
+    float4 c, float l);
 }
 
 ////////////////////////////////////////////////////////////
@@ -1025,196 +1045,196 @@ __TEXTURE_FUNCTIONS_DECL__ T tex1DGrad(hipTextureObject_t textureObject, float x
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(char* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(char1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(char2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(char4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(unsigned char* retVal, hipTextureObject_t textureObject,
                                       float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(uchar1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(uchar2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(uchar4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(short* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(short1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(short2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(short4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(unsigned short* retVal, hipTextureObject_t textureObject,
                                       float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(ushort1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(ushort2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(ushort4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(int* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(int1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(int2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(int4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(unsigned int* retVal, hipTextureObject_t textureObject,
                                       float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(uint1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(uint2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(uint4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(float* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_FLOAT;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(float1* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_FLOAT_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(float2* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_FLOAT_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2D(float4* retVal, hipTextureObject_t textureObject, float x,
                                       float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -1229,196 +1249,196 @@ __TEXTURE_FUNCTIONS_DECL__ T tex2D(hipTextureObject_t textureObject, float x, fl
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(char* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(char1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(char2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(char4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(unsigned char* retVal, hipTextureObject_t textureObject,
                                          float x, float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(uchar1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(uchar2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(uchar4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(short* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(short1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(short2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(short4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(unsigned short* retVal, hipTextureObject_t textureObject,
                                          float x, float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(ushort1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(ushort2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(ushort4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(int* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(int1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(int2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(int4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(unsigned int* retVal, hipTextureObject_t textureObject,
                                          float x, float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(uint1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(uint2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(uint4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(float* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_FLOAT;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(float1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_FLOAT_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(float2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_FLOAT_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex2DLod(float4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -1434,196 +1454,196 @@ __TEXTURE_FUNCTIONS_DECL__ T tex2DLod(hipTextureObject_t textureObject, float x,
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(char* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(char1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(char2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(char4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(unsigned char* retVal, hipTextureObject_t textureObject,
                                       float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(uchar1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(uchar2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(uchar4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(short* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(short1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(short2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(short4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(unsigned short* retVal, hipTextureObject_t textureObject,
                                       float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(ushort1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(ushort2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(ushort4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(int* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(int1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(int2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_SIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(int4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(unsigned int* retVal, hipTextureObject_t textureObject,
                                       float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(uint1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(uint2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_UNSIGNED_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(uint4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(float* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_FLOAT;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(float1* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_FLOAT_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(float2* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_FLOAT_XY;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex3D(float4* retVal, hipTextureObject_t textureObject, float x,
                                       float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -1638,7 +1658,7 @@ __TEXTURE_FUNCTIONS_DECL__ T tex3D(hipTextureObject_t textureObject, float x, fl
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_SIGNED;
 }
@@ -1646,7 +1666,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char* retVal, hipTextureObject_t textur
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_SIGNED_X;
 }
@@ -1654,7 +1674,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char1* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_SIGNED_XY;
 }
@@ -1662,7 +1682,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char2* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_SIGNED_XYZW;
 }
@@ -1670,7 +1690,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(char4* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(unsigned char* retVal, hipTextureObject_t textureObject,
                                          float x, float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_UNSIGNED;
 }
@@ -1678,7 +1698,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(unsigned char* retVal, hipTextureObject
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uchar1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_UNSIGNED_X;
 }
@@ -1686,7 +1706,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uchar1* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uchar2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_UNSIGNED_XY;
 }
@@ -1694,7 +1714,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uchar2* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uchar4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
@@ -1702,7 +1722,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uchar4* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_SIGNED;
 }
@@ -1710,7 +1730,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_SIGNED_X;
 }
@@ -1718,7 +1738,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short1* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_SIGNED_XY;
 }
@@ -1726,7 +1746,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short2* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_SIGNED_XYZW;
 }
@@ -1734,7 +1754,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(short4* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(unsigned short* retVal, hipTextureObject_t textureObject,
                                          float x, float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_UNSIGNED;
 }
@@ -1742,7 +1762,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(unsigned short* retVal, hipTextureObjec
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(ushort1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_UNSIGNED_X;
 }
@@ -1750,7 +1770,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(ushort1* retVal, hipTextureObject_t tex
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(ushort2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_UNSIGNED_XY;
 }
@@ -1758,7 +1778,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(ushort2* retVal, hipTextureObject_t tex
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(ushort4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
@@ -1766,7 +1786,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(ushort4* retVal, hipTextureObject_t tex
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_SIGNED;
 }
@@ -1774,7 +1794,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int* retVal, hipTextureObject_t texture
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_SIGNED_X;
 }
@@ -1782,7 +1802,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int1* retVal, hipTextureObject_t textur
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_SIGNED_XY;
 }
@@ -1790,7 +1810,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int2* retVal, hipTextureObject_t textur
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_SIGNED_XYZW;
 }
@@ -1798,7 +1818,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(int4* retVal, hipTextureObject_t textur
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(unsigned int* retVal, hipTextureObject_t textureObject,
                                          float x, float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_UNSIGNED;
 }
@@ -1806,7 +1826,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(unsigned int* retVal, hipTextureObject_
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uint1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_UNSIGNED_X;
 }
@@ -1814,7 +1834,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uint1* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uint2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_UNSIGNED_XY;
 }
@@ -1822,7 +1842,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uint2* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uint4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
@@ -1830,7 +1850,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(uint4* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_FLOAT;
 }
@@ -1838,7 +1858,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float* retVal, hipTextureObject_t textu
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float1* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_FLOAT_X;
 }
@@ -1846,7 +1866,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float1* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float2* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_FLOAT_XY;
 }
@@ -1854,7 +1874,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float2* retVal, hipTextureObject_t text
 __TEXTURE_FUNCTIONS_DECL__ void tex3DLod(float4* retVal, hipTextureObject_t textureObject, float x,
                                          float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_SET_FLOAT_XYZW;
 }
@@ -1871,189 +1891,189 @@ __TEXTURE_FUNCTIONS_DECL__ T tex3DLod(hipTextureObject_t textureObject, float x,
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(char* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(char1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(char2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_SIGNED_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(char4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(unsigned char* retVal,
                                              hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(uchar1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(uchar2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_UNSIGNED_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(uchar4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(short* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(short1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(short2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_SIGNED_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(short4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(unsigned short* retVal,
                                              hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(ushort1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(ushort2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_UNSIGNED_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(ushort4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(int* retVal, hipTextureObject_t textureObject, float x,
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_SIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(int1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_SIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(int2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_SIGNED_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(int4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_SIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(unsigned int* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_UNSIGNED;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(uint1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_UNSIGNED_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(uint2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_UNSIGNED_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(uint4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(float* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_FLOAT;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(float1* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_FLOAT_X;
 }
 
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(float2* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_FLOAT_XY;
 }
 __TEXTURE_FUNCTIONS_DECL__ void tex1DLayered(float4* retVal, hipTextureObject_t textureObject,
                                              float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -2069,7 +2089,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(char* retVal, hipTextureObject_t
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2077,7 +2097,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(char1* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2085,7 +2105,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(char2* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2093,7 +2113,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(char4* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2102,7 +2122,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(unsigned char* retVal,
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2110,7 +2130,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(uchar1* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2118,7 +2138,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(uchar2* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2126,7 +2146,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(uchar4* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2134,7 +2154,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(short* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2142,7 +2162,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(short1* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2150,7 +2170,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(short2* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2158,7 +2178,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(short4* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2167,7 +2187,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(unsigned short* retVal,
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2175,7 +2195,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(ushort1* retVal, hipTextureObjec
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2183,7 +2203,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(ushort2* retVal, hipTextureObjec
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2191,7 +2211,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(ushort4* retVal, hipTextureObjec
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2199,7 +2219,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(int* retVal, hipTextureObject_t 
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2207,7 +2227,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(int1* retVal, hipTextureObject_t
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2215,7 +2235,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(int2* retVal, hipTextureObject_t
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2223,7 +2243,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(int4* retVal, hipTextureObject_t
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2232,7 +2252,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(unsigned int* retVal,
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2240,7 +2260,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(uint1* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2248,7 +2268,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(uint2* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2256,7 +2276,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(uint4* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2264,7 +2284,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(float* retVal, hipTextureObject_
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_FLOAT;
 }
 
@@ -2272,7 +2292,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(float1* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_FLOAT_X;
 }
 
@@ -2280,7 +2300,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(float2* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_FLOAT_XY;
 }
 
@@ -2288,7 +2308,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredLod(float4* retVal, hipTextureObject
                                                 float x, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -2305,7 +2325,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(char* retVal, hipTextureObject_
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2313,7 +2333,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(char1* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2321,7 +2341,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(char2* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2329,7 +2349,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(char4* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2338,7 +2358,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(unsigned char* retVal,
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2346,7 +2366,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(uchar1* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2354,7 +2374,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(uchar2* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2362,7 +2382,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(uchar4* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2370,7 +2390,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(short* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2378,7 +2398,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(short1* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2386,7 +2406,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(short2* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2394,7 +2414,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(short4* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2403,7 +2423,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(unsigned short* retVal,
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2411,7 +2431,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(ushort1* retVal, hipTextureObje
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2419,7 +2439,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(ushort2* retVal, hipTextureObje
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2427,7 +2447,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(ushort4* retVal, hipTextureObje
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2435,7 +2455,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(int* retVal, hipTextureObject_t
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2443,7 +2463,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(int1* retVal, hipTextureObject_
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2451,7 +2471,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(int2* retVal, hipTextureObject_
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2459,7 +2479,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(int4* retVal, hipTextureObject_
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2468,7 +2488,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(unsigned int* retVal,
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2476,7 +2496,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(uint1* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2484,7 +2504,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(uint2* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2492,7 +2512,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(uint4* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2500,7 +2520,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(float* retVal, hipTextureObject
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_FLOAT;
 }
 
@@ -2508,7 +2528,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(float1* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_FLOAT_X;
 }
 
@@ -2516,7 +2536,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(float2* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_FLOAT_XY;
 }
 
@@ -2524,7 +2544,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex1DLayeredGrad(float4* retVal, hipTextureObjec
                                                  float x, int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -2541,7 +2561,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(char* retVal, hipTextureObject_t te
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_SIGNED;
 }
 
@@ -2549,7 +2569,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(char1* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2557,7 +2577,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(char2* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2565,7 +2585,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(char4* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2574,7 +2594,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(unsigned char* retVal,
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2582,7 +2602,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(uchar1* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2590,7 +2610,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(uchar2* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2598,7 +2618,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(uchar4* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2606,7 +2626,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(short* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_SIGNED;
 }
 
@@ -2614,7 +2634,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(short1* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2622,7 +2642,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(short2* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2630,7 +2650,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(short4* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2639,7 +2659,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(unsigned short* retVal,
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2647,7 +2667,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(ushort1* retVal, hipTextureObject_t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2655,7 +2675,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(ushort2* retVal, hipTextureObject_t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2663,7 +2683,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(ushort4* retVal, hipTextureObject_t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2671,7 +2691,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(int* retVal, hipTextureObject_t tex
                                              float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_SIGNED;
 }
 
@@ -2679,7 +2699,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(int1* retVal, hipTextureObject_t te
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2687,7 +2707,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(int2* retVal, hipTextureObject_t te
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2695,7 +2715,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(int4* retVal, hipTextureObject_t te
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2703,7 +2723,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(unsigned int* retVal, hipTextureObj
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2711,7 +2731,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(uint1* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2719,7 +2739,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(uint2* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2727,7 +2747,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(uint4* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2735,7 +2755,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(float* retVal, hipTextureObject_t t
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_FLOAT;
 }
 
@@ -2743,7 +2763,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(float1* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_FLOAT_X;
 }
 
@@ -2751,7 +2771,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(float2* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_FLOAT_XY;
 }
 
@@ -2759,7 +2779,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayered(float4* retVal, hipTextureObject_t 
                                              float x, float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -2776,7 +2796,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(char* retVal, hipTextureObject_t
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2784,7 +2804,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(char1* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2792,7 +2812,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(char2* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2800,7 +2820,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(char4* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2809,7 +2829,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(unsigned char* retVal,
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2817,7 +2837,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(uchar1* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2825,7 +2845,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(uchar2* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2833,7 +2853,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(uchar4* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2841,7 +2861,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(short* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2849,7 +2869,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(short1* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2857,7 +2877,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(short2* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2865,7 +2885,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(short4* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2874,7 +2894,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(unsigned short* retVal,
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2882,7 +2902,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(ushort1* retVal, hipTextureObjec
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2890,7 +2910,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(ushort2* retVal, hipTextureObjec
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2898,7 +2918,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(ushort4* retVal, hipTextureObjec
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2906,7 +2926,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(int* retVal, hipTextureObject_t 
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_SIGNED;
 }
 
@@ -2914,7 +2934,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(int1* retVal, hipTextureObject_t
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_SIGNED_X;
 }
 
@@ -2922,7 +2942,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(int2* retVal, hipTextureObject_t
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_SIGNED_XY;
 }
 
@@ -2930,7 +2950,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(int4* retVal, hipTextureObject_t
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_SIGNED_XYZW;
 }
 
@@ -2939,7 +2959,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(unsigned int* retVal,
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_UNSIGNED;
 }
 
@@ -2947,7 +2967,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(uint1* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_UNSIGNED_X;
 }
 
@@ -2955,7 +2975,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(uint2* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_UNSIGNED_XY;
 }
 
@@ -2963,7 +2983,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(uint4* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_UNSIGNED_XYZW;
 }
 
@@ -2971,7 +2991,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(float* retVal, hipTextureObject_
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_FLOAT;
 }
 
@@ -2979,7 +2999,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(float1* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_FLOAT_X;
 }
 
@@ -2987,7 +3007,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(float2* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_FLOAT_XY;
 }
 
@@ -2995,7 +3015,7 @@ __TEXTURE_FUNCTIONS_DECL__ void tex2DLayeredLod(float4* retVal, hipTextureObject
                                                 float x, float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_SET_FLOAT_XYZW;
 }
 
@@ -4799,28 +4819,28 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex1DGrad(texture<float4, texType, mode> texRe
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex2D(texture<char, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_CHAR;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex2D(texture<char1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_CHAR_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex2D(texture<char2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_CHAR_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex2D(texture<char4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -4828,56 +4848,56 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2D(texture<unsigned char, texType, mode> texRef,
                                                float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UCHAR;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2D(texture<uchar1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UCHAR_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2D(texture<uchar2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2D(texture<uchar4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short tex2D(texture<short, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_SHORT;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short1 tex2D(texture<short1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_SHORT_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short2 tex2D(texture<short2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_SHORT_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short4 tex2D(texture<short4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -4885,56 +4905,56 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2D(texture<unsigned short, texType, mode> texRef,
                                                 float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_USHORT;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2D(texture<ushort1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_USHORT_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2D(texture<ushort2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_USHORT_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2D(texture<ushort4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex2D(texture<int, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_INT;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex2D(texture<int1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_INT_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex2D(texture<int2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_INT_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex2D(texture<int4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -4942,28 +4962,28 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2D(texture<unsigned int, texType, mode> texRef, float x,
                                               float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UINT;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex2D(texture<uint1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UINT_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex2D(texture<uint2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UINT_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex2D(texture<uint4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -4974,7 +4994,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex2D(texture<char, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_CHAR;
 }
 
@@ -4982,7 +5002,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex2D(texture<char1, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -4990,7 +5010,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex2D(texture<char2, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -4998,7 +5018,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex2D(texture<char4, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -5006,7 +5026,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2D(texture<unsigned char, texType, mode> texRef,
                                                hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -5014,7 +5034,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2D(texture<uchar1, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -5022,7 +5042,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2D(texture<uchar2, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -5030,7 +5050,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2D(texture<uchar4, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -5038,7 +5058,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short tex2D(texture<short, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_SHORT;
 }
 
@@ -5046,7 +5066,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short1 tex2D(texture<short1, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -5054,7 +5074,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short2 tex2D(texture<short2, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -5062,7 +5082,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short4 tex2D(texture<short4, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -5071,7 +5091,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2D(texture<unsigned short, texType,
                                                 hipTextureObject_t textureObject, float x,
                                                 float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_USHORT;
 }
 
@@ -5079,7 +5099,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2D(texture<ushort1, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -5087,7 +5107,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2D(texture<ushort2, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -5095,7 +5115,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2D(texture<ushort4, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -5103,7 +5123,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex2D(texture<int, texType, mode> texRef,
                                      hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_INT;
 }
 
@@ -5111,7 +5131,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex2D(texture<int1, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_INT_X;
 }
 
@@ -5119,7 +5139,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex2D(texture<int2, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -5127,7 +5147,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex2D(texture<int4, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -5135,7 +5155,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2D(texture<unsigned int, texType, mode> texRef,
                                               hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UINT;
 }
 
@@ -5143,7 +5163,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex2D(texture<uint1, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -5151,7 +5171,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex2D(texture<uint2, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -5159,7 +5179,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex2D(texture<uint4, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -5167,21 +5187,21 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex2D(texture<float, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_FLOAT;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex2D(texture<float, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_FLOAT;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex2D(texture<float1, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -5189,14 +5209,14 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex2D(texture<float1, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_FLOAT_X;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex2D(texture<float2, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -5204,14 +5224,14 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex2D(texture<float2, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
 template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex2D(texture<float4, texType, mode> texRef, float x, float y) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -5219,7 +5239,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex2D(texture<float4, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_2D(i, s, hc::short_vector::float2(x, y).get_vector());
+    texel.f = __ockl_image_sample_2D(i, s, float2(x, y));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -5229,7 +5249,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex2DLod(texture<char, texType, mode> texRef, float x, float y,
                                          float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -5237,7 +5257,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLod(texture<char1, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -5245,7 +5265,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLod(texture<char2, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -5253,7 +5273,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLod(texture<char4, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -5261,7 +5281,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLod(texture<unsigned char, texType, mode> texRef,
                                                   float x, float y, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -5269,7 +5289,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLod(texture<uchar1, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -5277,7 +5297,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLod(texture<uchar2, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -5285,7 +5305,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLod(texture<uchar4, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -5293,7 +5313,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short tex2DLod(texture<short, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -5301,7 +5321,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLod(texture<short1, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -5309,7 +5329,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLod(texture<short2, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -5317,7 +5337,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLod(texture<short4, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -5325,7 +5345,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLod(texture<unsigned short, texType, mode> texRef,
                                                    float x, float y, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -5333,7 +5353,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLod(texture<ushort1, texType, mode> texRef, float x,
                                             float y, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -5341,7 +5361,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLod(texture<ushort2, texType, mode> texRef, float x,
                                             float y, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -5349,7 +5369,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLod(texture<ushort4, texType, mode> texRef, float x,
                                             float y, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -5357,7 +5377,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex2DLod(texture<int, texType, mode> texRef, float x, float y,
                                         float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_INT;
 }
 
@@ -5365,7 +5385,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLod(texture<int1, texType, mode> texRef, float x, float y,
                                          float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -5373,7 +5393,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLod(texture<int2, texType, mode> texRef, float x, float y,
                                          float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -5381,7 +5401,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLod(texture<int4, texType, mode> texRef, float x, float y,
                                          float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -5389,7 +5409,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLod(texture<unsigned int, texType, mode> texRef,
                                                  float x, float y, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UINT;
 }
 
@@ -5397,7 +5417,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLod(texture<uint1, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -5405,7 +5425,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLod(texture<uint2, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -5413,7 +5433,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLod(texture<uint4, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -5421,7 +5441,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex2DLod(texture<float, texType, mode> texRef, float x, float y,
                                           float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -5429,7 +5449,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLod(texture<float1, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -5437,7 +5457,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLod(texture<float2, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -5445,7 +5465,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLod(texture<float4, texType, mode> texRef, float x, float y,
                                            float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -5456,7 +5476,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLod(texture<char, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -5465,7 +5485,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLod(texture<char1, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -5474,7 +5494,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLod(texture<char2, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -5483,7 +5503,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLod(texture<char4, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -5492,7 +5512,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLod(texture<unsigned char, texType
                                                   hipTextureObject_t textureObject, float x,
                                                   float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -5501,7 +5521,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLod(texture<uchar1, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -5510,7 +5530,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLod(texture<uchar2, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -5519,7 +5539,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLod(texture<uchar4, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -5528,7 +5548,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLod(texture<short, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -5537,7 +5557,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLod(texture<short1, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -5546,7 +5566,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLod(texture<short2, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -5555,7 +5575,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLod(texture<short4, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -5564,7 +5584,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLod(texture<unsigned short, texTy
                                                    hipTextureObject_t textureObject, float x,
                                                    float y, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -5573,7 +5593,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLod(texture<ushort1, texType, mode> texR
                                             hipTextureObject_t textureObject, float x, float y,
                                             float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -5582,7 +5602,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLod(texture<ushort2, texType, mode> texR
                                             hipTextureObject_t textureObject, float x, float y,
                                             float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -5591,7 +5611,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLod(texture<ushort4, texType, mode> texR
                                             hipTextureObject_t textureObject, float x, float y,
                                             float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -5600,7 +5620,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLod(texture<int, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_INT;
 }
 
@@ -5609,7 +5629,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLod(texture<int1, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -5618,7 +5638,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLod(texture<int2, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -5627,7 +5647,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLod(texture<int4, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -5636,7 +5656,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLod(texture<unsigned int, texType, 
                                                  hipTextureObject_t textureObject, float x, float y,
                                                  float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UINT;
 }
 
@@ -5645,7 +5665,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLod(texture<uint1, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -5654,7 +5674,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLod(texture<uint2, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -5663,7 +5683,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLod(texture<uint4, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -5672,7 +5692,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLod(texture<float, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -5681,7 +5701,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLod(texture<float1, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -5690,7 +5710,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLod(texture<float2, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -5699,7 +5719,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLod(texture<float4, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_2D(i, s, hc::short_vector::float2(x, y).get_vector(), level);
+    texel.f = __ockl_image_sample_lod_2D(i, s, float2(x, y), level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -5709,9 +5729,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex2DGrad(texture<char, texType, mode> texRef, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR;
 }
 
@@ -5719,9 +5739,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex2DGrad(texture<char1, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -5729,9 +5749,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex2DGrad(texture<char2, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -5739,9 +5759,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex2DGrad(texture<char4, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -5749,9 +5769,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DGrad(texture<unsigned char, texType, mode> texRef,
                                                    float x, float y, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -5759,9 +5779,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DGrad(texture<uchar1, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -5769,9 +5789,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DGrad(texture<uchar2, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -5779,9 +5799,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DGrad(texture<uchar4, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -5789,9 +5809,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short tex2DGrad(texture<short, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT;
 }
 
@@ -5799,9 +5819,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short1 tex2DGrad(texture<short1, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -5809,9 +5829,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short2 tex2DGrad(texture<short2, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -5819,9 +5839,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short4 tex2DGrad(texture<short4, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -5829,9 +5849,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DGrad(texture<unsigned short, texType, mode> texRef,
                                                     float x, float y, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT;
 }
 
@@ -5839,9 +5859,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DGrad(texture<ushort1, texType, mode> texRef, float x,
                                              float y, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -5849,9 +5869,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DGrad(texture<ushort2, texType, mode> texRef, float x,
                                              float y, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -5859,9 +5879,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DGrad(texture<ushort4, texType, mode> texRef, float x,
                                              float y, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -5869,9 +5889,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex2DGrad(texture<int, texType, mode> texRef, float x, float y,
                                          float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_INT;
 }
 
@@ -5879,9 +5899,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex2DGrad(texture<int1, texType, mode> texRef, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_INT_X;
 }
 
@@ -5889,9 +5909,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex2DGrad(texture<int2, texType, mode> texRef, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -5899,9 +5919,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex2DGrad(texture<int4, texType, mode> texRef, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -5909,9 +5929,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DGrad(texture<unsigned int, texType, mode> texRef,
                                                   float x, float y, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT;
 }
 
@@ -5919,9 +5939,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DGrad(texture<uint1, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -5929,9 +5949,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DGrad(texture<uint2, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -5939,9 +5959,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DGrad(texture<uint4, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -5949,9 +5969,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex2DGrad(texture<float, texType, mode> texRef, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -5959,9 +5979,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex2DGrad(texture<float1, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -5969,9 +5989,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex2DGrad(texture<float2, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -5979,9 +5999,9 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex2DGrad(texture<float4, texType, mode> texRef, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -5992,9 +6012,9 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DGrad(texture<char, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR;
 }
 
@@ -6003,9 +6023,9 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DGrad(texture<char1, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -6014,9 +6034,9 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DGrad(texture<char2, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -6025,9 +6045,9 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DGrad(texture<char4, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -6036,9 +6056,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DGrad(texture<unsigned char, texTyp
                                                    hipTextureObject_t textureObject, float x,
                                                    float y, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -6047,9 +6067,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DGrad(texture<uchar1, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -6058,9 +6078,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DGrad(texture<uchar2, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -6069,9 +6089,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DGrad(texture<uchar4, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -6080,9 +6100,9 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DGrad(texture<short, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT;
 }
 
@@ -6091,9 +6111,9 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DGrad(texture<short1, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -6102,9 +6122,9 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DGrad(texture<short2, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -6113,9 +6133,9 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DGrad(texture<short4, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -6124,9 +6144,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DGrad(texture<unsigned short, texT
                                                     hipTextureObject_t textureObject, float x,
                                                     float y, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT;
 }
 
@@ -6135,9 +6155,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DGrad(texture<ushort1, texType, mode> tex
                                              hipTextureObject_t textureObject, float x, float y,
                                              float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -6146,9 +6166,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DGrad(texture<ushort2, texType, mode> tex
                                              hipTextureObject_t textureObject, float x, float y,
                                              float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -6157,9 +6177,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DGrad(texture<ushort4, texType, mode> tex
                                              hipTextureObject_t textureObject, float x, float y,
                                              float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -6168,9 +6188,9 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DGrad(texture<int, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_INT;
 }
 
@@ -6179,9 +6199,9 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DGrad(texture<int1, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_INT_X;
 }
 
@@ -6190,9 +6210,9 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DGrad(texture<int2, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -6201,9 +6221,9 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DGrad(texture<int4, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -6212,9 +6232,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DGrad(texture<unsigned int, texType,
                                                   hipTextureObject_t textureObject, float x,
                                                   float y, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT;
 }
 
@@ -6223,9 +6243,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DGrad(texture<uint1, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -6234,9 +6254,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DGrad(texture<uint2, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -6245,9 +6265,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DGrad(texture<uint4, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -6256,9 +6276,9 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DGrad(texture<float, texType, mode> texRef,
                                            hipTextureObject_t textureObject, float x, float y,
                                            float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -6267,9 +6287,9 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DGrad(texture<float1, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -6278,9 +6298,9 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DGrad(texture<float2, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -6289,9 +6309,9 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DGrad(texture<float4, texType, mode> texRe
                                             hipTextureObject_t textureObject, float x, float y,
                                             float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_grad_2D(i, s, hc::short_vector::float2(x, y).get_vector(),
-                                          hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                          hc::short_vector::float2(dy.x, dy.y).get_vector());
+    texel.f = __ockl_image_sample_grad_2D(i, s, float2(x, y),
+                                          float2(dx.x, dx.y),
+                                          float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -6301,7 +6321,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex3D(texture<char, texType, mode> texRef, float x, float y,
                                       float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_CHAR;
 }
 
@@ -6309,7 +6329,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex3D(texture<char1, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -6317,7 +6337,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex3D(texture<char2, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -6325,7 +6345,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex3D(texture<char4, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -6333,7 +6353,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex3D(texture<unsigned char, texType, mode> texRef,
                                                float x, float y, float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -6341,7 +6361,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex3D(texture<uchar1, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -6349,7 +6369,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex3D(texture<uchar2, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -6357,7 +6377,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex3D(texture<uchar4, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -6365,7 +6385,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short tex3D(texture<short, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_SHORT;
 }
 
@@ -6373,7 +6393,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short1 tex3D(texture<short1, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -6381,7 +6401,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short2 tex3D(texture<short2, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -6389,7 +6409,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short4 tex3D(texture<short4, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -6397,7 +6417,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned short tex3D(texture<unsigned short, texType, mode> texRef,
                                                 float x, float y, float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_USHORT;
 }
 
@@ -6405,7 +6425,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort1 tex3D(texture<ushort1, texType, mode> texRef, float x, float y,
                                          float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -6413,7 +6433,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort2 tex3D(texture<ushort2, texType, mode> texRef, float x, float y,
                                          float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -6421,7 +6441,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort4 tex3D(texture<ushort4, texType, mode> texRef, float x, float y,
                                          float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -6429,7 +6449,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex3D(texture<int, texType, mode> texRef, float x, float y,
                                      float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_INT;
 }
 
@@ -6437,7 +6457,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex3D(texture<int1, texType, mode> texRef, float x, float y,
                                       float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_INT_X;
 }
 
@@ -6445,7 +6465,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex3D(texture<int2, texType, mode> texRef, float x, float y,
                                       float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -6453,7 +6473,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex3D(texture<int4, texType, mode> texRef, float x, float y,
                                       float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -6461,7 +6481,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex3D(texture<unsigned int, texType, mode> texRef, float x,
                                               float y, float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UINT;
 }
 
@@ -6469,7 +6489,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex3D(texture<uint1, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -6477,7 +6497,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex3D(texture<uint2, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -6485,7 +6505,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex3D(texture<uint4, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -6493,7 +6513,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex3D(texture<float, texType, mode> texRef, float x, float y,
                                        float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -6501,7 +6521,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex3D(texture<float1, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -6509,7 +6529,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex3D(texture<float2, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -6517,7 +6537,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex3D(texture<float4, texType, mode> texRef, float x, float y,
                                         float z) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -6527,7 +6547,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex3D(texture<char, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_CHAR;
 }
 
@@ -6536,7 +6556,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex3D(texture<char1, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -6545,7 +6565,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex3D(texture<char2, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -6554,7 +6574,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex3D(texture<char4, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -6563,7 +6583,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex3D(texture<unsigned char, texType, m
                                                hipTextureObject_t textureObject, float x, float y,
                                                float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -6572,7 +6592,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex3D(texture<uchar1, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -6581,7 +6601,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex3D(texture<uchar2, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -6590,7 +6610,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex3D(texture<uchar4, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -6599,7 +6619,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex3D(texture<short, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_SHORT;
 }
 
@@ -6608,7 +6628,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex3D(texture<short1, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -6617,7 +6637,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex3D(texture<short2, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -6626,7 +6646,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex3D(texture<short4, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -6635,7 +6655,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex3D(texture<unsigned short, texType,
                                                 hipTextureObject_t textureObject, float x, float y,
                                                 float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_USHORT;
 }
 
@@ -6644,7 +6664,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex3D(texture<ushort1, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -6653,7 +6673,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex3D(texture<ushort2, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -6662,7 +6682,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex3D(texture<ushort4, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -6670,7 +6690,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex3D(texture<int, texType, mode> texRef,
                                      hipTextureObject_t textureObject, float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_INT;
 }
 
@@ -6678,7 +6698,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex3D(texture<int1, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_INT_X;
 }
 
@@ -6686,7 +6706,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex3D(texture<int2, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -6694,7 +6714,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex3D(texture<int4, texType, mode> texRef,
                                       hipTextureObject_t textureObject, float x, float y, float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -6703,7 +6723,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex3D(texture<unsigned int, texType, mod
                                               hipTextureObject_t textureObject, float x, float y,
                                               float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UINT;
 }
 
@@ -6712,7 +6732,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex3D(texture<uint1, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -6721,7 +6741,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex3D(texture<uint2, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -6730,7 +6750,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex3D(texture<uint4, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -6739,7 +6759,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex3D(texture<float, texType, mode> texRef,
                                        hipTextureObject_t textureObject, float x, float y,
                                        float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -6748,7 +6768,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex3D(texture<float1, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -6757,7 +6777,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex3D(texture<float2, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -6766,7 +6786,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex3D(texture<float4, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y,
                                         float z) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector());
+    texel.f = __ockl_image_sample_3D(i, s, float4(x, y, z, 0.0f));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -6776,7 +6796,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex3DLod(texture<char, texType, mode> texRef, float x, float y,
                                          float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_CHAR;
 }
@@ -6785,7 +6805,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex3DLod(texture<char1, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_CHAR_X;
 }
@@ -6794,7 +6814,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex3DLod(texture<char2, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_CHAR_XY;
 }
@@ -6803,7 +6823,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex3DLod(texture<char4, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
@@ -6812,7 +6832,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex3DLod(texture<unsigned char, texType, mode> texRef,
                                                   float x, float y, float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UCHAR;
 }
@@ -6821,7 +6841,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex3DLod(texture<uchar1, texType, mode> texRef, float x, float y,
                                            float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UCHAR_X;
 }
@@ -6830,7 +6850,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex3DLod(texture<uchar2, texType, mode> texRef, float x, float y,
                                            float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UCHAR_XY;
 }
@@ -6839,7 +6859,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex3DLod(texture<uchar4, texType, mode> texRef, float x, float y,
                                            float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
@@ -6848,7 +6868,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex3DLod(texture<int, texType, mode> texRef, float x, float y,
                                         float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_INT;
 }
@@ -6857,7 +6877,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex3DLod(texture<int1, texType, mode> texRef, float x, float y,
                                          float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_INT_X;
 }
@@ -6866,7 +6886,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex3DLod(texture<int2, texType, mode> texRef, float x, float y,
                                          float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_INT_XY;
 }
@@ -6875,7 +6895,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex3DLod(texture<int4, texType, mode> texRef, float x, float y,
                                          float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_INT_XYZW;
 }
@@ -6884,7 +6904,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex3DLod(texture<unsigned int, texType, mode> texRef,
                                                  float x, float y, float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UINT;
 }
@@ -6893,7 +6913,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex3DLod(texture<uint1, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UINT_X;
 }
@@ -6902,7 +6922,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex3DLod(texture<uint2, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UINT_XY;
 }
@@ -6911,7 +6931,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex3DLod(texture<uint4, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UINT_XYZW;
 }
@@ -6920,7 +6940,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex3DLod(texture<float, texType, mode> texRef, float x, float y,
                                           float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_FLOAT;
 }
@@ -6929,7 +6949,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex3DLod(texture<float1, texType, mode> texRef, float x, float y,
                                            float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_FLOAT_X;
 }
@@ -6938,7 +6958,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex3DLod(texture<float2, texType, mode> texRef, float x, float y,
                                            float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_FLOAT_XY;
 }
@@ -6947,7 +6967,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex3DLod(texture<float4, texType, mode> texRef, float x, float y,
                                            float z, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
@@ -6959,7 +6979,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex3DLod(texture<char, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_CHAR;
 }
@@ -6969,7 +6989,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex3DLod(texture<char1, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_CHAR_X;
 }
@@ -6979,7 +6999,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex3DLod(texture<char2, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_CHAR_XY;
 }
@@ -6989,7 +7009,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex3DLod(texture<char4, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
@@ -6999,7 +7019,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex3DLod(texture<unsigned char, texType
                                                   hipTextureObject_t textureObject, float x,
                                                   float y, float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UCHAR;
 }
@@ -7009,7 +7029,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex3DLod(texture<uchar1, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UCHAR_X;
 }
@@ -7019,7 +7039,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex3DLod(texture<uchar2, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UCHAR_XY;
 }
@@ -7029,7 +7049,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex3DLod(texture<uchar4, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
@@ -7039,7 +7059,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex3DLod(texture<int, texType, mode> texRef,
                                         hipTextureObject_t textureObject, float x, float y, float z,
                                         float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_INT;
 }
@@ -7049,7 +7069,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex3DLod(texture<int1, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_INT_X;
 }
@@ -7059,7 +7079,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex3DLod(texture<int2, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_INT_XY;
 }
@@ -7069,7 +7089,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex3DLod(texture<int4, texType, mode> texRef,
                                          hipTextureObject_t textureObject, float x, float y,
                                          float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_INT_XYZW;
 }
@@ -7079,7 +7099,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex3DLod(texture<unsigned int, texType, 
                                                  hipTextureObject_t textureObject, float x, float y,
                                                  float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UINT;
 }
@@ -7089,7 +7109,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex3DLod(texture<uint1, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UINT_X;
 }
@@ -7099,7 +7119,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex3DLod(texture<uint2, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UINT_XY;
 }
@@ -7109,7 +7129,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex3DLod(texture<uint4, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_UINT_XYZW;
 }
@@ -7119,7 +7139,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex3DLod(texture<float, texType, mode> texRef,
                                           hipTextureObject_t textureObject, float x, float y,
                                           float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_FLOAT;
 }
@@ -7129,7 +7149,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex3DLod(texture<float1, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_FLOAT_X;
 }
@@ -7139,7 +7159,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex3DLod(texture<float2, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_FLOAT_XY;
 }
@@ -7149,7 +7169,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex3DLod(texture<float4, texType, mode> texRef
                                            hipTextureObject_t textureObject, float x, float y,
                                            float z, float level) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_lod_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
+    texel.f = __ockl_image_sample_lod_3D(i, s, float4(x, y, z, 0.0f),
                                          level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
@@ -7161,9 +7181,9 @@ __TEXTURE_FUNCTIONS_DECL__ char tex3DGrad(texture<char, texType, mode> texRef, f
                                           float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_CHAR;
 }
 
@@ -7172,9 +7192,9 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex3DGrad(texture<char1, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -7183,9 +7203,9 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex3DGrad(texture<char2, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -7194,9 +7214,9 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex3DGrad(texture<char4, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -7206,9 +7226,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex3DGrad(texture<unsigned char, texTyp
                                                    float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -7217,9 +7237,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex3DGrad(texture<uchar1, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -7228,9 +7248,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex3DGrad(texture<uchar2, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -7239,9 +7259,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex3DGrad(texture<uchar4, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -7250,9 +7270,9 @@ __TEXTURE_FUNCTIONS_DECL__ short tex3DGrad(texture<short, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_SHORT;
 }
 
@@ -7261,9 +7281,9 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex3DGrad(texture<short1, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -7272,9 +7292,9 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex3DGrad(texture<short2, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -7283,9 +7303,9 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex3DGrad(texture<short4, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -7295,9 +7315,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex3DGrad(texture<unsigned short, texT
                                                     float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_USHORT;
 }
 
@@ -7306,9 +7326,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex3DGrad(texture<ushort1, texType, mode> tex
                                              float y, float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -7317,9 +7337,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex3DGrad(texture<ushort2, texType, mode> tex
                                              float y, float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -7328,9 +7348,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex3DGrad(texture<ushort4, texType, mode> tex
                                              float y, float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -7339,9 +7359,9 @@ __TEXTURE_FUNCTIONS_DECL__ int tex3DGrad(texture<int, texType, mode> texRef, flo
                                          float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_INT;
 }
 
@@ -7350,9 +7370,9 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex3DGrad(texture<int1, texType, mode> texRef, f
                                           float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_INT_X;
 }
 
@@ -7361,9 +7381,9 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex3DGrad(texture<int2, texType, mode> texRef, f
                                           float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -7372,9 +7392,9 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex3DGrad(texture<int4, texType, mode> texRef, f
                                           float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -7383,9 +7403,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex3DGrad(texture<unsigned int, texType,
                                                   float x, float y, float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UINT;
 }
 
@@ -7394,9 +7414,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex3DGrad(texture<uint1, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -7405,9 +7425,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex3DGrad(texture<uint2, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -7416,9 +7436,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex3DGrad(texture<uint4, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -7427,9 +7447,9 @@ __TEXTURE_FUNCTIONS_DECL__ float tex3DGrad(texture<float, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -7438,9 +7458,9 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex3DGrad(texture<float1, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -7449,9 +7469,9 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex3DGrad(texture<float2, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -7460,9 +7480,9 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex3DGrad(texture<float4, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -7473,9 +7493,9 @@ __TEXTURE_FUNCTIONS_DECL__ char tex3DGrad(texture<char, texType, mode> texRef,
                                           float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_CHAR;
 }
 
@@ -7485,9 +7505,9 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex3DGrad(texture<char1, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -7497,9 +7517,9 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex3DGrad(texture<char2, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -7509,9 +7529,9 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex3DGrad(texture<char4, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -7521,9 +7541,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex3DGrad(texture<unsigned char, texTyp
                                                    float y, float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -7533,9 +7553,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex3DGrad(texture<uchar1, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -7545,9 +7565,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex3DGrad(texture<uchar2, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -7557,9 +7577,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex3DGrad(texture<uchar4, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -7569,9 +7589,9 @@ __TEXTURE_FUNCTIONS_DECL__ short tex3DGrad(texture<short, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_SHORT;
 }
 
@@ -7581,9 +7601,9 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex3DGrad(texture<short1, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -7593,9 +7613,9 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex3DGrad(texture<short2, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -7605,9 +7625,9 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex3DGrad(texture<short4, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -7617,9 +7637,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex3DGrad(texture<unsigned short, texT
                                                     float y, float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_USHORT;
 }
 
@@ -7629,9 +7649,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex3DGrad(texture<ushort1, texType, mode> tex
                                              float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -7641,9 +7661,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex3DGrad(texture<ushort2, texType, mode> tex
                                              float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -7653,9 +7673,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex3DGrad(texture<ushort4, texType, mode> tex
                                              float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -7665,9 +7685,9 @@ __TEXTURE_FUNCTIONS_DECL__ int tex3DGrad(texture<int, texType, mode> texRef,
                                          float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_INT;
 }
 
@@ -7677,9 +7697,9 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex3DGrad(texture<int1, texType, mode> texRef,
                                           float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_INT_X;
 }
 
@@ -7689,9 +7709,9 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex3DGrad(texture<int2, texType, mode> texRef,
                                           float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -7701,9 +7721,9 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex3DGrad(texture<int4, texType, mode> texRef,
                                           float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -7713,9 +7733,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex3DGrad(texture<unsigned int, texType,
                                                   float y, float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UINT;
 }
 
@@ -7725,9 +7745,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex3DGrad(texture<uint1, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -7737,9 +7757,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex3DGrad(texture<uint2, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -7749,9 +7769,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex3DGrad(texture<uint4, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -7761,9 +7781,9 @@ __TEXTURE_FUNCTIONS_DECL__ float tex3DGrad(texture<float, texType, mode> texRef,
                                            float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -7773,9 +7793,9 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex3DGrad(texture<float1, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -7785,9 +7805,9 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex3DGrad(texture<float2, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -7797,9 +7817,9 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex3DGrad(texture<float4, texType, mode> texRe
                                             float z, float4 dx, float4 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_3D(i, s, hc::short_vector::float4(x, y, z, 0.0f).get_vector(),
-                                    hc::short_vector::float4(dx.x, dx.y, dx.z, dx.w).get_vector(),
-                                    hc::short_vector::float4(dy.x, dy.y, dy.z, dy.w).get_vector());
+        __ockl_image_sample_grad_3D(i, s, float4(x, y, z, 0.0f),
+                                    float4(dx.x, dx.y, dx.z, dx.w),
+                                    float4(dy.x, dy.y, dy.z, dy.w));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -7809,7 +7829,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex1DLayered(texture<char, texType, mode> texRef, float x,
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_CHAR;
 }
 
@@ -7817,7 +7837,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char1 tex1DLayered(texture<char1, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -7825,7 +7845,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char2 tex1DLayered(texture<char2, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -7833,7 +7853,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char4 tex1DLayered(texture<char4, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -7841,7 +7861,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned char tex1DLayered(texture<unsigned char, texType, mode> texRef,
                                                       float x, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -7849,7 +7869,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar1 tex1DLayered(texture<uchar1, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -7857,7 +7877,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar2 tex1DLayered(texture<uchar2, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -7865,7 +7885,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uchar4 tex1DLayered(texture<uchar4, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -7873,7 +7893,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short tex1DLayered(texture<short, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_SHORT;
 }
 
@@ -7881,7 +7901,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short1 tex1DLayered(texture<short1, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -7889,7 +7909,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short2 tex1DLayered(texture<short2, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -7897,7 +7917,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ short4 tex1DLayered(texture<short4, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -7905,7 +7925,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned short tex1DLayered(
     texture<unsigned short, texType, mode> texRef, float x, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_USHORT;
 }
 
@@ -7913,7 +7933,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort1 tex1DLayered(texture<ushort1, texType, mode> texRef, float x,
                                                 int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -7921,7 +7941,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort2 tex1DLayered(texture<ushort2, texType, mode> texRef, float x,
                                                 int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -7929,7 +7949,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ ushort4 tex1DLayered(texture<ushort4, texType, mode> texRef, float x,
                                                 int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -7937,7 +7957,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex1DLayered(texture<int, texType, mode> texRef, float x,
                                             int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_INT;
 }
 
@@ -7945,7 +7965,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex1DLayered(texture<int1, texType, mode> texRef, float x,
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_INT_X;
 }
 
@@ -7953,7 +7973,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex1DLayered(texture<int2, texType, mode> texRef, float x,
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -7961,7 +7981,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex1DLayered(texture<int4, texType, mode> texRef, float x,
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -7969,7 +7989,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ unsigned int tex1DLayered(texture<unsigned int, texType, mode> texRef,
                                                      float x, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UINT;
 }
 
@@ -7977,7 +7997,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint1 tex1DLayered(texture<uint1, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -7985,7 +8005,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint2 tex1DLayered(texture<uint2, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -7993,7 +8013,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ uint4 tex1DLayered(texture<uint4, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -8001,7 +8021,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float tex1DLayered(texture<float, texType, mode> texRef, float x,
                                               int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -8009,7 +8029,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float1 tex1DLayered(texture<float1, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -8017,7 +8037,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float2 tex1DLayered(texture<float2, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -8025,7 +8045,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ float4 tex1DLayered(texture<float4, texType, mode> texRef, float x,
                                                int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -8035,7 +8055,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ char tex1DLayered(texture<char, texType, mode> texRef,
                                              hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_CHAR;
 }
 
@@ -8044,7 +8064,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex1DLayered(texture<char1, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -8053,7 +8073,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex1DLayered(texture<char2, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -8062,7 +8082,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex1DLayered(texture<char4, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -8071,7 +8091,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex1DLayered(texture<unsigned char, tex
                                                       hipTextureObject_t textureObject, float x,
                                                       int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -8080,7 +8100,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex1DLayered(texture<uchar1, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -8089,7 +8109,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex1DLayered(texture<uchar2, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -8098,7 +8118,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex1DLayered(texture<uchar4, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -8107,7 +8127,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex1DLayered(texture<short, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_SHORT;
 }
 
@@ -8116,7 +8136,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex1DLayered(texture<short1, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -8125,7 +8145,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex1DLayered(texture<short2, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -8134,7 +8154,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex1DLayered(texture<short4, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -8143,7 +8163,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex1DLayered(
     texture<unsigned short, texType, mode> texRef, hipTextureObject_t textureObject, float x,
     int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_USHORT;
 }
 
@@ -8152,7 +8172,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex1DLayered(texture<ushort1, texType, mode> 
                                                 hipTextureObject_t textureObject, float x,
                                                 int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -8161,7 +8181,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex1DLayered(texture<ushort2, texType, mode> 
                                                 hipTextureObject_t textureObject, float x,
                                                 int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -8170,7 +8190,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex1DLayered(texture<ushort4, texType, mode> 
                                                 hipTextureObject_t textureObject, float x,
                                                 int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -8178,7 +8198,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int tex1DLayered(texture<int, texType, mode> texRef,
                                             hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_INT;
 }
 
@@ -8186,7 +8206,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int1 tex1DLayered(texture<int1, texType, mode> texRef,
                                              hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_INT_X;
 }
 
@@ -8194,7 +8214,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int2 tex1DLayered(texture<int2, texType, mode> texRef,
                                              hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -8202,7 +8222,7 @@ template <int texType, enum hipTextureReadMode mode>
 __TEXTURE_FUNCTIONS_DECL__ int4 tex1DLayered(texture<int4, texType, mode> texRef,
                                              hipTextureObject_t textureObject, float x, int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -8211,7 +8231,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex1DLayered(texture<unsigned int, texTy
                                                      hipTextureObject_t textureObject, float x,
                                                      int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UINT;
 }
 
@@ -8220,7 +8240,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex1DLayered(texture<uint1, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -8229,7 +8249,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex1DLayered(texture<uint2, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -8238,7 +8258,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex1DLayered(texture<uint4, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -8247,7 +8267,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex1DLayered(texture<float, texType, mode> texR
                                               hipTextureObject_t textureObject, float x,
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -8256,7 +8276,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex1DLayered(texture<float1, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -8265,7 +8285,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex1DLayered(texture<float2, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -8274,7 +8294,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex1DLayered(texture<float4, texType, mode> te
                                                hipTextureObject_t textureObject, float x,
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
-    texel.f = __ockl_image_sample_1Da(i, s, hc::short_vector::float2(x, layer).get_vector());
+    texel.f = __ockl_image_sample_1Da(i, s, float2(x, layer));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -8285,7 +8305,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex1DLayeredLod(texture<char, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -8294,7 +8314,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex1DLayeredLod(texture<char1, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -8303,7 +8323,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex1DLayeredLod(texture<char2, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -8312,7 +8332,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex1DLayeredLod(texture<char4, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -8321,7 +8341,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex1DLayeredLod(
     texture<unsigned char, texType, mode> texRef, float x, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -8330,7 +8350,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex1DLayeredLod(texture<uchar1, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -8339,7 +8359,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex1DLayeredLod(texture<uchar2, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -8348,7 +8368,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex1DLayeredLod(texture<uchar4, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -8357,7 +8377,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex1DLayeredLod(texture<short, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -8366,7 +8386,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex1DLayeredLod(texture<short1, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -8375,7 +8395,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex1DLayeredLod(texture<short2, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -8384,7 +8404,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex1DLayeredLod(texture<short4, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -8393,7 +8413,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex1DLayeredLod(
     texture<unsigned short, texType, mode> texRef, float x, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -8402,7 +8422,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex1DLayeredLod(texture<ushort1, texType, mod
                                                    int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -8411,7 +8431,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex1DLayeredLod(texture<ushort2, texType, mod
                                                    int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -8420,7 +8440,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex1DLayeredLod(texture<ushort4, texType, mod
                                                    int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -8429,7 +8449,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex1DLayeredLod(texture<int, texType, mode> texRe
                                                int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_INT;
 }
 
@@ -8438,7 +8458,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex1DLayeredLod(texture<int1, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -8447,7 +8467,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex1DLayeredLod(texture<int2, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -8456,7 +8476,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex1DLayeredLod(texture<int4, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -8465,7 +8485,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex1DLayeredLod(texture<unsigned int, te
                                                         float x, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UINT;
 }
 
@@ -8474,7 +8494,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex1DLayeredLod(texture<uint1, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -8483,7 +8503,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex1DLayeredLod(texture<uint2, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -8492,7 +8512,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex1DLayeredLod(texture<uint4, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -8501,7 +8521,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex1DLayeredLod(texture<float, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -8510,7 +8530,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex1DLayeredLod(texture<float1, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -8519,7 +8539,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex1DLayeredLod(texture<float2, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -8528,7 +8548,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex1DLayeredLod(texture<float4, texType, mode>
                                                   int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -8540,7 +8560,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex1DLayeredLod(texture<char, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -8550,7 +8570,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex1DLayeredLod(texture<char1, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -8560,7 +8580,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex1DLayeredLod(texture<char2, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -8570,7 +8590,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex1DLayeredLod(texture<char4, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -8580,7 +8600,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex1DLayeredLod(
     int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -8590,7 +8610,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex1DLayeredLod(texture<uchar1, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -8600,7 +8620,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex1DLayeredLod(texture<uchar2, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -8610,7 +8630,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex1DLayeredLod(texture<uchar4, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -8620,7 +8640,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex1DLayeredLod(texture<short, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -8630,7 +8650,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex1DLayeredLod(texture<short1, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -8640,7 +8660,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex1DLayeredLod(texture<short2, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -8650,7 +8670,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex1DLayeredLod(texture<short4, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -8660,7 +8680,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex1DLayeredLod(
     int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -8670,7 +8690,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex1DLayeredLod(texture<ushort1, texType, mod
                                                    int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -8680,7 +8700,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex1DLayeredLod(texture<ushort2, texType, mod
                                                    int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -8690,7 +8710,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex1DLayeredLod(texture<ushort4, texType, mod
                                                    int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -8700,7 +8720,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex1DLayeredLod(texture<int, texType, mode> texRe
                                                float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_INT;
 }
 
@@ -8710,7 +8730,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex1DLayeredLod(texture<int1, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -8720,7 +8740,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex1DLayeredLod(texture<int2, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -8730,7 +8750,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex1DLayeredLod(texture<int4, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -8740,7 +8760,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex1DLayeredLod(texture<unsigned int, te
                                                         int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UINT;
 }
 
@@ -8750,7 +8770,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex1DLayeredLod(texture<uint1, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -8760,7 +8780,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex1DLayeredLod(texture<uint2, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -8770,7 +8790,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex1DLayeredLod(texture<uint4, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -8780,7 +8800,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex1DLayeredLod(texture<float, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -8790,7 +8810,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex1DLayeredLod(texture<float1, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -8800,7 +8820,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex1DLayeredLod(texture<float2, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -8810,7 +8830,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex1DLayeredLod(texture<float4, texType, mode>
                                                   int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_lod_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), level);
+        __ockl_image_sample_lod_1Da(i, s, float2(x, layer), level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -8821,7 +8841,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex1DLayeredGrad(texture<char, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -8831,7 +8851,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex1DLayeredGrad(texture<char, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -8840,7 +8860,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex1DLayeredGrad(texture<char1, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -8850,7 +8870,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex1DLayeredGrad(texture<char1, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -8859,7 +8879,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex1DLayeredGrad(texture<char2, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -8869,7 +8889,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex1DLayeredGrad(texture<char2, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -8878,7 +8898,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex1DLayeredGrad(texture<char4, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -8888,7 +8908,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex1DLayeredGrad(texture<char4, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -8897,7 +8917,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex1DLayeredGrad(
     texture<unsigned char, texType, mode> texRef, float x, int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -8907,7 +8927,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex1DLayeredGrad(
     int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -8916,7 +8936,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex1DLayeredGrad(texture<uchar1, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -8926,7 +8946,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex1DLayeredGrad(texture<uchar1, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -8935,7 +8955,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex1DLayeredGrad(texture<uchar2, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -8945,7 +8965,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex1DLayeredGrad(texture<uchar2, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -8954,7 +8974,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex1DLayeredGrad(texture<uchar4, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -8964,7 +8984,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex1DLayeredGrad(texture<uchar4, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -8973,7 +8993,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex1DLayeredGrad(texture<short, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -8983,7 +9003,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex1DLayeredGrad(texture<short, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -8992,7 +9012,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex1DLayeredGrad(texture<short1, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -9002,7 +9022,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex1DLayeredGrad(texture<short1, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -9011,7 +9031,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex1DLayeredGrad(texture<short2, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -9021,7 +9041,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex1DLayeredGrad(texture<short2, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -9030,7 +9050,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex1DLayeredGrad(texture<short4, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -9040,7 +9060,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex1DLayeredGrad(texture<short4, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -9049,7 +9069,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex1DLayeredGrad(
     texture<unsigned short, texType, mode> texRef, float x, int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -9059,7 +9079,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex1DLayeredGrad(
     int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -9068,7 +9088,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex1DLayeredGrad(texture<ushort1, texType, mo
                                                     int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -9078,7 +9098,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex1DLayeredGrad(texture<ushort1, texType, mo
                                                     int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -9087,7 +9107,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex1DLayeredGrad(texture<ushort2, texType, mo
                                                     int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -9097,7 +9117,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex1DLayeredGrad(texture<ushort2, texType, mo
                                                     int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -9106,7 +9126,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex1DLayeredGrad(texture<ushort4, texType, mo
                                                     int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -9116,7 +9136,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex1DLayeredGrad(texture<ushort4, texType, mo
                                                     int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -9125,7 +9145,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex1DLayeredGrad(texture<int, texType, mode> texR
                                                 int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_INT;
 }
 
@@ -9135,7 +9155,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex1DLayeredGrad(texture<int, texType, mode> texR
                                                 int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_INT;
 }
 
@@ -9144,7 +9164,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex1DLayeredGrad(texture<int1, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -9154,7 +9174,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex1DLayeredGrad(texture<int1, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -9163,7 +9183,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex1DLayeredGrad(texture<int2, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -9173,7 +9193,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex1DLayeredGrad(texture<int2, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -9182,7 +9202,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex1DLayeredGrad(texture<int4, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -9192,7 +9212,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex1DLayeredGrad(texture<int4, texType, mode> te
                                                  int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -9201,7 +9221,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex1DLayeredGrad(
     texture<unsigned int, texType, mode> texRef, float x, int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UINT;
 }
 
@@ -9211,7 +9231,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex1DLayeredGrad(
     int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UINT;
 }
 
@@ -9220,7 +9240,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex1DLayeredGrad(texture<uint1, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -9230,7 +9250,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex1DLayeredGrad(texture<uint1, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -9239,7 +9259,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex1DLayeredGrad(texture<uint2, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -9249,7 +9269,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex1DLayeredGrad(texture<uint2, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -9258,7 +9278,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex1DLayeredGrad(texture<uint4, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -9268,7 +9288,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex1DLayeredGrad(texture<uint4, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -9277,7 +9297,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex1DLayeredGrad(texture<float, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -9287,7 +9307,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex1DLayeredGrad(texture<float, texType, mode> 
                                                   int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -9296,7 +9316,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex1DLayeredGrad(texture<float1, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -9306,7 +9326,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex1DLayeredGrad(texture<float1, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -9315,7 +9335,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex1DLayeredGrad(texture<float2, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -9325,7 +9345,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex1DLayeredGrad(texture<float2, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -9334,7 +9354,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex1DLayeredGrad(texture<float4, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -9344,7 +9364,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex1DLayeredGrad(texture<float4, texType, mode
                                                    int layer, float dx, float dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_1Da(i, s, hc::short_vector::float2(x, layer).get_vector(), dx, dy);
+        __ockl_image_sample_grad_1Da(i, s, float2(x, layer), dx, dy);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -9355,7 +9375,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLayered(texture<char, texType, mode> texRef
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_CHAR;
 }
 
@@ -9365,7 +9385,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLayered(texture<char, texType, mode> texRef
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_CHAR;
 }
 
@@ -9374,7 +9394,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLayered(texture<char1, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -9384,7 +9404,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLayered(texture<char1, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -9393,7 +9413,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLayered(texture<char2, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -9403,7 +9423,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLayered(texture<char2, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -9412,7 +9432,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLayered(texture<char4, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -9422,7 +9442,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLayered(texture<char4, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -9431,7 +9451,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLayered(texture<unsigned char, tex
                                                       float x, float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -9441,7 +9461,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLayered(texture<unsigned char, tex
                                                       float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -9450,7 +9470,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLayered(texture<uchar1, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -9460,7 +9480,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLayered(texture<uchar1, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -9469,7 +9489,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLayered(texture<uchar2, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -9479,7 +9499,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLayered(texture<uchar2, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -9488,7 +9508,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLayered(texture<uchar4, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -9498,7 +9518,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLayered(texture<uchar4, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -9507,7 +9527,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLayered(texture<short, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_SHORT;
 }
 
@@ -9517,7 +9537,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLayered(texture<short, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_SHORT;
 }
 
@@ -9526,7 +9546,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLayered(texture<short1, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -9536,7 +9556,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLayered(texture<short1, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -9545,7 +9565,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLayered(texture<short2, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -9555,7 +9575,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLayered(texture<short2, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -9564,7 +9584,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLayered(texture<short4, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -9574,7 +9594,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLayered(texture<short4, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -9583,7 +9603,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLayered(
     texture<unsigned short, texType, mode> texRef, float x, float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_USHORT;
 }
 
@@ -9593,7 +9613,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLayered(
     float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_USHORT;
 }
 
@@ -9602,7 +9622,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLayered(texture<ushort1, texType, mode> 
                                                 float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -9612,7 +9632,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLayered(texture<ushort1, texType, mode> 
                                                 int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -9621,7 +9641,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLayered(texture<ushort2, texType, mode> 
                                                 float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -9631,7 +9651,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLayered(texture<ushort2, texType, mode> 
                                                 int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -9640,7 +9660,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLayered(texture<ushort4, texType, mode> 
                                                 float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -9650,7 +9670,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLayered(texture<ushort4, texType, mode> 
                                                 int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -9659,7 +9679,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLayered(texture<int, texType, mode> texRef, 
                                             int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_INT;
 }
 
@@ -9669,7 +9689,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLayered(texture<int, texType, mode> texRef,
                                             int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_INT;
 }
 
@@ -9678,7 +9698,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLayered(texture<int1, texType, mode> texRef
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_INT_X;
 }
 
@@ -9688,7 +9708,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLayered(texture<int1, texType, mode> texRef
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_INT_X;
 }
 
@@ -9697,7 +9717,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLayered(texture<int2, texType, mode> texRef
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -9707,7 +9727,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLayered(texture<int2, texType, mode> texRef
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -9716,7 +9736,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLayered(texture<int4, texType, mode> texRef
                                              int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -9726,7 +9746,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLayered(texture<int4, texType, mode> texRef
                                              int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -9735,7 +9755,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLayered(texture<unsigned int, texTy
                                                      float x, float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UINT;
 }
 
@@ -9745,7 +9765,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLayered(texture<unsigned int, texTy
                                                      float y, int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UINT;
 }
 
@@ -9754,7 +9774,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLayered(texture<uint1, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -9764,7 +9784,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLayered(texture<uint1, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -9773,7 +9793,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLayered(texture<uint2, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -9783,7 +9803,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLayered(texture<uint2, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -9792,7 +9812,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLayered(texture<uint4, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -9802,7 +9822,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLayered(texture<uint4, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -9811,7 +9831,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLayered(texture<float, texType, mode> texR
                                               float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -9821,7 +9841,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLayered(texture<float, texType, mode> texR
                                               int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -9830,7 +9850,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLayered(texture<float1, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -9840,7 +9860,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLayered(texture<float1, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -9849,7 +9869,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLayered(texture<float2, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -9859,7 +9879,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLayered(texture<float2, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -9868,7 +9888,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLayered(texture<float4, texType, mode> te
                                                float y, int layer) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -9878,7 +9898,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLayered(texture<float4, texType, mode> te
                                                int layer) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector());
+        __ockl_image_sample_2Da(i, s, float4(x, y, layer, 0.0f));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -9889,7 +9909,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLayeredLod(texture<char, texType, mode> tex
                                                 float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -9899,7 +9919,7 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLayeredLod(texture<char, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_CHAR;
 }
 
@@ -9908,7 +9928,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLayeredLod(texture<char1, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -9918,7 +9938,7 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLayeredLod(texture<char1, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -9927,7 +9947,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLayeredLod(texture<char2, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -9937,7 +9957,7 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLayeredLod(texture<char2, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -9946,7 +9966,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLayeredLod(texture<char4, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -9956,7 +9976,7 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLayeredLod(texture<char4, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -9965,7 +9985,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLayeredLod(
     texture<unsigned char, texType, mode> texRef, float x, float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -9975,7 +9995,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLayeredLod(
     float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -9984,7 +10004,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLayeredLod(texture<uchar1, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -9994,7 +10014,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLayeredLod(texture<uchar1, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -10003,7 +10023,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLayeredLod(texture<uchar2, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -10013,7 +10033,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLayeredLod(texture<uchar2, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -10022,7 +10042,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLayeredLod(texture<uchar4, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -10032,7 +10052,7 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLayeredLod(texture<uchar4, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -10041,7 +10061,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLayeredLod(texture<short, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -10051,7 +10071,7 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLayeredLod(texture<short, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_SHORT;
 }
 
@@ -10060,7 +10080,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLayeredLod(texture<short1, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -10070,7 +10090,7 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLayeredLod(texture<short1, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -10079,7 +10099,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLayeredLod(texture<short2, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -10089,7 +10109,7 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLayeredLod(texture<short2, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -10098,7 +10118,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLayeredLod(texture<short4, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -10108,7 +10128,7 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLayeredLod(texture<short4, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -10117,7 +10137,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLayeredLod(
     texture<unsigned short, texType, mode> texRef, float x, float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -10127,7 +10147,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLayeredLod(
     float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_USHORT;
 }
 
@@ -10136,7 +10156,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLayeredLod(texture<ushort1, texType, mod
                                                    float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -10146,7 +10166,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLayeredLod(texture<ushort1, texType, mod
                                                    float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -10155,7 +10175,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLayeredLod(texture<ushort2, texType, mod
                                                    float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -10165,7 +10185,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLayeredLod(texture<ushort2, texType, mod
                                                    float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -10174,7 +10194,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLayeredLod(texture<ushort4, texType, mod
                                                    float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -10184,7 +10204,7 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLayeredLod(texture<ushort4, texType, mod
                                                    float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -10193,7 +10213,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLayeredLod(texture<int, texType, mode> texRe
                                                int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_INT;
 }
 
@@ -10203,7 +10223,7 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLayeredLod(texture<int, texType, mode> texRe
                                                int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_INT;
 }
 
@@ -10212,7 +10232,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLayeredLod(texture<int1, texType, mode> tex
                                                 float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -10222,7 +10242,7 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLayeredLod(texture<int1, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_INT_X;
 }
 
@@ -10231,7 +10251,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLayeredLod(texture<int2, texType, mode> tex
                                                 float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -10241,7 +10261,7 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLayeredLod(texture<int2, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -10250,7 +10270,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLayeredLod(texture<int4, texType, mode> tex
                                                 float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -10260,7 +10280,7 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLayeredLod(texture<int4, texType, mode> tex
                                                 int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -10269,7 +10289,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLayeredLod(texture<unsigned int, te
                                                         float x, float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UINT;
 }
 
@@ -10279,7 +10299,7 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLayeredLod(texture<unsigned int, te
                                                         float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UINT;
 }
 
@@ -10288,7 +10308,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLayeredLod(texture<uint1, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -10298,7 +10318,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLayeredLod(texture<uint1, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -10307,7 +10327,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLayeredLod(texture<uint2, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -10317,7 +10337,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLayeredLod(texture<uint2, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -10326,7 +10346,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLayeredLod(texture<uint4, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -10336,7 +10356,7 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLayeredLod(texture<uint4, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -10345,7 +10365,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLayeredLod(texture<float, texType, mode> t
                                                  float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -10355,7 +10375,7 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLayeredLod(texture<float, texType, mode> t
                                                  int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -10364,7 +10384,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLayeredLod(texture<float1, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -10374,7 +10394,7 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLayeredLod(texture<float1, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -10383,7 +10403,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLayeredLod(texture<float2, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -10393,7 +10413,7 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLayeredLod(texture<float2, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -10402,7 +10422,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLayeredLod(texture<float4, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -10412,7 +10432,7 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLayeredLod(texture<float4, texType, mode>
                                                   float y, int layer, float level) {
     TEXTURE_PARAMETERS_INIT;
     texel.f = __ockl_image_sample_lod_2Da(
-        i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(), level);
+        i, s, float4(x, y, layer, 0.0f), level);
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -10423,9 +10443,9 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLayeredGrad(texture<char, texType, mode> te
                                                  float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR;
 }
 
@@ -10435,9 +10455,9 @@ __TEXTURE_FUNCTIONS_DECL__ char tex2DLayeredGrad(texture<char, texType, mode> te
                                                  int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR;
 }
 
@@ -10446,9 +10466,9 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLayeredGrad(texture<char1, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -10458,9 +10478,9 @@ __TEXTURE_FUNCTIONS_DECL__ char1 tex2DLayeredGrad(texture<char1, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR_X;
 }
 
@@ -10469,9 +10489,9 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLayeredGrad(texture<char2, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -10481,9 +10501,9 @@ __TEXTURE_FUNCTIONS_DECL__ char2 tex2DLayeredGrad(texture<char2, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR_XY;
 }
 
@@ -10492,9 +10512,9 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLayeredGrad(texture<char4, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -10504,9 +10524,9 @@ __TEXTURE_FUNCTIONS_DECL__ char4 tex2DLayeredGrad(texture<char4, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_CHAR_XYZW;
 }
 
@@ -10516,9 +10536,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLayeredGrad(
     float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -10528,9 +10548,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned char tex2DLayeredGrad(
     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR;
 }
 
@@ -10539,9 +10559,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLayeredGrad(texture<uchar1, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -10551,9 +10571,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar1 tex2DLayeredGrad(texture<uchar1, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR_X;
 }
 
@@ -10562,9 +10582,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLayeredGrad(texture<uchar2, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -10574,9 +10594,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar2 tex2DLayeredGrad(texture<uchar2, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR_XY;
 }
 
@@ -10585,9 +10605,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLayeredGrad(texture<uchar4, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -10597,9 +10617,9 @@ __TEXTURE_FUNCTIONS_DECL__ uchar4 tex2DLayeredGrad(texture<uchar4, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UCHAR_XYZW;
 }
 
@@ -10608,9 +10628,9 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLayeredGrad(texture<short, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT;
 }
 
@@ -10620,9 +10640,9 @@ __TEXTURE_FUNCTIONS_DECL__ short tex2DLayeredGrad(texture<short, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT;
 }
 
@@ -10631,9 +10651,9 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLayeredGrad(texture<short1, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -10643,9 +10663,9 @@ __TEXTURE_FUNCTIONS_DECL__ short1 tex2DLayeredGrad(texture<short1, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT_X;
 }
 
@@ -10654,9 +10674,9 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLayeredGrad(texture<short2, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -10666,9 +10686,9 @@ __TEXTURE_FUNCTIONS_DECL__ short2 tex2DLayeredGrad(texture<short2, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT_XY;
 }
 
@@ -10677,9 +10697,9 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLayeredGrad(texture<short4, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -10689,9 +10709,9 @@ __TEXTURE_FUNCTIONS_DECL__ short4 tex2DLayeredGrad(texture<short4, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_SHORT_XYZW;
 }
 
@@ -10701,9 +10721,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLayeredGrad(
     float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT;
 }
 
@@ -10713,9 +10733,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned short tex2DLayeredGrad(
     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT;
 }
 
@@ -10724,9 +10744,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLayeredGrad(texture<ushort1, texType, mo
                                                     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -10736,9 +10756,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort1 tex2DLayeredGrad(texture<ushort1, texType, mo
                                                     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT_X;
 }
 
@@ -10747,9 +10767,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLayeredGrad(texture<ushort2, texType, mo
                                                     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -10759,9 +10779,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort2 tex2DLayeredGrad(texture<ushort2, texType, mo
                                                     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT_XY;
 }
 
@@ -10770,9 +10790,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLayeredGrad(texture<ushort4, texType, mo
                                                     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -10782,9 +10802,9 @@ __TEXTURE_FUNCTIONS_DECL__ ushort4 tex2DLayeredGrad(texture<ushort4, texType, mo
                                                     float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_USHORT_XYZW;
 }
 
@@ -10793,9 +10813,9 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLayeredGrad(texture<int, texType, mode> texR
                                                 float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_INT;
 }
 
@@ -10805,9 +10825,9 @@ __TEXTURE_FUNCTIONS_DECL__ int tex2DLayeredGrad(texture<int, texType, mode> texR
                                                 int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_INT;
 }
 
@@ -10816,9 +10836,9 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLayeredGrad(texture<int1, texType, mode> te
                                                  float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_INT_X;
 }
 
@@ -10828,9 +10848,9 @@ __TEXTURE_FUNCTIONS_DECL__ int1 tex2DLayeredGrad(texture<int1, texType, mode> te
                                                  int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_INT_X;
 }
 
@@ -10839,9 +10859,9 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLayeredGrad(texture<int2, texType, mode> te
                                                  float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -10851,9 +10871,9 @@ __TEXTURE_FUNCTIONS_DECL__ int2 tex2DLayeredGrad(texture<int2, texType, mode> te
                                                  int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_INT_XY;
 }
 
@@ -10862,9 +10882,9 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLayeredGrad(texture<int4, texType, mode> te
                                                  float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -10874,9 +10894,9 @@ __TEXTURE_FUNCTIONS_DECL__ int4 tex2DLayeredGrad(texture<int4, texType, mode> te
                                                  int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_INT_XYZW;
 }
 
@@ -10886,9 +10906,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLayeredGrad(
     float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT;
 }
 
@@ -10898,9 +10918,9 @@ __TEXTURE_FUNCTIONS_DECL__ unsigned int tex2DLayeredGrad(
     int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT;
 }
 
@@ -10909,9 +10929,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLayeredGrad(texture<uint1, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -10921,9 +10941,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint1 tex2DLayeredGrad(texture<uint1, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT_X;
 }
 
@@ -10932,9 +10952,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLayeredGrad(texture<uint2, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -10944,9 +10964,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint2 tex2DLayeredGrad(texture<uint2, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT_XY;
 }
 
@@ -10955,9 +10975,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLayeredGrad(texture<uint4, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -10967,9 +10987,9 @@ __TEXTURE_FUNCTIONS_DECL__ uint4 tex2DLayeredGrad(texture<uint4, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_UINT_XYZW;
 }
 
@@ -10978,9 +10998,9 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLayeredGrad(texture<float, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -10990,9 +11010,9 @@ __TEXTURE_FUNCTIONS_DECL__ float tex2DLayeredGrad(texture<float, texType, mode> 
                                                   float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT;
 }
 
@@ -11001,9 +11021,9 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLayeredGrad(texture<float1, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -11013,9 +11033,9 @@ __TEXTURE_FUNCTIONS_DECL__ float1 tex2DLayeredGrad(texture<float1, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT_X;
 }
 
@@ -11024,9 +11044,9 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLayeredGrad(texture<float2, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -11036,9 +11056,9 @@ __TEXTURE_FUNCTIONS_DECL__ float2 tex2DLayeredGrad(texture<float2, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT_XY;
 }
 
@@ -11047,9 +11067,9 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLayeredGrad(texture<float4, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_REF_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 
@@ -11059,9 +11079,9 @@ __TEXTURE_FUNCTIONS_DECL__ float4 tex2DLayeredGrad(texture<float4, texType, mode
                                                    float y, int layer, float2 dx, float2 dy) {
     TEXTURE_PARAMETERS_INIT;
     texel.f =
-        __ockl_image_sample_grad_2Da(i, s, hc::short_vector::float4(x, y, layer, 0.0f).get_vector(),
-                                     hc::short_vector::float2(dx.x, dx.y).get_vector(),
-                                     hc::short_vector::float2(dy.x, dy.y).get_vector());
+        __ockl_image_sample_grad_2Da(i, s, float4(x, y, layer, 0.0f),
+                                     float2(dx.x, dx.y),
+                                     float2(dy.x, dy.y));
     TEXTURE_RETURN_FLOAT_XYZW;
 }
 #endif


### PR DESCRIPTION
Include texture_functions.h on HIP-Clang path. Use HIP vector types instead of hc::short_vectors for texture_functions, and remove HCC headers.