### PR TITLE
[dtest] Remove redundant arguments from hipMemset3D test

### DIFF
--- a/tests/src/runtimeApi/memory/hipMemset3D.cpp
+++ b/tests/src/runtimeApi/memory/hipMemset3D.cpp
@@ -24,8 +24,7 @@ THE SOFTWARE.
 
 /* HIT_START
  * BUILD: %t %s ../../test_common.cpp
- * //Small copy
- * RUN: %t -N 10    --memsetval 0x42
+ * RUN: %t
  * HIT_END
  */
 


### PR DESCRIPTION
This PR doesn't make any logical or functional change.