### PR TITLE
[HIPIFY] Introduce '-I' option as hipify-clang's one

### DIFF
--- a/hipify-clang/README.md
+++ b/hipify-clang/README.md
@@ -321,7 +321,6 @@ For example:
 ./hipify-clang \
   square.cu \
   --cuda-path=/usr/local/cuda-8.0 \
-  -- \
   -I /usr/local/cuda-8.0/samples/common/inc
 ```
 

--- a/hipify-clang/src/ArgParse.cpp
+++ b/hipify-clang/src/ArgParse.cpp
@@ -89,4 +89,11 @@ cl::opt<bool> DashDash("-",
   cl::value_desc("--"),
   cl::cat(ToolTemplateCategory));
 
+cl::list<std::string> I("I",
+  cl::desc("Add directory to include search path"),
+  cl::value_desc("directory"),
+  cl::ZeroOrMore,
+  cl::Prefix,
+  cl::cat(ToolTemplateCategory));
+
 cl::extrahelp CommonHelp(ct::CommonOptionsParser::HelpMessage);

--- a/hipify-clang/src/ArgParse.h
+++ b/hipify-clang/src/ArgParse.h
@@ -33,6 +33,7 @@ extern cl::opt<std::string> OutputFilename;
 extern cl::opt<std::string> OutputDir;
 extern cl::opt<std::string> TemporaryDir;
 extern cl::opt<std::string> CudaPath;
+extern cl::list<std::string> I;
 extern cl::opt<bool> Inplace;
 extern cl::opt<bool> SaveTemps;
 extern cl::opt<bool> NoBackup;

--- a/hipify-clang/src/main.cpp
+++ b/hipify-clang/src/main.cpp
@@ -199,6 +199,12 @@ int main(int argc, const char **argv) {
 #if defined(HIPIFY_CLANG_RES)
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-resource-dir=" HIPIFY_CLANG_RES));
 #endif
+    if (!I.empty()) {
+      for (std::string s : I) {
+        Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-I", ct::ArgumentInsertPosition::END));
+        Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(s.c_str(), ct::ArgumentInsertPosition::END));
+      }
+    }
     Tool.appendArgumentsAdjuster(ct::getClangSyntaxOnlyAdjuster());
     Statistics& currentStat = Statistics::current();
     // Hipify _all_ the things!


### PR DESCRIPTION
+ '-I' might be set as hipify-clang option (before separator '--' or without specifying separator at all);
+ '-I' as a clang option might be specified as well (after options separator '--').