### PR TITLE
Allow HIP_LIB_PATH to be overriden at the command line. Use HIP_LIB_P…

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -58,6 +58,7 @@ $HIPCC_LINK_FLAGS_APPEND=$ENV{'HIPCC_LINK_FLAGS_APPEND'};
 
 $HIP_PATH=$ENV{'HIP_PATH'} // dirname (dirname $0); # use parent directory of hipcc
 $HIP_VDI_HOME=$ENV{'HIP_VDI_HOME'};
+$HIP_LIB_PATH=$ENV{'HIP_LIB_PATH'};
 $HIP_CLANG_PATH=$ENV{'HIP_CLANG_PATH'};
 $DEVICE_LIB_PATH=$ENV{'DEVICE_LIB_PATH'};
 $HIP_CLANG_HCC_COMPAT_MODE=$ENV{'HIP_CLANG_HCC_COMPAT_MODE'}; # HCC compatibility mode
@@ -120,7 +121,9 @@ if (defined $HIP_VDI_HOME) {
     }
     $HIP_CLANG_INCLUDE_PATH = "$HIP_VDI_HOME/include/clang";
     $HIP_INCLUDE_PATH = "$HIP_VDI_HOME/include";
-    $HIP_LIB_PATH = "$HIP_VDI_HOME/lib" . $bits;
+    if (!defined $HIP_LIB_PATH) {
+        $HIP_LIB_PATH = "$HIP_VDI_HOME/lib" . $bits;
+    }
 }
 
 if ($HIP_COMPILER eq "clang") {
@@ -754,9 +757,9 @@ if ($setStdLib eq 0 and $HIP_PLATFORM eq 'hcc')
 
 if ($needHipHcc) {
     if ($linkType eq 0) {
-        substr($HIPLDFLAGS,0,0) = "  $HIP_PATH/lib/libhip_hcc_static.a " ;
+        substr($HIPLDFLAGS,0,0) = "  $HIP_LIB_PATH/libhip_hcc_static.a " ;
     } else {
-        substr($HIPLDFLAGS,0,0) = "  -Wl,--rpath=$HIP_PATH/lib $HIP_PATH/lib/libhip_hcc.so ";
+        substr($HIPLDFLAGS,0,0) = "  -Wl,--rpath=$HIP_LIB_PATH $HIP_PATH/lib/libhip_hcc.so ";
     }
 }
 


### PR DESCRIPTION
…ATH for rpath instead of HIP_PATH/lib