### PR TITLE
In hipFree, synchronize owner of memory

### DIFF
--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -91,6 +91,7 @@ int HIP_EVENT_SYS_RELEASE = 0;
 int HIP_HOST_COHERENT = 1;
 
 int HIP_SYNC_HOST_ALLOC = 1;
+int HIP_SYNC_FREE = 0;
 
 
 int HIP_INIT_ALLOC = -1;
@@ -1281,6 +1282,8 @@ void HipReadEnv() {
 
     READ_ENV_I(release, HIP_SYNC_STREAM_WAIT, 0, "hipStreamWaitEvent will synchronize to host");
 
+    READ_ENV_I(release, HIP_SYNC_FREE, 0,
+               "Force all calls to hipFree to sync all devices and all streams");
 
     READ_ENV_I(release, HIP_HOST_COHERENT, 0,
                "If set, all host memory will be allocated as fine-grained system memory.  This "

--- a/src/hip_hcc_internal.h
+++ b/src/hip_hcc_internal.h
@@ -83,6 +83,8 @@ extern int HIP_SYNC_NULL_STREAM;
 extern int HIP_INIT_ALLOC;
 extern int HIP_FORCE_NULL_STREAM;
 
+extern int HIP_SYNC_FREE;
+
 extern int HIP_DUMP_CODE_OBJECT;
 
 // TODO - remove when this is standard behavior.

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1897,19 +1897,29 @@ hipError_t hipFree(void* ptr) {
         am_status_t status = hc::am_memtracker_getinfo(&amPointerInfo, ptr);
         if (status == AM_SUCCESS) {
             if (amPointerInfo._hostPointer == NULL) {
-                ihipCtx_t* ctx;
-                if (amPointerInfo._appId != -1) {
-#if USE_APP_PTR_FOR_CTX
-                    ctx = static_cast<ihipCtx_t*>(amPointerInfo._appPtr);
-#else
-                    ctx = ihipGetPrimaryCtx(amPointerInfo._appId);
-#endif
-                } else {
-                    ctx = ihipGetTlsDefaultCtx();
+                if (HIP_SYNC_FREE) {
+                    // Synchronize all devices, all streams
+                    // to ensure all work has finished on all devices.
+                    // This is disabled by default.
+                    for (unsigned i = 0; i < g_deviceCnt; i++) {
+                        ihipGetPrimaryCtx(i)->locked_waitAllStreams();
+                    }
                 }
-                // Synchronize to ensure all work has finished.
-                ctx->locked_waitAllStreams();  // ignores non-blocking streams, this waits
-                                               // for all activity to finish.
+                else {
+                    ihipCtx_t* ctx;
+                    if (amPointerInfo._appId != -1) {
+#if USE_APP_PTR_FOR_CTX
+                        ctx = static_cast<ihipCtx_t*>(amPointerInfo._appPtr);
+#else
+                        ctx = ihipGetPrimaryCtx(amPointerInfo._appId);
+#endif
+                    } else {
+                        ctx = ihipGetTlsDefaultCtx();
+                    }
+                    // Synchronize to ensure all work has finished on device owning the memory.
+                    ctx->locked_waitAllStreams();  // ignores non-blocking streams, this waits
+                                                   // for all activity to finish.
+                }
                 hc::am_free(ptr);
                 hipStatus = hipSuccess;
             }

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1897,22 +1897,19 @@ hipError_t hipFree(void* ptr) {
         am_status_t status = hc::am_memtracker_getinfo(&amPointerInfo, ptr);
         if (status == AM_SUCCESS) {
             if (amPointerInfo._hostPointer == NULL) {
+                ihipCtx_t* ctx;
                 if (amPointerInfo._appId != -1) {
-                    ihipCtx_t* ctx;
 #if USE_APP_PTR_FOR_CTX
                     ctx = static_cast<ihipCtx_t*>(amPointerInfo._appPtr);
 #else
                     ctx = ihipGetPrimaryCtx(amPointerInfo._appId);
 #endif
-                    // Synchronize to ensure all work has finished on device owning the memory.
-                    ctx->locked_waitAllStreams();  // ignores non-blocking streams, this waits
-                                                   // for all activity to finish.
                 } else {
-                    // Synchronize to ensure all work has finished on all devices.
-                    for (unsigned i = 0; i < g_deviceCnt; i++) {
-                        ihipGetPrimaryCtx(i)->locked_waitAllStreams();
-                    }
+                    ctx = ihipGetTlsDefaultCtx();
                 }
+                // Synchronize to ensure all work has finished.
+                ctx->locked_waitAllStreams();  // ignores non-blocking streams, this waits
+                                               // for all activity to finish.
                 hc::am_free(ptr);
                 hipStatus = hipSuccess;
             }


### PR DESCRIPTION
This changes the behavior from synchronizing the currently set TLS device.