### PR TITLE
[ci] Disable hipVectorTypes* tests in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,7 +177,7 @@ def docker_build_inside_image( def build_image, String inside_args, String platf
             cd ${build_dir_rel}
             make install -j\$(nproc)
             make build_tests -i -j\$(nproc)
-            ctest
+            ctest -E hipVectorTypes
           """
         // If unit tests output a junit or xunit file in the future, jenkins can parse that file
         // to display test results on the dashboard


### PR DESCRIPTION
Disable directed_tests/deviceLib/hipVectorTypes.tst & directed_tests/deviceLib/hipVectorTypesDevice.tst in CI due to HCC regressions. Once HCC fixes are in, the tests can be re-enabled in CI.