### PR TITLE
[HIPIFY] Introduce CUDA installation path option '--cuda-path'

### DIFF
--- a/hipify-clang/README.md
+++ b/hipify-clang/README.md
@@ -320,9 +320,9 @@ For example:
 ```shell
 ./hipify-clang \
   square.cu \
-  -- \
   --cuda-path=/usr/local/cuda-8.0 \
-  -isystem /usr/local/cuda-8.0/samples/common/inc
+  -- \
+  -I /usr/local/cuda-8.0/samples/common/inc
 ```
 
 `hipify-clang` arguments are given first, followed by a separator, and then the arguments you'd pass to `clang` if you

--- a/hipify-clang/src/ArgParse.cpp
+++ b/hipify-clang/src/ArgParse.cpp
@@ -39,6 +39,11 @@ cl::opt<std::string> TemporaryDir("temp-dir",
   cl::value_desc("directory"),
   cl::cat(ToolTemplateCategory));
 
+cl::opt<std::string> CudaPath("cuda-path",
+  cl::desc("CUDA installation path"),
+  cl::value_desc("directory"),
+  cl::cat(ToolTemplateCategory));
+
 cl::opt <bool> SaveTemps("save-temps",
   cl::desc("Save temporary files"),
   cl::value_desc("save-temps"),

--- a/hipify-clang/src/ArgParse.h
+++ b/hipify-clang/src/ArgParse.h
@@ -32,6 +32,7 @@ extern cl::OptionCategory ToolTemplateCategory;
 extern cl::opt<std::string> OutputFilename;
 extern cl::opt<std::string> OutputDir;
 extern cl::opt<std::string> TemporaryDir;
+extern cl::opt<std::string> CudaPath;
 extern cl::opt<bool> Inplace;
 extern cl::opt<bool> SaveTemps;
 extern cl::opt<bool> NoBackup;

--- a/hipify-clang/src/main.cpp
+++ b/hipify-clang/src/main.cpp
@@ -174,6 +174,10 @@ int main(int argc, const char **argv) {
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("cuda", ct::ArgumentInsertPosition::BEGIN));
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-x", ct::ArgumentInsertPosition::BEGIN));
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("--cuda-host-only", ct::ArgumentInsertPosition::BEGIN));
+    if (!CudaPath.empty()) {
+      std::string sCudaPath = "--cuda-path=" + CudaPath;
+      Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(sCudaPath.c_str(), ct::ArgumentInsertPosition::BEGIN));
+    }
     // Includes for clang's CUDA wrappers for using by packaged hipify-clang
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("./include", ct::ArgumentInsertPosition::BEGIN));
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-isystem", ct::ArgumentInsertPosition::BEGIN));

--- a/tests/hipify-clang/lit.cfg
+++ b/tests/hipify-clang/lit.cfg
@@ -75,7 +75,7 @@ else:
     clang_arguments += " -isystem'%s'/samples/common/inc"
 clang_arguments += " -I'%s'/include"
 
-hipify_arguments = "-cuda-path='%s'"
+hipify_arguments = "--cuda-path='%s'"
 
 config.substitutions.append(("%clang_args", clang_arguments % (config.cuda_sdk_root, config.cuda_dnn_root)))
 config.substitutions.append(("%hipify_args", hipify_arguments % (config.cuda_root)))

--- a/tests/hipify-clang/lit.cfg
+++ b/tests/hipify-clang/lit.cfg
@@ -64,18 +64,20 @@ if obj_root is not None:
     config.environment['PATH'] = path
 
 hipify_path = obj_root
-clang_args = "-v --cuda-path='%s'"
 
+clang_arguments = "-v"
 if sys.platform in ['win32']:
     run_test_ext = ".bat"
     hipify_path += "/" + config.build_type
-    clang_args += " -isystem'%s'/common/inc"
+    clang_arguments += " -isystem'%s'/common/inc"
 else:
     run_test_ext = ".sh"
-    clang_args += " -isystem'%s'/samples/common/inc"
+    clang_arguments += " -isystem'%s'/samples/common/inc"
+clang_arguments += " -I'%s'/include"
 
-clang_args += " -I'%s'/include"
+hipify_arguments = "-cuda-path='%s'"
 
-config.substitutions.append(("%cuda_args", clang_args % (config.cuda_root, config.cuda_sdk_root, config.cuda_dnn_root)))
+config.substitutions.append(("%clang_args", clang_arguments % (config.cuda_sdk_root, config.cuda_dnn_root)))
+config.substitutions.append(("%hipify_args", hipify_arguments % (config.cuda_root)))
 config.substitutions.append(("hipify", '"' + hipify_path + "/hipify-clang" + '"'))
 config.substitutions.append(("%run_test", '"' + config.test_source_root + "/run_test" + run_test_ext + '"'))

--- a/tests/hipify-clang/run_test.bat
+++ b/tests/hipify-clang/run_test.bat
@@ -2,17 +2,18 @@
 setlocal
 
 for %%i in (FileCheck.exe) do set FILE_CHECK=%%~$PATH:i
-if not defined FILE_CHECK (echo     Error: FileCheck.exe not found in PATH. && exit /b 1)
+if not defined FILE_CHECK (echo      Error: FileCheck.exe not found in PATH. && exit /b 1)
 
 set HIPIFY=%1
 set IN_FILE=%2
 set TMP_FILE=%3
+set CUDA_ROOT=%4
 
 set all_args=%*
-call set clang_args=%%all_args:*%4=%%
-set clang_args=%4%clang_args%
+call set clang_args=%%all_args:*%5=%%
+set clang_args=%5%clang_args%
 
-%HIPIFY% -o=%TMP_FILE% %IN_FILE% -- %clang_args%
+%HIPIFY% -o=%TMP_FILE% %IN_FILE% %CUDA_ROOT% -- %clang_args%
 if errorlevel 1 (echo      Error: hipify-clang.exe failed with exit code: %errorlevel% && exit /b %errorlevel%)
 
 findstr /v /r /c:"[ ]*//[ ]*[CHECK*|RUN]" %TMP_FILE% | %FILE_CHECK% %IN_FILE%

--- a/tests/hipify-clang/run_test.sh
+++ b/tests/hipify-clang/run_test.sh
@@ -9,9 +9,9 @@ set -o errexit
 HIPIFY=$1
 IN_FILE=$2
 TMP_FILE=$3
-shift 3
+CUDA_ROOT=$4
+shift 4
 
 # Remaining args are the ones to forward to clang proper.
 
-$HIPIFY -o=$TMP_FILE $IN_FILE -- $@ && cat $TMP_FILE | sed -Ee 's|//.+|// |g' | FileCheck $IN_FILE
-
+$HIPIFY -o=$TMP_FILE $IN_FILE $CUDA_ROOT -- $@ && cat $TMP_FILE | sed -Ee 's|//.+|// |g' | FileCheck $IN_FILE

--- a/tests/hipify-clang/unit_tests/headers/headers_test_01.cu
+++ b/tests/hipify-clang/unit_tests/headers/headers_test_01.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/hipify-clang/unit_tests/headers/headers_test_02.cu
+++ b/tests/hipify-clang/unit_tests/headers/headers_test_02.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include "hip/hip_runtime.h"
 // CHECK-NOT: #include "cuda_runtime.h"

--- a/tests/hipify-clang/unit_tests/headers/headers_test_03.cu
+++ b/tests/hipify-clang/unit_tests/headers/headers_test_03.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #pragma once
 // CHECK-NEXT: #include <hip/hip_runtime.h>

--- a/tests/hipify-clang/unit_tests/headers/headers_test_04.cu
+++ b/tests/hipify-clang/unit_tests/headers/headers_test_04.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NEXT: #include <stdio.h>

--- a/tests/hipify-clang/unit_tests/headers/headers_test_05.cu
+++ b/tests/hipify-clang/unit_tests/headers/headers_test_05.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #pragma once
 // CHECK-NEXT: #include <hip/hip_runtime.h>

--- a/tests/hipify-clang/unit_tests/headers/headers_test_06.cu
+++ b/tests/hipify-clang/unit_tests/headers/headers_test_06.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hipblas.h>
 // CHECK-NOT: #include <cublas_v2.h>

--- a/tests/hipify-clang/unit_tests/headers/headers_test_07.cu
+++ b/tests/hipify-clang/unit_tests/headers/headers_test_07.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include "hipblas.h"
 // CHECK-NOT: #include "cublas.h"

--- a/tests/hipify-clang/unit_tests/headers/headers_test_08.cu
+++ b/tests/hipify-clang/unit_tests/headers/headers_test_08.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK-NOT: #include <cuda_runtime.h>

--- a/tests/hipify-clang/unit_tests/headers/headers_test_09.cu
+++ b/tests/hipify-clang/unit_tests/headers/headers_test_09.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK: #include <memory>

--- a/tests/hipify-clang/unit_tests/libraries/cuBLAS/cublas_0_based_indexing.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuBLAS/cublas_0_based_indexing.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuBLAS/cublas_1_based_indexing.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuBLAS/cublas_1_based_indexing.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuBLAS/cublas_sgemm_matrix_multiplication.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuBLAS/cublas_sgemm_matrix_multiplication.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuComplex/cuComplex_Julia.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuComplex/cuComplex_Julia.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 // CHECK: #include "hip/hip_complex.h"

--- a/tests/hipify-clang/unit_tests/libraries/cuDNN/cudnn_convolution_forward.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuDNN/cudnn_convolution_forward.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #include <iomanip>
 #include <iostream>

--- a/tests/hipify-clang/unit_tests/libraries/cuDNN/cudnn_softmax.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuDNN/cudnn_softmax.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <stdio.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuFFT/simple_cufft.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuFFT/simple_cufft.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuRAND/benchmark_curand_generate.cpp
+++ b/tests/hipify-clang/unit_tests/libraries/cuRAND/benchmark_curand_generate.cpp
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // Copyright (c) 2017 Advanced Micro Devices, Inc. All rights reserved.
 //

--- a/tests/hipify-clang/unit_tests/libraries/cuRAND/benchmark_curand_kernel.cpp
+++ b/tests/hipify-clang/unit_tests/libraries/cuRAND/benchmark_curand_kernel.cpp
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // Copyright (c) 2017 Advanced Micro Devices, Inc. All rights reserved.
 //

--- a/tests/hipify-clang/unit_tests/libraries/cuRAND/poisson_api_example.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuRAND/poisson_api_example.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // Taken from: http://docs.nvidia.com/cuda/curand/device-api-overview.html#poisson-api-example
 /*

--- a/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_01.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_01.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #include <stdio.h>
 #include <stdlib.h>
 // CHECK: #include <hip/hip_runtime.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_02.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_02.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_03.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_03.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_04.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_04.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_05.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_05.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_06.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_06.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_07.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_07.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_08.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_08.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_09.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_09.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_10.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_10.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_11.cu
+++ b/tests/hipify-clang/unit_tests/libraries/cuSPARSE/cuSPARSE_11.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>

--- a/tests/hipify-clang/unit_tests/samples/allocators.cu
+++ b/tests/hipify-clang/unit_tests/samples/allocators.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #pragma once
 

--- a/tests/hipify-clang/unit_tests/samples/axpy.cu
+++ b/tests/hipify-clang/unit_tests/samples/axpy.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #include <iostream>
 

--- a/tests/hipify-clang/unit_tests/samples/coalescing.cu
+++ b/tests/hipify-clang/unit_tests/samples/coalescing.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // To measure effects of memory coalescing. Coalescing.cu
 // B. Wilkinson Jan 30, 2011

--- a/tests/hipify-clang/unit_tests/samples/cudaRegister.cu
+++ b/tests/hipify-clang/unit_tests/samples/cudaRegister.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 /*
 Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.

--- a/tests/hipify-clang/unit_tests/samples/dynamic_shared_memory.cu
+++ b/tests/hipify-clang/unit_tests/samples/dynamic_shared_memory.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // Taken from Jonathan Hui blog https://jhui.github.io/2017/03/06/CUDA
 

--- a/tests/hipify-clang/unit_tests/samples/intro.cu
+++ b/tests/hipify-clang/unit_tests/samples/intro.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/hipify-clang/unit_tests/samples/square.cu
+++ b/tests/hipify-clang/unit_tests/samples/square.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 /*
 Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.

--- a/tests/hipify-clang/unit_tests/samples/static_shared_memory.cu
+++ b/tests/hipify-clang/unit_tests/samples/static_shared_memory.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // Taken from Jonathan Hui blog https://jhui.github.io/2017/03/06/CUDA
 

--- a/tests/hipify-clang/unit_tests/samples/vec_add.cu
+++ b/tests/hipify-clang/unit_tests/samples/vec_add.cu
@@ -1,4 +1,4 @@
-// RUN: %run_test hipify "%s" "%t" %cuda_args
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
 
 // Kernel definition
 __global__ void  vecAdd(float* A, float* B, float* C)


### PR DESCRIPTION
Repeats clang's '--cuda-path' option.

[Reason]
In case of absence of any other clang's options setting '-cuda-path' allows not to specify separator '--' before clang's '--cuda-path'.

+ Tests and scripts are updated accordingly.