### PR TITLE
[HIPIFY][SPARSE][doc] Populate cuSPARSE API doc with CUDA version field

### DIFF
--- a/docs/markdown/CUSPARSE_API_supported_by_HIP.md
+++ b/docs/markdown/CUSPARSE_API_supported_by_HIP.md
@@ -2,112 +2,112 @@
 
 ## **1. cuSPARSE Data types**
 
-| **type**     |   **CUDA**                                                    |   **HIP**                                                  |
-|-------------:|---------------------------------------------------------------|------------------------------------------------------------|
-| enum         |***`cusparseAction_t`***                                       |***`hipsparseAction_t`***                                   |
-|            0 |*`CUSPARSE_ACTION_SYMBOLIC`*                                   |*`HIPSPARSE_ACTION_SYMBOLIC`*                               |
-|            1 |*`CUSPARSE_ACTION_NUMERIC`*                                    |*`HIPSPARSE_ACTION_NUMERIC`*                                |
-| enum         |***`cusparseDirection_t`***                                    |                                                            |
-|            0 |*`CUSPARSE_DIRECTION_ROW`*                                     |                                                            |
-|            1 |*`CUSPARSE_DIRECTION_COLUMN`*                                  |                                                            |
-| enum         |***`cusparseHybPartition_t`***                                 |***`hipsparseHybPartition_t`***                             |
-|            0 |*`CUSPARSE_HYB_PARTITION_AUTO`*                                |*`HIPSPARSE_HYB_PARTITION_AUTO`*                            |
-|            1 |*`CUSPARSE_HYB_PARTITION_USER`*                                |*`HIPSPARSE_HYB_PARTITION_USER`*                            |
-|            2 |*`CUSPARSE_HYB_PARTITION_MAX`*                                 |*`HIPSPARSE_HYB_PARTITION_MAX`*                             |
-| enum         |***`cusparseDiagType_t`***                                     |***`hipsparseDiagType_t`***                                 |
-|            0 |*`CUSPARSE_DIAG_TYPE_NON_UNIT`*                                |*`HIPSPARSE_DIAG_TYPE_NON_UNIT`*                            |
-|            1 |*`CUSPARSE_DIAG_TYPE_UNIT`*                                    |*`HIPSPARSE_DIAG_TYPE_UNIT`*                                |
-| enum         |***`cusparseFillMode_t`***                                     |***`hipsparseFillMode_t`***                                 |
-|            0 |*`CUSPARSE_FILL_MODE_LOWER`*                                   |*`HIPSPARSE_FILL_MODE_LOWER`*                               |
-|            1 |*`CUSPARSE_FILL_MODE_UPPER`*                                   |*`HIPSPARSE_FILL_MODE_UPPER`*                               |
-| enum         |***`cusparseIndexBase_t`***                                    |***`hipsparseIndexBase_t`***                                |
-|            0 |*`CUSPARSE_INDEX_BASE_ZERO`*                                   |*`HIPSPARSE_INDEX_BASE_ZERO`*                               |
-|            1 |*`CUSPARSE_INDEX_BASE_ONE`*                                    |*`HIPSPARSE_INDEX_BASE_ONE`*                                |
-| enum         |***`cusparseMatrixType_t`***                                   |***`hipsparseMatrixType_t`***                               |
-|            0 |*`CUSPARSE_MATRIX_TYPE_GENERAL`*                               |*`HIPSPARSE_MATRIX_TYPE_GENERAL`*                           |
-|            1 |*`CUSPARSE_MATRIX_TYPE_SYMMETRIC`*                             |*`HIPSPARSE_MATRIX_TYPE_SYMMETRIC`*                         |
-|            2 |*`CUSPARSE_MATRIX_TYPE_HERMITIAN`*                             |*`HIPSPARSE_MATRIX_TYPE_HERMITIAN`*                         |
-|            3 |*`CUSPARSE_MATRIX_TYPE_TRIANGULAR`*                            |*`HIPSPARSE_MATRIX_TYPE_TRIANGULAR`*                        |
-| enum         |***`cusparseOperation_t`***                                    |***`hipsparseOperation_t`***                                |
-|            0 |*`CUSPARSE_OPERATION_NON_TRANSPOSE`*                           |*`HIPSPARSE_OPERATION_NON_TRANSPOSE`*                       |
-|            1 |*`CUSPARSE_OPERATION_TRANSPOSE`*                               |*`HIPSPARSE_OPERATION_TRANSPOSE`*                           |
-|            2 |*`CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE`*                     |*`HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE`*                 |
-| enum         |***`cusparsePointerMode_t`***                                  |***`hipsparsePointerMode_t`***                              |
-|            0 |*`CUSPARSE_POINTER_MODE_HOST`*                                 |*`HIPSPARSE_POINTER_MODE_HOST`*                             |
-|            1 |*`CUSPARSE_POINTER_MODE_DEVICE`*                               |*`HIPSPARSE_POINTER_MODE_DEVICE`*                           |
-| enum         |***`cusparseAlgMode_t`***                                      |                                                            |
-|            0 |*`CUSPARSE_ALG0`*                                              |                                                            |
-|            1 |*`CUSPARSE_ALG1`*                                              |                                                            |
-|            0 |*`CUSPARSE_ALG_NAIVE`*                                         |                                                            |
-|            1 |*`CUSPARSE_ALG_MERGE_PATH`*                                    |                                                            |
-| enum         |***`cusparseSolvePolicy_t`***                                  |***`hipsparseSolvePolicy_t`***                              |
-|            0 |*`CUSPARSE_SOLVE_POLICY_NO_LEVEL`*                             |*`HIPSPARSE_SOLVE_POLICY_NO_LEVEL`*                         |
-|            1 |*`CUSPARSE_SOLVE_POLICY_USE_LEVEL`*                            |*`HIPSPARSE_SOLVE_POLICY_USE_LEVEL`*                        |
-| enum         |***`cusparseStatus_t`***                                       |***`hipsparseMatrixType_t`***                               |
-|            0 |*`CUSPARSE_STATUS_SUCCESS`*                                    |*`HIPSPARSE_STATUS_SUCCESS`*                                |
-|            1 |*`CUSPARSE_STATUS_NOT_INITIALIZED`*                            |*`HIPSPARSE_STATUS_NOT_INITIALIZED`*                        |
-|            2 |*`CUSPARSE_STATUS_ALLOC_FAILED`*                               |*`HIPSPARSE_STATUS_ALLOC_FAILED`*                           |
-|            3 |*`CUSPARSE_STATUS_INVALID_VALUE`*                              |*`HIPSPARSE_STATUS_INVALID_VALUE`*                          |
-|            4 |*`CUSPARSE_STATUS_ARCH_MISMATCH`*                              |*`HIPSPARSE_STATUS_ARCH_MISMATCH`*                          |
-|            5 |*`CUSPARSE_STATUS_MAPPING_ERROR`*                              |*`HIPSPARSE_STATUS_MAPPING_ERROR`*                          |
-|            6 |*`CUSPARSE_STATUS_EXECUTION_FAILED`*                           |*`HIPSPARSE_STATUS_EXECUTION_FAILED`*                       |
-|            7 |*`CUSPARSE_STATUS_INTERNAL_ERROR`*                             |*`HIPSPARSE_STATUS_INTERNAL_ERROR`*                         |
-|            8 |*`CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED`*                  |*`HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED`*              |
-|            9 |*`CUSPARSE_STATUS_ZERO_PIVOT`*                                 |*`HIPSPARSE_STATUS_ZERO_PIVOT`*                             |
-| struct       |`cusparseContext`                                              |                                                            |
-| typedef      |`cusparseHandle_t`                                             |`hipsparseHandle_t`                                         |
-| struct       |`cusparseHybMat`                                               |                                                            |
-| typedef      |`cusparseHybMat_t`                                             |`hipsparseHybMat_t`                                         |
-| struct       |`cusparseMatDescr`                                             |                                                            |
-| typedef      |`cusparseMatDescr_t`                                           |`hipsparseMatDescr_t`                                       |
-| struct       |`cusparseSolveAnalysisInfo`                                    |                                                            |
-| typedef      |`cusparseSolveAnalysisInfo_t`                                  |                                                            |
-| struct       |`csrsv2Info`                                                   |                                                            |
-| typedef      |`csrsv2Info_t`                                                 |`csrsv2Info_t`                                              |
-| struct       |`csrsm2Info`                                                   |                                                            |
-| typedef      |`csrsm2Info_t`                                                 |                                                            |
-| struct       |`bsrsv2Info`                                                   |                                                            |
-| typedef      |`bsrsv2Info_t`                                                 |                                                            |
-| struct       |`bsrsm2Info`                                                   |                                                            |
-| typedef      |`bsrsm2Info_t`                                                 |                                                            |
-| struct       |`bsric02Info`                                                  |                                                            |
-| typedef      |`bsric02Info_t`                                                |                                                            |
-| struct       |`csrilu02Info`                                                 |                                                            |
-| typedef      |`csrilu02Info_t`                                               |`csrilu02Info_t`                                            |
-| struct       |`bsrilu02Info`                                                 |                                                            |
-| typedef      |`bsrilu02Info_t`                                               |                                                            |
-| struct       |`csru2csrInfo`                                                 |                                                            |
-| typedef      |`csru2csrInfo_t`                                               |                                                            |
-| struct       |`cusparseColorInfo`                                            |                                                            |
-| typedef      |`cusparseColorInfo_t`                                          |                                                            |
-| struct       |`pruneInfo`                                                    |                                                            |
-| typedef      |`pruneInfo_t`                                                  |                                                            |
-| enum         |***`cusparseCsr2CscAlg_t`***                                   |                                                            |
-|            1 |*`CUSPARSE_CSR2CSC_ALG1`*                                      |                                                            |
-|            2 |*`CUSPARSE_CSR2CSC_ALG2`*                                      |                                                            |
-| enum         |***`cusparseFormat_t`***                                       |                                                            |
-|            1 |*`CUSPARSE_FORMAT_CSR`*                                        |                                                            |
-|            2 |*`CUSPARSE_FORMAT_CSC`*                                        |                                                            |
-|            3 |*`CUSPARSE_FORMAT_COO`*                                        |                                                            |
-| enum         |***`cusparseOrder_t`***                                        |                                                            |
-|            1 |*`CUSPARSE_ORDER_COL`*                                         |                                                            |
-|            2 |*`CUSPARSE_ORDER_ROW`*                                         |                                                            |
-| enum         |***`cusparseSpMMAlg_t`***                                      |                                                            |
-|            1 |*`CUSPARSE_COOMM_ALG1`*                                        |                                                            |
-|            2 |*`CUSPARSE_COOMM_ALG2`*                                        |                                                            |
-|            3 |*`CUSPARSE_COOMM_ALG3`*                                        |                                                            |
-| enum         |***`cusparseIndexType_t`***                                    |                                                            |
-|            1 |*`CUSPARSE_INDEX_16U`*                                         |                                                            |
-|            2 |*`CUSPARSE_INDEX_32I`*                                         |                                                            |
-| struct       |`cusparseSpMatDescr`                                           |                                                            |
-| typedef      |`cusparseSpMatDescr_t`                                         |                                                            |
-| struct       |`cusparseDnMatDescr`                                           |                                                            |
-| typedef      |`cusparseDnMatDescr_t`                                         |                                                            |
+| **type**     |   **CUDA**                                                    |**CUDA version\***|   **HIP**                                                  |
+|-------------:|---------------------------------------------------------------|:-----------------|------------------------------------------------------------|
+| enum         |***`cusparseAction_t`***                                       |                  |***`hipsparseAction_t`***                                   |
+|            0 |*`CUSPARSE_ACTION_SYMBOLIC`*                                   |                  |*`HIPSPARSE_ACTION_SYMBOLIC`*                               |
+|            1 |*`CUSPARSE_ACTION_NUMERIC`*                                    |                  |*`HIPSPARSE_ACTION_NUMERIC`*                                |
+| enum         |***`cusparseDirection_t`***                                    |                  |                                                            |
+|            0 |*`CUSPARSE_DIRECTION_ROW`*                                     |                  |                                                            |
+|            1 |*`CUSPARSE_DIRECTION_COLUMN`*                                  |                  |                                                            |
+| enum         |***`cusparseHybPartition_t`***                                 |                  |***`hipsparseHybPartition_t`***                             |
+|            0 |*`CUSPARSE_HYB_PARTITION_AUTO`*                                |                  |*`HIPSPARSE_HYB_PARTITION_AUTO`*                            |
+|            1 |*`CUSPARSE_HYB_PARTITION_USER`*                                |                  |*`HIPSPARSE_HYB_PARTITION_USER`*                            |
+|            2 |*`CUSPARSE_HYB_PARTITION_MAX`*                                 |                  |*`HIPSPARSE_HYB_PARTITION_MAX`*                             |
+| enum         |***`cusparseDiagType_t`***                                     |                  |***`hipsparseDiagType_t`***                                 |
+|            0 |*`CUSPARSE_DIAG_TYPE_NON_UNIT`*                                |                  |*`HIPSPARSE_DIAG_TYPE_NON_UNIT`*                            |
+|            1 |*`CUSPARSE_DIAG_TYPE_UNIT`*                                    |                  |*`HIPSPARSE_DIAG_TYPE_UNIT`*                                |
+| enum         |***`cusparseFillMode_t`***                                     |                  |***`hipsparseFillMode_t`***                                 |
+|            0 |*`CUSPARSE_FILL_MODE_LOWER`*                                   |                  |*`HIPSPARSE_FILL_MODE_LOWER`*                               |
+|            1 |*`CUSPARSE_FILL_MODE_UPPER`*                                   |                  |*`HIPSPARSE_FILL_MODE_UPPER`*                               |
+| enum         |***`cusparseIndexBase_t`***                                    |                  |***`hipsparseIndexBase_t`***                                |
+|            0 |*`CUSPARSE_INDEX_BASE_ZERO`*                                   |                  |*`HIPSPARSE_INDEX_BASE_ZERO`*                               |
+|            1 |*`CUSPARSE_INDEX_BASE_ONE`*                                    |                  |*`HIPSPARSE_INDEX_BASE_ONE`*                                |
+| enum         |***`cusparseMatrixType_t`***                                   |                  |***`hipsparseMatrixType_t`***                               |
+|            0 |*`CUSPARSE_MATRIX_TYPE_GENERAL`*                               |                  |*`HIPSPARSE_MATRIX_TYPE_GENERAL`*                           |
+|            1 |*`CUSPARSE_MATRIX_TYPE_SYMMETRIC`*                             |                  |*`HIPSPARSE_MATRIX_TYPE_SYMMETRIC`*                         |
+|            2 |*`CUSPARSE_MATRIX_TYPE_HERMITIAN`*                             |                  |*`HIPSPARSE_MATRIX_TYPE_HERMITIAN`*                         |
+|            3 |*`CUSPARSE_MATRIX_TYPE_TRIANGULAR`*                            |                  |*`HIPSPARSE_MATRIX_TYPE_TRIANGULAR`*                        |
+| enum         |***`cusparseOperation_t`***                                    |                  |***`hipsparseOperation_t`***                                |
+|            0 |*`CUSPARSE_OPERATION_NON_TRANSPOSE`*                           |                  |*`HIPSPARSE_OPERATION_NON_TRANSPOSE`*                       |
+|            1 |*`CUSPARSE_OPERATION_TRANSPOSE`*                               |                  |*`HIPSPARSE_OPERATION_TRANSPOSE`*                           |
+|            2 |*`CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE`*                     |                  |*`HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE`*                 |
+| enum         |***`cusparsePointerMode_t`***                                  |                  |***`hipsparsePointerMode_t`***                              |
+|            0 |*`CUSPARSE_POINTER_MODE_HOST`*                                 |                  |*`HIPSPARSE_POINTER_MODE_HOST`*                             |
+|            1 |*`CUSPARSE_POINTER_MODE_DEVICE`*                               |                  |*`HIPSPARSE_POINTER_MODE_DEVICE`*                           |
+| enum         |***`cusparseAlgMode_t`***                                      | 8.0              |                                                            |
+|            0 |*`CUSPARSE_ALG0`*                                              | 8.0              |                                                            |
+|            1 |*`CUSPARSE_ALG1`*                                              | 8.0              |                                                            |
+|            0 |*`CUSPARSE_ALG_NAIVE`*                                         | 9.2              |                                                            |
+|            1 |*`CUSPARSE_ALG_MERGE_PATH`*                                    | 9.2              |                                                            |
+| enum         |***`cusparseSolvePolicy_t`***                                  |                  |***`hipsparseSolvePolicy_t`***                              |
+|            0 |*`CUSPARSE_SOLVE_POLICY_NO_LEVEL`*                             |                  |*`HIPSPARSE_SOLVE_POLICY_NO_LEVEL`*                         |
+|            1 |*`CUSPARSE_SOLVE_POLICY_USE_LEVEL`*                            |                  |*`HIPSPARSE_SOLVE_POLICY_USE_LEVEL`*                        |
+| enum         |***`cusparseStatus_t`***                                       |                  |***`hipsparseMatrixType_t`***                               |
+|            0 |*`CUSPARSE_STATUS_SUCCESS`*                                    |                  |*`HIPSPARSE_STATUS_SUCCESS`*                                |
+|            1 |*`CUSPARSE_STATUS_NOT_INITIALIZED`*                            |                  |*`HIPSPARSE_STATUS_NOT_INITIALIZED`*                        |
+|            2 |*`CUSPARSE_STATUS_ALLOC_FAILED`*                               |                  |*`HIPSPARSE_STATUS_ALLOC_FAILED`*                           |
+|            3 |*`CUSPARSE_STATUS_INVALID_VALUE`*                              |                  |*`HIPSPARSE_STATUS_INVALID_VALUE`*                          |
+|            4 |*`CUSPARSE_STATUS_ARCH_MISMATCH`*                              |                  |*`HIPSPARSE_STATUS_ARCH_MISMATCH`*                          |
+|            5 |*`CUSPARSE_STATUS_MAPPING_ERROR`*                              |                  |*`HIPSPARSE_STATUS_MAPPING_ERROR`*                          |
+|            6 |*`CUSPARSE_STATUS_EXECUTION_FAILED`*                           |                  |*`HIPSPARSE_STATUS_EXECUTION_FAILED`*                       |
+|            7 |*`CUSPARSE_STATUS_INTERNAL_ERROR`*                             |                  |*`HIPSPARSE_STATUS_INTERNAL_ERROR`*                         |
+|            8 |*`CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED`*                  |                  |*`HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED`*              |
+|            9 |*`CUSPARSE_STATUS_ZERO_PIVOT`*                                 |                  |*`HIPSPARSE_STATUS_ZERO_PIVOT`*                             |
+| struct       |`cusparseContext`                                              |                  |                                                            |
+| typedef      |`cusparseHandle_t`                                             |                  |`hipsparseHandle_t`                                         |
+| struct       |`cusparseHybMat`                                               |                  |                                                            |
+| typedef      |`cusparseHybMat_t`                                             |                  |`hipsparseHybMat_t`                                         |
+| struct       |`cusparseMatDescr`                                             |                  |                                                            |
+| typedef      |`cusparseMatDescr_t`                                           |                  |`hipsparseMatDescr_t`                                       |
+| struct       |`cusparseSolveAnalysisInfo`                                    |                  |                                                            |
+| typedef      |`cusparseSolveAnalysisInfo_t`                                  |                  |                                                            |
+| struct       |`csrsv2Info`                                                   |                  |                                                            |
+| typedef      |`csrsv2Info_t`                                                 |                  |`csrsv2Info_t`                                              |
+| struct       |`csrsm2Info`                                                   | 9.2              |                                                            |
+| typedef      |`csrsm2Info_t`                                                 |                  |                                                            |
+| struct       |`bsrsv2Info`                                                   |                  |                                                            |
+| typedef      |`bsrsv2Info_t`                                                 |                  |                                                            |
+| struct       |`bsrsm2Info`                                                   |                  |                                                            |
+| typedef      |`bsrsm2Info_t`                                                 |                  |                                                            |
+| struct       |`bsric02Info`                                                  |                  |                                                            |
+| typedef      |`bsric02Info_t`                                                |                  |                                                            |
+| struct       |`csrilu02Info`                                                 |                  |                                                            |
+| typedef      |`csrilu02Info_t`                                               |                  |`csrilu02Info_t`                                            |
+| struct       |`bsrilu02Info`                                                 |                  |                                                            |
+| typedef      |`bsrilu02Info_t`                                               |                  |                                                            |
+| struct       |`csru2csrInfo`                                                 |                  |                                                            |
+| typedef      |`csru2csrInfo_t`                                               |                  |                                                            |
+| struct       |`cusparseColorInfo`                                            |                  |                                                            |
+| typedef      |`cusparseColorInfo_t`                                          |                  |                                                            |
+| struct       |`pruneInfo`                                                    | 9.0              |                                                            |
+| typedef      |`pruneInfo_t`                                                  | 9.0              |                                                            |
+| enum         |***`cusparseCsr2CscAlg_t`***                                   | 10.1             |                                                            |
+|            1 |*`CUSPARSE_CSR2CSC_ALG1`*                                      | 10.1             |                                                            |
+|            2 |*`CUSPARSE_CSR2CSC_ALG2`*                                      | 10.1             |                                                            |
+| enum         |***`cusparseFormat_t`***                                       | 10.1             |                                                            |
+|            1 |*`CUSPARSE_FORMAT_CSR`*                                        | 10.1             |                                                            |
+|            2 |*`CUSPARSE_FORMAT_CSC`*                                        | 10.1             |                                                            |
+|            3 |*`CUSPARSE_FORMAT_COO`*                                        | 10.1             |                                                            |
+| enum         |***`cusparseOrder_t`***                                        | 10.1             |                                                            |
+|            1 |*`CUSPARSE_ORDER_COL`*                                         | 10.1             |                                                            |
+|            2 |*`CUSPARSE_ORDER_ROW`*                                         | 10.1             |                                                            |
+| enum         |***`cusparseSpMMAlg_t`***                                      | 10.1             |                                                            |
+|            1 |*`CUSPARSE_COOMM_ALG1`*                                        | 10.1             |                                                            |
+|            2 |*`CUSPARSE_COOMM_ALG2`*                                        | 10.1             |                                                            |
+|            3 |*`CUSPARSE_COOMM_ALG3`*                                        | 10.1             |                                                            |
+| enum         |***`cusparseIndexType_t`***                                    | 10.1             |                                                            |
+|            1 |*`CUSPARSE_INDEX_16U`*                                         | 10.1             |                                                            |
+|            2 |*`CUSPARSE_INDEX_32I`*                                         | 10.1             |                                                            |
+| struct       |`cusparseSpMatDescr`                                           | 10.1             |                                                            |
+| typedef      |`cusparseSpMatDescr_t`                                         | 10.1             |                                                            |
+| struct       |`cusparseDnMatDescr`                                           | 10.1             |                                                            |
+| typedef      |`cusparseDnMatDescr_t`                                         | 10.1             |                                                            |
 
 ## **2. cuSPARSE Helper Function Reference**
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
 |`cusparseCreate`                                           |`hipsparseCreate`                                |
 |`cusparseCreateSolveAnalysisInfo`                          |                                                 |
 |`cusparseCreateHybMat`                                     |`hipsparseCreateHybMat`                          |
@@ -128,11 +128,11 @@
 |`cusparseSetMatType`                                       |`hipsparseSetMatType`                            |
 |`cusparseSetPointerMode`                                   |`hipsparseSetPointerMode`                        |
 |`cusparseSetStream`                                        |`hipsparseSetStream`                             |
-|`cusparseGetStream`                                        |`hipsparseGetStream`                             |
+|`cusparseGetStream`                                        |`hipsparseGetStream`                             | 8.0              |
 |`cusparseCreateCsrsv2Info`                                 |`hipsparseCreateCsrsv2Info`                      |
 |`cusparseDestroyCsrsv2Info`                                |`hipsparseDestroyCsrsv2Info`                     |
-|`cusparseCreateCsrsm2Info`                                 |                                                 |
-|`cusparseDestroyCsrsm2Info`                                |                                                 |
+|`cusparseCreateCsrsm2Info`                                 |                                                 | 9.2              |
+|`cusparseDestroyCsrsm2Info`                                |                                                 | 9.2              |
 |`cusparseCreateCsric02Info`                                |                                                 |
 |`cusparseDestroyCsric02Info`                               |                                                 |
 |`cusparseCreateCsrilu02Info`                               |`hipsparseCreateCsrilu02Info`                    |
@@ -147,13 +147,13 @@
 |`cusparseDestroyBsrilu02Info`                              |                                                 |
 |`cusparseCreateCsrgemm2Info`                               |                                                 |
 |`cusparseDestroyCsrgemm2Info`                              |                                                 |
-|`cusparseCreatePruneInfo`                                  |                                                 |
-|`cusparseDestroyPruneInfo`                                 |                                                 |
+|`cusparseCreatePruneInfo`                                  |                                                 | 9.0              |
+|`cusparseDestroyPruneInfo`                                 |                                                 | 9.0              |
 
 ## **3. cuSPARSE Level 1 Function Reference**
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
 |`cusparseSaxpyi`                                           |`hipsparseSaxpyi`                                |
 |`cusparseDaxpyi`                                           |`hipsparseDaxpyi`                                |
 |`cusparseCaxpyi`                                           |                                                 |
@@ -181,8 +181,8 @@
 
 ## **4. cuSPARSE Level 2 Function Reference**
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
 |`cusparseSbsrmv`                                           |                                                 |
 |`cusparseDbsrmv`                                           |                                                 |
 |`cusparseCbsrmv`                                           |                                                 |
@@ -195,20 +195,20 @@
 |`cusparseDcsrmv`                                           |`hipsparseDcsrmv`                                |
 |`cusparseCcsrmv`                                           |                                                 |
 |`cusparseZcsrmv`                                           |                                                 |
-|`cusparseCsrmvEx`                                          |                                                 |
-|`cusparseCsrmvEx_bufferSize`                               |                                                 |
-|`cusparseScsrmv_mp`                                        |                                                 |
-|`cusparseDcsrmv_mp`                                        |                                                 |
-|`cusparseCcsrmv_mp`                                        |                                                 |
-|`cusparseZcsrmv_mp`                                        |                                                 |
-|`cusparseSgemvi`                                           |                                                 |
-|`cusparseDgemvi`                                           |                                                 |
-|`cusparseCgemvi`                                           |                                                 |
-|`cusparseZgemvi`                                           |                                                 |
-|`cusparseSgemvi_bufferSize`                                |                                                 |
-|`cusparseDgemvi_bufferSize`                                |                                                 |
-|`cusparseCgemvi_bufferSize`                                |                                                 |
-|`cusparseZgemvi_bufferSize`                                |                                                 |
+|`cusparseCsrmvEx`                                          |                                                 | 8.0              |
+|`cusparseCsrmvEx_bufferSize`                               |                                                 | 8.0              |
+|`cusparseScsrmv_mp`                                        |                                                 | 8.0              |
+|`cusparseDcsrmv_mp`                                        |                                                 | 8.0              |
+|`cusparseCcsrmv_mp`                                        |                                                 | 8.0              |
+|`cusparseZcsrmv_mp`                                        |                                                 | 8.0              |
+|`cusparseSgemvi`                                           |                                                 | 7.5              |
+|`cusparseDgemvi`                                           |                                                 | 7.5              |
+|`cusparseCgemvi`                                           |                                                 | 7.5              |
+|`cusparseZgemvi`                                           |                                                 | 7.5              |
+|`cusparseSgemvi_bufferSize`                                |                                                 | 7.5              |
+|`cusparseDgemvi_bufferSize`                                |                                                 | 7.5              |
+|`cusparseCgemvi_bufferSize`                                |                                                 | 7.5              |
+|`cusparseZgemvi_bufferSize`                                |                                                 | 7.5              |
 |`cusparseSbsrsv2_bufferSize`                               |                                                 |
 |`cusparseDbsrsv2_bufferSize`                               |                                                 |
 |`cusparseCbsrsv2_bufferSize`                               |                                                 |
@@ -217,21 +217,21 @@
 |`cusparseDbsrsv2_analysis`                                 |                                                 |
 |`cusparseCbsrsv2_analysis`                                 |                                                 |
 |`cusparseZbsrsv2_analysis`                                 |                                                 |
-|`cusparseScsrsv_solve`                                     |                                                 |
-|`cusparseDcsrsv_solve`                                     |                                                 |
-|`cusparseCcsrsv_solve`                                     |                                                 |
-|`cusparseZcsrsv_solve`                                     |                                                 |
 |`cusparseXbsrsv2_zeroPivot`                                |                                                 |
+|`cusparseSbsrsv2_solve                                     |                                                 |
+|`cusparseDbsrsv2_solve                                     |                                                 |
+|`cusparseCbsrsv2_solve                                     |                                                 |
+|`cusparseZbsrsv2_solve                                     |                                                 |
 |`cusparseScsrsv_analysis`                                  |                                                 |
 |`cusparseDcsrsv_analysis`                                  |                                                 |
 |`cusparseCcsrsv_analysis`                                  |                                                 |
 |`cusparseZcsrsv_analysis`                                  |                                                 |
-|`cusparseCsrsv_analysisEx`                                 |                                                 |
+|`cusparseCsrsv_analysisEx`                                 |                                                 | 8.0              |
 |`cusparseScsrsv_solve`                                     |                                                 |
 |`cusparseDcsrsv_solve`                                     |                                                 |
 |`cusparseCcsrsv_solve`                                     |                                                 |
 |`cusparseZcsrsv_solve`                                     |                                                 |
-|`cusparseCsrsv_solveEx`                                    |                                                 |
+|`cusparseCsrsv_solveEx`                                    |                                                 | 8.0              |
 |`cusparseScsrsv2_bufferSize`                               |`hipsparseScsrsv2_bufferSize`                    |
 |`cusparseDcsrsv2_bufferSize`                               |`hipsparseDcsrsv2_bufferSize`                    |
 |`cusparseCcsrsv2_bufferSize`                               |                                                 |
@@ -260,8 +260,8 @@
 
 ## **5. cuSPARSE Level 3 Function Reference**
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
 |`cusparseScsrmm`                                           |`hipsparseScsrmm`                                |
 |`cusparseDcsrmm`                                           |`hipsparseDcsrmm`                                |
 |`cusparseCcsrmm`                                           |                                                 |
@@ -278,19 +278,19 @@
 |`cusparseDcsrsm_solve`                                     |                                                 |
 |`cusparseCcsrsm_solve`                                     |                                                 |
 |`cusparseZcsrsm_solve`                                     |                                                 |
-|`cusparseScsrsm2_bufferSizeExt`                            |                                                 |
-|`cusparseDcsrsm2_bufferSizeExt`                            |                                                 |
-|`cusparseCcsrsm2_bufferSizeExt`                            |                                                 |
-|`cusparseZcsrsm2_bufferSizeExt`                            |                                                 |
-|`cusparseScsrsm2_analysis`                                 |                                                 |
-|`cusparseDcsrsm2_analysis`                                 |                                                 |
-|`cusparseCcsrsm2_analysis`                                 |                                                 |
-|`cusparseZcsrsm2_analysis`                                 |                                                 |
-|`cusparseScsrsm2_solve`                                    |                                                 |
-|`cusparseDcsrsm2_solve`                                    |                                                 |
-|`cusparseCcsrsm2_solve`                                    |                                                 |
-|`cusparseZcsrsm2_solve`                                    |                                                 |
-|`cusparseXcsrsm2_zeroPivot`                                |                                                 |
+|`cusparseScsrsm2_bufferSizeExt`                            |                                                 | 9.2              |
+|`cusparseDcsrsm2_bufferSizeExt`                            |                                                 | 9.2              |
+|`cusparseCcsrsm2_bufferSizeExt`                            |                                                 | 9.2              |
+|`cusparseZcsrsm2_bufferSizeExt`                            |                                                 | 9.2              |
+|`cusparseScsrsm2_analysis`                                 |                                                 | 9.2              |
+|`cusparseDcsrsm2_analysis`                                 |                                                 | 9.2              |
+|`cusparseCcsrsm2_analysis`                                 |                                                 | 9.2              |
+|`cusparseZcsrsm2_analysis`                                 |                                                 | 9.2              |
+|`cusparseScsrsm2_solve`                                    |                                                 | 9.2              |
+|`cusparseDcsrsm2_solve`                                    |                                                 | 9.2              |
+|`cusparseCcsrsm2_solve`                                    |                                                 | 9.2              |
+|`cusparseZcsrsm2_solve`                                    |                                                 | 9.2              |
+|`cusparseXcsrsm2_zeroPivot`                                |                                                 | 9.2              |
 |`cusparseSbsrmm`                                           |                                                 |
 |`cusparseDbsrmm`                                           |                                                 |
 |`cusparseCbsrmm`                                           |                                                 |
@@ -308,24 +308,24 @@
 |`cusparseCbsrsm2_solve`                                    |                                                 |
 |`cusparseZbsrsm2_solve`                                    |                                                 |
 |`cusparseXbsrsm2_zeroPivot`                                |                                                 |
-|`cusparseSgemmi`                                           |                                                 |
-|`cusparseDgemmi`                                           |                                                 |
-|`cusparseCgemmi`                                           |                                                 |
-|`cusparseZgemmi`                                           |                                                 |
+|`cusparseSgemmi`                                           |                                                 | 8.0              |
+|`cusparseDgemmi`                                           |                                                 | 8.0              |
+|`cusparseCgemmi`                                           |                                                 | 8.0              |
+|`cusparseZgemmi`                                           |                                                 | 8.0              |
 
 ## **6. cuSPARSE Extra Function Reference**
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
 |`cusparseXcsrgeamNnz`                                      |                                                 |
 |`cusparseScsrgeam`                                         |                                                 |
 |`cusparseDcsrgeam`                                         |                                                 |
 |`cusparseCcsrgeam`                                         |                                                 |
 |`cusparseZcsrgeam`                                         |                                                 |
-|`cusparseScsrgeam2_bufferSizeExt`                          |                                                 |
-|`cusparseDcsrgeam2_bufferSizeExt`                          |                                                 |
-|`cusparseCcsrgeam2_bufferSizeExt`                          |                                                 |
-|`cusparseZcsrgeam2_bufferSizeExt`                          |                                                 |
+|`cusparseScsrgeam2_bufferSizeExt`                          |                                                 | 9.2              |
+|`cusparseDcsrgeam2_bufferSizeExt`                          |                                                 | 9.2              |
+|`cusparseCcsrgeam2_bufferSizeExt`                          |                                                 | 9.2              |
+|`cusparseZcsrgeam2_bufferSizeExt`                          |                                                 | 9.2              |
 |`cusparseXcsrgemmNnz`                                      |                                                 |
 |`cusparseScsrgemm`                                         |                                                 |
 |`cusparseDcsrgemm`                                         |                                                 |
@@ -340,8 +340,8 @@
 
 ## ***7.1. Incomplete Cholesky Factorization: level 0***
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
 |`cusparseScsric0`                                          |                                                 |
 |`cusparseDcsric0`                                          |                                                 |
 |`cusparseCcsric0`                                          |                                                 |
@@ -375,13 +375,13 @@
 
 ## ***7.2. Incomplete LU Factorization: level 0***
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
 |`cusparseScsrilu0`                                         |                                                 |
 |`cusparseDcsrilu0`                                         |                                                 |
 |`cusparseCcsrilu0`                                         |                                                 |
 |`cusparseZcsrilu0`                                         |                                                 |
-|`cusparseCsrilu0Ex`                                        |                                                 |
+|`cusparseCsrilu0Ex`                                        |                                                 | 8.0              |
 |`cusparseScsrilu02_numericBoost`                           |                                                 |
 |`cusparseDcsrilu02_numericBoost`                           |                                                 |
 |`cusparseCcsrilu02_numericBoost`                           |                                                 |
@@ -419,8 +419,8 @@
 
 ## ***7.3. Tridiagonal Solve***
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
 |`cusparseSgtsv`                                            |                                                 |
 |`cusparseDgtsv`                                            |                                                 |
 |`cusparseCgtsv`                                            |                                                 |
@@ -429,65 +429,65 @@
 |`cusparseDgtsv_nopivot`                                    |                                                 |
 |`cusparseCgtsv_nopivot`                                    |                                                 |
 |`cusparseZgtsv_nopivot`                                    |                                                 |
-|`cusparseSgtsv2_bufferSizeExt`                             |                                                 |
-|`cusparseDgtsv2_bufferSizeExt`                             |                                                 |
-|`cusparseCgtsv2_bufferSizeExt`                             |                                                 |
-|`cusparseZgtsv2_bufferSizeExt`                             |                                                 |
-|`cusparseSgtsv2`                                           |                                                 |
-|`cusparseDgtsv2`                                           |                                                 |
-|`cusparseCgtsv2`                                           |                                                 |
-|`cusparseZgtsv2`                                           |                                                 |
-|`cusparseSgtsv2_nopivot_bufferSizeExt`                     |                                                 |
-|`cusparseDgtsv2_nopivot_bufferSizeExt`                     |                                                 |
-|`cusparseCgtsv2_nopivot_bufferSizeExt`                     |                                                 |
-|`cusparseZgtsv2_nopivot_bufferSizeExt`                     |                                                 |
-|`cusparseSgtsv2_nopivot`                                   |                                                 |
-|`cusparseDgtsv2_nopivot`                                   |                                                 |
-|`cusparseCgtsv2_nopivot`                                   |                                                 |
-|`cusparseZgtsv2_nopivot`                                   |                                                 |
+|`cusparseSgtsv2_bufferSizeExt`                             |                                                 | 9.0              |
+|`cusparseDgtsv2_bufferSizeExt`                             |                                                 | 9.0              |
+|`cusparseCgtsv2_bufferSizeExt`                             |                                                 | 9.0              |
+|`cusparseZgtsv2_bufferSizeExt`                             |                                                 | 9.0              |
+|`cusparseSgtsv2`                                           |                                                 | 9.0              |
+|`cusparseDgtsv2`                                           |                                                 | 9.0              |
+|`cusparseCgtsv2`                                           |                                                 | 9.0              |
+|`cusparseZgtsv2`                                           |                                                 | 9.0              |
+|`cusparseSgtsv2_nopivot_bufferSizeExt`                     |                                                 | 9.0              |
+|`cusparseDgtsv2_nopivot_bufferSizeExt`                     |                                                 | 9.0              |
+|`cusparseCgtsv2_nopivot_bufferSizeExt`                     |                                                 | 9.0              |
+|`cusparseZgtsv2_nopivot_bufferSizeExt`                     |                                                 | 9.0              |
+|`cusparseSgtsv2_nopivot`                                   |                                                 | 9.0              |
+|`cusparseDgtsv2_nopivot`                                   |                                                 | 9.0              |
+|`cusparseCgtsv2_nopivot`                                   |                                                 | 9.0              |
+|`cusparseZgtsv2_nopivot`                                   |                                                 | 9.0              |
 
 ## ***7.4. Batched Tridiagonal Solve***
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
 |`cusparseSgtsvStridedBatch`                                |                                                 |
 |`cusparseDgtsvStridedBatch`                                |                                                 |
 |`cusparseCgtsvStridedBatch`                                |                                                 |
 |`cusparseZgtsvStridedBatch`                                |                                                 |
-|`cusparseSgtsv2StridedBatch_bufferSizeExt`                 |                                                 |
-|`cusparseDgtsv2StridedBatch_bufferSizeExt`                 |                                                 |
-|`cusparseCgtsv2StridedBatch_bufferSizeExt`                 |                                                 |
-|`cusparseZgtsv2StridedBatch_bufferSizeExt`                 |                                                 |
-|`cusparseSgtsv2StridedBatch`                               |                                                 |
-|`cusparseDgtsv2StridedBatch`                               |                                                 |
-|`cusparseCgtsv2StridedBatch`                               |                                                 |
-|`cusparseZgtsv2StridedBatch`                               |                                                 |
-|`cusparseSgtsvInterleavedBatch_bufferSizeExt`              |                                                 |
-|`cusparseDgtsvInterleavedBatch_bufferSizeExt`              |                                                 |
-|`cusparseCgtsvInterleavedBatch_bufferSizeExt`              |                                                 |
-|`cusparseZgtsvInterleavedBatch_bufferSizeExt`              |                                                 |
-|`cusparseSgtsvInterleavedBatch`                            |                                                 |
-|`cusparseDgtsvInterleavedBatch`                            |                                                 |
-|`cusparseCgtsvInterleavedBatch`                            |                                                 |
-|`cusparseZgtsvInterleavedBatch`                            |                                                 |
+|`cusparseSgtsv2StridedBatch_bufferSizeExt`                 |                                                 | 9.0              |
+|`cusparseDgtsv2StridedBatch_bufferSizeExt`                 |                                                 | 9.0              |
+|`cusparseCgtsv2StridedBatch_bufferSizeExt`                 |                                                 | 9.0              |
+|`cusparseZgtsv2StridedBatch_bufferSizeExt`                 |                                                 | 9.0              |
+|`cusparseSgtsv2StridedBatch`                               |                                                 | 9.0              |
+|`cusparseDgtsv2StridedBatch`                               |                                                 | 9.0              |
+|`cusparseCgtsv2StridedBatch`                               |                                                 | 9.0              |
+|`cusparseZgtsv2StridedBatch`                               |                                                 | 9.0              |
+|`cusparseSgtsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
+|`cusparseDgtsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
+|`cusparseCgtsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
+|`cusparseZgtsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
+|`cusparseSgtsvInterleavedBatch`                            |                                                 | 9.2              |
+|`cusparseDgtsvInterleavedBatch`                            |                                                 | 9.2              |
+|`cusparseCgtsvInterleavedBatch`                            |                                                 | 9.2              |
+|`cusparseZgtsvInterleavedBatch`                            |                                                 | 9.2              |
 
 ## ***7.5. Batched Pentadiagonal Solve***
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
-|`cusparseSgpsvInterleavedBatch_bufferSizeExt`              |                                                 |
-|`cusparseDgpsvInterleavedBatch_bufferSizeExt`              |                                                 |
-|`cusparseCgpsvInterleavedBatch_bufferSizeExt`              |                                                 |
-|`cusparseZgpsvInterleavedBatch_bufferSizeExt`              |                                                 |
-|`cusparseSgpsvInterleavedBatch`                            |                                                 |
-|`cusparseDgpsvInterleavedBatch`                            |                                                 |
-|`cusparseCgpsvInterleavedBatch`                            |                                                 |
-|`cusparseZgpsvInterleavedBatch`                            |                                                 |
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
+|`cusparseSgpsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
+|`cusparseDgpsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
+|`cusparseCgpsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
+|`cusparseZgpsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
+|`cusparseSgpsvInterleavedBatch`                            |                                                 | 9.2              |
+|`cusparseDgpsvInterleavedBatch`                            |                                                 | 9.2              |
+|`cusparseCgpsvInterleavedBatch`                            |                                                 | 9.2              |
+|`cusparseZgpsvInterleavedBatch`                            |                                                 | 9.2              |
 
 ## **8. cuSPARSE Matrix Reorderings Reference**
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
 |`cusparseScsrcolor`                                        |                                                 |
 |`cusparseDcsrcolor`                                        |                                                 |
 |`cusparseCcsrcolor`                                        |                                                 |
@@ -495,8 +495,8 @@
 
 ## **9. cuSPARSE Format Conversion Reference**
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
 |`cusparseSbsr2csr`                                         |                                                 |
 |`cusparseDbsr2csr`                                         |                                                 |
 |`cusparseCbsr2csr`                                         |                                                 |
@@ -550,17 +550,17 @@
 |`cusparseDcsr2csc`                                         |`hipsparseDcsr2csc`                              |
 |`cusparseCcsr2csc`                                         |                                                 |
 |`cusparseZcsr2csc`                                         |                                                 |
-|`cusparseCsr2cscEx`                                        |                                                 |
-|`cusparseCsr2cscEx2`                                       |                                                 |
-|`cusparseCsr2cscEx2_bufferSize`                            |                                                 |
+|`cusparseCsr2cscEx`                                        |                                                 | 8.0              |
+|`cusparseCsr2cscEx2`                                       |                                                 | 10.1             |
+|`cusparseCsr2cscEx2_bufferSize`                            |                                                 | 10.1             |
 |`cusparseScsr2dense`                                       |                                                 |
 |`cusparseDcsr2dense`                                       |                                                 |
 |`cusparseCcsr2dense`                                       |                                                 |
 |`cusparseZcsr2dense`                                       |                                                 |
-|`cusparseScsr2csr_compress`                                |                                                 |
-|`cusparseDcsr2csr_compress`                                |                                                 |
-|`cusparseCcsr2csr_compress`                                |                                                 |
-|`cusparseZcsr2csr_compress`                                |                                                 |
+|`cusparseScsr2csr_compress`                                |                                                 | 8.0              |
+|`cusparseDcsr2csr_compress`                                |                                                 | 8.0              |
+|`cusparseCcsr2csr_compress`                                |                                                 | 8.0              |
+|`cusparseZcsr2csr_compress`                                |                                                 | 8.0              |
 |`cusparseScsr2hyb`                                         |`hipsparseScsr2hyb`                              |
 |`cusparseDcsr2hyb`                                         |`hipsparseDcsr2hyb`                              |
 |`cusparseCcsr2hyb`                                         |                                                 |
@@ -611,62 +611,64 @@
 |`cusparseDcsru2csr`                                        |                                                 |
 |`cusparseCcsru2csr`                                        |                                                 |
 |`cusparseZcsru2csr`                                        |                                                 |
-|`cusparseHpruneDense2csr_bufferSizeExt`                    |                                                 |
-|`cusparseSpruneDense2csr_bufferSizeExt`                    |                                                 |
-|`cusparseDpruneDense2csr_bufferSizeExt`                    |                                                 |
-|`cusparseHpruneDense2csrNnz`                               |                                                 |
-|`cusparseSpruneDense2csrNnz`                               |                                                 |
-|`cusparseDpruneDense2csrNnz`                               |                                                 |
-|`cusparseHpruneCsr2csr_bufferSizeExt`                      |                                                 |
-|`cusparseSpruneCsr2csr_bufferSizeExt`                      |                                                 |
-|`cusparseDpruneCsr2csr_bufferSizeExt`                      |                                                 |
-|`cusparseHpruneCsr2csrNnz`                                 |                                                 |
-|`cusparseSpruneCsr2csrNnz`                                 |                                                 |
-|`cusparseDpruneCsr2csrNnz`                                 |                                                 |
-|`cusparseHpruneDense2csrByPercentage_bufferSizeExt`        |                                                 |
-|`cusparseSpruneDense2csrByPercentage_bufferSizeExt`        |                                                 |
-|`cusparseDpruneDense2csrByPercentage_bufferSizeExt`        |                                                 |
-|`cusparseHpruneDense2csrNnzByPercentage`                   |                                                 |
-|`cusparseSpruneDense2csrNnzByPercentage`                   |                                                 |
-|`cusparseDpruneDense2csrNnzByPercentage`                   |                                                 |
-|`cusparseHpruneCsr2csrByPercentage_bufferSizeExt`          |                                                 |
-|`cusparseSpruneCsr2csrByPercentage_bufferSizeExt`          |                                                 |
-|`cusparseDpruneCsr2csrByPercentage_bufferSizeExt`          |                                                 |
-|`cusparseHpruneCsr2csrNnzByPercentage`                     |                                                 |
-|`cusparseSpruneCsr2csrNnzByPercentage`                     |                                                 |
-|`cusparseDpruneCsr2csrNnzByPercentage`                     |                                                 |
-|`cusparseSnnz_compress`                                    |                                                 |
-|`cusparseDnnz_compress`                                    |                                                 |
-|`cusparseCnnz_compress`                                    |                                                 |
-|`cusparseZnnz_compress`                                    |                                                 |
+|`cusparseHpruneDense2csr_bufferSizeExt`                    |                                                 | 9.0              |
+|`cusparseSpruneDense2csr_bufferSizeExt`                    |                                                 | 9.0              |
+|`cusparseDpruneDense2csr_bufferSizeExt`                    |                                                 | 9.0              |
+|`cusparseHpruneDense2csrNnz`                               |                                                 | 9.0              |
+|`cusparseSpruneDense2csrNnz`                               |                                                 | 9.0              |
+|`cusparseDpruneDense2csrNnz`                               |                                                 | 9.0              |
+|`cusparseHpruneCsr2csr_bufferSizeExt`                      |                                                 | 9.0              |
+|`cusparseSpruneCsr2csr_bufferSizeExt`                      |                                                 | 9.0              |
+|`cusparseDpruneCsr2csr_bufferSizeExt`                      |                                                 | 9.0              |
+|`cusparseHpruneCsr2csrNnz`                                 |                                                 | 9.0              |
+|`cusparseSpruneCsr2csrNnz`                                 |                                                 | 9.0              |
+|`cusparseDpruneCsr2csrNnz`                                 |                                                 | 9.0              |
+|`cusparseHpruneDense2csrByPercentage_bufferSizeExt`        |                                                 | 9.0              |
+|`cusparseSpruneDense2csrByPercentage_bufferSizeExt`        |                                                 | 9.0              |
+|`cusparseDpruneDense2csrByPercentage_bufferSizeExt`        |                                                 | 9.0              |
+|`cusparseHpruneDense2csrNnzByPercentage`                   |                                                 | 9.0              |
+|`cusparseSpruneDense2csrNnzByPercentage`                   |                                                 | 9.0              |
+|`cusparseDpruneDense2csrNnzByPercentage`                   |                                                 | 9.0              |
+|`cusparseHpruneCsr2csrByPercentage_bufferSizeExt`          |                                                 | 9.0              |
+|`cusparseSpruneCsr2csrByPercentage_bufferSizeExt`          |                                                 | 9.0              |
+|`cusparseDpruneCsr2csrByPercentage_bufferSizeExt`          |                                                 | 9.0              |
+|`cusparseHpruneCsr2csrNnzByPercentage`                     |                                                 | 9.0              |
+|`cusparseSpruneCsr2csrNnzByPercentage`                     |                                                 | 9.0              |
+|`cusparseDpruneCsr2csrNnzByPercentage`                     |                                                 | 9.0              |
+|`cusparseSnnz_compress`                                    |                                                 | 8.0              |
+|`cusparseDnnz_compress`                                    |                                                 | 8.0              |
+|`cusparseCnnz_compress`                                    |                                                 | 8.0              |
+|`cusparseZnnz_compress`                                    |                                                 | 8.0              |
 
 ## **10. cuSPARSE Generic API Reference**
 
 ## ***10.1. Generic Sparse API helper functions***
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
-|`cusparseCreateCoo`                                        |                                                 |
-|`cusparseDestroySpMat`                                     |                                                 |
-|`cusparseCooGet`                                           |                                                 |
-|`cusparseSpMatGetFormat`                                   |                                                 |
-|`cusparseSpMatGetIndexBase`                                |                                                 |
-|`cusparseSpMatSetNumBatches`                               |                                                 |
-|`cusparseSpMatGetNumBatches`                               |                                                 |
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
+|`cusparseCreateCoo`                                        |                                                 | 10.1             |
+|`cusparseDestroySpMat`                                     |                                                 | 10.1             |
+|`cusparseCooGet`                                           |                                                 | 10.1             |
+|`cusparseSpMatGetFormat`                                   |                                                 | 10.1             |
+|`cusparseSpMatGetIndexBase`                                |                                                 | 10.1             |
+|`cusparseSpMatSetNumBatches`                               |                                                 | 10.1             |
+|`cusparseSpMatGetNumBatches`                               |                                                 | 10.1             |
 
 ## ***10.2. Generic Dense API helper functions***
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
-|`cusparseCreateDnMat`                                      |                                                 |
-|`cusparseDestroyDnMat`                                     |                                                 |
-|`cusparseDnMatGet`                                         |                                                 |
-|`cusparseDnMatSetStridedBatch`                             |                                                 |
-|`cusparseDnMatGetStridedBatch`                             |                                                 |
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
+|`cusparseCreateDnMat`                                      |                                                 | 10.1             |
+|`cusparseDestroyDnMat`                                     |                                                 | 10.1             |
+|`cusparseDnMatGet`                                         |                                                 | 10.1             |
+|`cusparseDnMatSetStridedBatch`                             |                                                 | 10.1             |
+|`cusparseDnMatGetStridedBatch`                             |                                                 | 10.1             |
 
 ## ***10.3. Generic SpMM API functions***
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
-|`cusparseSpMM`                                             |                                                 |
-|`cusparseSpMM_bufferSize`                                  |                                                 |
+|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
+|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
+|`cusparseSpMM`                                             |                                                 | 10.1             |
+|`cusparseSpMM_bufferSize`                                  |                                                 | 10.1             |
+
+\* CUDA version, in which API has appeared and (optional) last version before abandoning it; no value in case of earlier versions < 7.5.

--- a/hipify-clang/src/CUDA2HIP_SPARSE_API_functions.cpp
+++ b/hipify-clang/src/CUDA2HIP_SPARSE_API_functions.cpp
@@ -149,6 +149,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP{
   {"cusparseCcsrsv_solve",                        {"hipsparseCcsrsv_solve",                        "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
   {"cusparseZcsrsv_solve",                        {"hipsparseZcsrsv_solve",                        "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
 
+  {"cusparseSbsrsv2_solve",                       {"hipsparseSbsrsv2_solve",                       "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
+  {"cusparseDbsrsv2_solve",                       {"hipsparseDbsrsv2_solve",                       "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
+  {"cusparseCbsrsv2_solve",                       {"hipsparseCbsrsv2_solve",                       "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
+  {"cusparseZbsrsv2_solve",                       {"hipsparseZbsrsv2_solve",                       "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
   {"cusparseXbsrsv2_zeroPivot",                   {"hipsparseXbsrsv2_zeroPivot",                   "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
 
   {"cusparseScsrsv_analysis",                     {"hipsparseScsrsv_analysis",                     "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
@@ -157,12 +161,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_SPARSE_FUNCTION_MAP{
   {"cusparseZcsrsv_analysis",                     {"hipsparseZcsrsv_analysis",                     "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
 
   {"cusparseCsrsv_analysisEx",                    {"hipsparseCsrsv_analysisEx",                    "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
-
-  {"cusparseScsrsv_solve",                        {"hipsparseScsrsv_solve",                        "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
-  {"cusparseDcsrsv_solve",                        {"hipsparseDcsrsv_solve",                        "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
-  {"cusparseCcsrsv_solve",                        {"hipsparseCcsrsv_solve",                        "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
-  {"cusparseZcsrsv_solve",                        {"hipsparseZcsrsv_solve",                        "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
-
   {"cusparseCsrsv_solveEx",                       {"hipsparseCsrsv_solveEx",                       "", CONV_LIB_FUNC, API_SPARSE, HIP_UNSUPPORTED}},
 
   {"cusparseScsrsv2_bufferSize",                  {"hipsparseScsrsv2_bufferSize",                  "", CONV_LIB_FUNC, API_SPARSE}},


### PR DESCRIPTION
+ CUDA version - version in which API has appeared and (optional) the last version before abandoning it; no value in case of earlier versions < 7.5.
+ Fix typos.