### PR TITLE
[HIPIFY] Get rid of setting '--cuda-gpu-arch='

### DIFF
--- a/hipify-clang/README.md
+++ b/hipify-clang/README.md
@@ -322,7 +322,6 @@ For example:
   square.cu \
   -- \
   --cuda-path=/usr/local/cuda-8.0 \
-  --cuda-gpu-arch=sm_50 \
   -isystem /usr/local/cuda-8.0/samples/common/inc
 ```
 
@@ -338,5 +337,5 @@ The information contained herein is for informational purposes only, and is subj
 
 AMD, the AMD Arrow logo, and combinations thereof are trademarks of Advanced Micro Devices, Inc. Other product names used in this publication are for identification purposes only and may be trademarks of their respective companies.
 
-Copyright (c) 2014-2018 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2014-2019 Advanced Micro Devices, Inc. All rights reserved.
 

--- a/tests/hipify-clang/lit.cfg
+++ b/tests/hipify-clang/lit.cfg
@@ -60,7 +60,7 @@ if obj_root is not None:
     config.environment['PATH'] = path
 
 hipify_path = obj_root
-clang_args = "-v --cuda-gpu-arch=sm_30 --cuda-path='%s'"
+clang_args = "-v --cuda-path='%s'"
 
 if sys.platform in ['win32']:
     run_test_ext = ".bat"


### PR DESCRIPTION
[Reasons]
+ We don't compile kernel code at least for now as HIP kernel syntax is almost equal CUDA's;
+ clang always includes PTX in its binaries, so e.g. a binary compiled with --cuda-gpu-arch= would be forwards-compatible with e.g. sm_35 GPUs.