### PR TITLE
[HIP] hip_throw fails to output runtime_error string (github_issue#1008)

### DIFF
--- a/include/hip/hcc_detail/macro_based_grid_launch.hpp
+++ b/include/hip/hcc_detail/macro_based_grid_launch.hpp
@@ -85,7 +85,7 @@ requires(Domain<K> ==
         hc::parallel_for_each(acc_v, d, k);
     } catch (std::exception& ex) {
         std::cerr << "Failed in " << __func__ << ", with exception: " << ex.what() << std::endl;
-        hip_throw(ex);
+        throw;
     }
 }
 
@@ -113,7 +113,7 @@ requires(Domain<K> == {Ts...}) inline void grid_launch_hip_impl_(New_grid_launch
                               group_mem_bytes, acc_v, std::move(k));
     } catch (std::exception& ex) {
         std::cerr << "Failed in " << __func__ << ", with exception: " << ex.what() << std::endl;
-        hip_throw(ex);
+        throw;
     }
 }
 

--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -2511,14 +2511,4 @@ namespace hip_impl {
         return r;
     }
 
-    [[noreturn]]
-    void hip_throw(const std::exception& ex) {
-        #if defined(__cpp_exceptions)
-            throw ex;
-        #else
-            std::cerr << ex.what() << std::endl;
-            std::terminate();
-        #endif
-    }
-
 } // Namespace hip_impl.

--- a/src/hip_util.h
+++ b/src/hip_util.h
@@ -34,5 +34,11 @@ THE SOFTWARE.
 #include <vector>
 #include <algorithm>
 
+#if defined(__cpp_exceptions)
+    #define hip_throw(ex) {throw ex;}
+#else
+    #define hip_throw(ex) {std::cerr<< ex.what()<< std::endl;\
+			   std::terminate();}
+#endif
 
 #endif

--- a/src/program_state.inl
+++ b/src/program_state.inl
@@ -13,6 +13,8 @@
     #undef catch
 #endif
 
+#include "hip_util.h"
+
 #include <hsa/amd_hsa_kernel_code.h>
 #include <hsa/hsa.h>
 #include <hsa/hsa_ext_amd.h>
@@ -58,9 +60,6 @@ inline constexpr bool operator==(hsa_isa_t x, hsa_isa_t y) {
 }
 
 namespace hip_impl {
-
-[[noreturn]]
-void hip_throw(const std::exception&);
 
 std::vector<hsa_agent_t> all_hsa_agents();
 


### PR DESCRIPTION
 hip_hcc.cpp, hip_util.h : Created new hip_throw macro and removed old implementation
 macro_based_grid_launch.hpp : rethrow should not use exception object hence removed from catch block