### PR TITLE
introduce hostcall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 cmake_minimum_required(VERSION 3.4.3)
 project(hip)
 
+# Threads are required by the hostcall tests. The check uses the
+# system compiler, but it is affected by CMAKE_CXX_FLAGS. Later parts
+# of this file add flags like "-hc", which cause the system compiler
+# to error out.
+find_package(Threads)
+
 #############################
 # Options
 #############################
@@ -224,6 +230,12 @@ if(HIP_PLATFORM STREQUAL "hcc")
         set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DCOMPILE_HIP_ATP_MARKER=1")
     endif()
 
+    # FIXME: Make this a required package ASAP
+    find_package(amd_hostcall)
+    if (${amd_hostcall_FOUND})
+        set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DWITH_HOSTCALL")
+    endif()
+
     # Add HIP_VERSION to CMAKE_<LANG>_FLAGS
     set(HIP_HCC_BUILD_FLAGS "${HIP_HCC_BUILD_FLAGS} -DHIP_VERSION_MAJOR=${HIP_VERSION_MAJOR} -DHIP_VERSION_MINOR=${HIP_VERSION_MINOR} -DHIP_VERSION_PATCH=${HIP_VERSION_GITDATE}")
 
@@ -290,6 +302,11 @@ if(HIP_PLATFORM STREQUAL "hcc")
 
     target_link_libraries(hip_hcc PRIVATE amd_comgr)
     target_link_libraries(hip_hcc_static PRIVATE amd_comgr)
+
+    if (${amd_hostcall_FOUND})
+        target_link_libraries(hip_hcc PRIVATE amd_hostcall)
+        target_link_libraries(hip_hcc_static PRIVATE amd_hostcall)
+    endif()
 
     string(REPLACE " " ";" HCC_CXX_FLAGS_LIST ${HCC_CXX_FLAGS})
     foreach(TARGET hip_hcc hip_hcc_static)
@@ -513,6 +530,17 @@ if(${RUN_HIT} EQUAL 0)
 
     # Add custom target: check
     add_custom_target(check COMMAND "${CMAKE_COMMAND}" --build . --target test DEPENDS build_tests)
+
+    # Add independent tests for hostcall
+    if (${amd_hostcall_FOUND})
+        if(${Threads_FOUND})
+            add_custom_target(hostcall_tests)
+            add_subdirectory(${HIP_SRC_PATH}/tests/hostcall EXCLUDE_FROM_ALL)
+            add_dependencies(build_tests hostcall_tests)
+        else()
+            message(STATUS "Disbled hostcall tests; thread library not found.")
+        endif()
+    endif()
 else()
     message(STATUS "Testing targets will not be available. To enable them please ensure that the HIP installation directory is writeable. Use -DCMAKE_INSTALL_PREFIX to specify a suitable location")
 endif()

--- a/include/hip/hcc_detail/grid_launch.h
+++ b/include/hip/hcc_detail/grid_launch.h
@@ -62,6 +62,8 @@ typedef struct grid_launch_parm
   //! waiting on younger commands.
   hc::completion_future *cf;
 
+  void *hostcall_buffer;
+
   grid_launch_parm() = default;
 } grid_launch_parm;
 

--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -208,6 +208,12 @@ hipError_t ihipModuleLaunchKernel(TlsData *tls, hipFunction_t f, uint32_t global
             hStream, dim3(globalWorkSizeX/localWorkSizeX, globalWorkSizeY/localWorkSizeY, globalWorkSizeZ/localWorkSizeZ),
             dim3(localWorkSizeX, localWorkSizeY, localWorkSizeZ), &lp, f->_name.c_str(), isStreamLocked);
 
+        auto implicit_begin = reinterpret_cast<void**>(kernargs.data() + (kernargs.size() - HIP_IMPLICIT_KERNARG_SIZE));
+        auto hostcall_buffer = implicit_begin + 3;
+        tprintf(DB_SYNC, "using hostcall buffer %p for %s\n",
+                lp.hostcall_buffer, ToString(hStream).c_str());
+        *hostcall_buffer = lp.hostcall_buffer;
+
         hsa_kernel_dispatch_packet_t aql;
 
         memset(&aql, 0, sizeof(aql));

--- a/tests/hostcall/.clang-format
+++ b/tests/hostcall/.clang-format
@@ -1,0 +1,6 @@
+AlwaysBreakAfterReturnType: All
+BraceWrapping:
+  AfterFunction:   true
+BreakBeforeBraces: Custom
+IndentWidth:     4
+PenaltyBreakBeforeFirstCallParameter: 300

--- a/tests/hostcall/CMakeLists.txt
+++ b/tests/hostcall/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.4.3)
-
 include(${HIP_SRC_PATH}/cmake/FindHIP.cmake)
 message(STATUS "Using hipcc for hostcall tests: ${HIP_HIPCC_EXECUTABLE}")
 
@@ -34,10 +32,12 @@ endif()
 
 set(HOSTCALL_TEST_INC ${CMAKE_CURRENT_LIST_DIR})
 
-function(hostcall_add_test prefix filename)
+function(hostcall_build_test _testname filename)
+    get_filename_component(prefix ${CMAKE_CURRENT_LIST_DIR} NAME)
     get_filename_component(basename_we ${filename} NAME_WE)
     get_filename_component(basename ${filename} NAME)
     set(testname hostcall-${prefix}-${basename_we})
+    set(${_testname} ${testname} PARENT_SCOPE)
 
     add_custom_target(
         ${testname}
@@ -49,8 +49,19 @@ function(hostcall_add_test prefix filename)
         ${filename} -o ${testname}
         COMMENT "Building ${testname}")
 
-    add_test(${testname} ${testname})
     add_dependencies(hostcall_tests ${testname})
+endfunction()
+
+function(hostcall_add_test _testname filename)
+    hostcall_build_test(testname ${filename})
+    add_test(${testname} ${testname})
+    set(${_testname} ${testname} PARENT_SCOPE)
+endfunction()
+
+function(hostcall_add_tests files)
+    foreach(file ${files})
+        hostcall_add_test(testname ${file})
+    endforeach()
 endfunction()
 
 add_subdirectory(basic EXCLUDE_FROM_ALL)

--- a/tests/hostcall/CMakeLists.txt
+++ b/tests/hostcall/CMakeLists.txt
@@ -1,0 +1,57 @@
+cmake_minimum_required(VERSION 3.4.3)
+
+include(${HIP_SRC_PATH}/cmake/FindHIP.cmake)
+message(STATUS "Using hipcc for hostcall tests: ${HIP_HIPCC_EXECUTABLE}")
+
+# FIXME: The NAMES argument should not be necessary, but the default
+# HSA_PATH /opt/rocm/hsa/lib only contains a versioned
+# library. HSA_PATH should either point to /opt/rocm where lib/
+# contains an unversioned symlink, or /opt/rocm/hsa packaging should
+# be updated.
+#
+# This also requires extra work to detect the filename of the library
+# and pass it as "-l:filename" to the linker.
+find_library(
+    HSA_LIBRARY hsa-runtime64
+    NAMES libhsa-runtime64.so libhsa-runtime64.so.1
+    PATHS ${HSA_PATH}
+    PATH_SUFFIXES lib NO_DEFAULT_PATH)
+if (EXISTS ${HSA_LIBRARY})
+    get_filename_component(HSA_LIB_DIR ${HSA_LIBRARY} DIRECTORY)
+    get_filename_component(HSA_LIBRARY ${HSA_LIBRARY} NAME)
+    message(STATUS "Using HSA runtime for hostcall tests: ${HSA_LIB_DIR}")
+else()
+    message(FATAL_ERROR "*** Cannot find HSA libraries in ${HSA_PATH}")
+endif()
+
+find_path(HSA_HEADER hsa/hsa.h PATHS ${HSA_PATH} PATH_SUFFIXES include NO_DEFAULT_PATH)
+find_path(HSA_HEADER hsa/hsa.h PATHS /opt/rocm PATH_SUFFIXES include)
+if (NOT EXISTS ${HSA_HEADER})
+    message(FATAL_ERROR "*** Cannot find HSA headers in ${HSA_PATH}")
+else()
+    message(STATUS "Using HSA headers for hostcall tests: ${HSA_HEADER}")
+endif()
+
+set(HOSTCALL_TEST_INC ${CMAKE_CURRENT_LIST_DIR})
+
+function(hostcall_add_test prefix filename)
+    get_filename_component(basename_we ${filename} NAME_WE)
+    get_filename_component(basename ${filename} NAME)
+    set(testname hostcall-${prefix}-${basename_we})
+
+    add_custom_target(
+        ${testname}
+        COMMAND ${HIP_HIPCC_EXECUTABLE} -g
+        -I${HSA_HEADER} -I${HOSTCALL_TEST_INC}
+        -I$<TARGET_PROPERTY:amd_hostcall,INTERFACE_INCLUDE_DIRECTORIES>
+        -L$<TARGET_FILE_DIR:amd_hostcall> -L${HSA_LIB_DIR}
+        -lpthread -l:$<TARGET_FILE_NAME:amd_hostcall> -l:${HSA_LIBRARY}
+        ${filename} -o ${testname}
+        COMMENT "Building ${testname}")
+
+    add_test(${testname} ${testname})
+    add_dependencies(hostcall_tests ${testname})
+endfunction()
+
+add_subdirectory(basic EXCLUDE_FROM_ALL)
+add_subdirectory(device EXCLUDE_FROM_ALL)

--- a/tests/hostcall/README.md
+++ b/tests/hostcall/README.md
@@ -1,0 +1,19 @@
+# HIP applications that test hostcall #
+
+The tests for hostcall are arranged in the following directories:
+
+  * **basic:** Exercise the basic hostcall service by directly invoking
+    `__ockl_hostcall_preview()` from the device library.
+
+  * **device:** Exercise `__ockl_hostcall_preview()` from the device
+    library, but launch their own host-side consumer. This is useful
+    for testing the device implementaiton without relying on the host
+    implementation. The tests perform the following non-standard
+    actions, which are not supported in a HIP application:
+    - Create their own custom hostcall buffer and pass it as an explicit
+      argument to the kernel.
+    - Launch their own hostcall consumer thread which responds to
+      packets in the custom buffer.
+
+    Note that the HIP runtime still launches its own hostcall consumer
+    thread, but it remains unused.

--- a/tests/hostcall/basic/CMakeLists.txt
+++ b/tests/hostcall/basic/CMakeLists.txt
@@ -1,7 +1,5 @@
 file(GLOB files *.cpp)
-foreach(file ${files})
-    hostcall_add_test(basic ${file})
-endforeach()
+hostcall_add_tests("${files}")
 
 set_tests_properties(hostcall-basic-print-things PROPERTIES
   PASS_REGULAR_EXPRESSION "(42 -> 0)\r?\nkernel: kernel1; tid: 0")

--- a/tests/hostcall/basic/CMakeLists.txt
+++ b/tests/hostcall/basic/CMakeLists.txt
@@ -1,0 +1,7 @@
+file(GLOB files *.cpp)
+foreach(file ${files})
+    hostcall_add_test(basic ${file})
+endforeach()
+
+set_tests_properties(hostcall-basic-print-things PROPERTIES
+  PASS_REGULAR_EXPRESSION "(42 -> 0)\r?\nkernel: kernel1; tid: 0")

--- a/tests/hostcall/basic/function-call.cpp
+++ b/tests/hostcall/basic/function-call.cpp
@@ -1,0 +1,102 @@
+/*
+Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <amd_hostcall.h>
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+
+#include "common.h"
+
+static void
+callee(ulong *output, ulong *input)
+{
+    output[0] = input[0] + 1;
+    output[1] = input[1] + input[2];
+}
+
+__global__ void
+kernel(ulong fptr, ulong *retval0, ulong *retval1)
+{
+    uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    ulong arg0 = (ulong)fptr;
+    ulong arg1 = tid;
+    ulong arg2 = 42;
+    ulong arg3 = tid % 23;
+    ulong arg4 = 0;
+    ulong arg5 = 0;
+    ulong arg6 = 0;
+    ulong arg7 = 0;
+
+    long2 result = {0, 0};
+    if (tid % 71 != 1) {
+        result.data = __ockl_call_host_function(arg0, arg1, arg2, arg3, arg4,
+                                                arg5, arg6, arg7);
+        retval0[tid] = result.x;
+        retval1[tid] = result.y;
+    }
+}
+
+static void
+test()
+{
+    uint num_blocks = 5;
+    uint threads_per_block = 1000;
+    uint num_threads = num_blocks * threads_per_block;
+
+    void *retval0_void;
+    HIPCHECK(hipHostMalloc(&retval0_void, 8 * num_threads));
+    uint64_t *retval0 = (uint64_t *)retval0_void;
+    for (uint i = 0; i != num_threads; ++i) {
+        retval0[i] = 0x23232323;
+    }
+
+    void *retval1_void;
+    HIPCHECK(hipHostMalloc(&retval1_void, 8 * num_threads));
+    uint64_t *retval1 = (uint64_t *)retval1_void;
+    for (uint i = 0; i != num_threads; ++i) {
+        retval1[i] = 0x23232323;
+    }
+
+    hipLaunchKernelGGL(kernel, dim3(num_blocks), dim3(threads_per_block), 0, 0,
+                       (ulong)callee, retval0, retval1);
+    hipEvent_t mark;
+    HIPCHECK(hipEventCreate(&mark));
+    HIPCHECK(hipEventRecord(mark));
+
+    ASSERT(!timeout(mark, 500));
+
+    hipStreamSynchronize(0);
+
+    for (uint ii = 0; ii != num_threads; ++ii) {
+        ulong value = retval0[ii];
+        if (ii % 71 == 1) {
+            ASSERT(value == 0x23232323);
+        } else {
+            ASSERT(value == ii + 1);
+        }
+    }
+}
+
+int
+main(int argc, char **argv)
+{
+    ASSERT(set_flags(argc, argv));
+    test();
+    test_passed();
+}

--- a/tests/hostcall/basic/many-waves.cpp
+++ b/tests/hostcall/basic/many-waves.cpp
@@ -1,0 +1,96 @@
+/*
+Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <amd_hostcall.h>
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+
+#include "common.h"
+
+static int
+handler(void *state, uint32_t service, ulong *payload)
+{
+    *payload = *payload + 1;
+    return 0;
+}
+
+__global__ void
+kernel(ulong *retval)
+{
+    uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    ulong arg0 = tid;
+    ulong arg1 = 0;
+    ulong arg2 = 0;
+    ulong arg3 = 0;
+    ulong arg4 = 0;
+    ulong arg5 = 0;
+    ulong arg6 = 0;
+    ulong arg7 = 0;
+
+    long2 result = {0, 0};
+    if (tid % 71 != 1) {
+        result.data = __ockl_hostcall_preview(TEST_SERVICE, arg0, arg1, arg2,
+                                              arg3, arg4, arg5, arg6, arg7);
+        retval[tid] = result.x;
+    }
+}
+
+static void
+test()
+{
+    uint num_blocks = 5;
+    uint threads_per_block = 1000;
+    uint num_threads = num_blocks * threads_per_block;
+
+    void *retval_void;
+    HIPCHECK(hipHostMalloc(&retval_void, 8 * num_threads));
+    uint64_t *retval = (uint64_t *)retval_void;
+    for (uint i = 0; i != num_threads; ++i) {
+        retval[i] = 0x23232323;
+    }
+
+    amd_hostcall_register_service(TEST_SERVICE, handler, nullptr);
+
+    hipLaunchKernelGGL(kernel, dim3(num_blocks), dim3(threads_per_block), 0, 0,
+                       retval);
+    hipEvent_t mark;
+    HIPCHECK(hipEventCreate(&mark));
+    HIPCHECK(hipEventRecord(mark));
+
+    ASSERT(!timeout(mark, 500));
+
+    hipStreamSynchronize(0);
+
+    for (uint ii = 0; ii != num_threads; ++ii) {
+        ulong value = retval[ii];
+        if (ii % 71 == 1) {
+            ASSERT(value == 0x23232323);
+        } else {
+            ASSERT(value == ii + 1);
+        }
+    }
+}
+
+int
+main(int argc, char **argv)
+{
+    ASSERT(set_flags(argc, argv));
+    test();
+    test_passed();
+}

--- a/tests/hostcall/basic/print-things.cpp
+++ b/tests/hostcall/basic/print-things.cpp
@@ -1,0 +1,113 @@
+/*
+Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <amd_hostcall.h>
+#include <functional>
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+
+#include "common.h"
+
+void
+print_things_0(ulong *output, ulong *input)
+{
+    auto fmt = reinterpret_cast<const char *>(input);
+    auto arg0 = input[2];
+    auto arg1 = input[3];
+    output[0] = fprintf(stdout, fmt, arg0, arg1);
+}
+
+__global__ void
+kernel0(ulong fptr)
+{
+    uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    ulong arg0 = fptr;
+
+    const char *str = "(%lu -> %lu)\n";
+    ulong arg1 = 0;
+    for (int ii = 0; ii != 8; ++ii) {
+        arg1 |= (ulong)str[ii] << (8 * ii);
+    }
+    ulong arg2 = 0;
+    for (int ii = 0; ii != 7; ++ii) {
+        arg2 |= (ulong)str[ii + 8] << (8 * ii);
+    }
+
+    ulong arg3 = 42;
+    ulong arg4 = tid;
+    ulong arg5 = 0;
+    ulong arg6 = 0;
+    ulong arg7 = 0;
+
+    __ockl_call_host_function(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+}
+
+void
+print_things_1(ulong *output, const ulong *input)
+{
+    auto name = reinterpret_cast<const char *>(input[0]);
+    auto tid = input[1];
+    output[0] = fprintf(stdout, "kernel: %s; tid: %lu\n", name, tid);
+}
+
+__global__ void
+kernel1(ulong fptr, ulong name)
+{
+    uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    ulong arg0 = fptr;
+    ulong arg1 = name;
+    ulong arg2 = tid;
+    ulong arg3 = 0;
+    ulong arg4 = 0;
+    ulong arg5 = 0;
+    ulong arg6 = 0;
+    ulong arg7 = 0;
+
+    __ockl_call_host_function(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7);
+}
+
+static void
+test()
+{
+    uint num_blocks = 1;
+    uint threads_per_block = 1;
+    uint num_threads = num_blocks * threads_per_block;
+
+    hipEvent_t mark;
+    HIPCHECK(hipEventCreate(&mark));
+
+    hipLaunchKernelGGL(kernel0, dim3(num_blocks), dim3(threads_per_block), 0, 0,
+                       (ulong)print_things_0);
+    HIPCHECK(hipEventRecord(mark));
+    ASSERT(!timeout(mark, 500));
+
+    const char *name = "kernel1";
+    hipLaunchKernelGGL(kernel1, dim3(num_blocks), dim3(threads_per_block), 0, 0,
+                       (ulong)print_things_1, (ulong)name);
+    HIPCHECK(hipEventRecord(mark));
+    ASSERT(!timeout(mark, 500));
+}
+
+int
+main(int argc, char **argv)
+{
+    ASSERT(set_flags(argc, argv));
+    test();
+    test_passed();
+}

--- a/tests/hostcall/common.h
+++ b/tests/hostcall/common.h
@@ -1,0 +1,295 @@
+#ifndef COMMON_H
+#define COMMON_H
+
+#include <amd_hostcall.h>
+
+bool debug_mode;
+#define WHEN_DEBUG(xxx)                                                        \
+    do {                                                                       \
+        if (debug_mode) {                                                      \
+            xxx;                                                               \
+        }                                                                      \
+    } while (false)
+
+static bool
+set_flags(int argc, char *argv[])
+{
+    for (int ii = 1; ii != argc; ++ii) {
+        char *str = argv[ii];
+        if (str[0] != '-')
+            return false;
+        if (str[2])
+            return false;
+        switch (str[1]) {
+        case 'd':
+            debug_mode = true;
+            amd_hostcall_enable_debug();
+            break;
+        default:
+            return false;
+            break;
+        }
+    }
+
+    return true;
+}
+
+#define KNRM "\x1B[0m"
+#define KRED "\x1B[31m"
+#define KGRN "\x1B[32m"
+
+#define test_passed()                                                          \
+    printf("%sPASSED!%s\n", KGRN, KNRM);                                       \
+    exit(0);
+
+#define test_failed(...)                                                       \
+    printf("%serror: ", KRED);                                                 \
+    printf(__VA_ARGS__);                                                       \
+    printf("\n");                                                              \
+    printf("error: TEST FAILED\n%s", KNRM);                                    \
+    abort();
+
+#define ASSERT(expr)                                                           \
+    if ((expr)) {                                                              \
+    } else {                                                                   \
+        test_failed("%sassertion %s at %s:%d%s \n", KRED, #expr, __FILE__,     \
+                    __LINE__, KNRM);                                           \
+    }
+
+#define HIPCHECK(error)                                                        \
+    do {                                                                       \
+        hipError_t localError = error;                                         \
+        if ((localError != hipSuccess) &&                                      \
+            (localError != hipErrorPeerAccessAlreadyEnabled)) {                \
+            printf("%serror: '%s'(%d) from %s at %s:%d%s\n", KRED,             \
+                   hipGetErrorString(localError), localError, #error,          \
+                   __FILE__, __LINE__, KNRM);                                  \
+            test_failed("API returned error code.");                           \
+        }                                                                      \
+    } while (false);
+
+#define TEST_SERVICE 42
+
+extern "C" __device__ HIP_vector_base<long, 2>::Native_vec_
+__ockl_hostcall_internal(void *buffer, uint service_id, ulong arg0, ulong arg1,
+                         ulong arg2, ulong arg3, ulong arg4, ulong arg5,
+                         ulong arg6, ulong arg7);
+
+extern "C" __device__ HIP_vector_base<long, 2>::Native_vec_
+__ockl_hostcall_preview(uint service_id, ulong arg0, ulong arg1, ulong arg2,
+                        ulong arg3, ulong arg4, ulong arg5, ulong arg6,
+                        ulong arg7);
+
+extern "C" __device__ HIP_vector_base<long, 2>::Native_vec_
+__ockl_call_host_function(ulong fptr, ulong arg0, ulong arg1, ulong arg2,
+                          ulong arg3, ulong arg4, ulong arg5, ulong arg6);
+
+enum { SIGNAL_INIT = UINT64_MAX, SIGNAL_DONE = UINT64_MAX - 1 };
+
+typedef struct {
+    ulong next;
+    ulong activemask;
+    uint service;
+    uint control;
+} header_t;
+
+enum { PAYLOAD_ALIGNMENT = 64 };
+
+typedef struct {
+    // 64 slots of 8 ulongs each
+    ulong slots[64][8];
+} payload_t;
+
+typedef struct {
+    header_t *headers;
+    payload_t *payloads;
+    hsa_signal_t doorbell;
+    ulong free_stack;
+    ulong ready_stack;
+    uint index_size;
+} hostcall_buffer_t;
+
+static void
+work_done(hostcall_buffer_t *buffer)
+{
+    hsa_signal_store_release(buffer->doorbell, SIGNAL_DONE);
+}
+
+static ulong
+get_ptr_tag(ulong ptr, uint index_size)
+{
+    return ptr >> index_size;
+}
+
+static ulong
+get_ptr_index(ulong ptr, uint index_size)
+{
+    ulong mask = 1;
+    mask = (mask << index_size) - 1;
+    return ptr & mask;
+}
+
+static header_t *
+get_header(hostcall_buffer_t *buffer, ulong ptr)
+{
+    return buffer->headers + get_ptr_index(ptr, buffer->index_size);
+}
+
+static payload_t *
+get_payload(hostcall_buffer_t *buffer, ulong ptr)
+{
+    return buffer->payloads + get_ptr_index(ptr, buffer->index_size);
+}
+
+static uint
+get_ready_flag(uint control)
+{
+    return control & 1;
+}
+
+static uint
+reset_ready_flag(uint control)
+{
+    return control & ~1;
+}
+
+static uint
+set_ready_flag(uint control)
+{
+    return control | 1;
+}
+
+static ulong
+inc_ptr_tag(ulong ptr, uint index_size)
+{
+    ulong index = get_ptr_index(ptr, index_size);
+    ulong tag = get_ptr_tag(ptr, index_size);
+    return ((tag + 1) << index_size) | index;
+}
+
+static ulong
+set_tag(ulong ptr, ulong value, uint index_size)
+{
+    ulong index = get_ptr_index(ptr, index_size);
+    return (value <<= index_size) | index;
+}
+
+static uint
+align_to(uint value, uint alignment)
+{
+    if (value % alignment == 0)
+        return value;
+    return value - (value % alignment) + alignment;
+}
+
+static uint
+get_header_start()
+{
+    return align_to(sizeof(hostcall_buffer_t), alignof(header_t));
+}
+
+static uint
+get_payload_start(uint num_packets)
+{
+    uint header_start = get_header_start();
+    uint header_end = header_start + sizeof(header_t) * num_packets;
+    return align_to(header_end, PAYLOAD_ALIGNMENT);
+}
+
+static uint
+get_buffer_size(uint num_packets)
+{
+    uint payload_start = get_payload_start(num_packets);
+    uint payload_size = sizeof(payload_t) * num_packets;
+    return payload_start + payload_size;
+}
+
+static hostcall_buffer_t *
+createBuffer(uint num_packets, hsa_signal_t signal)
+{
+    if (num_packets == 0)
+        return nullptr;
+
+    void *buffer;
+    size_t buffer_size = get_buffer_size(num_packets);
+    WHEN_DEBUG(std::cout << "buffer_t size: " << sizeof(hostcall_buffer_t)
+                         << std::endl);
+    WHEN_DEBUG(std::cout << "header alignment: " << alignof(header_t)
+                         << std::endl);
+    WHEN_DEBUG(std::cout << "header start: " << get_header_start()
+                         << std::endl);
+    WHEN_DEBUG(std::cout << "payload alignment: " << PAYLOAD_ALIGNMENT
+                         << std::endl);
+    WHEN_DEBUG(std::cout << "payload start: " << get_payload_start(num_packets)
+                         << std::endl);
+    WHEN_DEBUG(std::cout << "buffer size: " << buffer_size << std::endl);
+    HIPCHECK(hipHostMalloc(&buffer, buffer_size, hipHostMallocCoherent));
+    memset(buffer, 0, buffer_size);
+
+    hostcall_buffer_t *retval = (hostcall_buffer_t *)buffer;
+    retval->doorbell = signal;
+
+    retval->headers = (header_t *)((uchar *)retval + get_header_start());
+    retval->payloads =
+        (payload_t *)((uchar *)retval + get_payload_start(num_packets));
+
+    uint index_size = 1;
+    if (num_packets > 2)
+        index_size = 32 - __builtin_clz(num_packets);
+    WHEN_DEBUG(std::cout << "num packets: " << num_packets
+                         << "; index size: " << index_size << std::endl);
+    retval->index_size = index_size;
+    retval->headers[0].next = 0;
+
+    ulong next = 0;
+    next = inc_ptr_tag(next, index_size);
+    for (uint ii = 1; ii != num_packets; ++ii) {
+        retval->headers[ii].next = next;
+        next = ii;
+    }
+    retval->free_stack = next;
+    WHEN_DEBUG(std::cout << "free stack: " << retval->free_stack << std::endl);
+    WHEN_DEBUG(std::cout << "next free: " << retval->headers[0].next
+                         << std::endl);
+
+    retval->ready_stack = 0;
+
+    return retval;
+}
+
+static bool
+timeout(hipEvent_t mark, uint millisecs)
+{
+    using std::chrono::system_clock;
+    system_clock::time_point start = system_clock::now();
+    while (hipEventQuery(mark) != hipSuccess) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        system_clock::time_point now = system_clock::now();
+        if (now - start > std::chrono::milliseconds(500)) {
+            WHEN_DEBUG(std::cout << "host timed out" << std::endl);
+            return true;
+        }
+    }
+    return false;
+}
+
+static ulong
+wait_on_signal(hsa_signal_t doorbell, ulong timeout, ulong old_value)
+{
+    WHEN_DEBUG(std::cout << std::endl
+                         << "old signal value: " << (int64_t)old_value
+                         << std::endl);
+
+    while (true) {
+        auto new_value =
+            hsa_signal_wait_scacquire(doorbell, HSA_SIGNAL_CONDITION_NE,
+                                      old_value, timeout,
+                                      HSA_WAIT_STATE_BLOCKED);
+        WHEN_DEBUG(std::cout << "\nnew signal value: " << new_value
+                             << std::endl);
+        if (new_value != old_value)
+            return new_value;
+    }
+}
+
+#endif

--- a/tests/hostcall/device/CMakeLists.txt
+++ b/tests/hostcall/device/CMakeLists.txt
@@ -1,4 +1,2 @@
 file(GLOB files *.cpp)
-foreach(file ${files})
-    hostcall_add_test(device ${file})
-endforeach()
+hostcall_add_tests("${files}")

--- a/tests/hostcall/device/CMakeLists.txt
+++ b/tests/hostcall/device/CMakeLists.txt
@@ -1,0 +1,4 @@
+file(GLOB files *.cpp)
+foreach(file ${files})
+    hostcall_add_test(device ${file})
+endforeach()

--- a/tests/hostcall/device/aba-wraparound.cpp
+++ b/tests/hostcall/device/aba-wraparound.cpp
@@ -1,0 +1,140 @@
+/*
+Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+
+#include "common.h"
+
+#define TAG_TO_ZERO 5
+
+static void
+process_packets(hostcall_buffer_t *buffer, ulong F)
+{
+    WHEN_DEBUG(std::cout << "processing cptr: " << F << std::endl);
+    ulong packet_index = get_ptr_index(F, buffer->index_size);
+    WHEN_DEBUG(std::cout << "packet index: " << packet_index << std::endl);
+    auto header = get_header(buffer, packet_index);
+    WHEN_DEBUG(std::cout << "packet header: " << header << std::endl);
+
+    ASSERT(get_ready_flag(header->control) != 0);
+
+    ASSERT(header->service == TEST_SERVICE);
+
+    __atomic_store_n(&header->control, reset_ready_flag(header->control),
+                     std::memory_order_release);
+}
+
+static ulong
+grab_ready_stack(hostcall_buffer_t *buffer)
+{
+    ulong *top = &buffer->ready_stack;
+    ulong F = __atomic_load_n(top, std::memory_order_acquire);
+    if (!F)
+        return F;
+
+    do {
+        WHEN_DEBUG(std::cout << "trying to grab ready stack: " << std::hex << F
+                             << std::endl);
+    } while (!__atomic_compare_exchange_n(top, &F, 0,
+                                          /* weak = */ false,
+                                          std::memory_order_acquire,
+                                          std::memory_order_relaxed));
+    return F;
+}
+
+static void
+consume_packets(hostcall_buffer_t *buffer)
+{
+    WHEN_DEBUG(std::cout << "launched consumer" << std::endl);
+    ulong signal_value = SIGNAL_INIT;
+    ulong timeout = 1024 * 1024;
+
+    while (true) {
+        signal_value = wait_on_signal(buffer->doorbell, timeout, signal_value);
+
+        ulong F = grab_ready_stack(buffer);
+        WHEN_DEBUG(std::cout << "grabbed ready stack: " << F << std::endl);
+        if (F) {
+            process_packets(buffer, F);
+        }
+
+        if (signal_value == SIGNAL_DONE) {
+            return;
+        }
+    }
+}
+
+__global__ void
+kernel(void *buffer)
+{
+    uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    ulong arg0 = tid;
+    ulong arg1 = 0;
+    ulong arg2 = 0;
+    ulong arg3 = 0;
+    ulong arg4 = 0;
+    ulong arg5 = 0;
+    ulong arg6 = 0;
+    ulong arg7 = 0;
+
+    for (int i = 0; i != TAG_TO_ZERO + 2; ++i) {
+        __ockl_hostcall_internal(buffer, TEST_SERVICE, arg0, arg1, arg2, arg3,
+                                 arg4, arg5, arg6, arg7);
+    }
+}
+
+static void
+test()
+{
+    uint num_blocks = 1;
+    uint threads_per_block = 64;
+    uint num_packets = 1;
+
+    hsa_signal_t signal;
+    ASSERT(hsa_signal_create(SIGNAL_INIT, 0, NULL, &signal) ==
+           HSA_STATUS_SUCCESS);
+
+    hostcall_buffer_t *buffer = createBuffer(num_packets, signal);
+    ASSERT(buffer);
+    buffer->free_stack = set_tag(buffer->free_stack, UINT64_MAX - TAG_TO_ZERO,
+                                 buffer->index_size);
+
+    hipLaunchKernelGGL(kernel, dim3(num_blocks), dim3(threads_per_block), 0, 0,
+                       buffer);
+    hipEvent_t mark;
+    HIPCHECK(hipEventCreate(&mark));
+    HIPCHECK(hipEventRecord(mark));
+
+    std::thread consumer_thread(consume_packets, buffer);
+
+    ASSERT(!timeout(mark, 500));
+
+    work_done(buffer);
+    consumer_thread.join();
+}
+
+int
+main(int argc, char **argv)
+{
+    hsa_init();
+    ASSERT(set_flags(argc, argv));
+    test();
+    test_passed();
+}

--- a/tests/hostcall/device/many-waves.cpp
+++ b/tests/hostcall/device/many-waves.cpp
@@ -1,0 +1,217 @@
+/*
+Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+
+#include "common.h"
+
+#include <vector>
+
+static void
+push(ulong *top, ulong ptr, hostcall_buffer_t *buffer)
+{
+    ulong F = __atomic_load_n((ulong *)top, std::memory_order_relaxed);
+    header_t *P = get_header(buffer, ptr);
+    P->next = F;
+
+    while (!__atomic_compare_exchange_n(top, &F, ptr,
+                                        /* weak = */ false,
+                                        std::memory_order_release,
+                                        std::memory_order_relaxed)) {
+        P->next = F;
+    }
+
+    WHEN_DEBUG(std::cout << "pushed free packet: " << ptr << std::endl);
+}
+
+static uint
+handle_packet(ulong *retval, const ulong *payload)
+{
+    *retval = *payload + 1;
+    return 0;
+}
+
+static void
+process_packets(hostcall_buffer_t *buffer, ulong F)
+{
+    WHEN_DEBUG(std::cout << "process packets starting with " << F << std::endl);
+    std::vector<ulong> R;
+    while (F) {
+        WHEN_DEBUG(std::cout << "found cptr: " << F << std::endl);
+        auto *P = get_header(buffer, F);
+        R.push_back(F);
+        F = P->next;
+    }
+
+    while (!R.empty()) {
+        auto II = R.back();
+        R.pop_back();
+
+        WHEN_DEBUG(std::cout << "processing cptr: " << II << std::endl);
+        ulong packet_index = get_ptr_index(II, buffer->index_size);
+        WHEN_DEBUG(std::cout << "packet index: " << packet_index << std::endl);
+        auto header = get_header(buffer, II);
+
+        ASSERT(get_ready_flag(header->control) != 0);
+
+        ASSERT(header->service == TEST_SERVICE);
+
+        ulong activemask = header->activemask;
+        WHEN_DEBUG(std::cout << "activemask: " << std::hex << activemask
+                             << std::dec << std::endl);
+
+        payload_t *payload = get_payload(buffer, II);
+        for (uint wi = 0; wi != 64; ++wi) {
+            ulong flag = activemask & ((ulong)1 << wi);
+            if (flag == 0)
+                continue;
+            auto slot = payload->slots[wi];
+            ulong retval;
+            uint status = handle_packet(&retval, slot);
+            ASSERT(status == 0);
+            *slot = retval;
+        }
+
+        WHEN_DEBUG(std::cout << "finished processing" << std::endl);
+
+        __atomic_store_n(&header->control, reset_ready_flag(header->control),
+                         std::memory_order_release);
+    }
+}
+
+static ulong
+grab_ready_stack(hostcall_buffer_t *buffer)
+{
+    ulong *top = &buffer->ready_stack;
+    ulong F = __atomic_load_n(top, std::memory_order_acquire);
+    if (!F)
+        return F;
+
+    do {
+        WHEN_DEBUG(std::cout << "trying to grab ready stack: " << F
+                             << std::endl);
+    } while (!__atomic_compare_exchange_n(top, &F, 0,
+                                          /* weak = */ false,
+                                          std::memory_order_acquire,
+                                          std::memory_order_relaxed));
+    return F;
+}
+
+static void
+consume_packets(hostcall_buffer_t *buffer)
+{
+    WHEN_DEBUG(std::cout << "launched consumer" << std::endl);
+    ulong signal_value = SIGNAL_INIT;
+    ulong timeout = 1024 * 1024;
+
+    while (true) {
+        signal_value = wait_on_signal(buffer->doorbell, timeout, signal_value);
+
+        ulong F = grab_ready_stack(buffer);
+        WHEN_DEBUG(std::cout << "grabbed ready stack: " << F << std::endl);
+
+        if (F) {
+            process_packets(buffer, F);
+        }
+
+        if (signal_value == SIGNAL_DONE) {
+            return;
+        }
+    }
+
+    return;
+}
+
+__global__ void
+kernel(void *buffer, ulong *retval)
+{
+    uint tid = hipThreadIdx_x + hipBlockIdx_x * hipBlockDim_x;
+    ulong arg0 = tid;
+    ulong arg1 = 0;
+    ulong arg2 = 0;
+    ulong arg3 = 0;
+    ulong arg4 = 0;
+    ulong arg5 = 0;
+    ulong arg6 = 0;
+    ulong arg7 = 0;
+
+    long2 result = {0, 0};
+    if (tid % 71 != 1) {
+        result.data =
+            __ockl_hostcall_internal(buffer, TEST_SERVICE, arg0, arg1, arg2,
+                                     arg3, arg4, arg5, arg6, arg7);
+        retval[tid] = result.x;
+    }
+}
+
+static void
+test()
+{
+    uint num_blocks = 5;
+    uint threads_per_block = 1000;
+    uint warps_per_block = (threads_per_block + 63) / 64;
+    uint num_threads = num_blocks * threads_per_block;
+    uint num_packets = warps_per_block * num_blocks;
+
+    hsa_signal_t signal;
+    ASSERT(hsa_signal_create(SIGNAL_INIT, 0, NULL, &signal) ==
+           HSA_STATUS_SUCCESS);
+
+    hostcall_buffer_t *buffer = createBuffer(num_packets, signal);
+    ASSERT(buffer);
+
+    void *retval_void;
+    HIPCHECK(hipHostMalloc(&retval_void, 8 * num_threads));
+    uint64_t *retval = (uint64_t *)retval_void;
+    for (uint i = 0; i != num_threads; ++i) {
+        retval[i] = 0x23232323;
+    }
+
+    hipLaunchKernelGGL(kernel, dim3(num_blocks), dim3(threads_per_block), 0, 0,
+                       buffer, retval);
+    hipEvent_t mark;
+    HIPCHECK(hipEventCreate(&mark));
+    HIPCHECK(hipEventRecord(mark));
+
+    std::thread consumer_thread(consume_packets, buffer);
+
+    ASSERT(!timeout(mark, 500));
+
+    work_done(buffer);
+    consumer_thread.join();
+
+    for (uint ii = 0; ii != num_threads; ++ii) {
+        ulong value = retval[ii];
+        if (ii % 71 == 1) {
+            ASSERT(value == 0x23232323);
+        } else {
+            ASSERT(value == ii + 1);
+        }
+    }
+}
+
+int
+main(int argc, char **argv)
+{
+    hsa_init();
+    ASSERT(set_flags(argc, argv));
+    test();
+    test_passed();
+}

--- a/tests/hostcall/device/one-wave.cpp
+++ b/tests/hostcall/device/one-wave.cpp
@@ -1,0 +1,162 @@
+/*
+Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+
+#include "common.h"
+
+__global__ void
+kernel(void *buffer, ulong *retval0, ulong *retval1)
+{
+    uint tid = hipThreadIdx_x;
+    if (tid % 3 != 0)
+        return;
+
+    uint count = hipThreadIdx_x * 8 + 1;
+    ulong arg0 = count++;
+    ulong arg1 = count++;
+    ulong arg2 = count++;
+    ulong arg3 = count++;
+    ulong arg4 = count++;
+    ulong arg5 = count++;
+    ulong arg6 = count++;
+    ulong arg7 = count++;
+
+    long2 result;
+    result.data = __ockl_hostcall_internal(buffer, TEST_SERVICE, arg0, arg1,
+                                           arg2, arg3, arg4, arg5, arg6, arg7);
+    retval0[tid] = result.x;
+    retval1[tid] = result.y;
+}
+
+static void
+check(hostcall_buffer_t *buffer)
+{
+    wait_on_signal(buffer->doorbell, 1024 * 1024, SIGNAL_INIT);
+    ulong cptr =
+        __atomic_load_n(&buffer->ready_stack, std::memory_order_acquire);
+    ASSERT(cptr != 0);
+    WHEN_DEBUG(std::cout << "received packet: " << std::hex << cptr << std::dec
+                         << std::endl);
+    ulong fptr =
+        __atomic_load_n(&buffer->free_stack, std::memory_order_relaxed);
+    WHEN_DEBUG(std::cout << "free stack: " << std::hex << fptr << std::dec
+                         << std::endl);
+    ASSERT(fptr == 0);
+    header_t *header = get_header(buffer, cptr);
+    ASSERT(header->next == 0);
+    ASSERT(get_ready_flag(header->control) != 0);
+
+    // If every third bit is set, we get a series of octal 1's
+    ASSERT(header->activemask == 01111111111111111111111);
+    ASSERT(header->service == TEST_SERVICE);
+
+    payload_t *payload = get_payload(buffer, cptr);
+    for (int tid = 0; tid != 64; ++tid) {
+        if (tid % 3 != 0)
+            continue;
+
+        WHEN_DEBUG(std::cout << "workitem: " << std::dec << tid << std::endl);
+        auto slot = payload->slots[tid];
+        for (int ii = 0; ii != 8; ++ii) {
+            WHEN_DEBUG(std::cout << "payload: " << std::hex << slot[ii]
+                                 << std::dec << std::endl);
+            ASSERT(slot[ii] == tid * 8 + ii + 1);
+        }
+        slot[0] = tid % 5 + 1;
+        slot[1] = tid % 7 + 1;
+    }
+
+    __atomic_store_n(&header->control, reset_ready_flag(header->control),
+                     std::memory_order_release);
+
+    // wait for the single wave to return its packet
+    ulong F = __atomic_load_n(&buffer->free_stack, std::memory_order_acquire);
+    while (F == fptr) {
+        std::this_thread::sleep_for(std::chrono::microseconds(5));
+        F = __atomic_load_n(&buffer->free_stack, std::memory_order_acquire);
+    }
+    WHEN_DEBUG(std::cout << "new free stack: " << std::hex << F << std::endl);
+    ASSERT(F == inc_ptr_tag(cptr, buffer->index_size));
+}
+
+static void
+test()
+{
+    unsigned int numThreads = 64;
+    unsigned int numBlocks = 1;
+
+    unsigned int numPackets = 1;
+
+    hsa_signal_t signal;
+    ASSERT(hsa_signal_create(SIGNAL_INIT, 0, NULL, &signal) ==
+           HSA_STATUS_SUCCESS);
+
+    hostcall_buffer_t *buffer = createBuffer(numPackets, signal);
+    ASSERT(buffer);
+
+    void *retval0_void;
+    HIPCHECK(hipHostMalloc(&retval0_void, 8 * numThreads));
+    uint64_t *retval0 = (uint64_t *)retval0_void;
+    for (int i = 0; i != numThreads; ++i) {
+        retval0[i] = 0x23232323;
+    }
+
+    void *retval1_void;
+    HIPCHECK(hipHostMalloc(&retval1_void, 8 * numThreads));
+    uint64_t *retval1 = (uint64_t *)retval1_void;
+    for (int i = 0; i != numThreads; ++i) {
+        retval1[i] = 0x17171717;
+    }
+
+    hipLaunchKernelGGL(kernel, dim3(numBlocks), dim3(numThreads, 1, 1), 0, 0,
+                       buffer, retval0, retval1);
+    hipEvent_t start;
+    HIPCHECK(hipEventCreate(&start));
+    HIPCHECK(hipEventRecord(start));
+
+    check(buffer);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    HIPCHECK(hipEventQuery(start));
+
+    HIPCHECK(hipDeviceSynchronize());
+    for (int i = 0; i != numThreads; ++i) {
+        switch (i % 3) {
+        case 0:
+            ASSERT(retval0[i] == i % 5 + 1);
+            ASSERT(retval1[i] == i % 7 + 1);
+            break;
+        default:
+            ASSERT(retval0[i] == 0x23232323);
+            ASSERT(retval1[i] == 0x17171717);
+            break;
+        }
+    }
+}
+
+int
+main(int argc, char **argv)
+{
+    hsa_init();
+    ASSERT(set_flags(argc, argv));
+    test();
+    test_passed();
+}

--- a/tests/hostcall/device/one-workitem.cpp
+++ b/tests/hostcall/device/one-workitem.cpp
@@ -1,0 +1,138 @@
+/*
+Copyright (c) 2018 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip/hip_runtime.h>
+#include <hsa/hsa.h>
+
+#include "common.h"
+
+__global__ void
+kernel(void *buffer, ulong *retval0, ulong *retval1)
+{
+    uint count = 1;
+    ulong arg0 = count++;
+    ulong arg1 = count++;
+    ulong arg2 = count++;
+    ulong arg3 = count++;
+    ulong arg4 = count++;
+    ulong arg5 = count++;
+    ulong arg6 = count++;
+    ulong arg7 = count++;
+
+    long2 result;
+    result.data = __ockl_hostcall_internal(buffer, TEST_SERVICE, arg0, arg1,
+                                           arg2, arg3, arg4, arg5, arg6, arg7);
+
+    *retval0 = result.x;
+    *retval1 = result.y;
+}
+
+static void
+check(hostcall_buffer_t *buffer)
+{
+    wait_on_signal(buffer->doorbell, 1024 * 1024, SIGNAL_INIT);
+    ulong cptr =
+        __atomic_load_n(&buffer->ready_stack, std::memory_order_acquire);
+    ASSERT(cptr != 0);
+    WHEN_DEBUG(std::cout << "received packet: " << std::hex << cptr << std::dec
+                         << std::endl);
+    ulong fptr =
+        __atomic_load_n(&buffer->free_stack, std::memory_order_relaxed);
+    WHEN_DEBUG(std::cout << "free stack: " << std::hex << fptr << std::dec
+                         << std::endl);
+    ASSERT(fptr == 0);
+
+    header_t *header = get_header(buffer, cptr);
+    ASSERT(header->next == 0);
+    ASSERT(get_ready_flag(header->control) != 0);
+    ASSERT(header->activemask == 1);
+    ASSERT(header->service == TEST_SERVICE);
+
+    payload_t *payload = get_payload(buffer, cptr);
+    auto p = payload->slots[0];
+
+    for (int ii = 0; ii != 8; ++ii) {
+        WHEN_DEBUG(std::cout << "payload: " << p[ii] << std::endl);
+        ASSERT(p[ii] == ii + 1);
+    }
+    p[0] = 42;
+    p[1] = 17;
+
+    __atomic_store_n(&header->control, reset_ready_flag(header->control),
+                     std::memory_order_release);
+
+    // wait for the single wave to return its packet
+    ulong F = __atomic_load_n(&buffer->free_stack, std::memory_order_acquire);
+    while (F == fptr) {
+        std::this_thread::sleep_for(std::chrono::microseconds(5));
+        F = __atomic_load_n(&buffer->free_stack, std::memory_order_acquire);
+    }
+    WHEN_DEBUG(std::cout << "new free stack: " << std::hex << F << std::endl);
+    ASSERT(F == inc_ptr_tag(cptr, buffer->index_size));
+}
+
+static void
+test()
+{
+    unsigned int numThreads = 1;
+    unsigned int numBlocks = 1;
+
+    unsigned int numPackets = 1;
+
+    hsa_signal_t signal;
+    ASSERT(hsa_signal_create(SIGNAL_INIT, 0, NULL, &signal) ==
+           HSA_STATUS_SUCCESS);
+
+    hostcall_buffer_t *buffer = createBuffer(numPackets, signal);
+    ASSERT(buffer);
+
+    void *retval0_void;
+    HIPCHECK(hipHostMalloc(&retval0_void, 8));
+    uint64_t *retval0 = (uint64_t *)retval0_void;
+    *retval0 = 0x23232323;
+
+    void *retval1_void;
+    HIPCHECK(hipHostMalloc(&retval1_void, 8));
+    uint64_t *retval1 = (uint64_t *)retval1_void;
+    *retval1 = 0x17171717;
+
+    hipLaunchKernelGGL(kernel, dim3(numBlocks), dim3(numThreads), 0, 0, buffer,
+                       retval0, retval1);
+    hipEvent_t start;
+    HIPCHECK(hipEventCreate(&start));
+    HIPCHECK(hipEventRecord(start));
+
+    check(buffer);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    ASSERT(hipEventQuery(start) == hipSuccess);
+
+    HIPCHECK(hipDeviceSynchronize());
+    ASSERT(*retval0 == 42);
+    ASSERT(*retval1 == 17);
+}
+
+int
+main(int argc, char **argv)
+{
+    hsa_init();
+    ASSERT(set_flags(argc, argv));
+    test();
+    test_passed();
+}


### PR DESCRIPTION
The hostcall feature allows a kernel to request a service from the
host, and expect to block until it receives a response. It depends on
an external host library libamd_hostcall to provide the host-side
support.

When initializing, the HIP runtime now launches a single consumer
process that responds to hostcalls invoked by active kernels. A
separate hostcall buffer is managed for each HSA queue.

This initial implementation is an early preview, and may change in
unspecified ways in future releases. The first supported service is
the ability to invoke a host function identified by a pointer passed
to the kernel.