### PR TITLE
Make correct checking of the returned hipDeviceptr_t from read_global…

### DIFF
--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -342,7 +342,7 @@ hipError_t read_agent_global_from_module(hipDeviceptr_t* dptr, size_t* bytes, hi
 
     tie(*dptr, *bytes) = read_global_description(it0->second.cbegin(), it0->second.cend(), name);
 
-    return dptr ? hipSuccess : hipErrorNotFound;
+    return *dptr ? hipSuccess : hipErrorNotFound;
 }
 
 hipError_t read_agent_global_from_process(hipDeviceptr_t* dptr, size_t* bytes, const char* name) {
@@ -367,7 +367,7 @@ hipError_t read_agent_global_from_process(hipDeviceptr_t* dptr, size_t* bytes, c
 
     tie(*dptr, *bytes) = read_global_description(it->second.cbegin(), it->second.cend(), name);
 
-    return dptr ? hipSuccess : hipErrorNotFound;
+    return *dptr ? hipSuccess : hipErrorNotFound;
 }
 
 hsa_executable_symbol_t find_kernel_by_name(hsa_executable_t executable, const char* kname) {


### PR DESCRIPTION
At the return locations of 
read_agent_global_from_module()   and
read_agent_global_from_process()

What to check should be  *dptr rather than dptr