### PR TITLE
Fix issue in kernarg metadata parsing due to early finalization

### DIFF
--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -590,14 +590,16 @@ unordered_map<string, vector<pair<size_t, size_t>>>& kernargs() {
     static once_flag f;
 
     call_once(f, []() {
-        for (auto&& blob : code_object_blobs()) {
-            stringstream tmp{std::string{
-                blob.second.front().cbegin(), blob.second.front().cend()}};
+        for (auto&& blobs_for_one_arch : code_object_blobs()) {
+            for (auto && blob : blobs_for_one_arch.second)  {
+                stringstream tmp{std::string{
+                    blob.cbegin(), blob.cend()}};
 
-            elfio reader;
-            if (!reader.load(tmp)) continue;
+                    elfio reader;
+                    if (!reader.load(tmp)) continue;
 
-            read_kernarg_metadata(reader, r);
+                    read_kernarg_metadata(reader, r);
+            }
         }
     });
 


### PR DESCRIPTION
The logic to parse the kernel metadata is unaware that enabling
of early finalization could result in multiple code blobs in a
single .kernel section.  This teaches the HIP runtime to handle
that.