### PR TITLE
Fix typo ( T in Vec3_cmp = needs to be int ).

### DIFF
--- a/include/hip/hcc_detail/hip_vector_types.h
+++ b/include/hip/hcc_detail/hip_vector_types.h
@@ -210,7 +210,7 @@ THE SOFTWARE.
                 return *this;
             }
 
-            using Vec3_cmp = T __NATIVE_VECTOR__(3, int);
+            using Vec3_cmp = int __NATIVE_VECTOR__(3, int);
             __host__ __device__
             Vec3_cmp operator==(const Native_vec_& x) const noexcept
             {


### PR DESCRIPTION
Typo introduced here:
commit 67abac1365c26fdf499e288ac7f3eec88b52c816
Author: Alex Voicu <alexandru.voicu@amd.com>
Date:   Mon Jun 24 20:02:09 2019 -0500

    Put 3-wide vector types on a ketogenic diet. (#1180)