### PR TITLE
remove stream locks where it is safe to do so

### DIFF
--- a/src/hip_event.cpp
+++ b/src/hip_event.cpp
@@ -191,10 +191,8 @@ hipError_t hipEventSynchronize(hipEvent_t event) {
             ctx->locked_syncDefaultStream(true, true);
             return ihipLogStatus(hipSuccess);
         } else {
-            ecd._stream->locked_eventWaitComplete(
-                ecd.marker(), (event->_flags & hipEventBlockingSync) ? hc::hcWaitModeBlocked
+            ecd.marker().wait((event->_flags & hipEventBlockingSync) ? hc::hcWaitModeBlocked
                                                                      : hc::hcWaitModeActive);
-
             return ihipLogStatus(hipSuccess);
         }
     } else {

--- a/src/hip_hcc_internal.h
+++ b/src/hip_hcc_internal.h
@@ -476,7 +476,7 @@ template <typename MUTEX_TYPE>
 class ihipStreamCriticalBase_t : public LockedBase<MUTEX_TYPE> {
    public:
     ihipStreamCriticalBase_t(ihipStream_t* parentStream, hc::accelerator_view av)
-        : _kernelCnt(0), _av(av), _parent(parentStream){};
+        : _av(av), _parent(parentStream){};
 
     ~ihipStreamCriticalBase_t() {}
 
@@ -500,7 +500,6 @@ class ihipStreamCriticalBase_t : public LockedBase<MUTEX_TYPE> {
 
    public:
     ihipStream_t* _parent;
-    uint32_t _kernelCnt;  // Count of inflight kernels in this stream.  Reset at ::wait().
 
     hc::accelerator_view _av;
 
@@ -564,7 +563,6 @@ class ihipStream_t {
     hc::completion_future locked_recordEvent(hipEvent_t event);
 
     bool locked_eventIsReady(hipEvent_t event);
-    void locked_eventWaitComplete(hc::completion_future& marker, hc::hcWaitMode waitMode);
 
     ihipStreamCritical_t& criticalData() { return _criticalData; };
 

--- a/src/hip_stream.cpp
+++ b/src/hip_stream.cpp
@@ -142,9 +142,8 @@ hipError_t hipStreamWaitEvent(hipStream_t stream, hipEvent_t event, unsigned int
                 // conservative wait on host for the specified event to complete:
                 // return _stream->locked_eventWaitComplete(this, waitMode);
                 //
-                ecd._stream->locked_eventWaitComplete(
-                ecd.marker(), (event->_flags & hipEventBlockingSync) ? hc::hcWaitModeBlocked
-                                                                     : hc::hcWaitModeActive);
+                ecd.marker().wait((event->_flags & hipEventBlockingSync) ? hc::hcWaitModeBlocked
+                                                                         : hc::hcWaitModeActive);
             } else {
                 stream = ihipSyncAndResolveStream(stream);
                 // This will use create_blocking_marker to wait on the specified queue.


### PR DESCRIPTION
Do not lock the HIP stream while waiting for an event.  Unlike previous versions of HCC, waiting on an event no longer causes HCC to reclaim stream resources, it only causes HCC to free HSA signals associated with the event.

Remove unused `_kernelCnt` member.  