### PR TITLE
Rename hip/hip_hcc.h to hip/hip_ext.h

### DIFF
--- a/include/hip/hcc_detail/macro_based_grid_launch.hpp
+++ b/include/hip/hcc_detail/macro_based_grid_launch.hpp
@@ -26,7 +26,7 @@ THE SOFTWARE.
 #include "helpers.hpp"
 
 #include "hc.hpp"
-#include "hip/hip_hcc.h"
+#include "hip/hip_ext.h"
 #include "hip_runtime.h"
 
 #include <functional>

--- a/include/hip/hip_ext.h
+++ b/include/hip/hip_ext.h
@@ -20,8 +20,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#ifndef HIP_INCLUDE_HIP_HIP_HCC_H
-#define HIP_INCLUDE_HIP_HIP_HCC_H
+#ifndef HIP_INCLUDE_HIP_HIP_EXT_H
+#define HIP_INCLUDE_HIP_HIP_EXT_H
 #include "hip/hip_runtime_api.h"
 #ifdef __HCC__
 
@@ -111,8 +111,8 @@ hipError_t hipHccModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,
                                     hipEvent_t stopEvent = nullptr)
                                     __attribute__((deprecated("use hipExtModuleLaunchKernel instead")));
 
-// doxygen end HCC-specific features
+// doxygen end AMD-specific features
 /**
  * @}
  */
-#endif  // #ifdef HIP_INCLUDE_HIP_HIP_HCC_H
+#endif  // #ifdef HIP_INCLUDE_HIP_HIP_EXT_H

--- a/include/hip/hip_ext.h
+++ b/include/hip/hip_ext.h
@@ -22,10 +22,8 @@ THE SOFTWARE.
 
 #ifndef HIP_INCLUDE_HIP_HIP_HCC_H
 #define HIP_INCLUDE_HIP_HIP_HCC_H
-
-#ifdef __HCC__
-
 #include "hip/hip_runtime_api.h"
+#ifdef __HCC__
 
 // Forward declarations:
 namespace hc {
@@ -59,6 +57,8 @@ hipError_t hipHccGetAccelerator(int deviceId, hc::accelerator* acc);
  */
 HIP_PUBLIC_API
 hipError_t hipHccGetAcceleratorView(hipStream_t stream, hc::accelerator_view** av);
+
+#endif  // #ifdef __HCC__
 
 
 /**
@@ -115,5 +115,4 @@ hipError_t hipHccModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,
 /**
  * @}
  */
-#endif  // #ifdef __HCC__
 #endif  // #ifdef HIP_INCLUDE_HIP_HIP_HCC_H

--- a/include/hip/hip_hcc.h
+++ b/include/hip/hip_hcc.h
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2015 - present Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#ifndef HIP_INCLUDE_HIP_HIP_HCC_H
+#define HIP_INCLUDE_HIP_HIP_HCC_H
+#warning "hip/hip_hcc.h is deprecated, please use hip/hip_ext.h"
+#include "hip/hip_ext.h"
+#endif  // #ifdef HIP_INCLUDE_HIP_HIP_HCC_H

--- a/samples/0_Intro/module_api/launchKernelHcc.cpp
+++ b/samples/0_Intro/module_api/launchKernelHcc.cpp
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <vector>
 
 #ifdef __HIP_PLATFORM_HCC__
-#include <hip/hip_hcc.h>
+#include <hip/hip_ext.h>
 #endif
 
 #define LEN 64

--- a/samples/0_Intro/module_api_global/runKernel.cpp
+++ b/samples/0_Intro/module_api_global/runKernel.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include <iostream>
 #include <fstream>
 #include <vector>
-#include <hip/hip_hcc.h>
+#include <hip/hip_ext.h>
 
 #define LEN 64
 #define SIZE LEN * sizeof(float)

--- a/samples/2_Cookbook/11_texture_driver/texture2dDrv.cpp
+++ b/samples/2_Cookbook/11_texture_driver/texture2dDrv.cpp
@@ -21,11 +21,9 @@ THE SOFTWARE.
 */
 
 #include "hip/hip_runtime.h"
-//#include "hip/hip_runtime_api.h"
 #include <iostream>
 #include <fstream>
 #include <vector>
-//#include <hip/hip_hcc.h>
 
 #define fileName "tex2dKernel.code"
 

--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -46,7 +46,7 @@ THE SOFTWARE.
 #include "hsa/hsa_ext_image.h"
 #include "hip/hip_runtime.h"
 #include "hip_hcc_internal.h"
-#include "hip/hip_hcc.h"
+#include "hip/hip_ext.h"
 #include "trace_helper.h"
 #include "env.h"
 

--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -25,7 +25,7 @@ THE SOFTWARE.
 #include "hip/hcc_detail/hsa_helpers.hpp"
 #include "hip/hcc_detail/program_state.hpp"
 #include "hip_hcc_internal.h"
-#include "hip/hip_hcc.h"
+#include "hip/hip_ext.h"
 #include "program_state.inl"
 #include "trace_helper.h"
 

--- a/tests/src/hipHcc.cpp
+++ b/tests/src/hipHcc.cpp
@@ -30,7 +30,7 @@ THE SOFTWARE.
 #include <stdio.h>
 #include <iostream>
 #include "hip/hip_runtime.h"
-#include "hip/hip_hcc.h"
+#include "hip/hip_ext.h"
 #include "test_common.h"
 
 #define CHECK(error)                                                                               \

--- a/tests/src/runtimeApi/module/hipModuleGetGlobal.cpp
+++ b/tests/src/runtimeApi/module/hipModuleGetGlobal.cpp
@@ -32,7 +32,7 @@ THE SOFTWARE.
 #include <iostream>
 #include <fstream>
 #include <vector>
-#include <hip/hip_hcc.h>
+#include <hip/hip_ext.h>
 
 #define LEN 64
 #define SIZE LEN * sizeof(float)

--- a/tests/src/runtimeApi/module/hipModuleTexture2dDrv.cpp
+++ b/tests/src/runtimeApi/module/hipModuleTexture2dDrv.cpp
@@ -27,11 +27,9 @@ THE SOFTWARE.
  */
 
 #include "hip/hip_runtime.h"
-//#include "hip/hip_runtime_api.h"
 #include <iostream>
 #include <fstream>
 #include <vector>
-//#include <hip/hip_hcc.h>
 
 #define fileName "tex2d_kernel.code"
 


### PR DESCRIPTION
With these changes #1338 shouldn't be needed.