### PR TITLE
Remove C++ function templates for hipMalloc and hipHostMalloc

### DIFF
--- a/include/hip/hip_runtime_api.h
+++ b/include/hip/hip_runtime_api.h
@@ -318,9 +318,13 @@ enum hipComputeMode {
  *
  * Perform automatic type conversion to eliminate need for excessive typecasting (ie void**)
  *
+ * __HIP_DISABLE_CPP_FUNCTIONS__ macro can be defined to suppress these
+ * wrappers. It is useful for applications which need to obtain decltypes of
+ * HIP runtime APIs.
+ *
  * @see hipMalloc
  */
-#ifdef __cplusplus
+#if defined(__cplusplus) && !defined(__HIP_DISABLE_CPP_FUNCTIONS__)
 template <class T>
 static inline hipError_t hipMalloc(T** devPtr, size_t size) {
     return hipMalloc((void**)devPtr, size);


### PR DESCRIPTION
This allows hipMalloc and hipHostMalloc be true C functions from application
perspective at compile time, so decltype(hipMalloc) and decltype(hipHostMalloc)
can be computed.

All HIP applications shall now correctly use C-style cast or reinterpret_cast
when invoking hipMalloc and hipHostMalloc.