### PR TITLE
Fix HIP-VDI using incorrect include files

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -118,10 +118,10 @@ if ($HIP_RUNTIME eq "VDI" and !defined $HIP_VDI_HOME) {
 if (defined $HIP_VDI_HOME) {
     if (!defined $HIP_CLANG_PATH and (-e "$HIP_VDI_HOME/bin/clang" or -e "$HIP_VDI_HOME/bin/clang.exe")) {
         $HIP_CLANG_PATH = "$HIP_VDI_HOME/bin";
-    }
-    # With HIP_VDI_HOME defined, assume the installation of clang components, including headers.
-    if (!defined $HIP_CLANG_INCLUDE_PATH) {
-        $HIP_CLANG_INCLUDE_PATH = "$HIP_VDI_HOME/include/clang";
+        # With HIP_VDI_HOME defined, assume the installation of clang components, including headers.
+        if (!defined $HIP_CLANG_INCLUDE_PATH) {
+            $HIP_CLANG_INCLUDE_PATH = "$HIP_VDI_HOME/include/clang";
+        }
     }
     if (!defined $DEVICE_LIB_PATH and -e "$HIP_VDI_HOME/lib/bitcode") {
         $DEVICE_LIB_PATH = "$HIP_VDI_HOME/lib/bitcode";


### PR DESCRIPTION
When HIP-VDI depends on an llvm-amdgpu package, the include clang directory is not properly assessed.

We need this fixed for CI.