### PR TITLE
[hip] fix a bug where we parse kernel's arguments layout for a given …

### DIFF
--- a/src/program_state.inl
+++ b/src/program_state.inl
@@ -738,7 +738,11 @@ public:
                 != AMD_COMGR_STATUS_SUCCESS)
                 continue;
 
-            parse_args(args_md, is_code_object_v3, kernargs[kernel_name_str]);
+            auto foundKernel = kernargs.find(kernel_name_str);
+            // parse arguments for a given kernel only once
+            if (foundKernel == kernargs.end()) {
+                parse_args(args_md, is_code_object_v3, kernargs[kernel_name_str]);
+            }
 
             if (amd_comgr_destroy_metadata(args_md) != AMD_COMGR_STATUS_SUCCESS
                 || amd_comgr_destroy_metadata(kernel_md)


### PR DESCRIPTION
…kernel multiple times
[background] During testing the new HIP API (hipExtLaunchMultiKernelMultiDevice) it was found that if there are multiple GPU architectures targeted during the compilation of a test then get_kernargs_size_align API returns extra kernel_argument_layouts (i.e., it returns one entry per GPU architecture) for example if a kernel only has one actual argument and if we target three different GPU targets such as gfx803, gfx900 and gfx906 for compiling the test executable then  get_kernargs_size_align API returns three as then kenrel_argument_layout instead of the actual one argument which is wrong and it leads to a segfault.