### PR TITLE
Let hipcc handle obj files in linker response file for hip-clang

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -453,6 +453,15 @@ foreach $arg (@ARGV)
                     system("cd $tmpdir; ar c $libBaseName $realObjs");
                     print $out "$tmpdir/$libBaseName\n";
                 }
+            } elsif ($line =~ m/\.o$/) {
+                my $fileType = `file $line`;
+                my $isObj = ($fileType =~ m/ELF/ or $fileType =~ m/COFF/);
+                if ($isObj) {
+                    print $out "$line\n";
+                } else {
+                    push (@inputs, $line);
+                    $new_arg = "$new_arg $line";
+                }
             } else {
                 print $out "$line\n";
             }


### PR DESCRIPTION
If obj files in linker response file contains device code, pass them to hip-clang, otherwise keep them in the linker response file.

This patch is required to build TensorFlow 1.8 with hip-clang.