### PR TITLE
fix __longlong_as_double() problem, return the double value

### DIFF
--- a/include/hip/hcc_detail/device_functions.h
+++ b/include/hip/hcc_detail/device_functions.h
@@ -593,7 +593,7 @@ __device__ static inline double __longlong_as_double(long long int x) {
     double tmp;
     __builtin_memcpy(&tmp, &x, sizeof(tmp));
 
-    return x;
+    return tmp;
 }
 
 __device__ static inline double __uint2double_rn(int x) { return (double)x; }


### PR DESCRIPTION
previous version return a long long valus *as* double, hence we may get the wrong result.
this also affect atomicAdd(double * ...), which use long long pointer to mimic double pointer.

Signed-off-by: carlushuang <carlus.huang@amd.com>