### PR TITLE
hip_api_name fixed to be inline to suppress not used warning

### DIFF
--- a/hip_prof_gen.py
+++ b/hip_prof_gen.py
@@ -333,7 +333,7 @@ def generate_prof_header(f, api_map, opts_map):
   
   # Generating the callbacks ID enumaration
   f.write('\n// Return HIP API string\n')
-  f.write('static const char* hip_api_name(const uint32_t& id) {\n')
+  f.write('static inline const char* hip_api_name(const uint32_t& id) {\n')
   f.write('  switch(id) {\n')
   for name in api_map.keys():
     f.write('    case HIP_API_ID_' + name + ': return "' +  name + '";\n')


### PR DESCRIPTION
hip_api_name fixed to be inline to suppress 'not used' warning