### PR TITLE
Revert pr457

### DIFF
--- a/include/hip/hcc_detail/program_state.hpp
+++ b/include/hip/hcc_detail/program_state.hpp
@@ -93,12 +93,11 @@ public:
     }
 };
 
-const std::unordered_map<hsa_agent_t, std::vector<hsa_executable_t>>& executables(
-    bool rebuild = false);
+const std::unordered_map<hsa_agent_t, std::vector<hsa_executable_t>>& executables();
 const std::unordered_map<std::uintptr_t, std::vector<std::pair<hsa_agent_t, Kernel_descriptor>>>&
-functions(bool rebuild = false);
-const std::unordered_map<std::uintptr_t, std::string>& function_names(bool rebuild = false);
-std::unordered_map<std::string, void*>& globals(bool rebuild = false);
+functions();
+const std::unordered_map<std::uintptr_t, std::string>& function_names();
+std::unordered_map<std::string, void*>& globals();
 
 hsa_executable_t load_executable(const std::string& file, hsa_executable_t executable,
                                  hsa_agent_t agent);

--- a/src/functional_grid_launch.inl
+++ b/src/functional_grid_launch.inl
@@ -92,19 +92,13 @@ namespace hip_impl
         hipStream_t stream,
         void** kernarg)
     {
-        auto it0 = functions().find(function_address);
+        const auto it0 = functions().find(function_address);
 
         if (it0 == functions().cend()) {
-            // Re-init device code maps once again to help locate kernels
-            // loaded after HIP runtime initialization via means such as
-            // dlopen().
-            it0 = functions(true).find(function_address);
-            if (it0 == functions().cend()) {
-                throw runtime_error{
-                    "No device code available for function: " +
-                    name(function_address)
-                };
-            }
+            throw runtime_error{
+                "No device code available for function: " +
+                name(function_address)
+            };
         }
 
         auto agent = target_agent(stream);

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -74,15 +74,11 @@ vector<string> copy_names_of_undefined_symbols(const symbol_section_accessor& se
 }
 
 const std::unordered_map<std::string, std::pair<ELFIO::Elf64_Addr, ELFIO::Elf_Xword>>&
-symbol_addresses(bool rebuild = false) {
+symbol_addresses() {
     static unordered_map<string, pair<Elf64_Addr, Elf_Xword>> r;
     static once_flag f;
 
-    auto cons = [rebuild]() {
-        if (rebuild) {
-            r.clear();
-        }
-
+    call_once(f, []() {
         dl_iterate_phdr(
             [](dl_phdr_info* info, size_t, void*) {
                 static constexpr const char self[] = "/proc/self/exe";
@@ -112,12 +108,7 @@ symbol_addresses(bool rebuild = false) {
                 return 0;
             },
             nullptr);
-    };
-
-    call_once(f, cons);
-    if (rebuild) {
-        cons();
-    }
+    });
 
     return r;
 }
@@ -175,17 +166,12 @@ vector<char> code_object_blob_for_process() {
     return r;
 }
 
-const unordered_map<hsa_isa_t, vector<vector<char>>>& code_object_blobs(bool rebuild = false) {
+const unordered_map<hsa_isa_t, vector<vector<char>>>& code_object_blobs() {
     static unordered_map<hsa_isa_t, vector<vector<char>>> r;
     static once_flag f;
 
-    auto cons = [rebuild]() {
+    call_once(f, []() {
         static vector<vector<char>> blobs{code_object_blob_for_process()};
-
-        if (rebuild) {
-            blobs.clear();
-            blobs.push_back(code_object_blob_for_process());
-        }
 
         dl_iterate_phdr(
             [](dl_phdr_info* info, std::size_t, void*) {
@@ -208,13 +194,7 @@ const unordered_map<hsa_isa_t, vector<vector<char>>>& code_object_blobs(bool reb
                 }
             }
         }
-    };
-
-
-    call_once(f, cons);
-    if (rebuild) {
-        cons();
-    }
+    });
 
     return r;
 }
@@ -236,13 +216,13 @@ vector<pair<uintptr_t, string>> function_names_for(const elfio& reader, section*
     return r;
 }
 
-const vector<pair<uintptr_t, string>>& function_names_for_process(bool rebuild = false) {
+const vector<pair<uintptr_t, string>>& function_names_for_process() {
     static constexpr const char self[] = "/proc/self/exe";
 
     static vector<pair<uintptr_t, string>> r;
     static once_flag f;
 
-    auto cons = [rebuild]() {
+    call_once(f, []() {
         elfio reader;
 
         if (!reader.load(self)) {
@@ -253,26 +233,16 @@ const vector<pair<uintptr_t, string>>& function_names_for_process(bool rebuild =
             find_section_if(reader, [](const section* x) { return x->get_type() == SHT_SYMTAB; });
 
         if (symtab) r = function_names_for(reader, symtab);
-    };
-
-    call_once(f, cons);
-    if (rebuild) {
-        cons();
-    }
+    });
 
     return r;
 }
 
-const unordered_map<string, vector<hsa_executable_symbol_t>>& kernels(bool rebuild = false) {
+const unordered_map<string, vector<hsa_executable_symbol_t>>& kernels() {
     static unordered_map<string, vector<hsa_executable_symbol_t>> r;
     static once_flag f;
 
-    auto cons = [rebuild]() {
-        if (rebuild) {
-            r.clear();
-            executables(rebuild);
-        }
-
+    call_once(f, []() {
         static const auto copy_kernels = [](hsa_executable_t, hsa_agent_t,
                                             hsa_executable_symbol_t s, void*) {
             if (type(s) == HSA_SYMBOL_KIND_KERNEL) r[name(s)].push_back(s);
@@ -286,12 +256,7 @@ const unordered_map<string, vector<hsa_executable_symbol_t>>& kernels(bool rebui
                                                      copy_kernels, nullptr);
             }
         }
-    };
-
-    call_once(f, cons);
-    if (rebuild) {
-        cons();
-    }
+    });
 
     return r;
 }
@@ -330,17 +295,12 @@ void load_code_object_and_freeze_executable(
 
 namespace hip_impl {
 const unordered_map<hsa_agent_t, vector<hsa_executable_t>>&
-executables(bool rebuild) {  // TODO: This leaks the hsa_executable_ts, it should use RAII.
+executables() {  // TODO: This leaks the hsa_executable_ts, it should use RAII.
     static unordered_map<hsa_agent_t, vector<hsa_executable_t>> r;
     static once_flag f;
 
-    auto cons = [rebuild]() {
+    call_once(f, []() {
         static const auto accelerators = hc::accelerator::get_all();
-
-        if (rebuild) {
-            r.clear();
-            code_object_blobs(rebuild);
-        }
 
         for (auto&& acc : accelerators) {
             auto agent = static_cast<hsa_agent_t*>(acc.get_hsa_agent());
@@ -375,29 +335,17 @@ executables(bool rebuild) {  // TODO: This leaks the hsa_executable_ts, it shoul
                                    },
                                    agent);
         }
-    };
-
-    call_once(f, cons);
-    if (rebuild) {
-        cons();
-    }
+    });
 
     return r;
 }
 
-const unordered_map<uintptr_t, string>& function_names(bool rebuild) {
+const unordered_map<uintptr_t, string>& function_names() {
     static unordered_map<uintptr_t, string> r{function_names_for_process().cbegin(),
                                               function_names_for_process().cend()};
     static once_flag f;
 
-    auto cons = [rebuild]() {
-        if (rebuild) {
-            r.clear();
-            function_names_for_process(rebuild);
-            r.insert(function_names_for_process().cbegin(),
-                     function_names_for_process().cend());
-        }
-
+    call_once(f, []() {
         dl_iterate_phdr(
             [](dl_phdr_info* info, size_t, void*) {
                 elfio tmp;
@@ -417,30 +365,16 @@ const unordered_map<uintptr_t, string>& function_names(bool rebuild) {
                 return 0;
             },
             nullptr);
-    };
-
-    call_once(f, cons);
-    if (rebuild) {
-        static mutex mtx;
-        lock_guard<mutex> lck{mtx};
-        cons();
-    }
+    });
 
     return r;
 }
 
-const unordered_map<uintptr_t, vector<pair<hsa_agent_t, Kernel_descriptor>>>& functions(bool rebuild) {
+const unordered_map<uintptr_t, vector<pair<hsa_agent_t, Kernel_descriptor>>>& functions() {
     static unordered_map<uintptr_t, vector<pair<hsa_agent_t, Kernel_descriptor>>> r;
     static once_flag f;
 
-    auto cons = [rebuild]() {
-        if (rebuild) {
-            r.clear();
-            function_names(rebuild);
-            kernels(rebuild);
-            globals(rebuild);
-        }
-
+    call_once(f, []() {
         for (auto&& function : function_names()) {
             const auto it = kernels().find(function.second);
 
@@ -452,34 +386,15 @@ const unordered_map<uintptr_t, vector<pair<hsa_agent_t, Kernel_descriptor>>>& fu
                 }
             }
         }
-    };
-
-    call_once(f, cons);
-    if (rebuild) {
-        static mutex mtx;
-        lock_guard<mutex> lck{mtx};
-        cons();
-    }
+    });
 
     return r;
 }
 
-unordered_map<string, void*>& globals(bool rebuild) {
+unordered_map<string, void*>& globals() {
     static unordered_map<string, void*> r;
     static once_flag f;
-    auto cons =[rebuild]() {
-        if (rebuild) {
-            r.clear();
-            symbol_addresses(rebuild);
-        }
-
-        r.reserve(symbol_addresses().size());
-    };
-
-    call_once(f, cons);
-    if (rebuild) {
-        cons();
-    }
+    call_once(f, []() { r.reserve(symbol_addresses().size()); });
 
     return r;
 }

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -444,9 +444,7 @@ const unordered_map<uintptr_t, vector<pair<hsa_agent_t, Kernel_descriptor>>>& fu
 
     auto cons = [rebuild]() {
         if (rebuild) {
-            // do NOT clear r so we reuse instances of pair<hsa_agent_t, Kernel_descriptor>
-            // created previously
-
+            r.clear();
             function_names(rebuild);
             kernels(rebuild);
             globals(rebuild);


### PR DESCRIPTION
HIP PR#457 has been identified not only breaks 1 test case in PaddlePaddle, but also at least 5 unit tests in TensorFlow. After some consideration it should be abandoned.

Propose to change the default HIP runtime behavior so kernel symbol resolution is deferred until 1st kernel launch, instead of initialization before main(). This would be filed as separate PR.

For benchmarking programs which requires low setup time, implement an env var to reinstate eager initialization. This would be filed as separate PR by @sunway513.
