### PR TITLE
[hipcc] Revise include path calculation.

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -118,6 +118,9 @@ if ($HIP_RUNTIME eq "VDI" and !defined $HIP_VDI_HOME) {
 if (defined $HIP_VDI_HOME) {
     if (!defined $HIP_CLANG_PATH and (-e "$HIP_VDI_HOME/bin/clang" or -e "$HIP_VDI_HOME/bin/clang.exe")) {
         $HIP_CLANG_PATH = "$HIP_VDI_HOME/bin";
+    }
+    # With HIP_VDI_HOME defined, assume the installation of clang components, including headers.
+    if (!defined $HIP_CLANG_INCLUDE_PATH) {
         $HIP_CLANG_INCLUDE_PATH = "$HIP_VDI_HOME/include/clang";
     }
     if (!defined $DEVICE_LIB_PATH and -e "$HIP_VDI_HOME/lib/bitcode") {


### PR DESCRIPTION
- Once HIP_VDI_HOME is defined but HIP_CLANG_INCLUDE_PATH is not,
  calculate it directly without HIP_CLANG_PATH is defined or not;
  Otherwise, we may leave HIP_CLANG_INCLUDE_PATH undefined, if clang is
  not installed following the official way (so far, HIP-Clang breaks
  that), we may leave HIP_CLANG_INCLUDE_PATH undefined before its uses.