### PR TITLE
Support hipModuleLaunchKernel API if the kernelParams are not null.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ bin/hipify-clang
 include/hip/hcc_detail/hip_prof_str.h
 
 samples/1_Utils/hipInfo/hipInfo
+install
+.vscode

--- a/include/hip/hcc_detail/program_state.hpp
+++ b/include/hip/hcc_detail/program_state.hpp
@@ -90,10 +90,17 @@ class Kernel_descriptor {
     std::uint64_t kernel_object_{};
     amd_kernel_code_t const* kernel_header_{nullptr};
     std::string name_{};
+    std::vector<std::pair<std::size_t, std::size_t>> kernarg_layout_{};
 public:
     Kernel_descriptor() = default;
-    Kernel_descriptor(std::uint64_t kernel_object, const std::string& name)
-        : kernel_object_{kernel_object}, name_{name}
+    Kernel_descriptor(
+        std::uint64_t kernel_object,
+        const std::string& name,
+        std::vector<std::pair<std::size_t, std::size_t>> kernarg_layout = {})
+        :
+        kernel_object_{kernel_object},
+        name_{name},
+        kernarg_layout_{std::move(kernarg_layout)}
     {
         bool supported{false};
         std::uint16_t min_v{UINT16_MAX};

--- a/samples/0_Intro/module_api/Makefile
+++ b/samples/0_Intro/module_api/Makefile
@@ -5,7 +5,7 @@ endif
 HIPCC=$(HIP_PATH)/bin/hipcc
 HIP_PLATFORM=$(shell $(HIP_PATH)/bin/hipconfig --compiler)
 
-all: vcpy_kernel.code runKernel.hip.out launchKernelHcc.hip.out
+all: vcpy_kernel.code runKernel.hip.out launchKernelHcc.hip.out defaultDriver.hip.out
 
 runKernel.hip.out: runKernel.cpp
 	$(HIPCC) $(HIPCC_FLAGS) $< -o $@
@@ -13,8 +13,8 @@ runKernel.hip.out: runKernel.cpp
 launchKernelHcc.hip.out: launchKernelHcc.cpp
 	$(HIPCC) $(HIPCC_FLAGS) $< -o $@
 
-#defaultDriver.hip.out: defaultDriver.cpp
-#	$(HIPCC)  $(HIPCC_FLAGS) $< -o $@
+defaultDriver.hip.out: defaultDriver.cpp
+	$(HIPCC)  $(HIPCC_FLAGS) $< -o $@
 
 vcpy_kernel.code: vcpy_kernel.cpp
 	$(HIPCC)  --genco  $(GENCO_FLAGS) $^ -o $@

--- a/src/hip_hcc_internal.h
+++ b/src/hip_hcc_internal.h
@@ -371,6 +371,8 @@ struct ihipModule_t {
     hsa_executable_t executable = {};
     hsa_code_object_reader_t coReader = {};
     std::string hash;
+    std::unordered_map<
+        std::string, std::vector<std::pair<std::size_t, std::size_t>>> kernargs;
 
     ~ihipModule_t() {
         if (executable.handle) hsa_executable_destroy(executable);

--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -90,6 +90,7 @@ struct ihipModuleSymbol_t {
     uint64_t _object{};  // The kernel object.
     amd_kernel_code_t const* _header{};
     string _name;  // TODO - review for performance cost.  Name is just used for debug.
+    vector<pair<size_t, size_t>> _kernarg_layout{};
 };
 
 template <>
@@ -131,6 +132,8 @@ hipError_t ihipModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,
                                   uint32_t localWorkSizeZ, size_t sharedMemBytes,
                                   hipStream_t hStream, void** kernelParams, void** extra,
                                   hipEvent_t startEvent, hipEvent_t stopEvent, uint32_t flags) {
+    using namespace hip_impl;
+
     auto ctx = ihipGetTlsDefaultCtx();
     hipError_t ret = hipSuccess;
 
@@ -145,19 +148,25 @@ hipError_t ihipModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,
         void* config[5] = {0};
         size_t kernArgSize;
 
-        if (kernelParams != NULL) {
-            std::string name = f->_name;
-            struct ihipKernArgInfo pl = kernelArguments[name];
-            char* argBuf = (char*)malloc(pl.totalSize);
-            memset(argBuf, 0, pl.totalSize);
-            int index = 0;
-            for (int i = 0; i < pl.Size.size(); i++) {
-                memcpy(argBuf + index, kernelParams[i], pl.Size[i]);
-                index += pl.Align[i];
+        std::vector<char> tmp{};
+        if (kernelParams) {
+            if (extra) return hipErrorInvalidValue;
+
+            for (auto&& x : f->_kernarg_layout) {
+                const auto p{static_cast<const char*>(*kernelParams)};
+
+                tmp.insert(
+                    tmp.cend(),
+                    round_up_to_next_multiple_nonnegative(
+                        tmp.size(), x.second) - tmp.size(),
+                    '\0');
+                tmp.insert(tmp.cend(), p, p + x.first);
+                ++kernelParams;
             }
-            config[1] = (void*)argBuf;
-            kernArgSize = pl.totalSize;
-        } else if (extra != NULL) {
+            config[1] = static_cast<void*>(tmp.data());
+
+            kernArgSize = tmp.size();
+        } else if (extra) {
             memcpy(config, extra, sizeof(size_t) * 5);
             if (config[0] == HIP_LAUNCH_PARAM_BUFFER_POINTER &&
                 config[2] == HIP_LAUNCH_PARAM_BUFFER_SIZE && config[4] == HIP_LAUNCH_PARAM_END) {
@@ -235,10 +244,6 @@ hipError_t ihipModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,
             stopEvent->attachToCompletionFuture(&cf, hStream, hipEventTypeStopCommand);
         }
 
-
-        if (kernelParams != NULL) {
-            free(config[1]);
-        }
         ihipPostLaunchKernel(f->_name.c_str(), hStream, lp);
     }
 
@@ -460,7 +465,7 @@ hipError_t ihipModuleGetFunction(hipFunction_t* func, hipModule_t hmod, const ch
     // TODO: refactor the whole ihipThisThat, which is a mess and yields the
     //       below, due to hipFunction_t being a pointer to ihipModuleSymbol_t.
     func[0][0] = *static_cast<hipFunction_t>(
-        Kernel_descriptor{kernel_object(kernel), name});
+        Kernel_descriptor{kernel_object(kernel), name, hmod->kernargs[name]});
 
     return hipSuccess;
 }
@@ -550,6 +555,9 @@ hipError_t ihipModuleLoadData(hipModule_t* module, const void* image) {
 
     (*module)->executable = load_executable(content, (*module)->executable,
                                             this_agent());
+    istringstream elf{content};
+    ELFIO::elfio reader;
+    if (reader.load(elf)) read_kernarg_metadata(reader, (*module)->kernargs);
 
     // compute the hash of the code object
     (*module)->hash = checksum(content.length(), content.data());


### PR DESCRIPTION
Read the kernel argument layout from the metadata.

This enables an important PyTorch use case of this API.

While there, add some items to gitignore.