### PR TITLE
Runtime changes to allocate implicit kernel arguments.

### DIFF
--- a/include/hip/hcc_detail/functional_grid_launch.hpp
+++ b/include/hip/hcc_detail/functional_grid_launch.hpp
@@ -108,10 +108,14 @@ inline std::vector<std::uint8_t> make_kernarg(
     kernarg.reserve(sizeof(to_formals));
 
     auto& ps = hip_impl::get_program_state();
-    return make_kernarg<0>(to_formals, 
+    auto kernargs =  make_kernarg<0>(to_formals,
                            ps.get_kernargs_size_align(
                                reinterpret_cast<std::uintptr_t>(kernel)),
                            std::move(kernarg));
+    // Insert 48-bytes at the end for implicit kernel arguments and fill with value zero.
+    size_t padSize = (~kernargs.size() + 1) & (HIP_KERNARG_ALIGNMENT - 1);
+    kernargs.insert(kernargs.end(), padSize + HIP_IMPLICIT_KERNARG_SIZE, 0);
+    return kernargs;
 }
 
 

--- a/include/hip/hip_hcc.h
+++ b/include/hip/hip_hcc.h
@@ -27,6 +27,10 @@ THE SOFTWARE.
 
 #include "hip/hip_runtime_api.h"
 
+// HIP implicit kernargs.
+#define HIP_IMPLICIT_KERNARG_SIZE 48
+#define HIP_KERNARG_ALIGNMENT 8
+
 // Forward declarations:
 namespace hc {
 class accelerator;

--- a/src/hip_clang.cpp
+++ b/src/hip_clang.cpp
@@ -233,6 +233,9 @@ hipError_t hipLaunchByPtr(const void *hostFunction)
         " for device %d!\n", hostFunction, deviceId);
     abort();
   } else {
+    // Insert 48-bytes at the end for implicit kernel arguments and fill with value zero.
+    size_t padSize = (~exec._arguments.size() + 1) & (HIP_KERNARG_ALIGNMENT - 1);
+    exec._arguments.insert(exec._arguments.end(), padSize + HIP_IMPLICIT_KERNARG_SIZE, 0);
     size_t size = exec._arguments.size();
     void *extra[] = {
         HIP_LAUNCH_PARAM_BUFFER_POINTER, &exec._arguments[0],


### PR DESCRIPTION
Appended the implicit kernel argument buffer in the argument area. This buffer (48-bytes) appears at the end of the user argument area. The hostcall services can utilize this area. 
This change should go into the runtime mainline once the compiler enables the implicit kernel argument for HIP.