### PR TITLE
Fix dlpi_name info empty when using GCC on ub18

### DIFF
--- a/src/program_state.inl
+++ b/src/program_state.inl
@@ -219,8 +219,8 @@ public:
             dl_iterate_phdr([](dl_phdr_info* info, std::size_t, void* p) {
                 ELFIO::elfio tmp;
 
-                const auto elf =
-                    info->dlpi_addr ? info->dlpi_name : "/proc/self/exe";
+                const auto elf = (info->dlpi_addr && std::strlen(info->dlpi_name) != 0) ?
+                    info->dlpi_name : "/proc/self/exe";
 
                 if (!tmp.load(elf)) return 0;
 
@@ -277,8 +277,8 @@ public:
                 program_state_impl* t = static_cast<program_state_impl*>(psi_ptr);
 
                 ELFIO::elfio tmp;
-                const auto elf =
-                    info->dlpi_addr ? info->dlpi_name : "/proc/self/exe";
+                const auto elf = (info->dlpi_addr && std::strlen(info->dlpi_name) != 0) ?
+                    info->dlpi_name : "/proc/self/exe";
 
                 if (!tmp.load(elf)) return 0;
 
@@ -503,8 +503,8 @@ public:
         std::call_once(function_names.first, [this]() {
             dl_iterate_phdr([](dl_phdr_info* info, std::size_t, void* p) {
                 ELFIO::elfio tmp;
-                const auto elf =
-                    info->dlpi_addr ? info->dlpi_name : "/proc/self/exe";
+                const auto elf = (info->dlpi_addr && std::strlen(info->dlpi_name) != 0) ?
+                    info->dlpi_name : "/proc/self/exe";
 
                 if (!tmp.load(elf)) return 0;
 


### PR DESCRIPTION
This fixes a bug where GCC++ on Ubuntu 18.04 creates failing executables compared to GCC++ on 16.04 and clang++. While creating function names on Ubuntu 18.04, dl_phdr_info seems to provide a non-zero value for dlpi_addr on initial iteration, and an empty string in dlpi_name. This is causing failure when linking with g++, since the empty string prevents the kernel function from being loaded. Clang++ and GCC on UB16 provide a zero value for dlpi_addr. To fix this, we need to verify both addr and name exists, so that /proc/self/exe can be properly loaded.