### PR TITLE
add little changes in hip_runtime_api.h to work with c language

### DIFF
--- a/include/hip/hcc_detail/hip_runtime_api.h
+++ b/include/hip/hcc_detail/hip_runtime_api.h
@@ -2528,7 +2528,7 @@ hipError_t hipModuleLoad(hipModule_t* module, const char* fname);
 
 hipError_t hipModuleUnload(hipModule_t module);
 
-/**/
+/**
  * @brief Function with kname will be extracted if present in module
  *
  * @param [in] module


### PR DESCRIPTION
Update /hcc_detail/hip_runtime_api.h

when i try to use mpicc or gcc to compile a c language code which call some hip runtime api , error occurred as
> /path/to/hcc_detail/hip_runtime_api.h:2268:33: error: unknown type name ‘hipFuncAttributes’; 
> hipFuncGetAttributes(hipFuncAttributes* attr, const void* func);
 
add ' struct ' for the first parameter of hipFuncGetAttributes will get ride of this problem.