### PR TITLE
HIP program state re-initialization logic (take 2)

### DIFF
--- a/include/hip/hcc_detail/program_state.hpp
+++ b/include/hip/hcc_detail/program_state.hpp
@@ -93,11 +93,12 @@ public:
     }
 };
 
-const std::unordered_map<hsa_agent_t, std::vector<hsa_executable_t>>& executables();
+const std::unordered_map<hsa_agent_t, std::vector<hsa_executable_t>>& executables(
+    bool rebuild = false);
 const std::unordered_map<std::uintptr_t, std::vector<std::pair<hsa_agent_t, Kernel_descriptor>>>&
-functions();
-const std::unordered_map<std::uintptr_t, std::string>& function_names();
-std::unordered_map<std::string, void*>& globals();
+functions(bool rebuild = false);
+const std::unordered_map<std::uintptr_t, std::string>& function_names(bool rebuild = false);
+std::unordered_map<std::string, void*>& globals(bool rebuild = false);
 
 hsa_executable_t load_executable(const std::string& file, hsa_executable_t executable,
                                  hsa_agent_t agent);

--- a/src/functional_grid_launch.inl
+++ b/src/functional_grid_launch.inl
@@ -92,13 +92,19 @@ namespace hip_impl
         hipStream_t stream,
         void** kernarg)
     {
-        const auto it0 = functions().find(function_address);
+        auto it0 = functions().find(function_address);
 
         if (it0 == functions().cend()) {
-            throw runtime_error{
-                "No device code available for function: " +
-                name(function_address)
-            };
+            // Re-init device code maps once again to help locate kernels
+            // loaded after HIP runtime initialization via means such as
+            // dlopen().
+            it0 = functions(true).find(function_address);
+            if (it0 == functions().cend()) {
+                throw runtime_error{
+                    "No device code available for function: " +
+                    name(function_address)
+                };
+            }
         }
 
         auto agent = target_agent(stream);

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -444,7 +444,9 @@ const unordered_map<uintptr_t, vector<pair<hsa_agent_t, Kernel_descriptor>>>& fu
 
     auto cons = [rebuild]() {
         if (rebuild) {
-            r.clear();
+            // do NOT clear r so we reuse instances of pair<hsa_agent_t, Kernel_descriptor>
+            // created previously
+
             function_names(rebuild);
             kernels(rebuild);
             globals(rebuild);

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -180,21 +180,29 @@ const unordered_map<hsa_isa_t, vector<vector<char>>>& code_object_blobs(bool reb
     static once_flag f;
 
     auto cons = [rebuild]() {
+        // names of shared libraries who .kernel sections already loaded
+        static unordered_set<string> lib_names;
         static vector<vector<char>> blobs{code_object_blob_for_process()};
 
         if (rebuild) {
+            r.clear();
             blobs.clear();
-            blobs.push_back(code_object_blob_for_process());
         }
 
         dl_iterate_phdr(
             [](dl_phdr_info* info, std::size_t, void*) {
                 elfio tmp;
-                if (tmp.load(info->dlpi_name)) {
+                if ((lib_names.find(info->dlpi_name) == lib_names.end()) &&
+                    (tmp.load(info->dlpi_name))) {
                     const auto it = find_section_if(
                         tmp, [](const section* x) { return x->get_name() == ".kernel"; });
 
-                    if (it) blobs.emplace_back(it->get_data(), it->get_data() + it->get_size());
+                    if (it) {
+                        blobs.emplace_back(
+                            it->get_data(), it->get_data() + it->get_size());
+                        // register the shared library as already loaded
+                        lib_names.emplace(info->dlpi_name);
+                    }
                 }
                 return 0;
             },
@@ -338,7 +346,8 @@ executables(bool rebuild) {  // TODO: This leaks the hsa_executable_ts, it shoul
         static const auto accelerators = hc::accelerator::get_all();
 
         if (rebuild) {
-            r.clear();
+            // do NOT clear r so we reuse instances of hsa_executable_t
+            // created previously
             code_object_blobs(rebuild);
         }
 


### PR DESCRIPTION
This PR tries to re-initialize HIP runtime data structures in program_state.cpp. In applications such as TensorFlow it was evident that HIP kernels within shared libraries may not be identified if they are loaded later after initialization by dlopen(). Instead of raising an exception immediately we re-initialize data structures within program_state.cpp with a rebuild flag.

In ROCm 1.9 the behavior of HIP runtime was changed so GPU kernel discovery is carried out upon the 1st GPU kernel invocation. That helped quite a few TensorFlow unit tests as well as PaddlePaddle tests. But it turns out there are additional TensorFlow-based applications and libraries (example: RCCL) which would load additional shared libraries *AFTER* TensorFlow is initialized, and thus logic in this PR is required to make sure GPU kernels in these shared libraries are properly discovered.