### PR TITLE
Fixing Compilation warnings

### DIFF
--- a/lpl_ca/clara/clara.hpp
+++ b/lpl_ca/clara/clara.hpp
@@ -637,7 +637,7 @@ struct BoundFlagRefBase : BoundRefBase {
     auto isFlag() const -> bool override { return true; }
 
     auto setValue(std::string const& arg) -> ParserResult override {
-        bool flag;
+        bool flag{false};
         auto result = convertInto(arg, flag);
         if (result) setFlag(flag);
         return result;

--- a/src/hiprtc.cpp
+++ b/src/hiprtc.cpp
@@ -354,13 +354,17 @@ namespace
 {
     class Unique_temporary_path {
         // DATA
+        std::string defaultName{"/tmp/hipTmpFile_"};
         std::experimental::filesystem::path path_{};
-    public:
+        static long counter;
+
+       public:
         // CREATORS
-        Unique_temporary_path() : path_{std::tmpnam(nullptr)}
+        Unique_temporary_path() : path_{defaultName.c_str()}
         {
             while (std::experimental::filesystem::exists(path_)) {
-                path_ = std::tmpnam(nullptr);
+                auto fileName = defaultName + std::to_string(counter++);
+                path_ = fileName.c_str();
             }
         }
         Unique_temporary_path(const std::string& extension)
@@ -388,6 +392,7 @@ namespace
             return path_;
         }
     };
+    long Unique_temporary_path::counter = 0;
 } // Unnamed namespace.
 
 namespace hip_impl


### PR DESCRIPTION
Fixing Few warnings which occur during compilation

- Initialize a bool variable
- Removed call to tmpnam, which is unsafe, replaced it with a log of incremental file name generation