### PR TITLE
Add device_builtin_texture_type attribute to texture type for hip-clang

### DIFF
--- a/include/hip/hcc_detail/hip_texture_types.h
+++ b/include/hip/hcc_detail/hip_texture_types.h
@@ -45,10 +45,15 @@ THE SOFTWARE.
  *                                                                              *
  *                                                                              *
  *******************************************************************************/
+#if __HIP__
+#define __HIP_TEXTURE_ATTRIB __attribute__((device_builtin_texture_type))
+#else
+#define __HIP_TEXTURE_ATTRIB
+#endif
 
 template <class T, int texType = hipTextureType1D,
           enum hipTextureReadMode mode = hipReadModeElementType>
-struct texture : public textureReference {
+struct __HIP_TEXTURE_ATTRIB texture : public textureReference {
     texture(int norm = 0, enum hipTextureFilterMode fMode = hipFilterModePoint,
             enum hipTextureAddressMode aMode = hipAddressModeClamp) {
         normalized = norm;


### PR DESCRIPTION
This is required to support texture type for hip-clang.