### PR TITLE
[HIPIFY] Change CUDA Driver's functions' cuMemsetD32(Async) mapping

### DIFF
--- a/docs/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -891,8 +891,8 @@
 | `cuMemsetD2D32Async`                                      |                               |
 | `cuMemsetD2D8`                                            |                               |
 | `cuMemsetD2D8Async`                                       |                               |
-| `cuMemsetD32`                                             | `hipMemset`                   |
-| `cuMemsetD32Async`                                        | `hipMemsetAsync`              |
+| `cuMemsetD32`                                             | `hipMemsetD32`                |
+| `cuMemsetD32Async`                                        | `hipMemsetD32Async`           |
 | `cuMemsetD8`                                              | `hipMemsetD8`                 |
 | `cuMemsetD8Async`                                         |                               |
 | `cuMipmappedArrayCreate`                                  |                               |

--- a/hipify-clang/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/hipify-clang/src/CUDA2HIP_Driver_API_functions.cpp
@@ -291,10 +291,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP{
   // no analogue
   {"cuMemsetD2D8Async",                                    {"hipMemsetD2D8Async",                                      "", CONV_MEMORY, API_DRIVER, HIP_UNSUPPORTED}},
   // cudaMemset
-  {"cuMemsetD32",                                          {"hipMemset",                                               "", CONV_MEMORY, API_DRIVER}},
-  {"cuMemsetD32_v2",                                       {"hipMemset",                                               "", CONV_MEMORY, API_DRIVER}},
+  {"cuMemsetD32",                                          {"hipMemsetD32",                                            "", CONV_MEMORY, API_DRIVER}},
+  {"cuMemsetD32_v2",                                       {"hipMemsetD32",                                            "", CONV_MEMORY, API_DRIVER}},
   // cudaMemsetAsync
-  {"cuMemsetD32Async",                                     {"hipMemsetAsync",                                          "", CONV_MEMORY, API_DRIVER}},
+  {"cuMemsetD32Async",                                     {"hipMemsetD32Async",                                       "", CONV_MEMORY, API_DRIVER}},
   // no analogue
   {"cuMemsetD8",                                           {"hipMemsetD8",                                             "", CONV_MEMORY, API_DRIVER}},
   {"cuMemsetD8_v2",                                        {"hipMemsetD8",                                             "", CONV_MEMORY, API_DRIVER}},


### PR DESCRIPTION
cuMemsetD32(Async) -> hipMemsetD32(Async) (was hipMemset(Async))

based on: [#933](https://github.com/ROCm-Developer-Tools/HIP/pull/933)