### PR TITLE
cache executables based on elf name, isa, and agent.

### DIFF
--- a/include/hip/hcc_detail/program_state.hpp
+++ b/include/hip/hcc_detail/program_state.hpp
@@ -86,6 +86,7 @@ namespace hip_impl {
 
 std::vector<hsa_agent_t> all_hsa_agents();
 void executables_cache(std::string, hsa_isa_t, hsa_agent_t, std::vector<hsa_executable_t>&, bool);
+extern std::mutex executables_cache_mutex;
 
 class Kernel_descriptor {
     std::uint64_t kernel_object_{};
@@ -405,6 +406,7 @@ const std::vector<hsa_executable_t>& executables(hsa_agent_t agent) {
 
                 hsa_agent_t a = *static_cast<hsa_agent_t*>(pa);
 
+                std::lock_guard<std::mutex> lock(executables_cache_mutex);
                 std::vector<hsa_executable_t> current_exes;
                 // check the cache for already loaded executables
                 hip_impl::executables_cache(elf, x, a, current_exes, false/*read, not write*/);

--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -2521,4 +2521,19 @@ namespace hip_impl {
             std::terminate();
         #endif
     }
+
+    void executables_cache(
+            std::string elf, hsa_isa_t isa, hsa_agent_t agent,
+            std::vector<hsa_executable_t>& exes, bool write) {
+        static std::unordered_map<std::string,
+            std::unordered_map<hsa_isa_t,
+                std::unordered_map<hsa_agent_t, std::vector<hsa_executable_t>>>> cache;
+        static std::mutex mtx;
+        std::lock_guard<std::mutex> lock(mtx);
+        if (write) {
+            cache[elf][isa][agent] = exes;
+        } else {
+            exes = cache[elf][isa][agent];
+        }
+    }
 } // Namespace hip_impl.

--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -2524,16 +2524,11 @@ namespace hip_impl {
 
     std::mutex executables_cache_mutex;
 
-    void executables_cache(
-            std::string elf, hsa_isa_t isa, hsa_agent_t agent,
-            std::vector<hsa_executable_t>& exes, bool write) {
+    std::vector<hsa_executable_t>& executables_cache(
+            std::string elf, hsa_isa_t isa, hsa_agent_t agent) {
         static std::unordered_map<std::string,
             std::unordered_map<hsa_isa_t,
                 std::unordered_map<hsa_agent_t, std::vector<hsa_executable_t>>>> cache;
-        if (write) {
-            cache[elf][isa][agent] = exes;
-        } else {
-            exes = cache[elf][isa][agent];
-        }
+        return cache[elf][isa][agent];
     }
 } // Namespace hip_impl.

--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -2522,14 +2522,14 @@ namespace hip_impl {
         #endif
     }
 
+    std::mutex executables_cache_mutex;
+
     void executables_cache(
             std::string elf, hsa_isa_t isa, hsa_agent_t agent,
             std::vector<hsa_executable_t>& exes, bool write) {
         static std::unordered_map<std::string,
             std::unordered_map<hsa_isa_t,
                 std::unordered_map<hsa_agent_t, std::vector<hsa_executable_t>>>> cache;
-        static std::mutex mtx;
-        std::lock_guard<std::mutex> lock(mtx);
         if (write) {
             cache[elf][isa][agent] = exes;
         } else {


### PR DESCRIPTION
This avoids program state reloading executables after a shared library is dlopened.