### PR TITLE
Fix hipBusBW overflow with setting beats/iterations

### DIFF
--- a/samples/1_Utils/hipBusBandwidth/hipBusBandwidth.cpp
+++ b/samples/1_Utils/hipBusBandwidth/hipBusBandwidth.cpp
@@ -205,7 +205,7 @@ void RunBenchmark_H2D(ResultDatabase& resultDB) {
             }
 
             double speed =
-                (double(sizeToBytes(thisSize) * p_beatsperiteration) / (1000 * 1000)) / t;
+                (double(double(sizeToBytes(thisSize)/1000) * p_beatsperiteration) /  1000) / t;
             char sizeStr[256];
             if (p_beatsperiteration > 1) {
                 sprintf(sizeStr, "%9sx%d", sizeToString(thisSize).c_str(), p_beatsperiteration);
@@ -377,7 +377,8 @@ void RunBenchmark_D2H(ResultDatabase& resultDB) {
                 std::cerr << "size " << sizeToString(thisSize) << " took " << t << " ms\n";
             }
 
-            double speed = (double(sizeToBytes(thisSize)) / (1000 * 1000)) / t;
+            double speed =
+                (double(double(sizeToBytes(thisSize)/1000) * p_beatsperiteration) / 1000) / t;
             char sizeStr[256];
             sprintf(sizeStr, "%9s", sizeToString(thisSize).c_str());
             if (p_beatsperiteration > 1) {
@@ -744,7 +745,7 @@ void RunBenchmark_P2P_Unidir(ResultDatabase& resultDB) {
                     }
 
                     double speed =
-                        (double(sizeToBytes(thisSize) * p_beatsperiteration) / (1000 * 1000)) / t;
+                        (double(double(sizeToBytes(thisSize)/1000) * p_beatsperiteration) / 1000) / t;
                     char sizeStr[256];
                     if (p_beatsperiteration > 1) {
                         sprintf(sizeStr, "%9sx%d", sizeToString(thisSize).c_str(),
@@ -867,7 +868,7 @@ void RunBenchmark_P2P_Bidir(ResultDatabase& resultDB) {
                     }
 
                     double speed =
-                        (double(sizeToBytes(2 * thisSize) * p_beatsperiteration) / (1000 * 1000)) /
+                        (double(double(sizeToBytes(2 * thisSize)/1000) * p_beatsperiteration) / 1000) /
                         t;
                     char sizeStr[256];
                     if (p_beatsperiteration > 1) {


### PR DESCRIPTION
Still limited by how big -b (beatsperiterations) can be, though should be good enough for regular use.