### PR TITLE
[HIPIFY][bash] Make 'find' sorted by extension

### DIFF
--- a/bin/findcode.sh
+++ b/bin/findcode.sh
@@ -2,4 +2,7 @@
 
 SEARCH_DIRS=$@
 
-find $SEARCH_DIRS -name '*.cpp' -o -name '*.h' -o -name '*.cu' -o -name '*.cuh' -o -name '*.c' -o -name '*.hpp' -o -name '*.inl'
+find $SEARCH_DIRS -name '*.cu'
+find $SEARCH_DIRS -name '*.cpp' -o -name '*.cxx' -o -name '*.c' -o -name '*.cc'
+find $SEARCH_DIRS -name '*.cuh'
+find $SEARCH_DIRS -name '*.h' -o -name '*.hpp' -o -name '*.inc' -o -name '*.inl' -o -name '*.hxx' -o -name '*.hdl'

--- a/bin/finduncodep.sh
+++ b/bin/finduncodep.sh
@@ -2,4 +2,4 @@
 
 SEARCH_DIR=$1
 
-find $SEARCH_DIR -not -name '*.cpp' -and  -not -name '*.h' -and -not -name '*.cu' -and -not -name '*.cuh' -and -not -name '*.c' -and -not -name '*.hpp'
+find $SEARCH_DIR -not -name '*.cu' -and -not -name '*.cpp' -and -not -name '*.cxx' -and -not -name '*.c' -and -not -name '*.cc' -and -not -name '*.cuh' -and -not -name '*.h' -and -not -name '*.hpp' -and -not -name '*.inc' -and -not -name '*.inl' -and -not -name '*.hxx' -and -not -name '*.hdl'


### PR DESCRIPTION
+ Source files are the first to go. It is needed for in-place hipification in order to avoid errors with included but already hipified header files.
+ More extensions support for batch processing.