### PR TITLE
Fixed HIP error check in P2P sample test

### DIFF
--- a/samples/2_Cookbook/8_peer2peer/peer2peer.cpp
+++ b/samples/2_Cookbook/8_peer2peer/peer2peer.cpp
@@ -43,7 +43,7 @@ using namespace std;
 #define HIPCHECK(error)                                                                            \
     {                                                                                              \
         hipError_t localError = error;                                                             \
-        if (localError != hipSuccess) {                                                            \
+        if ((localError != hipSuccess)||(localError != hipErrorPeerAccessAlreadyEnabled)) {        \
             printf("%serror: '%s'(%d) from %s at %s:%d%s\n", KRED, hipGetErrorString(localError),  \
                    localError, #error, __FILE__, __LINE__, KNRM);                                  \
             failed("API returned error code.");                                                    \


### PR DESCRIPTION
Ignore hipErrorPeerAccessAlreadyEnabled and continue with the test.