### PR TITLE
[HIPIFY][tests] Update lit testing infrastructure

### DIFF
--- a/tests/hipify-clang/lit.cfg
+++ b/tests/hipify-clang/lit.cfg
@@ -3,6 +3,7 @@ import os
 import platform
 import re
 import subprocess
+import struct
 
 import lit.formats
 import lit.util
@@ -11,7 +12,14 @@ import lit.util
 site_cfg = lit_config.params.get('site_config', None)
 lit_config.load_config(config, site_cfg)
 
-print("CUDA " + config.cuda_version + " will be used for testing.")
+print(str("========================================"))
+print("CUDA " + config.cuda_version + " - will be used for testing")
+print("LLVM " + config.llvm_version + " - will be used for testing")
+print(platform.machine() + " - Platform architecture")
+print(platform.system() + " " + platform.release() + " - Platform OS")
+print(str(config.pointer_size * 8) + " - hipify-clang binary bitness")
+print(str(struct.calcsize("P") * 8) + " - python " + str(platform.python_version()) + " binary bitness")
+print(str("========================================"))
 
 config.excludes = ['cmdparser.hpp']
 config.excludes.append('spatial_batch_norm_op.h')
@@ -77,6 +85,8 @@ else:
     run_test_ext = ".sh"
     clang_arguments += " -isystem'%s'/samples/common/inc"
 clang_arguments += " -I'%s'/include"
+if config.pointer_size == 8:
+    clang_arguments += " -D__LP64__"
 
 hipify_arguments = "--cuda-path='%s'"
 

--- a/tests/hipify-clang/lit.site.cfg.in
+++ b/tests/hipify-clang/lit.site.cfg.in
@@ -1,6 +1,8 @@
 import sys
 import os
 
+config.pointer_size = @CMAKE_SIZEOF_VOID_P@
+config.llvm_version = "@LLVM_PACKAGE_VERSION@"
 config.llvm_tools_dir = "@LLVM_TOOLS_BINARY_DIR@"
 config.obj_root = "@CMAKE_CURRENT_BINARY_DIR@"
 config.cuda_root = "@CUDA_TOOLKIT_ROOT_DIR@"
@@ -32,4 +34,3 @@ except KeyError:
     e = sys.exc_info()[1]
     key, = e.args
     lit_config.fatal("unable to find %r parameter, use '--param=%s=VALUE'" % (key,key))
-


### PR DESCRIPTION
1. Set -D__LP64__ in case of 64-bit hipify-clang binary [partial workaround for clang's bug [38811](https://bugs.llvm.org/show_bug.cgi?id=38811)]

 ```c++
 C:/GIT/LLVM/trunk/llvm-64-release-vs2017/dist/lib/clang/9.0.0\include\__clang_cuda_device_functions.h(1609,45): error GEF7559A7: no matching function for call to 'roundf'
  __DEVICE__ long lroundf(float __a) { return roundf(__a); }
```
```c++
  #if defined(__LP64__)
  __DEVICE__ long lround(double __a) { return llround(__a); }
  __DEVICE__ long lroundf(float __a) { return llroundf(__a); } // ok: llroundf should be used when 64-bit
  #else
  __DEVICE__ long lround(double __a) { return round(__a); }
  __DEVICE__ long lroundf(float __a) { return roundf(__a); } // error
  #endif
```

2. Print more system info while testing in the following form:
 ```
 ========================================
  CUDA 9.0 - will be used for testing
  LLVM 9.0.0svn - will be used for testing
  AMD64 - Platform architecture
  Windows 10 - Platform OS
  64 - hipify-clang binary bitness
  32 - python 3.7.2 binary bitness
  ========================================
```