### PR TITLE
Add hiprtc as a dependency of hip_hcc should hiprtc be configured.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,6 +273,7 @@ if(HIP_PLATFORM STREQUAL "hcc")
             hiprtc SYSTEM
                 PRIVATE ${PROJECT_SOURCE_DIR}/include ${HSA_PATH}/include)
         target_link_libraries(hiprtc PUBLIC stdc++fs)
+        add_dependencies(hip_hcc hiprtc)
     endif()
     set_target_properties(hip_hcc PROPERTIES CXX_VISIBILITY_PRESET hidden)
     set_target_properties(hip_hcc PROPERTIES VISIBILITY_INLINES_HIDDEN 1)


### PR DESCRIPTION
This allows following sequence work without issue:

```
cmake ..
make -j$(nproc) package
```

Prior to this PR, it has to go like this:

```
cmake ..
make -j$(nproc)
make hiprtc
make package
```