### PR TITLE
[HIPIFY] Introduce '--' option - a separator between hipify-clang and…

### DIFF
--- a/hipify-clang/src/ArgParse.cpp
+++ b/hipify-clang/src/ArgParse.cpp
@@ -84,4 +84,9 @@ cl::opt<bool> Examine("examine",
   cl::value_desc("examine"),
   cl::cat(ToolTemplateCategory));
 
+cl::opt<bool> DashDash("-",
+  cl::desc("Separator between hipify-clang and clang options;\ndon't specify if there are no clang options."),
+  cl::value_desc("--"),
+  cl::cat(ToolTemplateCategory));
+
 cl::extrahelp CommonHelp(ct::CommonOptionsParser::HelpMessage);

--- a/hipify-clang/src/ArgParse.h
+++ b/hipify-clang/src/ArgParse.h
@@ -42,3 +42,4 @@ extern cl::opt<std::string> OutputStatsFilename;
 extern cl::opt<bool> Examine;
 extern cl::extrahelp CommonHelp;
 extern cl::opt<bool> TranslateToRoc;
+extern cl::opt<bool> DashDash;

--- a/hipify-clang/src/main.cpp
+++ b/hipify-clang/src/main.cpp
@@ -68,6 +68,13 @@ std::string getAbsoluteDirectory(const std::string& sDir, std::error_code& EC,
 }
 
 int main(int argc, const char **argv) {
+  std::vector<const char*> new_argv(argv, argv + argc);
+  if (std::find(new_argv.begin(), new_argv.end(), std::string("--")) == new_argv.end()) {
+    new_argv.push_back("--");
+    new_argv.push_back(nullptr);
+    argv = new_argv.data();
+    argc++;
+  }
   llcompat::PrintStackTraceOnErrorSignal();
   ct::CommonOptionsParser OptionsParser(argc, argv, ToolTemplateCategory, llvm::cl::OneOrMore);
   std::vector<std::string> fileSources = OptionsParser.getSourcePathList();


### PR DESCRIPTION
+ Append '--' to the end of hipify-clang options in case of its absence.

[Reason]
Avoid the necessity for the user in JSON compilation database specification.
Otherwise:
  Error while trying to load a compilation database:
  Could not auto-detect compilation database for file "test.cu"

Though the hipification will be performed correctly without JSON database.