### PR TITLE
Let hipcc link -lpthread -lm by default

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -725,7 +725,7 @@ if ($needLDFLAGS and not $compileOnly) {
 }
 $CMD .= " $toolArgs";
 if ($needLDFLAGS and not $compileOnly and $HIP_PLATFORM eq "clang") {
-    $CMD .= " -lgcc_s -lgcc";
+    $CMD .= " -lgcc_s -lgcc -lpthread -lm";
 }
 
 if ($verbose & 0x1) {


### PR DESCRIPTION
rocRAND assumes hipcc linking with -lpthread -lm by default.