### PR TITLE
Fix build failure of hipTestHalf and hipTestIncludeMath for hip-clang

### DIFF
--- a/include/hip/hcc_detail/device_functions.h
+++ b/include/hip/hcc_detail/device_functions.h
@@ -27,11 +27,12 @@ THE SOFTWARE.
 #include "math_fwd.h"
 
 #include <hip/hip_runtime_api.h>
+#include <stddef.h>
+
+
 #include <hip/hip_vector_types.h>
 #include <hip/hcc_detail/device_library_decls.h>
 #include <hip/hcc_detail/llvm_intrinsics.h>
-#include <stddef.h>
-
 /*
 Integer Intrinsics
 */

--- a/include/hip/hcc_detail/hip_runtime.h
+++ b/include/hip/hcc_detail/hip_runtime.h
@@ -131,7 +131,7 @@ extern int HIP_TRACE_API;
 
 
 // Feature tests:
-#if defined(__HCC_ACCELERATOR__) && (__HCC_ACCELERATOR__ != 0)
+#if (defined(__HCC_ACCELERATOR__) && (__HCC_ACCELERATOR__ != 0)) || __HIP_DEVICE_COMPILE__
 // Device compile and not host compile:
 
 // 32-bit Atomics:

--- a/include/hip/hcc_detail/math_functions.h
+++ b/include/hip/hcc_detail/math_functions.h
@@ -22,14 +22,16 @@ THE SOFTWARE.
 
 #pragma once
 
-#include "math_fwd.h"
-
-#include <hip/hcc_detail/host_defines.h>
-
 #include <assert.h>
 #include <limits.h>
 #include <limits>
 #include <stdint.h>
+#include <algorithm>
+
+#include <hip/hcc_detail/host_defines.h>
+
+#include "hip_fp16_math_fwd.h"
+#include "math_fwd.h"
 
 // HCC's own math functions should be included first, otherwise there will
 // be conflicts when hip/math_functions.h is included before hip/hip_runtime.h.


### PR DESCRIPTION
This patch is needed for building TensorFlow 1.8 with hip-clang.