### PR TITLE
[HIPIFY][#1239] Fix an assert

### DIFF
--- a/hipify-clang/src/HipifyAction.cpp
+++ b/hipify-clang/src/HipifyAction.cpp
@@ -267,11 +267,12 @@ void HipifyAction::PragmaDirective(clang::SourceLocation Loc, clang::PragmaIntro
     return;
   }
   clang::Preprocessor& PP = getCompilerInstance().getPreprocessor();
-  const clang::Token tok = PP.LookAhead(0);
+  clang::Token tok;
+  PP.Lex(tok);
   StringRef Text(SM.getCharacterData(tok.getLocation()), tok.getLength());
   if (Text == "once") {
     pragmaOnce = true;
-    pragmaOnceLoc = PP.LookAhead(1).getLocation();
+    pragmaOnceLoc = tok.getEndLoc();
   }
 }
 


### PR DESCRIPTION
Fixes [ [HIPIFY][Win][debug] Assertion failed: LexLevel == 0 && "cannot use lookahead while lexing"](https://github.com/ROCm-Developer-Tools/HIP/issues/1239)