### PR TITLE
[HIPIFY][win] Set -std=c++14 if MSVC

### DIFF
--- a/hipify-clang/src/main.cpp
+++ b/hipify-clang/src/main.cpp
@@ -173,7 +173,11 @@ int main(int argc, const char **argv) {
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(sInclude.c_str(), ct::ArgumentInsertPosition::BEGIN));
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("--cuda-host-only", ct::ArgumentInsertPosition::BEGIN));
     // Ensure at least c++11 is used.
-    Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-std=c++11", ct::ArgumentInsertPosition::BEGIN));
+    std::string stdCpp = "-std=c++11";
+#if defined(_MSC_VER)
+    stdCpp = "-std=c++14";
+#endif
+    Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(stdCpp.c_str(), ct::ArgumentInsertPosition::BEGIN));
 #if defined(HIPIFY_CLANG_RES)
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-resource-dir=" HIPIFY_CLANG_RES));
 #endif

--- a/tests/hipify-clang/lit.cfg
+++ b/tests/hipify-clang/lit.cfg
@@ -65,7 +65,7 @@ clang_args = "-x cuda -v --cuda-gpu-arch=sm_30 --cuda-path='%s'"
 if sys.platform in ['win32']:
     run_test_ext = ".bat"
     hipify_path += "/" + config.build_type
-    clang_args += " -isystem'%s'/common/inc -std=c++14"
+    clang_args += " -isystem'%s'/common/inc"
 else:
     run_test_ext = ".sh"
     clang_args += " -isystem'%s'/samples/common/inc"


### PR DESCRIPTION
+ Due to latest Windows SDK implementation based on c++14 features, '-std+c++14' is a must;
+ Doesn't affect older versions of MSVC 2017, 2015 (the latest supported is MSVC 2015);
+ On linux still '-std=c++11' is a must;
+ Exclude '-std=' from lit config.