### PR TITLE
Consume the code obj args to prevent duplicates

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -424,8 +424,14 @@ foreach $arg (@ARGV)
         $swallowArg = 1;
     }
 
+    if (($trimarg eq '-mno-code-object-v3') and ($HIP_PLATFORM eq 'clang') ) {
+        $useCodeObjectV3 = 0;
+        $swallowArg = 1;
+    }
+
     if (($trimarg eq '-mcode-object-v3') and ($HIP_PLATFORM eq 'clang') ) {
         $useCodeObjectV3 = 1;
+        $swallowArg = 1;
     }
 
     if (($arg =~ /--genco/) and $HIP_PLATFORM eq 'clang' ) {


### PR DESCRIPTION
This should prevent duplicate code object arguments being passed into clang, which causes strange behaviour in toolchains' llc arguments.