### PR TITLE
hipcc should consume -mcode-object-v3 flag

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -300,6 +300,7 @@ my $runCmd = 1;
 my $buildDeps = 0;
 my $linkType = 1;
 my $setLinkType = 0;
+my $useCodeObjectV3 = 0;
 
 my @options = ();
 my @inputs  = ();
@@ -401,6 +402,10 @@ foreach $arg (@ARGV)
     # hip-clang does not accept --amdgpu-target= options.
     if (($arg =~ /--amdgpu-target=/) and $HIP_PLATFORM eq 'clang' ) {
         $swallowArg = 1;
+    }
+
+    if (($trimarg eq '-mcode-object-v3') and ($HIP_PLATFORM eq 'clang') ) {
+        $useCodeObjectV3 = 1;
     }
 
     if (($arg =~ /--genco/) and $HIP_PLATFORM eq 'clang' ) {
@@ -734,6 +739,12 @@ if ($buildDeps and $HIP_PLATFORM eq 'nvcc') {
 
 if ($buildDeps and $HIP_PLATFORM eq 'clang') {
     $HIPCXXFLAGS .= " --cuda-host-only";
+}
+
+if ($useCodeObjectV3 and $HIP_PLATFORM eq 'clang') {
+    $HIPCXXFLAGS .= " -mcode-object-v3";
+} else {
+    $HIPCXXFLAGS .= " -mno-code-object-v3";
 }
 
 # Add --hip-link only if there are no source files.

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -743,7 +743,7 @@ if ($buildDeps and $HIP_PLATFORM eq 'clang') {
 
 if ($useCodeObjectV3 and $HIP_PLATFORM eq 'clang') {
     $HIPCXXFLAGS .= " -mcode-object-v3";
-} else {
+} elsif ($HIP_PLATFORM eq 'clang') {
     $HIPCXXFLAGS .= " -mno-code-object-v3";
 }
 


### PR DESCRIPTION
Allow hipcc to accept the code-object-v3 flag, and pass it to clang. Some changes in clang upstream as well.