### PR TITLE
[HIPIFY] Starts implicitly setting '-x cuda' by hipify-clang itself

### DIFF
--- a/hipify-clang/README.md
+++ b/hipify-clang/README.md
@@ -321,7 +321,6 @@ For example:
 ./hipify-clang \
   square.cu \
   -- \
-  -x cuda \
   --cuda-path=/usr/local/cuda-8.0 \
   --cuda-gpu-arch=sm_50 \
   -isystem /usr/local/cuda-8.0/samples/common/inc

--- a/hipify-clang/src/main.cpp
+++ b/hipify-clang/src/main.cpp
@@ -171,6 +171,8 @@ int main(int argc, const char **argv) {
     ReplacementsFrontendActionFactory<HipifyAction> actionFactory(&replacementsToUse);
     std::string sInclude = "-I" + sys::path::parent_path(sourceAbsPath).str();
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(sInclude.c_str(), ct::ArgumentInsertPosition::BEGIN));
+    Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("cuda", ct::ArgumentInsertPosition::BEGIN));
+    Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-x", ct::ArgumentInsertPosition::BEGIN));
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("--cuda-host-only", ct::ArgumentInsertPosition::BEGIN));
     // Ensure at least c++11 is used.
     std::string stdCpp = "-std=c++11";

--- a/tests/hipify-clang/lit.cfg
+++ b/tests/hipify-clang/lit.cfg
@@ -60,7 +60,7 @@ if obj_root is not None:
     config.environment['PATH'] = path
 
 hipify_path = obj_root
-clang_args = "-x cuda -v --cuda-gpu-arch=sm_30 --cuda-path='%s'"
+clang_args = "-v --cuda-gpu-arch=sm_30 --cuda-path='%s'"
 
 if sys.platform in ['win32']:
     run_test_ext = ".bat"


### PR DESCRIPTION
+ No need in setting '-x cuda' for the user anymore;
+ Testing and Readme updated accordingly.