### PR TITLE
Add fine grained host memory lock support

### DIFF
--- a/include/hip/hcc_detail/hip_runtime_api.h
+++ b/include/hip/hcc_detail/hip_runtime_api.h
@@ -190,7 +190,7 @@ enum hipLimit_t {
     0x2  ///< Map the allocation into the address space for the current device.  The device pointer
          ///< can be obtained with #hipHostGetDevicePointer.
 #define hipHostRegisterIoMemory 0x4  ///< Not supported.
-
+#define hipExtHostRegisterCoarseGrained 0x8  ///< Coarse Grained host memory lock
 
 #define hipDeviceScheduleAuto 0x0  ///< Automatically select between Spin and Yield
 #define hipDeviceScheduleSpin                                                                      \

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -957,8 +957,8 @@ hipError_t hipHostRegister(void* hostPtr, size_t sizeBytes, unsigned int flags) 
         }
         // TODO-test : multi-gpu access to registered host memory.
         if (ctx) {
-            if ((flags & hipHostRegisterDefault) || (flags & hipHostRegisterPortable) ||
-                (flags & hipHostRegisterMapped)) {
+            if ((flags == hipHostRegisterDefault) || (flags & hipHostRegisterPortable) ||
+                (flags & hipHostRegisterMapped) || (flags == hipExtHostRegisterCoarseGrained)) {
                 auto device = ctx->getWriteableDevice();
                 std::vector<hc::accelerator> vecAcc;
                 for (int i = 0; i < g_deviceCnt; i++) {

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -957,15 +957,25 @@ hipError_t hipHostRegister(void* hostPtr, size_t sizeBytes, unsigned int flags) 
         }
         // TODO-test : multi-gpu access to registered host memory.
         if (ctx) {
-            if (flags == hipHostRegisterDefault || flags == hipHostRegisterPortable ||
-                flags == hipHostRegisterMapped) {
+            if ((flags & hipHostRegisterDefault) || (flags & hipHostRegisterPortable) ||
+                (flags & hipHostRegisterMapped)) {
                 auto device = ctx->getWriteableDevice();
                 std::vector<hc::accelerator> vecAcc;
                 for (int i = 0; i < g_deviceCnt; i++) {
                     vecAcc.push_back(ihipGetDevice(i)->_acc);
                 }
+#if (__hcc_workweek__ >= 19183)
+                if(flags & hipExtHostRegisterCoarseGrained) {
+                    am_status = hc::am_memory_host_lock(device->_acc, hostPtr, sizeBytes, &vecAcc[0],
+                                                    vecAcc.size());
+                } else {
+                    am_status = hc::am_memory_host_lock_with_flag(device->_acc, hostPtr, sizeBytes, &vecAcc[0],
+                                                    vecAcc.size());
+                }
+#else
                 am_status = hc::am_memory_host_lock(device->_acc, hostPtr, sizeBytes, &vecAcc[0],
                                                     vecAcc.size());
+#endif
                 if ( am_status == AM_SUCCESS ) {
                      am_status = hc::am_memtracker_getinfo(&amPointerInfo, hostPtr);
 


### PR DESCRIPTION
Default lock is fine grained and adds an AMD specific hipExtHostRegisterCoarseGrained flag for coarse grained lock.