### PR TITLE
[HIPIFY][LLVMCompat] Support of upcoming LLVM 8.0

### DIFF
--- a/hipify-clang/src/HipifyAction.cpp
+++ b/hipify-clang/src/HipifyAction.cpp
@@ -270,14 +270,14 @@ bool HipifyAction::cudaLaunchKernel(const clang::ast_matchers::MatchFinder::Matc
   if (numArgs > 0) {
     OS << ", ";
     // Start of the first argument.
-    clang::SourceLocation argStart = launchKernel->getArg(0)->getLocStart();
+    clang::SourceLocation argStart = llcompat::getBeginLoc(launchKernel->getArg(0));
     // End of the last argument.
-    clang::SourceLocation argEnd = launchKernel->getArg(numArgs - 1)->getLocEnd();
+    clang::SourceLocation argEnd = llcompat::getEndLoc(launchKernel->getArg(numArgs - 1));
     OS << readSourceText(*SM, {argStart, argEnd});
   }
   OS << ")";
 
-  clang::SourceRange replacementRange = getWriteRange(*SM, {launchKernel->getLocStart(), launchKernel->getLocEnd()});
+  clang::SourceRange replacementRange = getWriteRange(*SM, {llcompat::getBeginLoc(launchKernel), llcompat::getEndLoc(launchKernel)});
   clang::SourceLocation launchStart = replacementRange.getBegin();
   clang::SourceLocation launchEnd = replacementRange.getEnd();
   size_t length = SM->getCharacterData(clang::Lexer::getLocForEndOfToken(launchEnd, 0, *SM, DefaultLangOptions)) - SM->getCharacterData(launchStart);
@@ -320,8 +320,8 @@ bool HipifyAction::cudaSharedIncompleteArrayVar(const clang::ast_matchers::Match
   }
 
   if (!typeName.empty()) {
-    clang::SourceLocation slStart = sharedVar->getLocStart();
-    clang::SourceLocation slEnd = sharedVar->getLocEnd();
+    clang::SourceLocation slStart = llcompat::getBeginLoc(sharedVar->getTypeSourceInfo()->getTypeLoc());
+    clang::SourceLocation slEnd = llcompat::getEndLoc(sharedVar->getTypeSourceInfo()->getTypeLoc());
     clang::SourceManager* SM = Result.SourceManager;
     size_t repLength = SM->getCharacterData(slEnd) - SM->getCharacterData(slStart) + 1;
     std::string varName = sharedVar->getNameAsString();

--- a/hipify-clang/src/HipifyAction.h
+++ b/hipify-clang/src/HipifyAction.h
@@ -9,6 +9,7 @@
 #include "Statistics.h"
 
 namespace ct = clang::tooling;
+using namespace llvm;
 
 /**
   * A FrontendAction that hipifies CUDA programs.

--- a/hipify-clang/src/LLVMCompat.cpp
+++ b/hipify-clang/src/LLVMCompat.cpp
@@ -8,11 +8,11 @@ void PrintStackTraceOnErrorSignal() {
 #if (LLVM_VERSION_MAJOR == 3) && (LLVM_VERSION_MINOR == 8)
   llvm::sys::PrintStackTraceOnErrorSignal();
 #else
-  llvm::sys::PrintStackTraceOnErrorSignal(clang::StringRef());
+  llvm::sys::PrintStackTraceOnErrorSignal(StringRef());
 #endif
 }
 
-ct::Replacements& getReplacements(ct::RefactoringTool& Tool, clang::StringRef file) {
+ct::Replacements& getReplacements(ct::RefactoringTool& Tool, StringRef file) {
 #if LLVM_VERSION_MAJOR > 3
   // getReplacements() now returns a map from filename to Replacements - so create an entry
   // for this source file and return a reference to it.
@@ -37,6 +37,38 @@ void EnterPreprocessorTokenStream(clang::Preprocessor& _pp, const clang::Token *
   _pp.EnterTokenStream(start, len, false, DisableMacroExpansion);
 #else
   _pp.EnterTokenStream(clang::ArrayRef<clang::Token>{start, len}, DisableMacroExpansion);
+#endif
+}
+
+clang::SourceLocation getBeginLoc(const clang::Stmt* stmt) {
+#if LLVM_VERSION_MAJOR < 8
+  return stmt->getLocStart();
+#else
+  return stmt->getBeginLoc();
+#endif
+}
+
+clang::SourceLocation getBeginLoc(const clang::TypeLoc& typeLoc) {
+#if LLVM_VERSION_MAJOR < 8
+  return typeLoc.getLocStart();
+#else
+  return typeLoc.getBeginLoc();
+#endif
+}
+
+clang::SourceLocation getEndLoc(const clang::Stmt* stmt) {
+#if LLVM_VERSION_MAJOR < 8
+  return stmt->getLocEnd();
+#else
+  return stmt->getEndLoc();
+#endif
+}
+
+clang::SourceLocation getEndLoc(const clang::TypeLoc& typeLoc) {
+#if LLVM_VERSION_MAJOR < 8
+  return typeLoc.getLocEnd();
+#else
+  return typeLoc.getEndLoc();
 #endif
 }
 

--- a/hipify-clang/src/LLVMCompat.h
+++ b/hipify-clang/src/LLVMCompat.h
@@ -25,7 +25,15 @@ namespace llcompat {
   #define LLVM_DEBUG(X) DEBUG(X)
 #endif
 
+clang::SourceLocation getBeginLoc(const clang::Stmt* stmt);
+clang::SourceLocation getBeginLoc(const clang::TypeLoc& typeLoc);
+
+clang::SourceLocation getEndLoc(const clang::Stmt* stmt);
+clang::SourceLocation getEndLoc(const clang::TypeLoc& typeLoc);
+
 void PrintStackTraceOnErrorSignal();
+
+using namespace llvm;
 
 /**
   * Get the replacement map for a given filename in a RefactoringTool.
@@ -33,7 +41,7 @@ void PrintStackTraceOnErrorSignal();
   * Older LLVM versions don't actually support multiple filenames, so everything all gets
   * smushed together. It is the caller's responsibility to cope with this.
   */
-ct::Replacements& getReplacements(ct::RefactoringTool& Tool, clang::StringRef file);
+ct::Replacements& getReplacements(ct::RefactoringTool& Tool, StringRef file);
 
 /**
   * Add a Replacement to a Replacements.


### PR DESCRIPTION
+ StringRef issue, which is finally moved to LLVM from Clang
+ Renamed getBeginLoc() and getEndLoc() resolution for Expr and TypeLoc classes
+ Support all the previous LLVM versions via LLVCompat