### PR TITLE
fix compilation error when host compiler is clang

### DIFF
--- a/include/hip/hcc_detail/hip_fp16.h
+++ b/include/hip/hcc_detail/hip_fp16.h
@@ -34,7 +34,7 @@ THE SOFTWARE.
     #include <utility>
 #endif
 
-#if __HCC__ || __HIP__ 
+#if __HCC_OR_HIP_CLANG__
     typedef _Float16 _Float16_2 __attribute__((ext_vector_type(2)));
 
     struct __half_raw {

--- a/include/hip/hcc_detail/hip_fp16.h
+++ b/include/hip/hcc_detail/hip_fp16.h
@@ -34,7 +34,7 @@ THE SOFTWARE.
     #include <utility>
 #endif
 
-#if defined(__clang__) && (__clang_major__ > 5)
+#if __HCC__ || __HIP__ 
     typedef _Float16 _Float16_2 __attribute__((ext_vector_type(2)));
 
     struct __half_raw {


### PR DESCRIPTION
The original `if defined` guard was there to provide an alternative code path when compiling with g++; however, this breaks when a plan vanilla clang is used for compiling host code.  The new guard fixes the problem.