### PR TITLE
[HIPIFY] Add system includes for packaged hipify-clang to use it with…

### DIFF
--- a/hipify-clang/src/main.cpp
+++ b/hipify-clang/src/main.cpp
@@ -174,6 +174,11 @@ int main(int argc, const char **argv) {
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("cuda", ct::ArgumentInsertPosition::BEGIN));
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-x", ct::ArgumentInsertPosition::BEGIN));
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("--cuda-host-only", ct::ArgumentInsertPosition::BEGIN));
+    // Includes for clang's CUDA wrappers for using by packaged hipify-clang
+    Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("./include/cuda_wrappers", ct::ArgumentInsertPosition::BEGIN));
+    Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-isystem", ct::ArgumentInsertPosition::BEGIN));
+    Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("./include", ct::ArgumentInsertPosition::BEGIN));
+    Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-isystem", ct::ArgumentInsertPosition::BEGIN));
     // Ensure at least c++11 is used.
     std::string stdCpp = "-std=c++11";
 #if defined(_MSC_VER)


### PR DESCRIPTION
…out the necessity of installing clang

Header files in those dirs are an integral part of clang, which includes wrapper headers for CUDA.
There is no need in checking those dirs.

[Reasons]
1. clang will not take into account empty or irrelevant include dirs;
2. Packages for different clang versions will have different header files in the above dirs.