### PR TITLE
Fix hipMemcpy-size test running out of Host Mem

### DIFF
--- a/tests/src/runtimeApi/memory/hipMemcpy.cpp
+++ b/tests/src/runtimeApi/memory/hipMemcpy.cpp
@@ -35,6 +35,7 @@ THE SOFTWARE.
 #include "test_common.h"
 
 #ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #else
 #include "sys/types.h"

--- a/tests/src/runtimeApi/memory/hipMemcpy.cpp
+++ b/tests/src/runtimeApi/memory/hipMemcpy.cpp
@@ -299,10 +299,10 @@ void memcpytest2_get_host_memory(size_t& free, size_t& total) {
 struct sysinfo memInfo;
 void memcpytest2_get_host_memory(size_t& free, size_t& total) {
     sysinfo(&memInfo);
-    long long freePhysMem=memInfo.freeram + memInfo.freeswap;
+    long long freePhysMem=memInfo.freeram;
     freePhysMem *= memInfo.mem_unit;
     free = freePhysMem;
-    long long totalPhysMem=memInfo.totalram + memInfo.totalswap;
+    long long totalPhysMem=memInfo.totalram;
     totalPhysMem *= memInfo.mem_unit;
     total = totalPhysMem;
 }

--- a/tests/src/runtimeApi/memory/hipMemcpy.cpp
+++ b/tests/src/runtimeApi/memory/hipMemcpy.cpp
@@ -33,9 +33,13 @@ THE SOFTWARE.
 #include "hip/hip_runtime.h"
 #include "hip/hip_runtime.h"
 #include "test_common.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
 #include "sys/types.h"
 #include "sys/sysinfo.h"
-
+#endif
 
 void printSep() {
     printf(
@@ -282,6 +286,15 @@ void memcpytest2_for_type(size_t numElements) {
     }
 }
 
+#ifdef _WIN32
+void memcpytest2_get_host_memory(size_t& free, size_t& total) {
+    MEMORYSTATUSEX status;
+    status.dwLength = sizeof(status);
+    GlobalMemoryStatusEx(&status);
+    free = status.ullAvailPhys;
+    total = status.ullTotalPhys;
+}
+#else
 struct sysinfo memInfo;
 void memcpytest2_get_host_memory(size_t& free, size_t& total) {
     sysinfo(&memInfo);
@@ -292,6 +305,7 @@ void memcpytest2_get_host_memory(size_t& free, size_t& total) {
     totalPhysMem *= memInfo.mem_unit;
     total = totalPhysMem;
 }
+#endif
 
 //---
 // Try many different sizes to memory copy.


### PR DESCRIPTION
The hipMemcpy-size uses a maxElem calculated from the total GPU mem /8. Then it will allocate 4 times that amount of host memory. This tests begins failing when there is not enough host memory, such as on systems with 32GB GPU mem, and 16GB RAM. This fixes the test if not enough host memory is available on the system.