### PR TITLE
Revert metadata for kerarg

### DIFF
--- a/include/hip/hcc_detail/functional_grid_launch.hpp
+++ b/include/hip/hcc_detail/functional_grid_launch.hpp
@@ -102,8 +102,6 @@ inline std::vector<std::uint8_t> make_kernarg(
     static_assert(sizeof...(Formals) == sizeof...(Actuals),
         "The count of formal arguments must match the count of actuals.");
 
-    if (sizeof...(Formals) == 0) return {};
-
     const auto it = function_names().find(
         reinterpret_cast<std::uintptr_t>(kernel));
 

--- a/include/hip/hcc_detail/program_state.hpp
+++ b/include/hip/hcc_detail/program_state.hpp
@@ -99,8 +99,6 @@ const std::unordered_map<std::uintptr_t, std::vector<std::pair<hsa_agent_t, Kern
 functions(bool rebuild = false);
 const std::unordered_map<std::uintptr_t, std::string>& function_names(bool rebuild = false);
 std::unordered_map<std::string, void*>& globals(bool rebuild = false);
-std::unordered_map<
-    std::string, std::vector<std::pair<std::size_t, std::size_t>>>& kernargs();
 
 hsa_executable_t load_executable(const std::string& file, hsa_executable_t executable,
                                  hsa_agent_t agent);

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -404,10 +404,11 @@ void read_kernarg_metadata(
             if (dx == string::npos) break;
 
             static constexpr decltype(tmp.size()) name_sz{5};
-            dx = tmp.find_first_not_of(" '", dx + name_sz);
+            dx = tmp.find_first_not_of(' ', dx + name_sz);
 
-            auto fn = tmp.substr(dx, tmp.find_first_of("'\n", dx) - dx);
+            auto fn = tmp.substr(dx, tmp.find('\n', dx) - dx);
             dx += fn.size();
+
             dx = tmp.find("Args:", dx);
 
             if (dx == string::npos) break;
@@ -595,7 +596,6 @@ unordered_map<string, vector<pair<size_t, size_t>>>& kernargs() {
         }
     });
 
-    for (auto&& x : r) std::cerr << x.first << std::endl;
     return r;
 }
 

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -312,8 +312,8 @@ const unordered_map<string, vector<hsa_executable_symbol_t>>& kernels(bool rebui
 
 void load_code_object_and_freeze_executable(
     const string& file, hsa_agent_t agent,
-    hsa_executable_t executable) {
-    // TODO: the following sequence is inefficient, should be refactored
+    hsa_executable_t
+        executable) {  // TODO: the following sequence is inefficient, should be refactored
     //       into a single load of the file and subsequent ELFIO
     //       processing.
     static const auto cor_deleter = [](hsa_code_object_reader_t* p) {
@@ -338,85 +338,6 @@ void load_code_object_and_freeze_executable(
 
         lock_guard<mutex> lck{mtx};
         code_readers.push_back(move(tmp));
-    }
-}
-
-size_t parse_args(
-    const string& metadata,
-    size_t f,
-    size_t l,
-    vector<pair<size_t, size_t>>& size_align) {
-    if (f == l) return f;
-
-    do {
-        static constexpr size_t size_sz{5};
-        f = metadata.find("Size:", f) + size_sz;
-
-        if (l <= f) return f;
-
-        auto size = strtoul(&metadata[f], nullptr, 10);
-
-        static constexpr size_t align_sz{6};
-        f = metadata.find("Align:", f) + align_sz;
-
-        char* l{};
-        auto align = strtoul(&metadata[f], &l, 10);
-
-        f += (l - &metadata[f]) + 1;
-
-        size_align.emplace_back(size, align);
-    } while (true);
-}
-
-void read_kernarg_metadata(
-    elfio& reader,
-    unordered_map<string, vector<pair<size_t, size_t>>>& kernargs)
-{   // TODO: this is inefficient.
-    auto it = find_section_if(
-        reader, [](const section* x) { return x->get_type() == SHT_NOTE; });
-
-    if (!it) return;
-
-    const note_section_accessor acc{reader, it};
-    for (decltype(acc.get_notes_num()) i = 0; i != acc.get_notes_num(); ++i) {
-        ELFIO::Elf_Word type{};
-        string name{};
-        void* desc{};
-        Elf_Word desc_size{};
-
-        acc.get_note(i, type, name, desc, desc_size);
-
-        if (name != "AMD") continue; // TODO: switch to using NT_AMD_AMDGPU_HSA_METADATA.
-
-        string tmp{
-            static_cast<char*>(desc), static_cast<char*>(desc) + desc_size};
-
-        auto dx = tmp.find("Kernels:");
-
-        if (dx == string::npos) continue;
-
-        static constexpr decltype(tmp.size()) kernels_sz{8};
-        dx += kernels_sz;
-
-        do {
-            dx = tmp.find("Name:", dx);
-
-            if (dx == string::npos) break;
-
-            static constexpr decltype(tmp.size()) name_sz{5};
-            dx = tmp.find_first_not_of(' ', dx + name_sz);
-
-            auto fn = tmp.substr(dx, tmp.find('\n', dx) - dx);
-            dx += fn.size();
-
-            dx = tmp.find("Args:", dx);
-
-            if (dx == string::npos) break;
-
-            static constexpr decltype(tmp.size()) args_sz{5};
-            dx = parse_args(
-                tmp, dx + args_sz, tmp.find("CodeProps", dx), kernargs[fn]);
-        } while (true);
     }
 }
 }  // namespace
@@ -576,25 +497,6 @@ unordered_map<string, void*>& globals(bool rebuild) {
     if (rebuild) {
         cons();
     }
-
-    return r;
-}
-
-unordered_map<string, vector<pair<size_t, size_t>>>& kernargs() {
-    static unordered_map<string, vector<pair<size_t, size_t>>> r;
-    static once_flag f;
-
-    call_once(f, []() {
-        for (auto&& blob : code_object_blobs()) {
-            stringstream tmp{std::string{
-                blob.second.front().cbegin(), blob.second.front().cend()}};
-
-            elfio reader;
-            if (!reader.load(tmp)) continue;
-
-            read_kernarg_metadata(reader, r);
-        }
-    });
 
     return r;
 }

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -590,16 +590,14 @@ unordered_map<string, vector<pair<size_t, size_t>>>& kernargs() {
     static once_flag f;
 
     call_once(f, []() {
-        for (auto&& blobs_for_one_arch : code_object_blobs()) {
-            for (auto && blob : blobs_for_one_arch.second)  {
-                stringstream tmp{std::string{
-                    blob.cbegin(), blob.cend()}};
+        for (auto&& blob : code_object_blobs()) {
+            stringstream tmp{std::string{
+                blob.second.front().cbegin(), blob.second.front().cend()}};
 
-                    elfio reader;
-                    if (!reader.load(tmp)) continue;
+            elfio reader;
+            if (!reader.load(tmp)) continue;
 
-                    read_kernarg_metadata(reader, r);
-            }
+            read_kernarg_metadata(reader, r);
         }
     });
 

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -409,18 +409,13 @@ void read_kernarg_metadata(
 
             auto fn = tmp.substr(dx, tmp.find_first_of("'\n", dx) - dx);
             dx += fn.size();
-
-            auto dx1 = tmp.find("CodeProps", dx);
             dx = tmp.find("Args:", dx);
 
-            if (dx1 < dx) {
-                dx = dx1;
-                continue;
-            }
             if (dx == string::npos) break;
 
             static constexpr decltype(tmp.size()) args_sz{5};
-            dx = parse_args(tmp, dx + args_sz, dx1, kernargs[fn]);
+            dx = parse_args(
+                tmp, dx + args_sz, tmp.find("CodeProps", dx), kernargs[fn]);
         } while (true);
     }
 }

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -347,7 +347,6 @@ size_t parse_args(
     size_t l,
     vector<pair<size_t, size_t>>& size_align) {
     if (f == l) return f;
-    if (!size_align.empty()) return l;
 
     do {
         static constexpr size_t size_sz{5};
@@ -596,6 +595,7 @@ unordered_map<string, vector<pair<size_t, size_t>>>& kernargs() {
         }
     });
 
+    for (auto&& x : r) std::cerr << x.first << std::endl;
     return r;
 }
 


### PR DESCRIPTION
Temporary reverting the following PRs related to relying on metadata for kernargs until we get a better understanding of its interaction with early finalization and resolve correctness and performance issues it exposes.
https://github.com/ROCm-Developer-Tools/HIP/pull/731
https://github.com/ROCm-Developer-Tools/HIP/pull/772