### PR TITLE
Fix hip-config.cmake for hip-clang

### DIFF
--- a/hip-config-clang.cmake.in
+++ b/hip-config-clang.cmake.in
@@ -39,6 +39,8 @@ if (NOT _CMakeFindDependencyMacro_FOUND)
   endmacro()
 endif()
 
+set(HIP_COMPILER "@HIP_COMPILER@")
+set(HIP_RUNTIME "@HIP_RUNTIME@")
 
 set_and_check( hip_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@" )
 set_and_check( hip_INCLUDE_DIRS "${hip_INCLUDE_DIR}" )

--- a/hip-config-hcc.cmake.in
+++ b/hip-config-hcc.cmake.in
@@ -39,6 +39,8 @@ if (NOT _CMakeFindDependencyMacro_FOUND)
   endmacro()
 endif()
 
+set(HIP_COMPILER "@HIP_COMPILER@")
+set(HIP_RUNTIME "@HIP_RUNTIME@")
 
 set_and_check( hip_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@" )
 set_and_check( hip_INCLUDE_DIRS "${hip_INCLUDE_DIR}" )


### PR DESCRIPTION
Define HIP_COMPILER and HIP_RUNTIME in hip-config.cmake to
facilitate other packages identify hip-clang and HIP/VDI
runtime.