### PR TITLE
[dtests] Fix build issue with hipMemcpy_simple.cpp on windows

### DIFF
--- a/tests/src/runtimeApi/memory/hipMemcpy_simple.cpp
+++ b/tests/src/runtimeApi/memory/hipMemcpy_simple.cpp
@@ -29,6 +29,9 @@ THE SOFTWARE.
 
 #include "hip/hip_runtime.h"
 #include "test_common.h"
+#ifdef _WIN64
+#define aligned_alloc _aligned_malloc
+#endif
 
 bool p_async = false;
 


### PR DESCRIPTION
Compilation error being observed on windows due to aligned_alloc() call. Mapped the call to _aligned_malloc() for windows.