### PR TITLE
Make hip_prof_gen.py compatible with both python 2 and 3

### DIFF
--- a/hip_prof_gen.py
+++ b/hip_prof_gen.py
@@ -13,7 +13,7 @@ line_num = -1
 
 # Verbose message
 def message(msg):
-  if verbose: print >>sys.stdout, msg
+  if verbose: sys.stdout.write(msg + '\n')
 
 # Fatal error termination
 def error(msg):
@@ -24,8 +24,8 @@ def error(msg):
   else:
     msg = " Warning: " + msg
 
-  print >>sys.stdout, msg
-  print >>sys.stderr, sys.argv[0] + msg
+  sys.stdout.write(msg + '\n')
+  sys.stderr.write(sys.argv[0] + msg +'\n')
 
 def fatal(msg):
   error(msg)
@@ -451,7 +451,7 @@ parse_api(api_hfile, api_map)
 parse_src(api_map, src_dir, src_pat, opts_map)
 
 # Checking for non-conformant APIs
-for name in opts_map.keys():
+for name in list(opts_map.keys()):
   m = re.match(r'\.(\S*)', name)
   if m:
     message("Init missing: " + m.group(1))


### PR DESCRIPTION
Convert python 2 constructs to python 3 compatible ones.

In python 3, print is a function, so use write methods (which are always functions) instead.

In python3 keys() returns an iterator, rather than a list. This means you can't change the data structure that is being iterated over. Converting this iterator into a list mimics the python 2 behavior.