### PR TITLE
Use chrono instead of sys/time.h in test

### DIFF
--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -19,7 +19,7 @@ THE SOFTWARE.
 
 #include <iostream>
 #include <iomanip>
-#include <sys/time.h>
+#include <chrono>
 #include <stddef.h>
 
 #include "hip/hip_runtime.h"
@@ -105,9 +105,8 @@ namespace HipTest {
 
 // Returns the current system time in microseconds
 inline long long get_time() {
-    struct timeval tv;
-    gettimeofday(&tv, 0);
-    return (tv.tv_sec * 1000000) + tv.tv_usec;
+    return std::chrono::high_resolution_clock::now().time_since_epoch()
+        /std::chrono::microseconds(1);
 }
 
 double elapsed_time(long long startTimeUs, long long stopTimeUs);


### PR DESCRIPTION
sys/time.h is not available on Windows. Use C++11 <chrono> instead so that the tests
compile on Windows.