### PR TITLE
Introduce hash key to HIP module implementation

### DIFF
--- a/src/hip_hcc_internal.h
+++ b/src/hip_hcc_internal.h
@@ -374,6 +374,7 @@ struct ihipModule_t {
     std::string fileName;
     hsa_executable_t executable = {};
     hsa_code_object_reader_t coReader = {};
+    std::string hash;
 
     ~ihipModule_t() {
         if (executable.handle) hsa_executable_destroy(executable);


### PR DESCRIPTION
A hash calculated via FNV-1a algorithm is introduced in ihipModule_t, the
internal of hipModule_t. The hash is used by HIP module APIs such as

- read_agent_global_from_module

to determine whether the agent-scope globals for a module have been iterated.

This commit fixes one issue that applications which load / unload modules
frequently would occasionally fail. After deep investigation of the issue it
turns out the old implementation in read_agent_global_from_module uses
hipModule_t as the key, which is not robust enough, as hipModule_t instances
are allocated dynamically so there are cases that one memory address may be
used by multiple hipModule_t instances. The real solution is to introduce a
uniquely identifiable hash for the code object associated with the HIP module.
And that's the rationale behind this commit.