### PR TITLE
hipcc defaults to HIP-Clang if built with HIP-Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,15 @@ endif()
 message(STATUS "HIP Compiler: " ${HIP_COMPILER})
 add_to_config(_buildInfo HIP_COMPILER)
 
+# Determine HIP_RUNTIME
+# Either HCC or VDI; default is HCC
+if(NOT DEFINED ENV{HIP_RUNTIME})
+    set(HIP_RUNTIME "HCC" CACHE STRING "HIP Runtime")
+else()
+    set(HIP_RUNTIME $ENV{HIP_RUNTIME} CACHE STRING "HIP Runtime")
+endif()
+add_to_config(_buildInfo HIP_RUNTIME)
+
 
 # If HIP_PLATFORM is hcc, we need HCC_HOME and HSA_PATH to be defined
 if(HIP_PLATFORM STREQUAL "hcc")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ if(NOT (HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang"))
     message(FATAL_ERROR "Must use HIP_COMPILER as hcc or clang")
 endif()
 message(STATUS "HIP Compiler: " ${HIP_COMPILER})
+add_to_config(_buildInfo HIP_COMPILER)
 
 
 # If HIP_PLATFORM is hcc, we need HCC_HOME and HSA_PATH to be defined

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -58,8 +58,8 @@ $HIPCC_LINK_FLAGS_APPEND=$ENV{'HIPCC_LINK_FLAGS_APPEND'};
 
 $HIP_PATH=$ENV{'HIP_PATH'} // dirname (dirname $0); # use parent directory of hipcc
 $HIP_VDI_HOME=$ENV{'HIP_VDI_HOME'};
-$HIP_CLANG_PATH=$ENV{'HIP_CLANG_PATH'};
-$DEVICE_LIB_PATH=$ENV{'DEVICE_LIB_PATH'};
+$HIP_CLANG_PATH=$ENV{'HIP_CLANG_PATH'} // "/opt/rocm/llvm/bin";
+$DEVICE_LIB_PATH=$ENV{'DEVICE_LIB_PATH'} // "/opt/rocm/lib";
 $HIP_CLANG_HCC_COMPAT_MODE=$ENV{'HIP_CLANG_HCC_COMPAT_MODE'}; # HCC compatibility mode
 
 #---
@@ -93,6 +93,7 @@ sub delete_temp_dirs {
 $HIP_PLATFORM= `$HIP_PATH/bin/hipconfig --platform` // "hcc";
 $HIP_VERSION= `$HIP_PATH/bin/hipconfig --version`;
 ($HIP_VERSION_MAJOR, $HIP_VERSION_MINOR, $HIP_VERSION_PATCH) = split(/\./, $HIP_VERSION);
+$HIP_COMPILER=$hipConfig{'HIP_COMPILER'};
 
 if (defined $HIP_VDI_HOME) {
     my $bits = "";
@@ -110,7 +111,7 @@ if (defined $HIP_VDI_HOME) {
     $HIP_LIB_PATH = "$HIP_VDI_HOME/lib" . $bits;
 }
 
-if (defined $HIP_CLANG_PATH) {
+if ($HIP_COMPILER eq "clang") {
   $HIP_PLATFORM = "clang"
 }
 

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -58,8 +58,8 @@ $HIPCC_LINK_FLAGS_APPEND=$ENV{'HIPCC_LINK_FLAGS_APPEND'};
 
 $HIP_PATH=$ENV{'HIP_PATH'} // dirname (dirname $0); # use parent directory of hipcc
 $HIP_VDI_HOME=$ENV{'HIP_VDI_HOME'};
-$HIP_CLANG_PATH=$ENV{'HIP_CLANG_PATH'} // "/opt/rocm/llvm/bin";
-$DEVICE_LIB_PATH=$ENV{'DEVICE_LIB_PATH'} // "/opt/rocm/lib";
+$HIP_CLANG_PATH=$ENV{'HIP_CLANG_PATH'};
+$DEVICE_LIB_PATH=$ENV{'DEVICE_LIB_PATH'};
 $HIP_CLANG_HCC_COMPAT_MODE=$ENV{'HIP_CLANG_HCC_COMPAT_MODE'}; # HCC compatibility mode
 
 #---
@@ -93,7 +93,13 @@ sub delete_temp_dirs {
 $HIP_PLATFORM= `$HIP_PATH/bin/hipconfig --platform` // "hcc";
 $HIP_VERSION= `$HIP_PATH/bin/hipconfig --version`;
 ($HIP_VERSION_MAJOR, $HIP_VERSION_MINOR, $HIP_VERSION_PATCH) = split(/\./, $HIP_VERSION);
-$HIP_COMPILER=$hipConfig{'HIP_COMPILER'};
+$HIP_COMPILER= $hipConfig{'HIP_COMPILER'};
+$HIP_RUNTIME= $hipConfig{'HIP_RUNTIME'};
+
+# If using VDI runtime, need to find HIP_VDI_HOME
+if ($HIP_RUNTIME eq "VDI" and !defined $HIP_VDI_HOME) {
+    $HIP_VDI_HOME = "/opt/rocm/hip"
+}
 
 if (defined $HIP_VDI_HOME) {
     my $bits = "";
@@ -112,7 +118,13 @@ if (defined $HIP_VDI_HOME) {
 }
 
 if ($HIP_COMPILER eq "clang") {
-  $HIP_PLATFORM = "clang"
+  $HIP_PLATFORM = "clang";
+  if (!defined $HIP_CLANG_PATH) {
+    $HIP_CLANG_PATH = "/opt/rocm/llvm/bin";
+  }
+  if (!defined $DEVICE_LIB_PATH) {
+    $DEVICE_LIB_PATH = "/opt/rocm/lib";
+  }
 }
 
 if ($verbose & 0x2) {


### PR DESCRIPTION
Add HIP_COMPILER to hipConfig, so that HIP packages built with HIP_COMPILER for HIP-Clang will be known during runtime by hipcc. Also add default locations to check for llvm and device-libs.