### PR TITLE
Add keyword 'explicit' to avoid ambiguity

### DIFF
--- a/include/hip/hcc_detail/hip_complex.h
+++ b/include/hip/hcc_detail/hip_complex.h
@@ -121,7 +121,7 @@ THE SOFTWARE.
         return ret;                                                                                \
     }
 #define MAKE_COMPONENT_CONSTRUCTOR_TWO_COMPONENT(ComplexT, T)                                      \
-    __device__ __host__ ComplexT(T val) : x(val), y(val) {}                                        \
+    explicit __device__ __host__ ComplexT(T val) : x(val), y(val) {}                               \
     __device__ __host__ ComplexT(T val1, T val2) : x(val1), y(val2) {}
 
 #endif
@@ -130,8 +130,8 @@ struct hipFloatComplex {
 #ifdef __cplusplus
    public:
    typedef float value_type;
-    __device__ __host__ hipFloatComplex() : x(0.0f), y(0.0f) {}
-    __device__ __host__ hipFloatComplex(float x) : x(x), y(0.0f) {}
+    explicit __device__ __host__ hipFloatComplex() : x(0.0f), y(0.0f) {}
+    explicit __device__ __host__ hipFloatComplex(float x) : x(x), y(0.0f) {}
     __device__ __host__ hipFloatComplex(float x, float y) : x(x), y(y) {}
     MAKE_COMPONENT_CONSTRUCTOR_TWO_COMPONENT(hipFloatComplex, unsigned short)
     MAKE_COMPONENT_CONSTRUCTOR_TWO_COMPONENT(hipFloatComplex, signed short)

--- a/include/hip/hcc_detail/hip_complex.h
+++ b/include/hip/hcc_detail/hip_complex.h
@@ -130,7 +130,7 @@ struct hipFloatComplex {
 #ifdef __cplusplus
    public:
    typedef float value_type;
-    explicit __device__ __host__ hipFloatComplex() : x(0.0f), y(0.0f) {}
+    __device__ __host__ hipFloatComplex() : x(0.0f), y(0.0f) {}
     explicit __device__ __host__ hipFloatComplex(float x) : x(x), y(0.0f) {}
     __device__ __host__ hipFloatComplex(float x, float y) : x(x), y(y) {}
     MAKE_COMPONENT_CONSTRUCTOR_TWO_COMPONENT(hipFloatComplex, unsigned short)
@@ -151,7 +151,7 @@ struct hipDoubleComplex {
    public:
    typedef double value_type;
     __device__ __host__ hipDoubleComplex() : x(0.0f), y(0.0f) {}
-    __device__ __host__ hipDoubleComplex(double x) : x(x), y(0.0f) {}
+    explicit __device__ __host__ hipDoubleComplex(double x) : x(x), y(0.0f) {}
     __device__ __host__ hipDoubleComplex(double x, double y) : x(x), y(y) {}
     MAKE_COMPONENT_CONSTRUCTOR_TWO_COMPONENT(hipDoubleComplex, unsigned short)
     MAKE_COMPONENT_CONSTRUCTOR_TWO_COMPONENT(hipDoubleComplex, signed short)


### PR DESCRIPTION
Older gcc, e.g., 5.x, see an ambiguity in some calls. Example error
output as seen with gcc 5.5:

In file included from benchmark_wino.cpp:1:
In file included from ./miopen.hpp:13:
In file included from /usr/lib/gcc/x86_64-linux-gnu/5.5.0/../../../../include/c++/5.5.0/regex:38:
In file included from /usr/lib/gcc/x86_64-linux-gnu/5.5.0/../../../../include/c++/5.5.0/algorithm:62:
In file included from /usr/lib/gcc/x86_64-linux-gnu/5.5.0/../../../../include/c++/5.5.0/bits/stl_algo.h:66:
In file included from /usr/lib/gcc/x86_64-linux-gnu/5.5.0/../../../../include/c++/5.5.0/random:51:
/usr/lib/gcc/x86_64-linux-gnu/5.5.0/../../../../include/c++/5.5.0/bits/random.tcc:1324:27: error: call to 'abs' is ambiguous
                    const double __y = -std::abs(__n) * __param._M_sm - 1;
                                        ^~~~~~~~
/opt/rocm/hip/include/hip/hcc_detail/hip_complex.h:345:31: note: candidate function
__DEFINE_HIP_COMPLEX_REAL_FUN(abs, hipCabs)