### PR TITLE
hipLaunchKernel, hipLaunchParm are deprecated, and shall be removed.

### DIFF
--- a/include/hip/hcc_detail/functional_grid_launch.hpp
+++ b/include/hip/hcc_detail/functional_grid_launch.hpp
@@ -120,6 +120,8 @@ inline void hipLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& dimB
 }
 
 template <typename... Args, typename F = void (*)(hipLaunchParm, Args...)>
+[[deprecated("hipLaunchKernel is deprecated and will be removed in the next "
+             "version of HIP; please upgrade to hipLaunchKernelGGL.")]]
 inline void hipLaunchKernel(F kernel, const dim3& numBlocks, const dim3& dimBlocks,
                             std::uint32_t groupMemBytes, hipStream_t stream, Args... args) {
     hipLaunchKernelGGL(kernel, numBlocks, dimBlocks, groupMemBytes, stream, hipLaunchParm{},


### PR DESCRIPTION
Let's mark these as deprecated for now, so that users have time to adapt. I've just stumbled across internal examples being written in the present time and still using `hipLaunchParm`, which is outright ghastly, so the only way to get rid of these is to completely remove them in 2.x.