### PR TITLE
Fix default HIP_VDI_HOME

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -108,7 +108,7 @@ $HIP_RUNTIME= $hipConfig{'HIP_RUNTIME'};
 # If using VDI runtime, need to find HIP_VDI_HOME
 if ($HIP_RUNTIME eq "VDI" and !defined $HIP_VDI_HOME) {
     my $hipcc_dir = dirname($0);
-    if (-e "$hipcc_dir/.hipVersion") {
+    if (-e "$hipcc_dir/../lib/bitcode") {
         $HIP_VDI_HOME = abs_path($hipcc_dir . "/..");
     } else {
         $HIP_VDI_HOME = "/opt/rocm/hip";


### PR DESCRIPTION
There is soft link /opt/rocm/bin/.hipVersion, therefore when hipcc is executed
as /opt/rocm/bin/hipcc, it will set HIP_VDI_HOME to /opt/rocm, which is
incorrect. Check ../lib/bitcode instead to identify HIP_VDI_HOME.