### PR TITLE
Remove adipose extension from genco output

### DIFF
--- a/lpl_ca/lpl.hpp
+++ b/lpl_ca/lpl.hpp
@@ -80,7 +80,7 @@ inline void copy_kernel_section_to_fat_binary(const std::string& tmp, const std:
         std::find_if(reader.sections.begin(), reader.sections.end(),
                      [](const ELFIO::section* x) { return x->get_name() == kernel_section(); });
 
-    std::ofstream out{output + fat_binary_extension()};
+    std::ofstream out{output};
 
     if (it == reader.sections.end()) {
         std::cerr << "Warning: no kernels were generated; fat binary shall "
@@ -95,8 +95,8 @@ inline void generate_fat_binary(const std::vector<std::string>& sources,
                                 const std::vector<std::string>& targets, const std::string& flags,
                                 const std::string& output) {
     static const auto d = [](const std::string* f) { remove(f->c_str()); };
-
-    std::unique_ptr<const std::string, decltype(d)> tmp{&output, d};
+    std::string temp_str = output + ".tmp";
+    std::unique_ptr<const std::string, decltype(d)> tmp{&temp_str, d};
 
     redi::ipstream hipcc{make_hipcc_call(sources, targets, flags, *tmp), redi::pstream::pstderr};
 

--- a/samples/0_Intro/module_api/runKernel.cpp
+++ b/samples/0_Intro/module_api/runKernel.cpp
@@ -30,7 +30,7 @@ THE SOFTWARE.
 #define LEN 64
 #define SIZE LEN << 2
 
-#define fileName "vcpy_kernel.code.adipose"
+#define fileName "vcpy_kernel.code"
 #define kernel_name "hello_world"
 
 #define HIP_CHECK(status)                                                                          \
@@ -66,32 +66,13 @@ int main() {
     HIP_CHECK(hipModuleLoad(&Module, fileName));
     HIP_CHECK(hipModuleGetFunction(&Function, Module, kernel_name));
 
-#ifdef __HIP_PLATFORM_HCC__
-    uint32_t len = LEN;
-    uint32_t one = 1;
-
     struct {
         void* _Ad;
         void* _Bd;
     } args;
 
-    args._Ad = Ad;
-    args._Bd = Bd;
-
-#endif
-
-#ifdef __HIP_PLATFORM_NVCC__
-    struct {
-        uint32_t _hidden[1];
-        void* _Ad;
-        void* _Bd;
-    } args;
-
-    args._hidden[0] = 0;
-    args._Ad = Ad;
-    args._Bd = Bd;
-#endif
-
+    args._Ad = (void*) Ad;
+    args._Bd = (void*) Bd;
 
     size_t size = sizeof(args);
 

--- a/samples/0_Intro/module_api_global/runKernel.cpp
+++ b/samples/0_Intro/module_api_global/runKernel.cpp
@@ -30,7 +30,7 @@ THE SOFTWARE.
 #define LEN 64
 #define SIZE LEN * sizeof(float)
 
-#define fileName "vcpy_kernel.code.adipose"
+#define fileName "vcpy_kernel.code"
 float myDeviceGlobal;
 float myDeviceGlobalArray[16];
 #define HIP_CHECK(cmd)                                                                             \
@@ -79,32 +79,13 @@ int main() {
         myDeviceGlobalArray[i] = i * 1000.0f;
     }
 
-#ifdef __HIP_PLATFORM_HCC__
-    uint32_t len = LEN;
-    uint32_t one = 1;
-
     struct {
         void* _Ad;
         void* _Bd;
     } args;
 
-    args._Ad = Ad;
-    args._Bd = Bd;
-
-#endif
-
-#ifdef __HIP_PLATFORM_NVCC__
-    struct {
-        uint32_t _hidden[1];
-        void* _Ad;
-        void* _Bd;
-    } args;
-
-    args._hidden[0] = 0;
-    args._Ad = Ad;
-    args._Bd = Bd;
-#endif
-
+    args._Ad = (void*) Ad;
+    args._Bd = (void*) Bd;
 
     size_t size = sizeof(args);
 

--- a/samples/2_Cookbook/11_texture_driver/texture2dDrv.cpp
+++ b/samples/2_Cookbook/11_texture_driver/texture2dDrv.cpp
@@ -21,13 +21,13 @@ THE SOFTWARE.
 */
 
 #include "hip/hip_runtime.h"
-#include "hip/hip_runtime_api.h"
+//#include "hip/hip_runtime_api.h"
 #include <iostream>
 #include <fstream>
 #include <vector>
-#include <hip/hip_hcc.h>
+//#include <hip/hip_hcc.h>
 
-#define fileName "tex2dKernel.code.adipose"
+#define fileName "tex2dKernel.code"
 
 texture<float, 2, hipReadModeElementType> tex;
 bool testResult = false;
@@ -87,33 +87,14 @@ bool runTest(int argc, char** argv) {
     float* dData = NULL;
     hipMalloc((void**)&dData, size);
 
-#ifdef __HIP_PLATFORM_HCC__
-
     struct {
         void* _Ad;
         unsigned int _Bd;
         unsigned int _Cd;
     } args;
-    args._Ad = dData;
+    args._Ad = (void*) dData;
     args._Bd = width;
     args._Cd = height;
-
-#endif
-
-#ifdef __HIP_PLATFORM_NVCC__
-    struct {
-        uint32_t _hidden[1];
-        void* _Ad;
-        unsigned int _Bd;
-        unsigned int _Cd;
-    } args;
-
-    args._hidden[0] = 0;
-    args._Ad = dData;
-    args._Bd = width;
-    args._Cd = height;
-#endif
-
 
     size_t sizeTemp = sizeof(args);
 


### PR DESCRIPTION
This change is for generating the output code-object file as application defined. For example , 
"--genco test.cpp -o test.code " should generate output file as "test.code".