### PR TITLE
Only LLVM6 and higher contain the necessary intrinsics.

### DIFF
--- a/include/hip/hcc_detail/hip_fp16.h
+++ b/include/hip/hcc_detail/hip_fp16.h
@@ -29,7 +29,7 @@ THE SOFTWARE.
     #include <utility>
 #endif
 
-#if defined(__clang__) && (__clang_major__ > 3)
+#if defined(__clang__) && (__clang_major__ > 5)
     typedef _Float16 _Float16_2 __attribute__((ext_vector_type(2)));
 
     struct __half_raw {


### PR DESCRIPTION
This is required if we want to move to LLVM5 as a base compiler for PyTorch