### PR TITLE
[HIPIFY] Introduce option -o-dir

### DIFF
--- a/hipify-clang/src/ArgParse.cpp
+++ b/hipify-clang/src/ArgParse.cpp
@@ -29,6 +29,11 @@ cl::opt<std::string> OutputFilename("o",
   cl::value_desc("filename"),
   cl::cat(ToolTemplateCategory));
 
+cl::opt<std::string> OutputDir("o-dir",
+  cl::desc("Output direcory"),
+  cl::value_desc("directory"),
+  cl::cat(ToolTemplateCategory));
+
 cl::opt<std::string> TemporaryDir("temp-dir",
   cl::desc("Temporary direcory"),
   cl::value_desc("directory"),

--- a/hipify-clang/src/ArgParse.h
+++ b/hipify-clang/src/ArgParse.h
@@ -30,6 +30,7 @@ namespace ct = clang::tooling;
 
 extern cl::OptionCategory ToolTemplateCategory;
 extern cl::opt<std::string> OutputFilename;
+extern cl::opt<std::string> OutputDir;
 extern cl::opt<std::string> TemporaryDir;
 extern cl::opt<bool> Inplace;
 extern cl::opt<bool> SaveTemps;


### PR DESCRIPTION
Option -o-dir for output directory:
  + if not specified source file(s) directory is used;
  + creates the directory if the directory doesn't exist (only one level in a tree);
  + if -o and -o-dir both are specified the hipified file is placed to "-o-dir" + "-o";
  + reports an error in case of a wrong directory specified, in case of necessity of creating a tree of subfolders, or in case of a filename specified.