### PR TITLE
[hip] Repace `--rpath` with `--rpath-link`

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -191,7 +191,7 @@ if ($HIP_PLATFORM eq "clang") {
     $HIPCXXFLAGS .= " -std=c++11 -isystem $HIP_CLANG_INCLUDE_PATH";
     $HIPLDFLAGS .= " -L$HIP_LIB_PATH";
     if (not $isWindows) {
-      $HIPLDFLAGS .= " -Wl,--rpath=$HIP_LIB_PATH";
+      $HIPLDFLAGS .= " -Wl,--rpath-link=$HIP_LIB_PATH";
       $HIPLDFLAGS .= " -lhip_hcc";
     } else {
       $HIPLDFLAGS .= " -lamdhip64";


### PR DESCRIPTION
- With `--rpath`, app's RUNPATH is set to the temporary library path
  during build. Instead, `--rpath-link` should be used to leave RUNPATH
  untouched. User should set LD_LIBRARY_PATH or system ld.so.conf to
  proper setting.