### PR TITLE
Disable non-default-rounded functions

### DIFF
--- a/tests/src/deviceLib/hipFloatMath.cpp
+++ b/tests/src/deviceLib/hipFloatMath.cpp
@@ -39,10 +39,10 @@ __global__ void floatMath(hipLaunchParm lp, float* In, float* Out) {
     Out[tid] = __exp10f(Out[tid]);
     Out[tid] = __expf(Out[tid]);
     Out[tid] = __frsqrt_rn(Out[tid]);
-    Out[tid] = __fsqrt_rd(Out[tid]);
-    Out[tid] = __fsqrt_rn(Out[tid]);
-    Out[tid] = __fsqrt_ru(Out[tid]);
-    Out[tid] = __fsqrt_rz(Out[tid]);
+    //Out[tid] = __fsqrt_rd(Out[tid]);
+    //Out[tid] = __fsqrt_rn(Out[tid]);
+    //Out[tid] = __fsqrt_ru(Out[tid]);
+    //Out[tid] = __fsqrt_rz(Out[tid]);
     Out[tid] = __log10f(Out[tid]);
     Out[tid] = __log2f(Out[tid]);
     Out[tid] = __logf(Out[tid]);


### PR DESCRIPTION
Device library has removed the non-default-rounded functions, so hipFloatMath will fail to build. These include the removal of __ocml_sqrt_rte, __ocml_sqrt_rtn, __ocml_sqrt_rtp, and __ocml_sqrt_rtz. As seen here: https://github.com/RadeonOpenCompute/ROCm-Device-Libs/commit/2fc04e10e1354edee331ce700f98a60f8255effb . Disable these function tests for now, until they are re-enabled, or deleted completely.