### PR TITLE
Change the type of hipTextureObject_t to pointer to a struct. This is…

### DIFF
--- a/include/hip/hcc_detail/texture_types.h
+++ b/include/hip/hcc_detail/texture_types.h
@@ -45,7 +45,8 @@ THE SOFTWARE.
 /**
  * An opaque value that represents a hip texture object
  */
-typedef unsigned long long hipTextureObject_t;
+struct __hip_texture;
+typedef struct __hip_texture* hipTextureObject_t;
 
 /**
  * hip texture address modes


### PR DESCRIPTION
… necessary to allow Runtime to perform required texture buffer handling.