### PR TITLE
Set device before processing each one

### DIFF
--- a/samples/1_Utils/hipInfo/hipInfo.cpp
+++ b/samples/1_Utils/hipInfo/hipInfo.cpp
@@ -192,6 +192,7 @@ int main(int argc, char* argv[]) {
     HIPCHECK(hipGetDeviceCount(&deviceCnt));
 
     for (int i = 0; i < deviceCnt; i++) {
+        hipSetDevice(i);
         printDeviceProp(i);
     }
 


### PR DESCRIPTION
If we don't call hipSetDevice(i), the total/free memory will be wrong.