### PR TITLE
Feature: launch kernel with status code

### DIFF
--- a/include/hip/hcc_detail/functional_grid_launch.hpp
+++ b/include/hip/hcc_detail/functional_grid_launch.hpp
@@ -175,28 +175,6 @@ hipError_t hipLaunchKernelGGLImpl(
 
 template <typename... Args, typename F = void (*)(Args...)>
 inline
-void hipLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& dimBlocks,
-                        std::uint32_t sharedMemBytes, hipStream_t stream,
-                        Args... args) {
-    hip_impl::hip_init();
-    auto kernarg = hip_impl::make_kernarg(
-        kernel, std::tuple<Args...>{std::move(args)...});
-    std::size_t kernarg_size = kernarg.size();
-
-    void* config[]{
-        HIP_LAUNCH_PARAM_BUFFER_POINTER,
-        kernarg.data(),
-        HIP_LAUNCH_PARAM_BUFFER_SIZE,
-        &kernarg_size,
-        HIP_LAUNCH_PARAM_END};
-
-    hip_impl::hipLaunchKernelGGLImpl(reinterpret_cast<std::uintptr_t>(kernel),
-                                     numBlocks, dimBlocks, sharedMemBytes,
-                                     stream, &config[0]);
-}
-
-template <typename... Args, typename F = void (*)(Args...)>
-inline
 hipError_t hipLaunchKernelGGLEx(F kernel, const dim3& numBlocks,
                                 const dim3& dimBlocks,
                                 std::uint32_t sharedMemBytes,
@@ -216,6 +194,15 @@ hipError_t hipLaunchKernelGGLEx(F kernel, const dim3& numBlocks,
     return hip_impl::hipLaunchKernelGGLImpl(reinterpret_cast<std::uintptr_t>(kernel),
                                             numBlocks, dimBlocks, sharedMemBytes,
                                             stream, &config[0]);
+}
+
+template <typename... Args, typename F = void (*)(Args...)>
+inline
+void hipLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& dimBlocks,
+                        std::uint32_t sharedMemBytes, hipStream_t stream,
+                        Args... args) {
+    hipLaunchKernelGGLEx(kernel, numBlocks, dimBlocks, sharedMemBytes, stream,
+                         std::move(args)...);
 }
 
 template <typename... Args, typename F = void (*)(hipLaunchParm, Args...)>

--- a/tests/src/kernel/hipLaunchKernelGGLEx.cpp
+++ b/tests/src/kernel/hipLaunchKernelGGLEx.cpp
@@ -18,7 +18,7 @@ THE SOFTWARE.
 */
 
 /* HIT_START
- * BUILD: %t %s ../test_common.cpp
+ * BUILD: %t %s ../test_common.cpp EXCLUDE_HIP_PLATFORM nvcc
  * RUN: %t
  * HIT_END
  */

--- a/tests/src/kernel/hipLaunchKernelGGLEx.cpp
+++ b/tests/src/kernel/hipLaunchKernelGGLEx.cpp
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2015-2017 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/* HIT_START
+ * BUILD: %t %s ../test_common.cpp
+ * RUN: %t
+ * HIT_END
+ */
+
+#include "test_common.h"
+
+__global__ void Empty(int param) {}
+
+int main() {
+    HIPCHECK(hipLaunchKernelGGLEx(HIP_KERNEL_NAME(Empty), dim3(1), dim3(1), 0, 0, 0));
+    HIPCHECK(hipDeviceSynchronize());
+    passed();
+}


### PR DESCRIPTION
To support client applications which requires understanding if a kernel has been dispatched, introducing `hipLaunchKernelGGLEx` in this PR, plus supplying a new test case to check this new interface.

It can be discussed whether to change existing `hipLaunchKernelGGL` to return `hipError_t`.

I add a new API so it becomes less intrusive to existing HIP clients.