### PR TITLE
Increased the number of implicit-kernarg bytes to 56

### DIFF
--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -56,7 +56,7 @@ using namespace ELFIO;
 using namespace std;
 
 // For HIP implicit kernargs.
-static const size_t HIP_IMPLICIT_KERNARG_SIZE = 48;
+static const size_t HIP_IMPLICIT_KERNARG_SIZE = 56;
 static const size_t HIP_IMPLICIT_KERNARG_ALIGNMENT = 8;
 
 struct amd_kernel_code_v3_t {


### PR DESCRIPTION
Allocate 8 bytes more for the new implicit kernarg - multi grid synchronization. Any consumers of this argument should note that it will be appended to the end of existing implicit kernargs.