### PR TITLE
introduce hostcall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.4.3)
 project(hip)
 
+# Threads are are required by the hostcall tests. The check uses the
+# system compiler, but it is affected by CMAKE_CXX_FLAGS. Later parts
+# of this file add flags like "-hc", which cause the system compiler
+# to error out.
+find_package(Threads)
+
 #############################
 # Options
 #############################
@@ -217,6 +223,12 @@ if(HIP_PLATFORM STREQUAL "hcc")
         set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DCOMPILE_HIP_ATP_MARKER=1")
     endif()
 
+    # FIXME: Make this a required package ASAP
+    find_package(amd_hostcall)
+    if (${amd_hostcall_FOUND})
+        set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DWITH_HOSTCALL")
+    endif()
+
     # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
     set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_PATCH}")
 
@@ -269,6 +281,11 @@ if(HIP_PLATFORM STREQUAL "hcc")
             hiprtc SYSTEM
                 PRIVATE ${PROJECT_SOURCE_DIR}/include ${HSA_PATH}/include)
         target_link_libraries(hiprtc PUBLIC stdc++fs)
+    endif()
+
+    if (${amd_hostcall_FOUND})
+        target_link_libraries(hip_hcc PRIVATE amd_hostcall)
+        target_link_libraries(hip_hcc_static PRIVATE amd_hostcall)
     endif()
 
     string(REPLACE " " ";" HCC_CXX_FLAGS_LIST ${HCC_CXX_FLAGS})
@@ -493,6 +510,17 @@ if(${RUN_HIT} EQUAL 0)
 
     # Add custom target: check
     add_custom_target(check COMMAND "${CMAKE_COMMAND}" --build . --target test DEPENDS build_tests)
+
+    # Add independent tests for hostcall
+    if (${amd_hostcall_FOUND})
+        if(${Threads_FOUND})
+            add_custom_target(hostcall_tests)
+            add_subdirectory(${HIP_SRC_PATH}/tests/hostcall EXCLUDE_FROM_ALL)
+            add_dependencies(build_tests hostcall_tests)
+        else()
+            message(STATUS "Disbled hostcall tests; thread library not found.")
+        endif()
+    endif()
 else()
     message(STATUS "Testing targets will not be available. To enable them please ensure that the HIP installation directory is writeable. Use -DCMAKE_INSTALL_PREFIX to specify a suitable location")
 endif()

--- a/include/hip/hcc_detail/grid_launch.h
+++ b/include/hip/hcc_detail/grid_launch.h
@@ -62,6 +62,8 @@ typedef struct grid_launch_parm
   //! waiting on younger commands.
   hc::completion_future *cf;
 
+  void *hostcall_buffer;
+
   grid_launch_parm() = default;
 } grid_launch_parm;
 

--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -40,6 +40,10 @@ THE SOFTWARE.
 #include <atomic>
 #include <mutex>
 
+#ifdef WITH_HOSTCALL
+#include <amd_hostcall.h>
+#endif // WITH_HOSTCALL
+
 #include <hc.hpp>
 #include <hc_am.hpp>
 #include "hsa/hsa_ext_amd.h"
@@ -138,6 +142,103 @@ std::atomic<int> g_lastShortTid(1);
 //
 std::vector<ProfTrigger> g_dbStartTriggers;
 std::vector<ProfTrigger> g_dbStopTriggers;
+
+#ifdef WITH_HOSTCALL
+//=================================================================================================
+// Hostcall global state; destructed on application exit
+//=================================================================================================
+
+class hostcallState {
+    amd_hostcall_consumer_t *consumer;
+    std::unordered_multimap<const void*, void*> deviceQueues;
+    std::unordered_map<void*, void*> buffers;
+    std::mutex _mutex;
+
+    // Functions with suffix _internal do not try to obtain a
+    // lock. They should be called from a context where the critical
+    // data is already locked.
+    void removeBuffer_internal(void *queue) {
+        auto buffer = findBuffer_internal(queue);
+        if (!buffer)
+            return;
+        amd_hostcall_deregister_buffer(consumer, buffer);
+        buffers.erase(queue);
+
+        tprintf(DB_SYNC, "discarded hostcall buffer %p for queue %p\n", buffer, queue);
+    }
+
+    void* findBuffer_internal(void *queue) {
+        if (buffers.find(queue) == buffers.end())
+            return nullptr;
+        return buffers[queue];
+    }
+
+public:
+    hostcallState() : consumer(nullptr) {}
+
+    ~hostcallState() {
+        if (consumer) {
+            amd_hostcall_destroy_consumer(consumer);
+        }
+    }
+
+    amd_hostcall_consumer_t* launchConsumer() {
+        std::lock_guard<decltype(_mutex)> lock(_mutex);
+        if (consumer) {
+            throw ihipException(hipErrorInitializationError);
+        }
+        consumer = amd_hostcall_create_consumer();
+        if (!consumer) {
+            throw ihipException(hipErrorInitializationError);
+        }
+        if (amd_hostcall_launch_consumer(consumer) != AMD_HOSTCALL_SUCCESS) {
+            throw ihipException(hipErrorInitializationError);
+        }
+        return consumer;
+    }
+
+    void addBuffer(hc::accelerator_view *av, void *queue, void *buffer) {
+        std::lock_guard<decltype(_mutex)> lock(_mutex);
+        buffers[queue] = buffer;
+        amd_hostcall_register_buffer(consumer, buffer);
+
+        // The view provides a copy of the accelerator, which is not
+        // unique enough to track hostcall buffers allocated on the
+        // same device. Instead, we extract the raw pointer to the
+        // underlying device, which is guarantee to be unique.
+        auto acc = av->get_accelerator();
+        auto device = acc.get_raw_device();
+
+        deviceQueues.insert(std::make_pair(device, queue));
+        tprintf(DB_SYNC, "registered hostcall buffer %p on queue %p for raw device %p\n",
+                buffer, queue, device);
+    }
+
+    void* findBuffer(void *queue) {
+        std::lock_guard<decltype(_mutex)> lock(_mutex);
+        return findBuffer_internal(queue);
+    }
+
+    amd_hostcall_consumer_t *getConsumer() {
+        std::lock_guard<decltype(_mutex)> lock(_mutex);
+        return consumer;
+    }
+
+    void resetDevice(hc::accelerator acc)
+    {
+        std::lock_guard<decltype(_mutex)> lock(_mutex);
+        auto device = acc.get_raw_device();
+        auto queues = deviceQueues.equal_range(device);
+        tprintf(DB_SYNC, "resetting hostcall buffers for raw device %p\n", device);
+        for (auto q = queues.first; q != queues.second; ++q) {
+            removeBuffer_internal(q->second);
+        }
+        deviceQueues.erase(device);
+    }
+};
+
+hostcallState g_hostcallState;
+#endif // WITH_HOSTCALL
 
 //=================================================================================================
 // Thread-local storage:
@@ -563,10 +664,13 @@ void ihipDevice_t::locked_reset() {
     // Obtain mutex access to the device critical data, release by destructor
     LockedAccessor_DeviceCrit_t crit(_criticalData);
 
-
     //---
     // Wait for pending activity to complete?  TODO - check if this is required behavior:
     tprintf(DB_SYNC, "locked_reset waiting for activity to complete.\n");
+
+#ifdef WITH_HOSTCALL
+    g_hostcallState.resetDevice(_acc);
+#endif // WITH_HOSTCALL
 
     // Reset and remove streams:
     // Delete all created streams including the default one.
@@ -976,6 +1080,9 @@ void ihipCtx_t::locked_reset() {
     // FIXME - This is clearly a non-const action!  Is this a context reset or a device reset - maybe should reference count?
     ihipDevice_t *device = getWriteableDevice();
     device->_state = 0;
+
+    // WARNING: If reseting allocated memory, g_hostcallState must also be reset for this device.
+    // See ihipDevice_t::locked_reset() for details.
     am_memtracker_reset(device->_acc);
 #endif
 };
@@ -1367,11 +1474,19 @@ void HipReadEnv() {
 
 
 //---
-// Function called one-time at initialization time to construct a table of all GPU devices.
-// HIP/CUDA uses integer "deviceIds" - these are indexes into this table.
-// AMP maintains a table of accelerators, but some are emulated - ie for debug or CPU.
-// This function creates a vector with only the GPU accelerators.
-// It is called with C++11 call_once, which provided thread-safety.
+// Function called once at initialization time for the following:
+//
+// 1. Construct a table of all GPU devices. HIP/CUDA uses integer
+//    "deviceIds" - these are indexes into this table. AMP maintains a
+//    table of accelerators, but some are emulated - ie for debug or
+//    CPU. This function creates a vector with only the GPU
+//    accelerators.
+//
+// 2. Launch the global hostcall consumer. This runs in a separate
+//    thread, and must be terminated before the application exits.
+//
+// std::call_once is used to ensure thread safety.
+//
 void ihipInit() {
 #if COMPILE_HIP_ATP_MARKER
     amdtInitializeActivityLogger();
@@ -1444,6 +1559,9 @@ void ihipInit() {
             g_numLogicalThreads);
 
     g_initDeviceFound = true;
+#ifdef WITH_HOSTCALL
+    auto consumer = g_hostcallState.launchConsumer();
+#endif // WITH_HOSTCALL
 }
 
 namespace hip_impl {
@@ -1575,6 +1693,77 @@ void ihipPrintKernelLaunch(const char* kernelName, const grid_launch_parm* lp,
     }
 }
 
+#ifdef WITH_HOSTCALL
+uint32_t
+getMinHostcallPackets(void *aptr)
+{
+    auto agent = reinterpret_cast<hsa_agent_t*>(aptr);
+    hsa_device_type_t dtype;
+    if (hsa_agent_get_info(*agent, HSA_AGENT_INFO_DEVICE, &dtype) !=
+        HSA_STATUS_SUCCESS)
+        return 0;
+
+    if (dtype != HSA_DEVICE_TYPE_GPU)
+        return 0;
+
+    uint32_t numCu;
+    if (hsa_agent_get_info(*agent,
+                           (hsa_agent_info_t)
+                               HSA_AMD_AGENT_INFO_COMPUTE_UNIT_COUNT,
+                           &numCu) != HSA_STATUS_SUCCESS)
+        return 0;
+
+    uint32_t waverPerCu;
+    if (hsa_agent_get_info(*agent,
+                           (hsa_agent_info_t)
+                               HSA_AMD_AGENT_INFO_MAX_WAVES_PER_CU,
+                           &waverPerCu) != HSA_STATUS_SUCCESS)
+        return 0;
+
+    return numCu * waverPerCu;
+}
+
+static void*
+createHostcallBuffer(hc::accelerator_view *av)
+{
+    auto num_packets = getMinHostcallPackets(av->get_hsa_agent());
+    if (num_packets == 0) {
+        throw ihipException(hipErrorInitializationError);
+    }
+
+    auto size = amd_hostcall_get_buffer_size(num_packets);
+    auto align = amd_hostcall_get_buffer_alignment();
+
+    auto acc = av->get_accelerator();
+    void *ptr = hc::am_aligned_alloc(size, acc, amHostCoherent, align);
+    if (!ptr) {
+        throw ihipException(hipErrorRuntimeMemory);
+    }
+    if (amd_hostcall_initialize_buffer(ptr, num_packets)
+        != AMD_HOSTCALL_SUCCESS) {
+        throw ihipException(hipErrorInitializationError);
+    }
+    tprintf(DB_SYNC, "created hostcall buffer %p with %d packets for raw device %p\n",
+            ptr, num_packets, acc.get_raw_device());
+    return ptr;
+}
+
+#endif // WITH_HOSTCALL
+static void* assignHostcallBuffer(hc::accelerator_view *av, void *hwqueue)
+{
+#ifdef WITH_HOSTCALL
+    void *buffer = g_hostcallState.findBuffer(hwqueue);
+    if (!buffer) {
+        buffer = createHostcallBuffer(av);
+        g_hostcallState.addBuffer(av, hwqueue, buffer);
+    }
+    assert(buffer);
+    return buffer;
+#else
+    return nullptr;
+#endif // WITH_HOSTCALL
+}
+
 // Called just before a kernel is launched from hipLaunchKernel.
 // Allows runtime to track some information about the stream.
 hipStream_t ihipPreLaunchKernel(hipStream_t stream, dim3 grid, dim3 block, grid_launch_parm* lp,
@@ -1592,6 +1781,10 @@ hipStream_t ihipPreLaunchKernel(hipStream_t stream, dim3 grid, dim3 block, grid_
     auto crit = stream->lockopen_preKernelCommand();
     lp->av = &(crit->_av);
     lp->cf = nullptr;
+    void *hwqueue = lp->av->acquire_locked_hsa_queue();
+    lp->hostcall_buffer = assignHostcallBuffer(lp->av, hwqueue);
+    tprintf(DB_SYNC, "using hostcall buffer %p for %s\n",
+            lp->hostcall_buffer, ToString(stream).c_str());
     ihipPrintKernelLaunch(kernelNameStr, lp, stream);
 
     return (stream);
@@ -1615,13 +1808,13 @@ hipStream_t ihipPreLaunchKernel(hipStream_t stream, size_t grid, size_t block, g
     return ihipPreLaunchKernel(stream, dim3(grid), dim3(block), lp, kernelNameStr);
 }
 
-
 //---
 // Called after kernel finishes execution.
 // This releases the lock on the stream.
 void ihipPostLaunchKernel(const char* kernelName, hipStream_t stream, grid_launch_parm& lp) {
     tprintf(DB_SYNC, "ihipPostLaunchKernel, unlocking stream\n");
 
+    lp.av->release_locked_hsa_queue();
     stream->lockclose_postKernelCommand(kernelName, lp.av);
     if (HIP_PROFILE_API) {
         MARKER_END();

--- a/tests/hostcall/.clang-format
+++ b/tests/hostcall/.clang-format
@@ -1,0 +1,6 @@
+AlwaysBreakAfterReturnType: All
+BraceWrapping:
+  AfterFunction:   true
+BreakBeforeBraces: Custom
+IndentWidth:     4
+PenaltyBreakBeforeFirstCallParameter: 300

--- a/tests/hostcall/CMakeLists.txt
+++ b/tests/hostcall/CMakeLists.txt
@@ -1,0 +1,64 @@
+cmake_minimum_required(VERSION 3.4.3)
+
+include(${HIP_SRC_PATH}/cmake/FindHIP.cmake)
+message(STATUS "Using hipcc for hostcall tests: ${HIP_HIPCC_EXECUTABLE}")
+
+# FIXME: The NAMES argument should not be necessary, but the default
+# HSA_PATH /opt/rocm/hsa/lib only contains a versioned
+# library. HSA_PATH should either point to /opt/rocm where lib/
+# contains an unversioned symlink, or /opt/rocm/hsa packaging should
+# be updated.
+#
+# This also requires extra work to detect the filename of the library
+# and pass it as "-l:filename" to the linker.
+find_library(
+    HSA_LIBRARY hsa-runtime64
+    NAMES libhsa-runtime64.so libhsa-runtime64.so.1
+    PATHS ${HSA_PATH}
+    PATH_SUFFIXES lib NO_DEFAULT_PATH)
+if (EXISTS ${HSA_LIBRARY})
+    get_filename_component(HSA_LIB_DIR ${HSA_LIBRARY} DIRECTORY)
+    get_filename_component(HSA_LIBRARY ${HSA_LIBRARY} NAME)
+    message(STATUS "Using HSA runtime for hostcall tests: ${HSA_LIB_DIR}")
+else()
+    message(FATAL_ERROR "*** Cannot find HSA libraries in ${HSA_PATH}")
+endif()
+
+find_path(HSA_HEADER hsa/hsa.h PATHS ${HSA_PATH} PATH_SUFFIXES include NO_DEFAULT_PATH)
+find_path(HSA_HEADER hsa/hsa.h PATHS /opt/rocm PATH_SUFFIXES include)
+if (NOT EXISTS ${HSA_HEADER})
+    message(FATAL_ERROR "*** Cannot find HSA headers in ${HSA_PATH}")
+else()
+    message(STATUS "Using HSA headers for hostcall tests: ${HSA_HEADER}")
+endif()
+
+set(HOSTCALL_TEST_INC ${CMAKE_CURRENT_LIST_DIR})
+
+function(hostcall_add_test retval prefix filename)
+    get_filename_component(basename_we ${filename} NAME_WE)
+    get_filename_component(basename ${filename} NAME)
+    set(testname hostcall-${prefix}-${basename_we})
+    set(${retval} ${testname} PARENT_SCOPE)
+    string(REPLACE "-" "_" testname_str ${testname})
+
+    add_custom_target(
+        ${testname}
+        COMMAND ${HIP_HIPCC_EXECUTABLE} -g
+        -I${HSA_HEADER} -I${HOSTCALL_TEST_INC}
+        -I$<TARGET_PROPERTY:amd_hostcall,INTERFACE_INCLUDE_DIRECTORIES>
+        -L$<TARGET_FILE_DIR:amd_hostcall> -L${HSA_LIB_DIR}
+        -lpthread -l:$<TARGET_FILE_NAME:amd_hostcall> -l:${HSA_LIBRARY}
+        -DTESTNAME=${testname_str}
+        ${filename} -o ${testname}
+        COMMENT "Building ${testname}")
+
+    add_test(${testname} ${testname})
+    add_dependencies(hostcall_tests ${testname})
+endfunction()
+
+file(GLOB files *.cpp)
+foreach(file ${files})
+    hostcall_add_test(testname toplevel ${file})
+endforeach()
+
+add_subdirectory(device EXCLUDE_FROM_ALL)

--- a/tests/hostcall/common.h
+++ b/tests/hostcall/common.h
@@ -1,0 +1,268 @@
+#ifndef COMMON_H
+#define COMMON_H
+
+bool debug_mode;
+#define WHEN_DEBUG(xxx)                                                 \
+    do {                                                                \
+        if (debug_mode) {                                               \
+            xxx;                                                        \
+        }                                                               \
+    } while (false)
+
+static bool parse_options(int argc, char *argv[]) {
+    for (int ii = 1; ii != argc; ++ii) {
+        char *str = argv[ii];
+        if (str[0] != '-')
+            return false;
+        if (str[2])
+            return false;
+        switch (str[1]) {
+        case 'd':
+            debug_mode = true;
+            break;
+        default:
+            return false;
+            break;
+        }
+    }
+
+    return true;
+}
+
+static bool set_flags(int argc, char *argv[]) {
+    debug_mode = false;
+
+    if (!parse_options(argc, argv)) {
+        std::cout << "invalid command-line arguments" << std::endl;
+        return false;
+    }
+
+    return true;
+}
+
+#define KNRM "\x1B[0m"
+#define KRED "\x1B[31m"
+#define KGRN "\x1B[32m"
+
+#define failed(...)                                                     \
+    printf("%serror: ", KRED);                                          \
+    printf(__VA_ARGS__);                                                \
+    printf("\n");                                                       \
+    printf("error: TEST FAILED\n%s", KNRM);                             \
+    abort();
+
+#define test_passed(test_name) printf("%s %s  PASSED!%s\n",             \
+                                      KGRN, test_name, KNRM);
+
+#define runTest(name)                                                   \
+    do {                                                                \
+        uint status = name();                                           \
+        if (status != 0) {                                              \
+            std::cout << "status: " << status << std::endl;             \
+            failed(#name);                                              \
+        }                                                               \
+        hipDeviceReset();                                               \
+    } while (false);                                                    \
+
+#define HIPCHECK(error)                                                 \
+    do {                                                                \
+        hipError_t localError = error;                                  \
+        if ((localError != hipSuccess) &&                               \
+            (localError != hipErrorPeerAccessAlreadyEnabled)) {         \
+            printf("%serror: '%s'(%d) from %s at %s:%d%s\n",            \
+                   KRED, hipGetErrorString(localError),                 \
+                   localError, #error, __FILE__, __LINE__, KNRM);       \
+            failed("API returned error code.");                         \
+        }                                                               \
+    } while (false);
+
+#define TEST_SERVICE 42
+
+extern "C" __device__ HIP_vector_base<long, 2>::Native_vec_
+__ockl_hostcall_internal(void *buffer, uint service_id,
+                         ulong arg0, ulong arg1, ulong arg2, ulong arg3,
+                         ulong arg4, ulong arg5, ulong arg6, ulong arg7);
+
+extern "C" __device__ HIP_vector_base<long, 2>::Native_vec_
+__ockl_hostcall_preview(uint service_id,
+                        ulong arg0, ulong arg1, ulong arg2, ulong arg3,
+                        ulong arg4, ulong arg5, ulong arg6, ulong arg7);
+
+extern "C" __device__ HIP_vector_base<long, 2>::Native_vec_
+__ockl_call_host_function(ulong fptr,
+                          ulong arg0, ulong arg1, ulong arg2, ulong arg3,
+                          ulong arg4, ulong arg5, ulong arg6);
+
+enum {
+    SIGNAL_INIT = UINT64_MAX,
+    SIGNAL_DONE = UINT64_MAX - 1
+};
+
+typedef struct {
+    ulong next;
+    ulong activemask;
+    uint service;
+    uint control;
+} header_t;
+
+enum {
+    PAYLOAD_ALIGNMENT = 64
+};
+
+typedef struct {
+    // 64 slots of 8 ulongs each
+    ulong slots[64][8];
+} payload_t;
+
+typedef struct {
+    header_t *headers;
+    payload_t *payloads;
+    hsa_signal_t doorbell;
+    ulong free_stack;
+    ulong ready_stack;
+    uint index_size;
+} hostcall_buffer_t;
+
+static void
+work_done(hostcall_buffer_t *buffer)
+{
+    hsa_signal_store_release(buffer->doorbell, SIGNAL_DONE);
+}
+
+static ulong get_ptr_tag(ulong ptr, uint index_size) {
+    return ptr >> index_size;
+}
+
+static ulong get_ptr_index(ulong ptr, uint index_size) {
+    ulong mask = 1;
+    mask = (mask << index_size) - 1;
+    return ptr & mask;
+}
+
+static header_t* get_header(hostcall_buffer_t* buffer, ulong ptr) {
+    return buffer->headers + get_ptr_index(ptr, buffer->index_size);
+}
+
+static payload_t* get_payload(hostcall_buffer_t* buffer, ulong ptr) {
+    return buffer->payloads + get_ptr_index(ptr, buffer->index_size);
+}
+
+static uint get_ready_flag(uint control) { return control & 1; }
+
+static uint reset_ready_flag(uint control) { return control & ~1; }
+
+static uint set_ready_flag(uint control) { return control | 1; }
+
+static ulong inc_ptr_tag(ulong ptr, uint index_size) {
+    ulong index = get_ptr_index(ptr, index_size);
+    ulong tag = get_ptr_tag(ptr, index_size);
+    return ((tag + 1) << index_size) | index;
+}
+
+static ulong set_tag(ulong ptr, ulong value, uint index_size)
+{
+    ulong index = get_ptr_index(ptr, index_size);
+    return (value <<= index_size) | index;
+}
+
+static uint align_to(uint value, uint alignment) {
+    if (value % alignment == 0) return value;
+    return value - (value % alignment) + alignment;
+}
+
+static uint
+get_header_start() {
+    return align_to(sizeof(hostcall_buffer_t), alignof(header_t));
+}
+
+static uint
+get_payload_start(uint num_packets) {
+    uint header_start = get_header_start();
+    uint header_end = header_start + sizeof(header_t) * num_packets;
+    return align_to(header_end, PAYLOAD_ALIGNMENT);
+}
+
+static uint
+get_buffer_size(uint num_packets) {
+    uint payload_start = get_payload_start(num_packets);
+    uint payload_size = sizeof(payload_t) * num_packets;
+    return payload_start + payload_size;
+}
+
+static hostcall_buffer_t* createBuffer(uint num_packets, hsa_signal_t signal) {
+    if (num_packets == 0) return nullptr;
+
+    void* buffer;
+    size_t buffer_size = get_buffer_size(num_packets);
+    WHEN_DEBUG(std::cout << "buffer_t size: " << sizeof(hostcall_buffer_t) << std::endl);
+    WHEN_DEBUG(std::cout << "header alignment: " << alignof(header_t) << std::endl);
+    WHEN_DEBUG(std::cout << "header start: " << get_header_start() << std::endl);
+    WHEN_DEBUG(std::cout << "payload alignment: " << PAYLOAD_ALIGNMENT << std::endl);
+    WHEN_DEBUG(std::cout << "payload start: " << get_payload_start(num_packets) << std::endl);
+    WHEN_DEBUG(std::cout << "buffer size: " << buffer_size << std::endl);
+    HIPCHECK(hipHostMalloc(&buffer, buffer_size, hipHostMallocCoherent));
+    memset(buffer, 0, buffer_size);
+
+    hostcall_buffer_t* retval = (hostcall_buffer_t*)buffer;
+    retval->doorbell = signal;
+
+    retval->headers = (header_t*)((uchar*)retval + get_header_start());
+    retval->payloads = (payload_t*)((uchar*)retval + get_payload_start(num_packets));
+
+    uint index_size = 1;
+    if (num_packets > 2)
+        index_size = 32 - __builtin_clz(num_packets);
+    WHEN_DEBUG(std::cout << "num packets: " << num_packets
+               << "; index size: " << index_size << std::endl);
+    retval->index_size = index_size;
+    retval->headers[0].next = 0;
+
+    ulong next = 0;
+    next = inc_ptr_tag(next, index_size);
+    for (uint ii = 1; ii != num_packets; ++ii) {
+        retval->headers[ii].next = next;
+        next = ii;
+    }
+    retval->free_stack = next;
+    WHEN_DEBUG(std::cout << "free stack: " << retval->free_stack << std::endl);
+    WHEN_DEBUG(std::cout << "next free: " << retval->headers[0].next << std::endl);
+
+    retval->ready_stack = 0;
+
+    return retval;
+}
+
+static bool
+timeout(hipEvent_t mark, uint millisecs) {
+    using std::chrono::system_clock;
+    system_clock::time_point start = system_clock::now();
+    while (hipEventQuery(mark) != hipSuccess) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        system_clock::time_point now = system_clock::now();
+        if (now - start > std::chrono::milliseconds(500)) {
+            WHEN_DEBUG(std::cout << "host timed out" << std::endl);
+            return true;
+        }
+    }
+    return false;
+}
+
+static ulong
+wait_on_signal(hsa_signal_t doorbell, ulong timeout, ulong old_value)
+{
+    WHEN_DEBUG(std::cout << std::endl << "old signal value: "
+               << (int64_t)old_value << std::endl);
+
+    while (true) {
+        auto new_value =
+            hsa_signal_wait_scacquire(doorbell, HSA_SIGNAL_CONDITION_NE,
+                                      old_value, timeout,
+                                      HSA_WAIT_STATE_BLOCKED);
+        WHEN_DEBUG(std::cout << "\nnew signal value: "
+                   << new_value << std::endl);
+        if (new_value != old_value)
+            return new_value;
+    }
+}
+
+#endif

--- a/tests/hostcall/device/CMakeLists.txt
+++ b/tests/hostcall/device/CMakeLists.txt
@@ -1,0 +1,4 @@
+file(GLOB files *.cpp)
+foreach(file ${files})
+    hostcall_add_test(testname device ${file})
+endforeach()

--- a/tests/hostcall/device/aba-wraparound.cpp
+++ b/tests/hostcall/device/aba-wraparound.cpp
@@ -1,0 +1,164 @@
+/*
+Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+
+#include "common.h"
+
+#define TAG_TO_ZERO 5
+
+static uint
+process_packets(hostcall_buffer_t *buffer, ulong F)
+{
+    WHEN_DEBUG(std::cout << "processing cptr: " << F << std::endl);
+    ulong packet_index = get_ptr_index(F, buffer->index_size);
+    WHEN_DEBUG(std::cout << "packet index: " << packet_index << std::endl);
+    auto header = get_header(buffer, packet_index);
+    WHEN_DEBUG(std::cout << "packet header: " << header << std::endl);
+
+    if (get_ready_flag(header->control) == 0) {
+        return __LINE__;
+    }
+
+    if (header->service != TEST_SERVICE)
+        return __LINE__;
+
+    __atomic_store_n(&header->control, reset_ready_flag(header->control),
+                     std::memory_order_release);
+    return 0;
+}
+
+static ulong
+grab_ready_stack(hostcall_buffer_t *buffer)
+{
+    ulong *top = &buffer->ready_stack;
+    ulong F = __atomic_load_n(top, std::memory_order_acquire);
+    if (!F)
+        return F;
+
+    do {
+        WHEN_DEBUG(std::cout << "trying to grab ready stack: " << std::hex << F
+                             << std::endl);
+    } while (!__atomic_compare_exchange_n(top, &F, 0,
+                                          /* weak = */ false,
+                                          std::memory_order_acquire,
+                                          std::memory_order_relaxed));
+    return F;
+}
+
+static void
+consume_packets(uint *status, hostcall_buffer_t *buffer)
+{
+    *status = 0;
+
+    WHEN_DEBUG(std::cout << "launched consumer" << std::endl);
+    ulong signal_value = SIGNAL_INIT;
+    ulong timeout = 1024 * 1024;
+
+    while (true) {
+        signal_value = wait_on_signal(buffer->doorbell, timeout, signal_value);
+
+        ulong F = grab_ready_stack(buffer);
+        WHEN_DEBUG(std::cout << "grabbed ready stack: " << F << std::endl);
+        if (F) {
+            *status = process_packets(buffer, F);
+            if (*status != 0)
+                return;
+        }
+
+        if (signal_value == SIGNAL_DONE) {
+            *status = 0;
+            return;
+        }
+    }
+
+    *status = __LINE__;
+    return;
+}
+
+__global__ void
+kernelAbaWraparound(void *buffer)
+{
+    uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    ulong arg0 = tid;
+    ulong arg1 = 0;
+    ulong arg2 = 0;
+    ulong arg3 = 0;
+    ulong arg4 = 0;
+    ulong arg5 = 0;
+    ulong arg6 = 0;
+    ulong arg7 = 0;
+
+    for (int i = 0; i != TAG_TO_ZERO + 2; ++i) {
+        __ockl_hostcall_internal(buffer, TEST_SERVICE, arg0, arg1, arg2, arg3,
+                                arg4, arg5, arg6, arg7);
+    }
+}
+
+uint
+testAbaWraparound()
+{
+    uint num_blocks = 1;
+    uint threads_per_block = 64;
+    uint num_packets = 1;
+
+    hsa_signal_t signal;
+    if (hsa_signal_create(SIGNAL_INIT, 0, NULL, &signal) != HSA_STATUS_SUCCESS)
+        return __LINE__;
+
+    hostcall_buffer_t *buffer = createBuffer(num_packets, signal);
+    if (!buffer)
+        return __LINE__;
+    buffer->free_stack =
+        set_tag(buffer->free_stack,
+                UINT64_MAX - TAG_TO_ZERO, buffer->index_size);
+
+    hipLaunchKernelGGL(kernelAbaWraparound, dim3(num_blocks),
+                       dim3(threads_per_block), 0, 0, buffer);
+    hipEvent_t mark;
+    HIPCHECK(hipEventCreate(&mark));
+    HIPCHECK(hipEventRecord(mark));
+
+    uint consumer_status;
+    std::thread consumer_thread(consume_packets, &consumer_status,
+                                buffer);
+
+    bool timed_out = timeout(mark, 500);
+    if (consumer_status)
+        return consumer_status;
+    if (timed_out) {
+        std::cout << "timed out" << std::endl;
+        return __LINE__;
+    }
+
+    work_done(buffer);
+    consumer_thread.join();
+
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    set_flags(argc, argv);
+    runTest(testAbaWraparound);
+    test_passed(__FILE__);
+    return 0;
+}

--- a/tests/hostcall/device/many-threads.cpp
+++ b/tests/hostcall/device/many-threads.cpp
@@ -1,0 +1,250 @@
+/*
+Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+
+#include "common.h"
+
+#include <vector>
+
+static void
+push(ulong *top, ulong ptr, hostcall_buffer_t *buffer)
+{
+    ulong F = __atomic_load_n((ulong *)top, std::memory_order_relaxed);
+    header_t *P = get_header(buffer, ptr);
+    P->next = F;
+
+    while (!__atomic_compare_exchange_n(top, &F, ptr,
+                                        /* weak = */ false,
+                                        std::memory_order_release,
+                                        std::memory_order_relaxed)) {
+        P->next = F;
+    }
+
+    WHEN_DEBUG(std::cout << "pushed free packet: " << ptr << std::endl);
+}
+
+static uint
+handle_packet(ulong *retval, const ulong *payload)
+{
+    *retval = *payload + 1;
+    return 0;
+}
+
+static uint
+process_packets(hostcall_buffer_t *buffer, ulong F)
+{
+    WHEN_DEBUG(std::cout << "process packets starting with " << F << std::endl);
+    std::vector<ulong> R;
+    while (F) {
+        WHEN_DEBUG(std::cout << "found cptr: " << F << std::endl);
+        auto *P = get_header(buffer, F);
+        R.push_back(F);
+        F = P->next;
+    }
+
+    while (!R.empty()) {
+        auto II = R.back();
+        R.pop_back();
+
+        WHEN_DEBUG(std::cout << "processing cptr: " << II << std::endl);
+        ulong packet_index = get_ptr_index(II, buffer->index_size);
+        WHEN_DEBUG(std::cout << "packet index: " << packet_index << std::endl);
+        auto header = get_header(buffer, II);
+
+        if (get_ready_flag(header->control) == 0) {
+            return __LINE__;
+        }
+
+        if (header->service != TEST_SERVICE)
+            return __LINE__;
+
+        ulong activemask = header->activemask;
+        WHEN_DEBUG(std::cout << "activemask: " << std::hex << activemask
+                             << std::dec << std::endl);
+
+        payload_t *payload = get_payload(buffer, II);
+        for (uint wi = 0; wi != 64; ++wi) {
+            ulong flag = activemask & ((ulong)1 << wi);
+            if (flag == 0)
+                continue;
+            auto slot = payload->slots[wi];
+            ulong retval;
+            uint status = handle_packet(&retval, slot);
+            if (status != 0) {
+                return status;
+            }
+            *slot = retval;
+        }
+
+        WHEN_DEBUG(std::cout << "finished processing" << std::endl);
+
+        __atomic_store_n(&header->control, reset_ready_flag(header->control),
+                         std::memory_order_release);
+    }
+
+    return 0;
+}
+
+static ulong
+grab_ready_stack(hostcall_buffer_t *buffer)
+{
+    ulong *top = &buffer->ready_stack;
+    ulong F = __atomic_load_n(top, std::memory_order_acquire);
+    if (!F)
+        return F;
+
+    do {
+        WHEN_DEBUG(std::cout << "trying to grab ready stack: " << F
+                             << std::endl);
+    } while (!__atomic_compare_exchange_n(top, &F, 0,
+                                          /* weak = */ false,
+                                          std::memory_order_acquire,
+                                          std::memory_order_relaxed));
+    return F;
+}
+
+static void
+consume_packets(uint *status, hostcall_buffer_t *buffer)
+{
+    WHEN_DEBUG(std::cout << "launched consumer" << std::endl);
+    ulong signal_value = SIGNAL_INIT;
+    ulong timeout = 1024 * 1024;
+
+    while (true) {
+        signal_value = wait_on_signal(buffer->doorbell, timeout, signal_value);
+
+        ulong F = grab_ready_stack(buffer);
+        WHEN_DEBUG(std::cout << "grabbed ready stack: " << F << std::endl);
+
+        if (F) {
+            *status = process_packets(buffer, F);
+            if (*status != 0) {
+                return;
+            }
+        }
+
+        if (signal_value == SIGNAL_DONE) {
+            *status = 0;
+            return;
+        }
+    }
+
+    return;
+}
+
+__global__ void
+kernelManyThreads(void *buffer, ulong *retval)
+{
+    uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    ulong arg0 = tid;
+    ulong arg1 = 0;
+    ulong arg2 = 0;
+    ulong arg3 = 0;
+    ulong arg4 = 0;
+    ulong arg5 = 0;
+    ulong arg6 = 0;
+    ulong arg7 = 0;
+
+    long2 result = {0, 0};
+    if (tid % 71 != 1) {
+        result.data = __ockl_hostcall_internal(buffer, TEST_SERVICE, arg0, arg1, arg2,
+                                               arg3, arg4, arg5, arg6, arg7);
+        retval[tid] = result.x;
+    }
+}
+
+uint
+testManyThreads()
+{
+    uint num_blocks = 5;
+    uint threads_per_block = 1000;
+    uint warps_per_block = (threads_per_block + 63) / 64;
+    uint num_threads = num_blocks * threads_per_block;
+    uint num_packets = warps_per_block * num_blocks;
+
+    hsa_signal_t signal;
+    if (hsa_signal_create(SIGNAL_INIT, 0, NULL, &signal) != HSA_STATUS_SUCCESS)
+        return __LINE__;
+
+    hostcall_buffer_t *buffer = createBuffer(num_packets, signal);
+    if (!buffer)
+        return __LINE__;
+
+    void *retval_void;
+    if (hipHostMalloc(&retval_void, 8 * num_threads) != hipSuccess)
+        return __LINE__;
+    uint64_t *retval = (uint64_t *)retval_void;
+    for (uint i = 0; i != num_threads; ++i) {
+        retval[i] = 0x23232323;
+    }
+
+    hipLaunchKernelGGL(kernelManyThreads, dim3(num_blocks),
+                       dim3(threads_per_block), 0, 0, buffer, retval);
+    hipEvent_t mark;
+    HIPCHECK(hipEventCreate(&mark));
+    HIPCHECK(hipEventRecord(mark));
+
+    uint consumer_status;
+    std::thread consumer_thread(consume_packets, &consumer_status, buffer);
+
+    uint timeout_status = 0;
+    using std::chrono::system_clock;
+    system_clock::time_point start = system_clock::now();
+    while (hipEventQuery(mark) != hipSuccess) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        system_clock::time_point now = system_clock::now();
+        if (now - start > std::chrono::milliseconds(500)) {
+            WHEN_DEBUG(std::cout << "host timed out" << std::endl);
+            timeout_status = __LINE__;
+            break;
+        }
+    }
+
+    work_done(buffer);
+    consumer_thread.join();
+
+    if (consumer_status)
+        return consumer_status;
+    if (timeout_status)
+        return timeout_status;
+
+    for (uint ii = 0; ii != num_threads; ++ii) {
+        ulong value = retval[ii];
+        if (ii % 71 == 1) {
+            if (value != 0x23232323)
+                return __LINE__;
+        } else {
+            if (value != ii + 1)
+                return __LINE__;
+        }
+    }
+
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    set_flags(argc, argv);
+    runTest(testManyThreads);
+    test_passed(__FILE__);
+    return 0;
+}

--- a/tests/hostcall/device/single-thread.cpp
+++ b/tests/hostcall/device/single-thread.cpp
@@ -1,0 +1,166 @@
+/*
+Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+
+#include "common.h"
+
+__global__ void
+kernelSinglePacketSingleWorkitem(void *buffer, ulong *retval0, ulong *retval1)
+{
+    uint count = 1;
+    ulong arg0 = count++;
+    ulong arg1 = count++;
+    ulong arg2 = count++;
+    ulong arg3 = count++;
+    ulong arg4 = count++;
+    ulong arg5 = count++;
+    ulong arg6 = count++;
+    ulong arg7 = count++;
+
+    long2 result;
+    result.data =
+        __ockl_hostcall_internal(buffer, TEST_SERVICE, arg0, arg1, arg2, arg3,
+                                arg4, arg5, arg6, arg7);
+
+    *retval0 = result.x;
+    *retval1 = result.y;
+}
+
+static uint
+checkSinglePacketSingleWorkitem(hostcall_buffer_t *buffer)
+{
+    wait_on_signal(buffer->doorbell, 1024 * 1024, SIGNAL_INIT);
+    ulong cptr =
+        __atomic_load_n(&buffer->ready_stack, std::memory_order_acquire);
+    if (cptr == 0) {
+        return __LINE__;
+    }
+    WHEN_DEBUG(std::cout << "received packet: " << std::hex << cptr << std::dec
+                         << std::endl);
+    ulong fptr =
+        __atomic_load_n(&buffer->free_stack, std::memory_order_relaxed);
+    WHEN_DEBUG(std::cout << "free stack: " << std::hex << fptr << std::dec
+                         << std::endl);
+    if (fptr != 0)
+        return __LINE__;
+
+    header_t *header = get_header(buffer, cptr);
+    if (header->next != 0)
+        return __LINE__;
+
+    if (get_ready_flag(header->control) == 0)
+        return __LINE__;
+
+    if (header->activemask != 1)
+        return __LINE__;
+    if (header->service != TEST_SERVICE)
+        return __LINE__;
+
+    payload_t *payload = get_payload(buffer, cptr);
+    auto p = payload->slots[0];
+
+    for (int ii = 0; ii != 8; ++ii) {
+        WHEN_DEBUG(std::cout << "payload: " << p[ii] << std::endl);
+        if (p[ii] != ii + 1)
+            return __LINE__;
+    }
+    p[0] = 42;
+    p[1] = 17;
+
+    __atomic_store_n(&header->control, reset_ready_flag(header->control),
+                     std::memory_order_release);
+
+    // wait for the single wave to return its packet
+    ulong F = __atomic_load_n(&buffer->free_stack, std::memory_order_acquire);
+    while (F == fptr) {
+        std::this_thread::sleep_for(std::chrono::microseconds(5));
+        F = __atomic_load_n(&buffer->free_stack, std::memory_order_acquire);
+    }
+    WHEN_DEBUG(std::cout << "new free stack: " << std::hex << F << std::endl);
+    if (F != inc_ptr_tag(cptr, buffer->index_size)) {
+        return __LINE__;
+    }
+
+    return 0;
+}
+
+static uint
+testSinglePacketSingleWorkitem()
+{
+    unsigned int numThreads = 1;
+    unsigned int numBlocks = 1;
+
+    unsigned int numPackets = 1;
+
+    hsa_signal_t signal;
+    if (hsa_signal_create(SIGNAL_INIT, 0, NULL, &signal) != HSA_STATUS_SUCCESS)
+        return __LINE__;
+
+    hostcall_buffer_t *buffer = createBuffer(numPackets, signal);
+    if (!buffer)
+        return __LINE__;
+
+    void *retval0_void;
+    if (hipHostMalloc(&retval0_void, 8) != hipSuccess)
+        return __LINE__;
+    uint64_t *retval0 = (uint64_t *)retval0_void;
+    *retval0 = 0x23232323;
+
+    void *retval1_void;
+    if (hipHostMalloc(&retval1_void, 8) != hipSuccess)
+        return __LINE__;
+    uint64_t *retval1 = (uint64_t *)retval1_void;
+    *retval1 = 0x17171717;
+
+    hipLaunchKernelGGL(kernelSinglePacketSingleWorkitem, dim3(numBlocks),
+                       dim3(numThreads), 0, 0, buffer, retval0, retval1);
+    hipEvent_t start;
+    HIPCHECK(hipEventCreate(&start));
+    HIPCHECK(hipEventRecord(start));
+
+    uint status = checkSinglePacketSingleWorkitem(buffer);
+    WHEN_DEBUG(std::cout << "check status: " << std::dec << status << std::endl);
+    if (status != 0)
+        return status;
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    if (hipEventQuery(start) != hipSuccess) {
+        return __LINE__;
+    }
+
+    HIPCHECK(hipDeviceSynchronize());
+    if (*retval0 != 42)
+        return __LINE__;
+
+    if (*retval1 != 17)
+        return __LINE__;
+
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    set_flags(argc, argv);
+    runTest(testSinglePacketSingleWorkitem);
+    test_passed(__FILE__);
+    return 0;
+}

--- a/tests/hostcall/device/single-warp.cpp
+++ b/tests/hostcall/device/single-warp.cpp
@@ -1,0 +1,192 @@
+/*
+Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+
+#include "common.h"
+
+__global__ void
+kernelSinglePacketSingleWarpModThree(void *buffer, ulong *retval0,
+                                     ulong *retval1)
+{
+    uint tid = hipThreadIdx_x;
+    if (tid % 3 != 0)
+        return;
+
+    uint count = hipThreadIdx_x * 8 + 1;
+    ulong arg0 = count++;
+    ulong arg1 = count++;
+    ulong arg2 = count++;
+    ulong arg3 = count++;
+    ulong arg4 = count++;
+    ulong arg5 = count++;
+    ulong arg6 = count++;
+    ulong arg7 = count++;
+
+    long2 result;
+    result.data =
+        __ockl_hostcall_internal(buffer, TEST_SERVICE, arg0, arg1, arg2, arg3,
+                                 arg4, arg5, arg6, arg7);
+    retval0[tid] = result.x;
+    retval1[tid] = result.y;
+}
+
+static uint
+checkSinglePacketSingleWarpModThree(hostcall_buffer_t *buffer)
+{
+    wait_on_signal(buffer->doorbell, 1024 * 1024, SIGNAL_INIT);
+    ulong cptr =
+        __atomic_load_n(&buffer->ready_stack, std::memory_order_acquire);
+    if (cptr == 0) {
+        return __LINE__;
+    }
+    WHEN_DEBUG(std::cout << "received packet: " << std::hex << cptr << std::dec
+                         << std::endl);
+    ulong fptr =
+        __atomic_load_n(&buffer->free_stack, std::memory_order_relaxed);
+    WHEN_DEBUG(std::cout << "free stack: " << std::hex << fptr << std::dec
+                         << std::endl);
+    if (fptr != 0)
+        return __LINE__;
+
+    header_t *header = get_header(buffer, cptr);
+    if (header->next != 0)
+        return __LINE__;
+
+    if (get_ready_flag(header->control) == 0)
+        return __LINE__;
+
+    // If every third bit is set, we get a series of octal 1's
+    if (header->activemask != 01111111111111111111111)
+        return __LINE__;
+    if (header->service != TEST_SERVICE)
+        return __LINE__;
+
+    payload_t *payload = get_payload(buffer, cptr);
+    for (int tid = 0; tid != 64; ++tid) {
+        if (tid % 3 != 0)
+            continue;
+
+        WHEN_DEBUG(std::cout << "workitem: " << std::dec << tid << std::endl);
+        auto slot = payload->slots[tid];
+        for (int ii = 0; ii != 8; ++ii) {
+            WHEN_DEBUG(std::cout << "payload: " << std::hex << slot[ii] << std::dec
+                                 << std::endl);
+            if (slot[ii] != tid * 8 + ii + 1)
+                return __LINE__;
+        }
+        slot[0] = tid % 5 + 1;
+        slot[1] = tid % 7 + 1;
+    }
+
+    __atomic_store_n(&header->control, reset_ready_flag(header->control),
+                     std::memory_order_release);
+
+    // wait for the single wave to return its packet
+    ulong F = __atomic_load_n(&buffer->free_stack, std::memory_order_acquire);
+    while (F == fptr) {
+        std::this_thread::sleep_for(std::chrono::microseconds(5));
+        F = __atomic_load_n(&buffer->free_stack, std::memory_order_acquire);
+    }
+    WHEN_DEBUG(std::cout << "new free stack: " << std::hex << F << std::endl);
+    if (F != inc_ptr_tag(cptr, buffer->index_size)) {
+        return __LINE__;
+    }
+
+    return 0;
+}
+
+uint
+testSinglePacketSingleWarpModThree()
+{
+    unsigned int numThreads = 64;
+    unsigned int numBlocks = 1;
+
+    unsigned int numPackets = 1;
+
+    hsa_signal_t signal;
+    if (hsa_signal_create(SIGNAL_INIT, 0, NULL, &signal) != HSA_STATUS_SUCCESS)
+        return __LINE__;
+
+    hostcall_buffer_t *buffer = createBuffer(numPackets, signal);
+    if (!buffer)
+        return __LINE__;
+
+    void *retval0_void;
+    if (hipHostMalloc(&retval0_void, 8 * numThreads) != hipSuccess)
+        return __LINE__;
+    uint64_t *retval0 = (uint64_t *)retval0_void;
+    for (int i = 0; i != numThreads; ++i) {
+        retval0[i] = 0x23232323;
+    }
+
+    void *retval1_void;
+    if (hipHostMalloc(&retval1_void, 8 * numThreads) != hipSuccess)
+        return __LINE__;
+    uint64_t *retval1 = (uint64_t *)retval1_void;
+    for (int i = 0; i != numThreads; ++i) {
+        retval1[i] = 0x17171717;
+    }
+
+    hipLaunchKernelGGL(kernelSinglePacketSingleWarpModThree, dim3(numBlocks),
+                       dim3(numThreads, 1, 1), 0, 0, buffer, retval0, retval1);
+    hipEvent_t start;
+    HIPCHECK(hipEventCreate(&start));
+    HIPCHECK(hipEventRecord(start));
+
+    uint status = checkSinglePacketSingleWarpModThree(buffer);
+    WHEN_DEBUG(std::cout << "check status: " << std::dec << status << std::endl);
+    if (status != 0)
+        return status;
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    if (hipEventQuery(start) != hipSuccess) {
+        return __LINE__;
+    }
+
+    HIPCHECK(hipDeviceSynchronize());
+    for (int i = 0; i != numThreads; ++i) {
+        switch (i % 3) {
+        case 0:
+            if (retval0[i] != i % 5 + 1)
+                return __LINE__;
+            if (retval1[i] != i % 7 + 1)
+                return __LINE__;
+            break;
+        default:
+            if (retval0[i] != 0x23232323)
+                return __LINE__;
+            if (retval1[i] != 0x17171717)
+                return __LINE__;
+            break;
+        }
+    }
+
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    set_flags(argc, argv);
+    runTest(testSinglePacketSingleWarpModThree);
+    test_passed(__FILE__);
+    return 0;
+}

--- a/tests/hostcall/function-call.cpp
+++ b/tests/hostcall/function-call.cpp
@@ -1,0 +1,114 @@
+/*
+Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip/hip_runtime.h>
+#include <amd_hostcall.h>
+#include <hsa/hsa.h>
+
+#include "common.h"
+
+static void
+callee(ulong *output, ulong *input)
+{
+    output[0] = input[0] + 1;
+    output[1] = input[1] + input[2];
+}
+
+__global__ void
+kernel(ulong fptr, ulong *retval0, ulong *retval1)
+{
+    uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    ulong arg0 = (ulong)fptr;
+    ulong arg1 = tid;
+    ulong arg2 = 42;
+    ulong arg3 = tid % 23;
+    ulong arg4 = 0;
+    ulong arg5 = 0;
+    ulong arg6 = 0;
+    ulong arg7 = 0;
+
+    long2 result = {0, 0};
+    if (tid % 71 != 1) {
+        result.data =
+            __ockl_call_host_function(arg0, arg1, arg2, arg3, arg4,
+                                      arg5, arg6, arg7);
+        retval0[tid] = result.x;
+        retval1[tid] = result.y;
+    }
+}
+
+uint
+test()
+{
+    uint num_blocks = 5;
+    uint threads_per_block = 1000;
+    uint num_threads = num_blocks * threads_per_block;
+
+    void *retval0_void;
+    if (hipHostMalloc(&retval0_void, 8 * num_threads) != hipSuccess)
+        return __LINE__;
+    uint64_t *retval0 = (uint64_t *)retval0_void;
+    for (uint i = 0; i != num_threads; ++i) {
+        retval0[i] = 0x23232323;
+    }
+
+    void *retval1_void;
+    if (hipHostMalloc(&retval1_void, 8 * num_threads) != hipSuccess)
+        return __LINE__;
+    uint64_t *retval1 = (uint64_t *)retval1_void;
+    for (uint i = 0; i != num_threads; ++i) {
+        retval1[i] = 0x23232323;
+    }
+
+    hipLaunchKernelGGL(kernel, dim3(num_blocks),
+                       dim3(threads_per_block), 0, 0, (ulong)callee, retval0, retval1);
+    hipEvent_t mark;
+    HIPCHECK(hipEventCreate(&mark));
+    HIPCHECK(hipEventRecord(mark));
+
+    bool timed_out = timeout(mark, 500);
+    if (timed_out)
+        return __LINE__;
+
+    hipStreamSynchronize(0);
+
+    for (uint ii = 0; ii != num_threads; ++ii) {
+        ulong value = retval0[ii];
+        if (ii % 71 == 1) {
+            if (value != 0x23232323)
+                return __LINE__;
+        } else {
+            if (value != ii + 1)
+                return __LINE__;
+        }
+    }
+
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    set_flags(argc, argv);
+    if (debug_mode)
+        amd_hostcall_enable_debug();
+    runTest(test);
+    test_passed(__FILE__);
+    return 0;
+}

--- a/tests/hostcall/many-threads.cpp
+++ b/tests/hostcall/many-threads.cpp
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip/hip_runtime.h>
+#include <amd_hostcall.h>
+#include <hsa/hsa.h>
+
+#include "common.h"
+
+static int
+handler(void *state, uint32_t service, ulong *payload)
+{
+    *payload = *payload + 1;
+    return 0;
+}
+
+__global__ void
+kernel(ulong *retval)
+{
+    uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    ulong arg0 = tid;
+    ulong arg1 = 0;
+    ulong arg2 = 0;
+    ulong arg3 = 0;
+    ulong arg4 = 0;
+    ulong arg5 = 0;
+    ulong arg6 = 0;
+    ulong arg7 = 0;
+
+    long2 result = {0, 0};
+    if (tid % 71 != 1) {
+        result.data =
+            __ockl_hostcall_preview(TEST_SERVICE, arg0, arg1, arg2, arg3, arg4,
+                                  arg5, arg6, arg7);
+        retval[tid] = result.x;
+    }
+}
+
+uint
+test()
+{
+    uint num_blocks = 5;
+    uint threads_per_block = 1000;
+    uint num_threads = num_blocks * threads_per_block;
+
+    void *retval_void;
+    if (hipHostMalloc(&retval_void, 8 * num_threads) != hipSuccess)
+        return __LINE__;
+    uint64_t *retval = (uint64_t *)retval_void;
+    for (uint i = 0; i != num_threads; ++i) {
+        retval[i] = 0x23232323;
+    }
+
+    amd_hostcall_register_service(TEST_SERVICE, handler, nullptr);
+
+    hipLaunchKernelGGL(kernel, dim3(num_blocks),
+                       dim3(threads_per_block), 0, 0, retval);
+    hipEvent_t mark;
+    HIPCHECK(hipEventCreate(&mark));
+    HIPCHECK(hipEventRecord(mark));
+
+    bool timed_out = timeout(mark, 500);
+    if (timed_out)
+        return __LINE__;
+
+    hipStreamSynchronize(0);
+
+    for (uint ii = 0; ii != num_threads; ++ii) {
+        ulong value = retval[ii];
+        if (ii % 71 == 1) {
+            if (value != 0x23232323)
+                return __LINE__;
+        } else {
+            if (value != ii + 1)
+                return __LINE__;
+        }
+    }
+
+    return 0;
+}
+
+int
+main(int argc, char **argv)
+{
+    set_flags(argc, argv);
+    if (debug_mode)
+        amd_hostcall_enable_debug();
+    runTest(test);
+    test_passed(__FILE__);
+    return 0;
+}


### PR DESCRIPTION
This an early proof of concept for introducing hostcall in HIP.

The change introduces a global hostcall state as follows:

1. Launch a consumer thread in hip_init.
2. Maintain a list of mappings from HSA queue to hostcall buffers.
3. Retrieve or create a hostcall buffer for the HSA queue at the time of launching a kernel. This requires locking the HIP stream so that the HSA queue is not stolen until the kernel is launched.
4. The destructor for the global state is responsible for terminating the consumer thread.

The change also includes a temporary hack that assigns the hostcall buffer poiner to the first explicit argument of the kernel. This will be replaced by an implicit kernel argument with suitable changes in the HIP compiler.

A working testcase can be seen here:
http://gitlab1.amd.com/ssahasra/test-hostcall

It combines the following components:
1. The hostcall [device library](http://git.amd.com:8080/c/lightning/ec/device-libs/+/212864). 
2. The hostcall [host library](http://git.amd.com:8080/c/lightning/ec/support/+/216834).
3. This POC change to the HIP runtime.