### PR TITLE
[HIPIFY][#812] Finishing with temps

### DIFF
--- a/hipify-clang/src/ArgParse.cpp
+++ b/hipify-clang/src/ArgParse.cpp
@@ -29,6 +29,16 @@ cl::opt<std::string> OutputFilename("o",
   cl::value_desc("filename"),
   cl::cat(ToolTemplateCategory));
 
+cl::opt<std::string> TemporaryDir("temp-dir",
+  cl::desc("Temporary direcory"),
+  cl::value_desc("directory"),
+  cl::cat(ToolTemplateCategory));
+
+cl::opt <bool> SaveTemps("save-temps",
+  cl::desc("Save temporary files"),
+  cl::value_desc("save-temps"),
+  cl::cat(ToolTemplateCategory));
+
 cl::opt <bool> TranslateToRoc("roc",
   cl::desc("Translate to roc instead of hip where it is possible"),
   cl::value_desc("roc"),

--- a/hipify-clang/src/ArgParse.h
+++ b/hipify-clang/src/ArgParse.h
@@ -30,7 +30,9 @@ namespace ct = clang::tooling;
 
 extern cl::OptionCategory ToolTemplateCategory;
 extern cl::opt<std::string> OutputFilename;
+extern cl::opt<std::string> TemporaryDir;
 extern cl::opt<bool> Inplace;
+extern cl::opt<bool> SaveTemps;
 extern cl::opt<bool> NoBackup;
 extern cl::opt<bool> NoOutput;
 extern cl::opt<bool> PrintStats;


### PR DESCRIPTION
1. Option -temp-dir for temporary directory:
  + if not specified system temp is used;
  + creates the directory if the directory doesn't exist (only one level in a tree);
  + reports an error in case of a wrong directory specified, in case of necessity of creating a tree of subfolders, or in case of a filename specified.
2. Option -save-temps for preserving temporary files:
  + if specified temporary files are not being deleted from system temps and user temps as well.
3. Work with files in terms of calculated absolute paths by collapsing all '.' and '..' patterns, resolving symlinks and expanding '~' expression to the user's home directory:
  + to produce correct include paths;
  + to avoid possible errors on file routines.