### PR TITLE
revert hipcc changes about code object v3

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -763,7 +763,7 @@ if ($buildDeps and $HIP_PLATFORM eq 'clang') {
 
 if ($useCodeObjectV3 and $HIP_PLATFORM eq 'clang') {
     $HIPCXXFLAGS .= " -mcode-object-v3";
-} elsif ($HIP_PLATFORM eq 'clang') {
+} else {
     $HIPCXXFLAGS .= " -mno-code-object-v3";
 }
 

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -320,7 +320,6 @@ my $runCmd = 1;
 my $buildDeps = 0;
 my $linkType = 1;
 my $setLinkType = 0;
-my $useCodeObjectV3 = 0;
 
 my @options = ();
 my @inputs  = ();
@@ -422,10 +421,6 @@ foreach $arg (@ARGV)
     # hip-clang does not accept --amdgpu-target= options.
     if (($arg =~ /--amdgpu-target=/) and $HIP_PLATFORM eq 'clang' ) {
         $swallowArg = 1;
-    }
-
-    if (($trimarg eq '-mcode-object-v3') and ($HIP_PLATFORM eq 'clang') ) {
-        $useCodeObjectV3 = 1;
     }
 
     if (($arg =~ /--genco/) and $HIP_PLATFORM eq 'clang' ) {
@@ -759,12 +754,6 @@ if ($buildDeps and $HIP_PLATFORM eq 'nvcc') {
 
 if ($buildDeps and $HIP_PLATFORM eq 'clang') {
     $HIPCXXFLAGS .= " --cuda-host-only";
-}
-
-if ($useCodeObjectV3 and $HIP_PLATFORM eq 'clang') {
-    $HIPCXXFLAGS .= " -mcode-object-v3";
-} else {
-    $HIPCXXFLAGS .= " -mno-code-object-v3";
 }
 
 # Add --hip-link only if there are no source files.

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -424,14 +424,8 @@ foreach $arg (@ARGV)
         $swallowArg = 1;
     }
 
-    if (($trimarg eq '-mno-code-object-v3') and ($HIP_PLATFORM eq 'clang') ) {
-        $useCodeObjectV3 = 0;
-        $swallowArg = 1;
-    }
-
     if (($trimarg eq '-mcode-object-v3') and ($HIP_PLATFORM eq 'clang') ) {
         $useCodeObjectV3 = 1;
-        $swallowArg = 1;
     }
 
     if (($arg =~ /--genco/) and $HIP_PLATFORM eq 'clang' ) {


### PR DESCRIPTION
We need to revert this since it does not work with llc and caused regressions with rocblas. We need to find some other way to control object v3.