### PR TITLE
[HIPIFY] Statistics to CSV file dumping revise

### DIFF
--- a/hipify-clang/src/ArgParse.cpp
+++ b/hipify-clang/src/ArgParse.cpp
@@ -104,6 +104,11 @@ cl::opt<bool> PrintStats("print-stats",
   cl::value_desc("print-stats"),
   cl::cat(ToolTemplateCategory));
 
+cl::opt<bool> PrintStatsCSV("print-stats-csv",
+  cl::desc("Print translation statistics in CSV file"),
+  cl::value_desc("print-stats-csv"),
+  cl::cat(ToolTemplateCategory));
+
 cl::opt<std::string> OutputStatsFilename("o-stats",
   cl::desc("Output filename for statistics"),
   cl::value_desc("filename"),

--- a/hipify-clang/src/ArgParse.h
+++ b/hipify-clang/src/ArgParse.h
@@ -46,6 +46,7 @@ extern cl::opt<bool> Verbose;
 extern cl::opt<bool> NoBackup;
 extern cl::opt<bool> NoOutput;
 extern cl::opt<bool> PrintStats;
+extern cl::opt<bool> PrintStatsCSV;
 extern cl::opt<std::string> OutputStatsFilename;
 extern cl::opt<bool> Examine;
 extern cl::extrahelp CommonHelp;

--- a/hipify-clang/src/main.cpp
+++ b/hipify-clang/src/main.cpp
@@ -291,7 +291,7 @@ int main(int argc, const char **argv) {
   }
   int Result = 0;
   SmallString<128> tmpFile;
-  StringRef sourceFileName, ext = "hip";
+  StringRef sourceFileName, ext = "hip", csv_ext = "csv";
   std::string sTmpFileName, sSourceAbsPath;
   std::string sTmpDirAbsParh = getAbsoluteDirectoryPath(TemporaryDir, EC);
   if (EC) {
@@ -300,7 +300,20 @@ int main(int argc, const char **argv) {
   // Arguments for the Statistics print routines.
   std::unique_ptr<std::ostream> csv = nullptr;
   llvm::raw_ostream* statPrint = nullptr;
+  bool create_csv = false;
   if (!OutputStatsFilename.empty()) {
+    PrintStatsCSV = true;
+    create_csv = true;
+  } else {
+    if (PrintStatsCSV && fileSources.size() > 1) {
+      OutputStatsFilename = "sum_stat.csv";
+      create_csv = true;
+    }
+  }
+  if (create_csv) {
+    if (!OutputDir.empty()) {
+      OutputStatsFilename = sOutputDirAbsPath + "/" + OutputStatsFilename;
+    }
     csv = std::unique_ptr<std::ostream>(new std::ofstream(OutputStatsFilename, std::ios_base::trunc));
   }
   if (PrintStats) {
@@ -341,6 +354,17 @@ int main(int argc, const char **argv) {
       llvm::errs() << "\n" << sHipify << sError << EC.message() << ": while copying " << src << " to " << tmpFile << "\n";
       Result = 1;
       continue;
+    }
+    if (PrintStatsCSV) {
+      if (OutputStatsFilename.empty()) {
+        OutputStatsFilename = sourceFileName.str() + "." + csv_ext.str();
+        if (!OutputDir.empty()) {
+          OutputStatsFilename = sOutputDirAbsPath + "/" + OutputStatsFilename;
+        }
+      }
+      if (!csv) {
+        csv = std::unique_ptr<std::ostream>(new std::ofstream(OutputStatsFilename, std::ios_base::trunc));
+      }
     }
     // Initialise the statistics counters for this file.
     Statistics::setActive(src);


### PR DESCRIPTION
+ Add option -print-stats-csv to dump statistics to CSV file
+ If -o-dir is specified, CSV file will be dumped there
+ Generate 1 summary file sum_stat.csv in case of multiple sources