### PR TITLE
load program state once per agent

### DIFF
--- a/include/hip/hcc_detail/functional_grid_launch.hpp
+++ b/include/hip/hcc_detail/functional_grid_launch.hpp
@@ -162,7 +162,8 @@ void hipLaunchKernelGGLImpl(
     if (it == functions(agent).cend()) {
         hip_throw(std::runtime_error{
             "No device code available for function: " +
-            name(function_address)});
+            name(function_address) +
+            ", for agent: " + name(agent)});
     }
 
     hipModuleLaunchKernel(it->second, numBlocks.x, numBlocks.y, numBlocks.z,

--- a/include/hip/hcc_detail/functional_grid_launch.hpp
+++ b/include/hip/hcc_detail/functional_grid_launch.hpp
@@ -155,30 +155,17 @@ void hipLaunchKernelGGLImpl(
     std::uint32_t sharedMemBytes,
     hipStream_t stream,
     void** kernarg) {
-    auto it0 = functions().find(function_address);
 
-    if (it0 == functions().cend()) {
+    auto agent = target_agent(stream);
+    auto it = functions(agent).find(function_address);
+
+    if (it == functions(agent).cend()) {
         hip_throw(std::runtime_error{
             "No device code available for function: " +
             name(function_address)});
     }
 
-    auto agent = target_agent(stream);
-
-    const auto it1 = std::find_if(
-        it0->second.cbegin(),
-        it0->second.cend(),
-        [=](const std::pair<hsa_agent_t, Kernel_descriptor>& x) {
-        return x.first == agent;
-    });
-
-    if (it1 == it0->second.cend()) {
-        hip_throw(std::runtime_error{
-            "No code available for function: " + name(function_address) +
-            ", for agent: " + name(agent)});
-    }
-
-    hipModuleLaunchKernel(it1->second, numBlocks.x, numBlocks.y, numBlocks.z,
+    hipModuleLaunchKernel(it->second, numBlocks.x, numBlocks.y, numBlocks.z,
                           dimBlocks.x, dimBlocks.y, dimBlocks.z, sharedMemBytes,
                           stream, nullptr, kernarg);
 }

--- a/include/hip/hcc_detail/hip_runtime_api.h
+++ b/include/hip/hcc_detail/hip_runtime_api.h
@@ -2659,30 +2659,33 @@ inline
 __attribute__((visibility("hidden")))
 hipError_t read_agent_global_from_process(hipDeviceptr_t* dptr, size_t* bytes,
                                           const char* name) {
-    static std::unordered_map<
-        hsa_agent_t, std::vector<Agent_global>> agent_globals;
+    static std::unordered_map<hsa_agent_t, std::pair<std::once_flag,
+        std::vector<Agent_global>>> agent_globals;
     static std::once_flag f;
+    auto agent = this_agent();
 
     std::call_once(f, []() {
-        for (auto&& agent_executables : executables()) {
-            std::vector<Agent_global> tmp0;
-            for (auto&& executable : agent_executables.second) {
-                auto tmp1 = read_agent_globals(agent_executables.first,
-                                               executable);
-
-                tmp0.insert(tmp0.end(), make_move_iterator(tmp1.begin()),
-                            make_move_iterator(tmp1.end()));
-            }
-            agent_globals.emplace(agent_executables.first, move(tmp0));
+        for (auto&& agent : hip_impl::all_hsa_agents()) {
+            agent_globals[agent].second.clear();
         }
     });
 
-    const auto it = agent_globals.find(this_agent());
+    std::call_once(agent_globals[agent].first, [](hsa_agent_t agent) {
+        std::vector<Agent_global> tmp0;
+        for (auto&& executable : executables(agent)) {
+            auto tmp1 = read_agent_globals(agent, executable);
+            tmp0.insert(tmp0.end(), make_move_iterator(tmp1.begin()),
+                        make_move_iterator(tmp1.end()));
+        }
+        agent_globals[agent].second = move(tmp0);
+    }, agent);
+
+    const auto it = agent_globals.find(agent);
 
     if (it == agent_globals.cend()) return hipErrorNotInitialized;
 
-    std::tie(*dptr, *bytes) = read_global_description(it->second.cbegin(),
-                                                      it->second.cend(), name);
+    std::tie(*dptr, *bytes) = read_global_description(it->second.second.cbegin(),
+                                                      it->second.second.cend(), name);
 
     return *dptr ? hipSuccess : hipErrorNotFound;
 }

--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -490,21 +490,12 @@ hipError_t hipFuncGetAttributes(hipFuncAttributes* attr, const void* func)
     if (!attr) return hipErrorInvalidValue;
     if (!func) return hipErrorInvalidDeviceFunction;
 
-    const auto it0 = functions().find(reinterpret_cast<uintptr_t>(func));
-
-    if (it0 == functions().cend()) return hipErrorInvalidDeviceFunction;
-
     auto agent = this_agent();
-    const auto it1 = find_if(
-        it0->second.cbegin(),
-        it0->second.cend(),
-        [=](const pair<hsa_agent_t, Kernel_descriptor>& x) {
-        return x.first == agent;
-    });
+    const auto it = functions(agent).find(reinterpret_cast<uintptr_t>(func));
 
-    if (it1 == it0->second.cend()) return hipErrorInvalidDeviceFunction;
+    if (it == functions(agent).cend()) return hipErrorInvalidDeviceFunction;
 
-    const auto header = static_cast<hipFunction_t>(it1->second)->_header;
+    const auto header = static_cast<hipFunction_t>(it->second)->_header;
 
     if (!header) throw runtime_error{"Ill-formed Kernel_descriptor."};
 


### PR DESCRIPTION
This replaces #985.  Any function in `program_state.hpp` that previously iterated over all agents has been converted to instead take a single hsa_agent_t parameter.  This results in program state becoming explicitly initialized once and only once for the requested agent, without the side effect of loading state for the remaining agents.

This change also resulted in simpler code for `hipLaunchKernelGGLImpl` and `hipFuncGetAttributes`.