### PR TITLE
Disable startup loader by default and guard with env var

### DIFF
--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -516,16 +516,11 @@ hsa_executable_t load_executable(const string& file, hsa_executable_t executable
 // HIP startup kernel loader logic
 // When enabled HIP_STARTUP_LOADER, HIP will load the kernels and setup
 // the function symbol map on program startup
-class startup_kernel_loader {
-   private:
-    startup_kernel_loader() { functions(); }
-    startup_kernel_loader(const startup_kernel_loader&) = delete;
-    startup_kernel_loader& operator=(const startup_kernel_loader&) = delete;
-    static startup_kernel_loader skl;
-};
-
 extern "C" void __attribute__((constructor)) __startup_kernel_loader_init() {
-    if (atoi(std::getenv("HIP_STARTUP_LOADER")) == 1) functions();
+    int hip_startup_loader=0;
+    if (std::getenv("HIP_STARTUP_LOADER"))
+        hip_startup_loader = atoi(std::getenv("HIP_STARTUP_LOADER"));
+    if (hip_startup_loader) functions();
 }
 
 extern "C" void __attribute__((destructor)) __startup_kernel_loader_fini() {

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -525,7 +525,7 @@ class startup_kernel_loader {
 };
 
 extern "C" void __attribute__((constructor)) __startup_kernel_loader_init() {
-    if (atoi(std::getenv("HIP_STARTUP_LOADER"))) functions();
+    if (atoi(std::getenv("HIP_STARTUP_LOADER")) == 1) functions();
 }
 
 extern "C" void __attribute__((destructor)) __startup_kernel_loader_fini() {

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -513,8 +513,9 @@ hsa_executable_t load_executable(const string& file, hsa_executable_t executable
     return executable;
 }
 
-// To force HIP to load the kernels and to setup the function
-// symbol map on program startup
+// HIP startup kernel loader logic
+// When enabled HIP_STARTUP_LOADER, HIP will load the kernels and setup
+// the function symbol map on program startup
 class startup_kernel_loader {
    private:
     startup_kernel_loader() { functions(); }
@@ -522,6 +523,12 @@ class startup_kernel_loader {
     startup_kernel_loader& operator=(const startup_kernel_loader&) = delete;
     static startup_kernel_loader skl;
 };
-startup_kernel_loader startup_kernel_loader::skl;
+
+extern "C" void __attribute__((constructor)) __startup_kernel_loader_init() {
+    if (atoi(std::getenv("HIP_STARTUP_LOADER"))) functions();
+}
+
+extern "C" void __attribute__((destructor)) __startup_kernel_loader_fini() {
+}
 
 }  // Namespace hip_impl.


### PR DESCRIPTION
This PR changed the HIP default behavior and disabling the startup loader by default.
Users can turn it on by setting the environment variable as follows:
`export HIP_STARTUP_LOADER=1`
If the environment variable is not set or is set to other values, including '0', the startup loader will be disabled.