### PR TITLE
Support of printing process ID for HIP tracing 

### DIFF
--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -179,7 +179,7 @@ uint64_t recordApiTrace(std::string* fullStr, const std::string& apiStr) {
 
 
     if (COMPILE_HIP_DB && HIP_TRACE_API) {
-        fprintf(stderr, "%s<<hip-api tid:%s @%lu%s\n", API_COLOR, fullStr->c_str(), apiStartTick,
+        fprintf(stderr, "%s<<hip-api pid:%d tid:%s @%lu%s\n", API_COLOR, tls_tidInfo.pid(), fullStr->c_str(), apiStartTick,
                 API_COLOR_END);
     }
 
@@ -237,6 +237,7 @@ hipError_t ihipSynchronize(void) {
 //=================================================================================================
 TidInfo::TidInfo() : _apiSeqNum(0) {
     _shortTid = g_lastShortTid.fetch_add(1);
+    _pid = getpid(); 
 
     if (COMPILE_HIP_DB && HIP_TRACE_API) {
         std::stringstream tid_ss;
@@ -1535,7 +1536,7 @@ void ihipPrintKernelLaunch(const char* kernelName, const grid_launch_parm* lp,
     if ((HIP_TRACE_API & (1 << TRACE_KCMD)) || HIP_PROFILE_API ||
         (COMPILE_HIP_DB & HIP_TRACE_API)) {
         std::stringstream os;
-        os << tls_tidInfo.tid() << "." << tls_tidInfo.apiSeqNum() << " hipLaunchKernel '"
+        os << tls_tidInfo.pid() << " " << tls_tidInfo.tid() << "." << tls_tidInfo.apiSeqNum() << " hipLaunchKernel '"
            << kernelName << "'"
            << " gridDim:" << lp->grid_dim << " groupDim:" << lp->group_dim << " sharedMem:+"
            << lp->dynamic_group_mem_bytes << " " << *stream;

--- a/src/hip_hcc_internal.h
+++ b/src/hip_hcc_internal.h
@@ -94,11 +94,13 @@ class TidInfo {
     TidInfo();
 
     int tid() const { return _shortTid; };
+    pid_t pid() const { return _pid; }; 
     uint64_t incApiSeqNum() { return ++_apiSeqNum; };
     uint64_t apiSeqNum() const { return _apiSeqNum; };
 
    private:
     int _shortTid;
+    pid_t _pid; 
 
     // monotonically increasing API sequence number for this threa.
     uint64_t _apiSeqNum;
@@ -243,14 +245,14 @@ static const DbName dbName[] = {
 
 
 #if COMPILE_HIP_DB
-#define tprintf(trace_level, ...)                                                                  \
-    {                                                                                              \
-        if (HIP_DB & (1 << (trace_level))) {                                                       \
-            char msgStr[1000];                                                                     \
-            snprintf(msgStr, sizeof(msgStr), __VA_ARGS__);                                         \
-            fprintf(stderr, "  %ship-%s tid:%d:%s%s", dbName[trace_level]._color,                  \
-                    dbName[trace_level]._shortName, tls_tidInfo.tid(), msgStr, KNRM);              \
-        }                                                                                          \
+#define tprintf(trace_level, ...)                                                                                     \
+    {                                                                                                                 \
+        if (HIP_DB & (1 << (trace_level))) {                                                                          \
+            char msgStr[1000];                                                                                        \
+            snprintf(msgStr, sizeof(msgStr), __VA_ARGS__);                                                            \
+            fprintf(stderr, "  %ship-%s pid:%d tid:%d:%s%s", dbName[trace_level]._color,                              \
+                    dbName[trace_level]._shortName, tls_tidInfo.pid(), tls_tidInfo.tid(), msgStr, KNRM);              \
+        }                                                                                                             \
     }
 #else
 /* Compile to empty code */
@@ -313,22 +315,22 @@ extern uint64_t recordApiTrace(std::string* fullStr, const std::string& apiStr);
 // This macro should be called at the end of every HIP API, and only at the end of top-level hip
 // APIS (not internal hip) It has dual function: logs the last error returned for use by
 // hipGetLastError, and also prints the closing message when the debug trace is enabled.
-#define ihipLogStatus(hipStatus)                                                                   \
-    ({                                                                                             \
-        hipError_t localHipStatus = hipStatus; /*local copy so hipStatus only evaluated once*/     \
-        tls_lastHipError = localHipStatus;                                                         \
-                                                                                                   \
-        if ((COMPILE_HIP_TRACE_API & 0x2) && HIP_TRACE_API & (1 << TRACE_ALL)) {                   \
-            auto ticks = getTicks() - hipApiStartTick;                                             \
-            fprintf(stderr, "  %ship-api tid:%d.%lu %-30s ret=%2d (%s)>> +%lu ns%s\n",             \
-                    (localHipStatus == 0) ? API_COLOR : KRED, tls_tidInfo.tid(),                   \
-                    tls_tidInfo.apiSeqNum(), __func__, localHipStatus,                             \
-                    ihipErrorString(localHipStatus), ticks, API_COLOR_END);                        \
-        }                                                                                          \
-        if (HIP_PROFILE_API) {                                                                     \
-            MARKER_END();                                                                          \
-        }                                                                                          \
-        localHipStatus;                                                                            \
+#define ihipLogStatus(hipStatus)                                                                    \
+    ({                                                                                              \
+        hipError_t localHipStatus = hipStatus; /*local copy so hipStatus only evaluated once*/      \
+        tls_lastHipError = localHipStatus;                                                          \
+                                                                                                    \
+        if ((COMPILE_HIP_TRACE_API & 0x2) && HIP_TRACE_API & (1 << TRACE_ALL)) {                    \
+            auto ticks = getTicks() - hipApiStartTick;                                              \
+            fprintf(stderr, "  %ship-api pid:%d tid:%d.%lu %-30s ret=%2d (%s)>> +%lu ns%s\n",       \
+                    (localHipStatus == 0) ? API_COLOR : KRED, tls_tidInfo.pid(), tls_tidInfo.tid(), \
+                    tls_tidInfo.apiSeqNum(), __func__, localHipStatus,                              \
+                    ihipErrorString(localHipStatus), ticks, API_COLOR_END);                         \
+        }                                                                                           \
+        if (HIP_PROFILE_API) {                                                                      \
+            MARKER_END();                                                                           \
+        }                                                                                           \
+        localHipStatus;                                                                             \
     })
 
 


### PR DESCRIPTION
Output the process ID together with the Thread ID and other information is needed for HIP debugging since HIP applications may be written using multiple processes. For example,  Sugon is currently testing HPL, which has separated HIP process generated on each GPU by MPI. 