### PR TITLE
Fix for __ffsll() device functions.

### DIFF
--- a/include/hip/hcc_detail/device_functions.h
+++ b/include/hip/hcc_detail/device_functions.h
@@ -58,7 +58,7 @@ __device__ static inline unsigned int __ffs(unsigned int input) {
 }
 
 __device__ static inline unsigned int __ffsll(unsigned long long int input) {
-    return ( input == 0 ? -1 : __builtin_ctzl(input) ) + 1;
+    return ( input == 0 ? -1 : __builtin_ctzll(input) ) + 1;
 }
 
 __device__ static inline unsigned int __ffs(int input) {
@@ -66,7 +66,7 @@ __device__ static inline unsigned int __ffs(int input) {
 }
 
 __device__ static inline unsigned int __ffsll(long long int input) {
-    return ( input == 0 ? -1 : __builtin_ctzl(input) ) + 1;
+    return ( input == 0 ? -1 : __builtin_ctzll(input) ) + 1;
 }
 
 __device__ static inline unsigned int __brev(unsigned int input) {


### PR DESCRIPTION
Use __builtin_ctzll() intrinsic in the __ffsll() implementation instead of __builtin_ctzl().