### PR TITLE
[hip] Fix use of `__HIP_CLANG_ONLY__` in `hip_ldg.h`.

### DIFF
--- a/include/hip/hcc_detail/hip_ldg.h
+++ b/include/hip/hcc_detail/hip_ldg.h
@@ -24,7 +24,7 @@ THE SOFTWARE.
 #define HIP_INCLUDE_HIP_HCC_DETAIL_HIP_LDG_H
 
 #if defined(__HCC_OR_HIP_CLANG__)
-#if __hcc_workweek__ >= 16164 || defined(__HIP_CLANG_ONLY__)
+#if __hcc_workweek__ >= 16164 || __HIP_CLANG_ONLY__
 #include "hip_vector_types.h"
 #include "host_defines.h"
 
@@ -96,7 +96,7 @@ __device__ inline static double __ldg(const double* ptr) { return ptr[0]; }
 
 __device__ inline static double2 __ldg(const double2* ptr) { return ptr[0]; }
 
-#endif  // __hcc_workweek__ || defined(__HIP_CLANG_ONLY__)
+#endif  // __hcc_workweek__ || __HIP_CLANG_ONLY__
 
 #endif  // defined(__HCC_OR_HIP_CLANG__)
 


### PR DESCRIPTION
- Check its value instead of whether it's defined or not.