### PR TITLE
[dtests] Fix build issues with hipLaunchParm.cpp on windows

### DIFF
--- a/tests/src/kernel/hipLaunchParm.cpp
+++ b/tests/src/kernel/hipLaunchParm.cpp
@@ -577,7 +577,7 @@ __global__ void vAdd(float* a) {}
 // Some wrapper macro for testing:
 #define WRAP(...) __VA_ARGS__
 
-#define GPU_PRINT_TIME(cmd, elapsed, quiet)                         \
+#define MY_LAUNCH_MACRO(cmd, elapsed, quiet)                         \
     do {                                                            \
         hipDeviceSynchronize();                                     \
         cmd;                                                        \
@@ -913,14 +913,14 @@ int main() {
 
     // Test: Passing hipLaunchKernelGGL inside another macro:
     float e0;
-    GPU_PRINT_TIME(hipLaunchKernelGGL(vAdd, dim3(1024),
+    MY_LAUNCH_MACRO(hipLaunchKernelGGL(vAdd, dim3(1024),
                    dim3(1), 0, 0, Ad), e0, j);
-    GPU_PRINT_TIME(WRAP(hipLaunchKernelGGL(vAdd, dim3(1024),
+    MY_LAUNCH_MACRO(WRAP(hipLaunchKernelGGL(vAdd, dim3(1024),
                    dim3(1), 0, 0, Ad)), e0, j);
 
 #ifdef EXTRA_PARENS_1
     // Don't wrap hipLaunchKernelGGL in extra set of parens:
-    GPU_PRINT_TIME((hipLaunchKernelGGL(vAdd, dim3(1024),
+    MY_LAUNCH_MACRO((hipLaunchKernelGGL(vAdd, dim3(1024),
                     dim3(1), 0, 0, Ad)), e0, j);
 #endif
 

--- a/tests/src/kernel/hipLaunchParm.cpp
+++ b/tests/src/kernel/hipLaunchParm.cpp
@@ -577,16 +577,11 @@ __global__ void vAdd(float* a) {}
 // Some wrapper macro for testing:
 #define WRAP(...) __VA_ARGS__
 
-#include <sys/time.h>
 #define GPU_PRINT_TIME(cmd, elapsed, quiet)                         \
     do {                                                            \
-        struct timeval start, stop;                                 \
-        float elapsed;                                              \
-        gettimeofday(&start, NULL);                                 \
         hipDeviceSynchronize();                                     \
         cmd;                                                        \
         hipDeviceSynchronize();                                     \
-        gettimeofday(&stop, NULL);                                  \
     } while (0);
 
 


### PR DESCRIPTION
"Removed unwanted #include sys/time.h , gettimeofday() and timeval variables and this also helps avoid compilation error in windows due to gettimeofday() call equivalent of which is not available in windows"