### PR TITLE
Fix call to cuda library

### DIFF
--- a/include/hip/nvcc_detail/hip_runtime_api.h
+++ b/include/hip/nvcc_detail/hip_runtime_api.h
@@ -1216,11 +1216,9 @@ inline static hipError_t hipFuncSetCacheConfig(const void* func, hipFuncCache_t 
 template <class T>
 inline static hipError_t hipOccupancyMaxPotentialBlockSize(int* minGridSize, int* blockSize, T func,
                                                            size_t dynamicSMemSize = 0,
-                                                           int blockSizeLimit = 0,
-                                                           unsigned int flags = 0) {
+                                                           int blockSizeLimit = 0) {
     cudaError_t cerror;
-    cerror = cudaOccupancyMaxPotentialBlockSizeWithFlags(minGridSize, blockSize, func, dynamicSMemSize,
-                                                blockSizeLimit, flags);
+    cerror = cudaOccupancyMaxPotentialBlockSize(minGridSize, blockSize, func, dynamicSMemSize, blockSizeLimit);
     return hipCUDAErrorTohipError(cerror);
 }
 

--- a/include/hip/nvcc_detail/hip_runtime_api.h
+++ b/include/hip/nvcc_detail/hip_runtime_api.h
@@ -1219,7 +1219,7 @@ inline static hipError_t hipOccupancyMaxPotentialBlockSize(int* minGridSize, int
                                                            int blockSizeLimit = 0,
                                                            unsigned int flags = 0) {
     cudaError_t cerror;
-    cerror = cudaOccupancyMaxPotentialBlockSize(minGridSize, blockSize, func, dynamicSMemSize,
+    cerror = cudaOccupancyMaxPotentialBlockSizeWithFlags(minGridSize, blockSize, func, dynamicSMemSize,
                                                 blockSizeLimit, flags);
     return hipCUDAErrorTohipError(cerror);
 }


### PR DESCRIPTION
The wrong function was called with the given arguments. cudaOccupancyMaxPotentialBlockSize can only be called with max. 5 arguments. There is an extra function cudaOccupancyMaxPotentialBlockSizeWithFlags which additionally can accept optional flags - like described in the [official documentation].

So currently (without this fix) the following error occurs when compiling a hip program, which uses hipOccupancyMaxPotentialBlockSize, for a nvidia device:

```
/opt/rocm/include/hip/nvcc_detail/hip_runtime_api.h:1217:44: error: no matching function for call to ‘cudaOccupancyMaxPotentialBlockSize(int*&, int*&, const void*&, size_t&, int&, unsigned int&)’
     cerror = cudaOccupancyMaxPotentialBlockSize(minGridSize, blockSize, func, dynamicSMemSize,
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~                   
/usr/local/cuda/include/cuda_runtime.h:1827:1: note: candidate: template<class T> cudaError_t cudaOccupancyMaxPotentialBlockSize(int*, int*, T, size_t, int)
 static __inline__ __host__ CUDART_DEVICE cudaError_t cudaOccupancyMaxPotentialBlockSize(
 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/local/cuda/include/cuda_runtime.h:1827:1: note:   template argument deduction/substitution failed:
/opt/rocm/include/hip/nvcc_detail/hip_runtime_api.h:1217:44: note:   candidate expects 5 arguments, 6 provided
     cerror = cudaOccupancyMaxPotentialBlockSize(minGridSize, blockSize, func, dynamicSMemSize,
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~   
```

[official documentation]: https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__HIGHLEVEL.html#group__CUDART__HIGHLEVEL_1gd0524825c5c01bbc9a5e29e890745800