### PR TITLE
Support more than one device code blobs in a single .kernel section

### DIFF
--- a/include/hip/hcc_detail/code_object_bundle.hpp
+++ b/include/hip/hcc_detail/code_object_bundle.hpp
@@ -84,6 +84,9 @@ class Bundled_code_header {
                 std::copy_n(f + y.header.offset, y.header.bundle_sz, std::back_inserter(y.blob));
 
                 it += y.header.triple_sz;
+
+                x.bundled_code_size = std::max(x.bundled_code_size, 
+                                               y.header.offset + y.header.bundle_sz);
             }
 
             return true;
@@ -123,6 +126,8 @@ class Bundled_code_header {
     // MANIPULATORS
     Bundled_code_header& operator=(const Bundled_code_header&) = default;
     Bundled_code_header& operator=(Bundled_code_header&&) = default;
+
+    size_t bundled_code_size = 0;
 };
 
 // CREATORS

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -209,10 +209,16 @@ const unordered_map<hsa_isa_t, vector<vector<char>>>& code_object_blobs(bool reb
             nullptr);
 
         for (auto&& blob : blobs) {
-            Bundled_code_header tmp{blob};
-            if (valid(tmp)) {
-                for (auto&& bundle : bundles(tmp)) {
-                    r[triple_to_hsa_isa(bundle.triple)].push_back(bundle.blob);
+            for (auto sub_blob = blob.begin(); sub_blob != blob.end(); ) {
+                Bundled_code_header tmp(sub_blob, blob.end());
+                if (valid(tmp)) {
+                    for (auto&& bundle : bundles(tmp)) {
+                        r[triple_to_hsa_isa(bundle.triple)].push_back(bundle.blob);
+                    }
+                    sub_blob+=tmp.bundled_code_size;
+                }
+                else {
+                    break;
                 }
             }
         }


### PR DESCRIPTION
When compiling with Early Finalization enabled in HCC,
the resulting .kernel section of the host object now may
contain more than one device code blobs.  This patch teaches 
the HIP runtime to correctly extract all the
blobs from a .kernel section.