### PR TITLE
Partial clean to avoid top-level apps bypass HIP

### DIFF
--- a/include/hip/hcc_detail/code_object_bundle.hpp
+++ b/include/hip/hcc_detail/code_object_bundle.hpp
@@ -34,48 +34,6 @@ THE SOFTWARE.
 
 namespace hip_impl {
 
-inline
-std::string transmogrify_triple(const std::string& triple)
-{
-    static constexpr const char old_prefix[]{"hcc-amdgcn--amdhsa-gfx"};
-    static constexpr const char new_prefix[]{"hcc-amdgcn-amd-amdhsa--gfx"};
-
-    if (triple.find(old_prefix) == 0) {
-        return new_prefix + triple.substr(sizeof(old_prefix) - 1);
-    }
-
-    return (triple.find(new_prefix) == 0) ? triple : "";
-}
-
-inline
-std::string isa_name(std::string triple)
-{
-    static constexpr const char offload_prefix[]{"hcc-"};
-
-    triple = transmogrify_triple(triple);
-    if (triple.empty()) return {};
-
-    triple.erase(0, sizeof(offload_prefix) - 1);
-
-    return triple;
-}
-
-inline
-hsa_isa_t triple_to_hsa_isa(const std::string& triple) {
-    const std::string isa{isa_name(std::move(triple))};
-
-    if (isa.empty()) return hsa_isa_t({});
-
-    hsa_isa_t r{};
-
-    if(HSA_STATUS_SUCCESS != hsa_isa_from_name(isa.c_str(), &r)) {
-        r.handle = 0;
-    }
-
-    return r;
-}
-
-
 struct Bundled_code {
     union Header {
         struct {

--- a/include/hip/hcc_detail/functional_grid_launch.hpp
+++ b/include/hip/hcc_detail/functional_grid_launch.hpp
@@ -135,16 +135,8 @@ std::string name(std::uintptr_t function_address)
     return it->second;
 }
 
-inline
-std::string name(hsa_agent_t agent)
-{
-    char n[64]{};
-    hsa_agent_get_info(agent, HSA_AGENT_INFO_NAME, n);
-
-    return std::string{n};
-}
-
 hsa_agent_t target_agent(hipStream_t stream);
+std::string target_name(hsa_agent_t agent);
 
 inline
 __attribute__((visibility("hidden")))
@@ -157,13 +149,15 @@ void hipLaunchKernelGGLImpl(
     void** kernarg) {
 
     auto agent = target_agent(stream);
+
     auto it = functions(agent).find(function_address);
 
     if (it == functions(agent).cend()) {
+        auto agent_name = target_name(agent);
         hip_throw(std::runtime_error{
             "No device code available for function: " +
             name(function_address) +
-            ", for agent: " + name(agent)});
+            ", for agent: " + agent_name});
     }
 
     hipModuleLaunchKernel(it->second, numBlocks.x, numBlocks.y, numBlocks.z,

--- a/include/hip/hcc_detail/hsa_helpers.hpp
+++ b/include/hip/hcc_detail/hsa_helpers.hpp
@@ -99,4 +99,37 @@ inline hsa_symbol_kind_t type(hsa_executable_symbol_t x) {
 
     return r;
 }
+
+inline std::string transmogrify_triple(const std::string& triple) {
+    static constexpr const char old_prefix[]{"hcc-amdgcn--amdhsa-gfx"};
+    static constexpr const char new_prefix[]{"hcc-amdgcn-amd-amdhsa--gfx"};
+
+    if (triple.find(old_prefix) == 0) {
+        return new_prefix + triple.substr(sizeof(old_prefix) - 1);
+    }
+
+    return (triple.find(new_prefix) == 0) ? triple : "";
+}
+
+inline std::string isa_name(std::string triple) {
+    static constexpr const char offload_prefix[]{"hcc-"};
+
+    triple = transmogrify_triple(triple);
+    if (triple.empty()) return {};
+
+    triple.erase(0, sizeof(offload_prefix) - 1);
+
+    return triple;
+}
+
+inline hsa_isa_t triple_to_hsa_isa(const std::string& triple) {
+    const std::string isa{isa_name(std::move(triple))};
+    if (isa.empty()) return hsa_isa_t({});
+    hsa_isa_t r{};
+    if(HSA_STATUS_SUCCESS != hsa_isa_from_name(isa.c_str(), &r)) {
+        r.handle = 0;
+    }
+    return r;
+}
+
 }  // namespace hip_impl

--- a/src/functional_grid_launch.inl
+++ b/src/functional_grid_launch.inl
@@ -57,4 +57,11 @@ namespace hip_impl
                 accelerator{}.get_default_view().get_hsa_agent());
         }
     }
+
+    std::string target_name(hsa_agent_t agent)
+    {
+        char n[64]{};
+        hsa_agent_get_info(agent, HSA_AGENT_INFO_NAME, n);
+        return std::string{n};
+    }
 }


### PR DESCRIPTION
PR https://github.com/ROCm-Developer-Tools/HIP/pull/929 introduces some library-link pollution problems from applications that are supported to call HIP only (happens since ROCm 2.3.x). This is 1 out of 2 steps to get over such pollution.

Signed-off-by: CUI Wei <ghostplant@qq.com>