### PR TITLE
look for HSA in /opt/rocm instead of /opt/rocm/hsa

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ if(HIP_PLATFORM STREQUAL "hcc")
     # Determine HSA_PATH
     if(NOT DEFINED HSA_PATH)
         if(NOT DEFINED ENV{HSA_PATH})
-            set(HSA_PATH "/opt/rocm/hsa" CACHE PATH "Path to which HSA runtime has been installed")
+            set(HSA_PATH "/opt/rocm" CACHE PATH "Path to which HSA runtime has been installed")
         else()
             set(HSA_PATH $ENV{HSA_PATH} CACHE PATH "Path to which HSA runtime has been installed")
         endif()

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,7 +80,7 @@ For applications and benchmarks outside the directed test environment, developme
 ## Environment Variables
 - **HIP_PATH** : Location of HIP include, src, bin, lib directories.  
 - **HCC_HOME** : Path to HCC compiler.  Default /opt/rocm/hcc.
-- **HSA_PATH** : Path to HSA include, lib.  Default /opt/rocm/hsa.
+- **HSA_PATH** : Path to HSA include, lib.  Default /opt/rocm.
 - **CUDA_PATH* : On nvcc system, this points to root of CUDA installation.
 
 ### Contribution guidelines ###

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -32,7 +32,7 @@ apt-get install hip_hcc
 * Default paths and environment variables:
 
    * By default HIP looks for hcc in /opt/rocm/hcc (can be overridden by setting HCC_HOME environment variable)
-   * By default HIP looks for HSA in /opt/rocm/hsa (can be overridden by setting HSA_PATH environment variable) 
+   * By default HIP looks for HSA in /opt/rocm (can be overridden by setting HSA_PATH environment variable) 
    * By default HIP is installed into /opt/rocm/hip (can be overridden by setting HIP_PATH environment variable).
    * Optionally, consider adding /opt/rocm/bin to your PATH to make it easier to use the tools.
 
@@ -65,7 +65,7 @@ apt-get install hip_hcc
    
 * Default paths and environment variables:
 
-   * By default HIP looks for HSA in /opt/rocm/hsa (can be overridden by setting HSA_PATH environment variable) 
+   * By default HIP looks for HSA in /opt/rocm (can be overridden by setting HSA_PATH environment variable) 
    * By default HIP is installed into /opt/rocm/hip (can be overridden by setting HIP_PATH environment variable).
    * Optionally, consider adding /opt/rocm/bin to your PATH to make it easier to use the tools.
    * Optionally, set HIPCC_VERBOSE=7 to output the command line for compilation to make sure clang is used instead of hcc.
@@ -110,7 +110,7 @@ make install
 
 * Default paths:
   * By default cmake looks for hcc in /opt/rocm/hcc (can be overridden by setting ```-DHCC_HOME=/path/to/hcc``` in the cmake step).*
-  * By default cmake looks for HSA in /opt/rocm/hsa (can be overridden by setting ```-DHSA_PATH=/path/to/hsa``` in the cmake step).*
+  * By default cmake looks for HSA in /opt/rocm (can be overridden by setting ```-DHSA_PATH=/path/to/hsa``` in the cmake step).*
   * By default cmake installs HIP to /opt/rocm/hip (can be overridden by setting ```-DCMAKE_INSTALL_PREFIX=/where/to/install/hip``` in the cmake step).*
 
 Here's a richer command-line that overrides the default paths:

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -23,7 +23,7 @@ use Cwd 'abs_path';
 # HIP_PATH  : Path to HIP directory, default is one dir level above location of this script
 # CUDA_PATH : Path to CUDA SDK (default /usr/local/cuda). Used on NVIDIA platforms only.
 # HCC_HOME  : Path to HCC SDK (default /opt/rocm/hcc).  Used on AMD platforms only.
-# HSA_PATH  : Path to HSA dir (default /opt/rocm/hsa).  Used on AMD platforms only.
+# HSA_PATH  : Path to HSA dir (default /opt/rocm).  Used on AMD platforms only.
 # HIP_VDI_HOME : Path to HIP/VDI directory. Used on AMD platforms only.
 
 if(scalar @ARGV == 0){
@@ -209,7 +209,7 @@ if ($HIP_PLATFORM eq "clang") {
     if (! defined $HIP_LIB_PATH) {
         $HIP_LIB_PATH = "$HIP_PATH/lib";
     }
-    $HSA_PATH=$ENV{'HSA_PATH'} // "/opt/rocm/hsa";
+    $HSA_PATH=$ENV{'HSA_PATH'} // "/opt/rocm";
 
     $HCC_HOME=$ENV{'HCC_HOME'} // $hipConfig{'HCC_HOME'} // "/opt/rocm/hcc";
 

--- a/bin/hipconfig
+++ b/bin/hipconfig
@@ -73,7 +73,7 @@ sub can_run {
 
 $CUDA_PATH=$ENV{'CUDA_PATH'} // '/usr/local/cuda';
 $HCC_HOME=$ENV{'HCC_HOME'} // '/opt/rocm/hcc';
-$HSA_PATH=$ENV{'HSA_PATH'} // '/opt/rocm/hsa';
+$HSA_PATH=$ENV{'HSA_PATH'} // '/opt/rocm';
 
 #---
 #HIP_PLATFORM controls whether to use NVCC or HCC for compilation:

--- a/packaging/hip-targets.cmake
+++ b/packaging/hip-targets.cmake
@@ -45,16 +45,16 @@ set(_IMPORT_PREFIX "/opt/rocm/hip")
 add_library(hip::hip_hcc_static STATIC IMPORTED)
 
 set_target_properties(hip::hip_hcc_static PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;/opt/rocm/hsa/include"
-  INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;/opt/rocm/hsa/include"
+  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;/opt/rocm/include"
+  INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;/opt/rocm/include"
 )
 
 # Create imported target hip::hip_hcc
 add_library(hip::hip_hcc SHARED IMPORTED)
 
 set_target_properties(hip::hip_hcc PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;/opt/rocm/hsa/include"
-  INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;/opt/rocm/hsa/include"
+  INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;/opt/rocm/include"
+  INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/include;/opt/rocm/include"
 )
 
 # Create imported target hip::host


### PR DESCRIPTION
The directory /opt/rocm/hsa/lib does not contain a symlink named libhsa-runtime64.so, but it is present in /opt/rocm/lib. General opinion seems to be that /opt/rocm should be treated as the base for all components of ROCm, including HSA.