### PR TITLE
[hip] Fix including of hip_fp16.h

### DIFF
--- a/include/hip/hcc_detail/hip_common.h
+++ b/include/hip/hcc_detail/hip_common.h
@@ -1,0 +1,40 @@
+/*
+Copyright (c) 2019 - present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#ifndef HIP_INCLUDE_HIP_HCC_DETAIL_HIP_COMMON_H
+#define HIP_INCLUDE_HIP_HCC_DETAIL_HIP_COMMON_H
+
+#if defined(__HCC__)
+#define __HCC_OR_HIP_CLANG__ 1
+#define __HCC_ONLY__ 1
+#define __HIP_CLANG_ONLY__ 0
+#elif defined(__clang__) && defined(__HIP__)
+#define __HCC_OR_HIP_CLANG__ 1
+#define __HCC_ONLY__ 0
+#define __HIP_CLANG_ONLY__ 1
+#else
+#define __HCC_OR_HIP_CLANG__ 0
+#define __HCC_ONLY__ 0
+#define __HIP_CLANG_ONLY__ 0
+#endif
+
+#endif // HIP_INCLUDE_HIP_HCC_DETAIL_HIP_COMMON_H

--- a/include/hip/hcc_detail/hip_fp16.h
+++ b/include/hip/hcc_detail/hip_fp16.h
@@ -21,6 +21,11 @@ THE SOFTWARE.
 */
 
 #pragma once
+#ifndef HIP_INCLUDE_HIP_HCC_DETAIL_HIP_FP16_H
+#define HIP_INCLUDE_HIP_HCC_DETAIL_HIP_FP16_H
+
+#include <hip/hcc_detail/hip_common.h>
+
 #include "hip/hcc_detail/host_defines.h"
 #include <assert.h>
 #if defined(__cplusplus)
@@ -1643,3 +1648,5 @@ THE SOFTWARE.
 #elif defined(__GNUC__)
     #include "hip_fp16_gcc.h"
 #endif // !defined(__clang__) && defined(__GNUC__)
+
+#endif // HIP_INCLUDE_HIP_HCC_DETAIL_HIP_FP16_H

--- a/include/hip/hcc_detail/hip_runtime.h
+++ b/include/hip/hcc_detail/hip_runtime.h
@@ -29,19 +29,7 @@ THE SOFTWARE.
 #ifndef HIP_INCLUDE_HIP_HCC_DETAIL_HIP_RUNTIME_H
 #define HIP_INCLUDE_HIP_HCC_DETAIL_HIP_RUNTIME_H
 
-#if defined(__HCC__)
-#define __HCC_OR_HIP_CLANG__ 1
-#define __HCC_ONLY__ 1
-#define __HIP_CLANG_ONLY__ 0
-#elif defined(__clang__) && defined(__HIP__)
-#define __HCC_OR_HIP_CLANG__ 1
-#define __HCC_ONLY__ 0
-#define __HIP_CLANG_ONLY__ 1
-#else
-#define __HCC_OR_HIP_CLANG__ 0
-#define __HCC_ONLY__ 0
-#define __HIP_CLANG_ONLY__ 0
-#endif
+#include <hip/hcc_detail/hip_common.h>
 
 //---
 // Top part of file can be compiled with any compiler


### PR DESCRIPTION
- Separate the definition of `__HCC_OR_HIP_CLANG__`, `__HCC_ONLY__`, and
  `__HIP_CLANG_ONLY__` into hip_common.h so that it could be included in
  hip_fp16.h, which may be included separately in app.