### PR TITLE
[hcc] Fix previous replacement of `result_of_t`.

### DIFF
--- a/include/hip/hcc_detail/helpers.hpp
+++ b/include/hip/hcc_detail/helpers.hpp
@@ -89,7 +89,7 @@ template <typename, typename = void>
 struct is_callable_impl : std::false_type {};
 
 template <FunctionalProcedure F, typename... Ts>
-struct is_callable_impl<F(Ts...), void_t_<typename> std::result_of<F>::type(Ts...) > > : std::true_type {};
+struct is_callable_impl<F(Ts...), void_t_<typename std::result_of<F(Ts...)>::type > > : std::true_type {};
 #else
 
 // C++17


### PR DESCRIPTION
- `result_of_t` is defined as the shortcut of
  ```
  template< class T >
  using result_of_t = typename result_of<T>::type;
  ```