### PR TITLE
Revert "Fixed issue of GPU device losing access to host pinned memory"

### DIFF
--- a/src/hip_peer.cpp
+++ b/src/hip_peer.cpp
@@ -129,7 +129,7 @@ hipError_t ihipEnablePeerAccess(hipCtx_t peerCtx, unsigned int flags) {
             LockedAccessor_CtxCrit_t peerCrit(peerCtx->criticalData());
             // Add thisCtx to peerCtx's access list so that new allocations on peer will be made
             // visible to this device:
-            bool isNewPeer = peerCrit->addPeerWatcher(thisCtx, peerCtx);
+            bool isNewPeer = peerCrit->addPeerWatcher(peerCtx, thisCtx);
             if (isNewPeer) {
                 tprintf(DB_MEM, "device=%s can now see all memory allocated on peer=%s\n",
                         thisCtx->toString().c_str(), peerCtx->toString().c_str());


### PR DESCRIPTION
Reverts ROCm-Developer-Tools/HIP#873
@mangupta although this fixed the issue of GPU device losing access to host pinned memory, but this would break actual P2P access. hipDeviceEnablePeerAccess actually adds current device to peer device's watch list.
