### PR TITLE
[HIPIFY][perl] Initial support of hipify-perl generation from hipify-clang

### DIFF
--- a/hipify-clang/src/ArgParse.cpp
+++ b/hipify-clang/src/ArgParse.cpp
@@ -34,6 +34,21 @@ cl::opt<std::string> OutputDir("o-dir",
   cl::value_desc("directory"),
   cl::cat(ToolTemplateCategory));
 
+cl::opt <bool> GeneratePerl("perl",
+  cl::desc("Generate hipify-perl"),
+  cl::value_desc("perl"),
+  cl::cat(ToolTemplateCategory));
+
+cl::opt<std::string> OutputPerlMapFilename("o-perl-map",
+  cl::desc("Output filename for Perl map"),
+  cl::value_desc("filename"),
+  cl::cat(ToolTemplateCategory));
+
+cl::opt<std::string> OutputPerlMapDir("o-perl-map-dir",
+  cl::desc("Output direcory for Perl map"),
+  cl::value_desc("directory"),
+  cl::cat(ToolTemplateCategory));
+
 cl::opt<std::string> TemporaryDir("temp-dir",
   cl::desc("Temporary direcory"),
   cl::value_desc("directory"),

--- a/hipify-clang/src/ArgParse.h
+++ b/hipify-clang/src/ArgParse.h
@@ -30,6 +30,8 @@ namespace ct = clang::tooling;
 
 extern cl::OptionCategory ToolTemplateCategory;
 extern cl::opt<std::string> OutputFilename;
+extern cl::opt<std::string> OutputPerlMapFilename;
+extern cl::opt<std::string> OutputPerlMapDir;
 extern cl::opt<std::string> OutputDir;
 extern cl::opt<std::string> TemporaryDir;
 extern cl::opt<std::string> CudaPath;
@@ -37,6 +39,7 @@ extern cl::list<std::string> IncludeDirs;
 extern cl::list<std::string> MacroNames;
 extern cl::opt<bool> Inplace;
 extern cl::opt<bool> SaveTemps;
+extern cl::opt<bool> GeneratePerl;
 extern cl::opt<bool> Verbose;
 extern cl::opt<bool> NoBackup;
 extern cl::opt<bool> NoOutput;


### PR DESCRIPTION
+ Only a generation of transformation map of CUDA entities supported by HIP is implemented.
+ 3 hipify-clang options are added: -perl, -o-perl-map, -o-perl-map-dir.
+ OptionsParser's mode is changed from OneOrMore to Optional to support hipify-perl generation without actual hipification.
+ Add explicit control of source files specification absence in case of no perl generation.