### PR TITLE
Revert "Remove device mapping from shareWithAll memory"

### DIFF
--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -1808,7 +1808,7 @@ bool ihipStream_t::canSeeMemory(const ihipCtx_t* copyEngineCtx, const hc::AmPoin
     // TODO - pointer-info stores a deviceID not a context,may have some unusual side-effects here:
     if (dstPtrInfo->_sizeBytes == 0) {
         return false;
-    } else if (dstPtrInfo->_appId != -1) {
+    } else {
 #if USE_APP_PTR_FOR_CTX
         ihipCtx_t* dstCtx = static_cast<ihipCtx_t*>(dstPtrInfo->_appPtr);
 #else
@@ -1831,7 +1831,7 @@ bool ihipStream_t::canSeeMemory(const ihipCtx_t* copyEngineCtx, const hc::AmPoin
     // TODO - pointer-info stores a deviceID not a context,may have some unusual side-effects here:
     if (srcPtrInfo->_sizeBytes == 0) {
         return false;
-    } else if (srcPtrInfo->_appId != -1) {
+    } else {
 #if USE_APP_PTR_FOR_CTX
         ihipCtx_t* srcCtx = static_cast<ihipCtx_t*>(srcPtrInfo->_appPtr);
 #else

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -61,20 +61,19 @@ int sharePtr(void* ptr, ihipCtx_t* ctx, bool shareWithAll, unsigned hipFlags) {
 
     auto device = ctx->getWriteableDevice();
 
+#if USE_APP_PTR_FOR_CTX
+    hc::am_memtracker_update(ptr, device->_deviceId, hipFlags, ctx);
+#else
+    hc::am_memtracker_update(ptr, device->_deviceId, hipFlags);
+#endif
+
     if (shareWithAll) {
-        // shareWithAll memory is not mapped to any device
-        hc::am_memtracker_update(ptr, -1, hipFlags);
         hsa_status_t s = hsa_amd_agents_allow_access(g_deviceCnt + 1, g_allAgents, NULL, ptr);
         tprintf(DB_MEM, "    allow access to CPU + all %d GPUs (shareWithAll)\n", g_deviceCnt);
         if (s != HSA_STATUS_SUCCESS) {
             ret = -1;
         }
     } else {
-#if USE_APP_PTR_FOR_CTX
-        hc::am_memtracker_update(ptr, device->_deviceId, hipFlags, ctx);
-#else
-        hc::am_memtracker_update(ptr, device->_deviceId, hipFlags);
-#endif
         int peerCnt = 0;
         {
             LockedAccessor_CtxCrit_t crit(ctx->criticalData());


### PR DESCRIPTION
This is not a request for review. This PR is created only to trigger a Jenkins build for further investigation.

This change reverts commit 4e0a554f59ee0a9ed8bac6172054732af44c9226 on the roc-1.9.x branch. 