### PR TITLE
Avoid double mapping of devices to hostMalloc buffer

### DIFF
--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -339,15 +339,19 @@ hipError_t hipHostMalloc(void** ptr, size_t sizeBytes, unsigned int flags) {
             hip_status = hipErrorInvalidValue;
         } else {
             auto device = ctx->getWriteableDevice();
-
+#if (__hcc_workweek__ >= 19115)
+            //Avoid mapping host pinned memory to all devices by HCC
+            unsigned amFlags = amHostUnmapped;
+#else
             unsigned amFlags = 0;
+#endif
             if (flags & hipHostMallocCoherent) {
-                amFlags = amHostCoherent;
+                amFlags |= amHostCoherent;
             } else if (flags & hipHostMallocNonCoherent) {
-                amFlags = amHostNonCoherent;
+                amFlags |= amHostNonCoherent;
             } else {
                 // depends on env variables:
-                amFlags = HIP_HOST_COHERENT ? amHostCoherent : amHostNonCoherent;
+                amFlags |= HIP_HOST_COHERENT ? amHostCoherent : amHostNonCoherent;
             }
 
 

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -357,7 +357,7 @@ hipError_t hipHostMalloc(void** ptr, size_t sizeBytes, unsigned int flags) {
 
             *ptr = hip_internal::allocAndSharePtr(
                 (amFlags & amHostCoherent) ? "finegrained_host" : "pinned_host", sizeBytes, ctx,
-                (trueFlags & hipHostMallocPortable) /*shareWithAll*/, amFlags, flags, 0);
+                true  /*shareWithAll*/, amFlags, flags, 0);
 
             if (sizeBytes && (*ptr == NULL)) {
                 hip_status = hipErrorMemoryAllocation;


### PR DESCRIPTION
Avoid double mapping of devices to hostMalloc buffer