### PR TITLE
Fix PyTorch build failure

### DIFF
--- a/include/hip/hcc_detail/host_defines.h
+++ b/include/hip/hcc_detail/host_defines.h
@@ -85,7 +85,7 @@ THE SOFTWARE.
 #define __global__
 
 #define __noinline__
-#define __forceinline__ inline
+#define __forceinline__
 
 #define __shared__
 #define __constant__


### PR DESCRIPTION
- Duplicated `inline` as PyTorch uses rocRand, which official release
  introducs another `inline`.
- Quick fix but needs more comprehensive solution if this `inline` is
  necessary.