### PR TITLE
Fixes global symbols tracking in hip_module

### DIFF
--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -267,7 +267,12 @@ inline void track(const Agent_global& x) {
     hc::AmPointerInfo ptr_info(nullptr, x.address, x.address, x.byte_cnt, device->_acc, true,
                                false);
     hc::am_memtracker_add(x.address, ptr_info);
+#if USE_APP_PTR_FOR_CTX
+    hc::am_memtracker_update(x.address, device->_deviceId, 0u, ihipGetTlsDefaultCtx());
+#else
     hc::am_memtracker_update(x.address, device->_deviceId, 0u);
+#endif
+
 }
 
 template <typename Container = vector<Agent_global>>


### PR DESCRIPTION
Issue was causing seg fault while using hipMemcpyDtoD with HIP module APIs.