### PR TITLE
remove dependencies on /opt/rocm path

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -22,8 +22,10 @@ use Cwd 'abs_path';
 # Other environment variable controls:
 # HIP_PATH  : Path to HIP directory, default is one dir level above location of this script
 # CUDA_PATH : Path to CUDA SDK (default /usr/local/cuda). Used on NVIDIA platforms only.
-# HCC_HOME  : Path to HCC SDK (default /opt/rocm/hcc).  Used on AMD platforms only.
-# HSA_PATH  : Path to HSA dir (default /opt/rocm/hsa).  Used on AMD platforms only.
+# HCC_HOME  : Path to HCC SDK (defaults to ../../hcc relative to this
+#             script's abs_path). Used on AMD platforms only.
+# HSA_PATH  : Path to HSA dir (defaults to ../../hsa relative to abs_path
+#             of this script). Used on AMD platforms only.
 # HIP_VDI_HOME : Path to HIP/VDI directory. Used on AMD platforms only.
 
 if(scalar @ARGV == 0){
@@ -58,7 +60,18 @@ $isWindows = $^O eq 'MSWin32';
 $HIPCC_COMPILE_FLAGS_APPEND=$ENV{'HIPCC_COMPILE_FLAGS_APPEND'};
 $HIPCC_LINK_FLAGS_APPEND=$ENV{'HIPCC_LINK_FLAGS_APPEND'};
 
-$HIP_PATH=$ENV{'HIP_PATH'} // dirname (dirname $0); # use parent directory of hipcc
+#
+# TODO: Fix rpath LDFLAGS settings
+#
+# Since this hipcc script gets installed at two uneven hierarchical levels,
+# linked by symlink, the absolute path of this script should be used to
+# derive HIP_PATH, as dirname $0 could be /opt/rocm/bin or /opt/rocm/hip/bin
+# depending on how it gets invoked.
+# HIP_PATH points to <rocm_install_dir>/hip. 
+# Defining ROCM_ROOTDIR to be used instead of hardcoded /opt/rocm defaults
+#
+$HIP_PATH=$ENV{'HIP_PATH'} // dirname(Cwd::abs_path("$0/../")); # use parent directory of hipcc
+$ROCM_ROOTDIR=dirname("$HIP_PATH"); # use parent directory of HIP_PATH
 $HIP_VDI_HOME=$ENV{'HIP_VDI_HOME'};
 $HIP_LIB_PATH=$ENV{'HIP_LIB_PATH'};
 $HIP_CLANG_PATH=$ENV{'HIP_CLANG_PATH'};
@@ -68,7 +81,7 @@ $HIP_CLANG_HCC_COMPAT_MODE=$ENV{'HIP_CLANG_HCC_COMPAT_MODE'}; # HCC compatibilit
 if (defined $HIP_VDI_HOME) {
     $HIP_INFO_PATH= "$HIP_VDI_HOME/lib/.hipInfo";
 } else {
-    $HIP_INFO_PATH= "$HIP_PATH/lib/.hipInfo";
+    $HIP_INFO_PATH= "$HIP_PATH/lib/.hipInfo"; # use actual file
 }
 
 #---
@@ -112,7 +125,7 @@ if (defined $HIP_RUNTIME and $HIP_RUNTIME eq "VDI" and !defined $HIP_VDI_HOME) {
     if (-e "$hipcc_dir/../lib/bitcode") {
         $HIP_VDI_HOME = abs_path($hipcc_dir . "/..");
     } else {
-        $HIP_VDI_HOME = "/opt/rocm/hip";
+        $HIP_VDI_HOME = $HIP_PATH; # use HIP_PATH
     }
 }
 
@@ -136,10 +149,10 @@ if (defined $HIP_VDI_HOME) {
 if (defined $HIP_COMPILER and $HIP_COMPILER eq "clang") {
   $HIP_PLATFORM = "clang";
   if (!defined $HIP_CLANG_PATH) {
-    $HIP_CLANG_PATH = "/opt/rocm/llvm/bin";
+    $HIP_CLANG_PATH = "$ROCM_ROOTDIR/llvm/bin"; # use ROCM_ROOTDIR
   }
   if (!defined $DEVICE_LIB_PATH) {
-    $DEVICE_LIB_PATH = "/opt/rocm/lib";
+    $DEVICE_LIB_PATH = "$ROCM_ROOTDIR/lib"; # use ROCM_ROOTDIR
   }
 }
 
@@ -163,7 +176,7 @@ $target_gfx1012 = 0;
 $default_amdgpu_target = 1;
 
 if ($HIP_PLATFORM eq "clang") {
-    $ROCM_PATH=$ENV{'ROCM_PATH'} // "/opt/rocm";
+    $ROCM_PATH=$ENV{'ROCM_PATH'} // "$ROCM_ROOTDIR";
     $HIPCC="$HIP_CLANG_PATH/clang++";
 
     # If $HIPCC clang++ is not compiled, use clang instead
@@ -215,7 +228,7 @@ if ($HIP_PLATFORM eq "clang") {
     }
 
     if ($HIP_RUNTIME eq "HCC" ) {
-      $HSA_PATH=$ENV{'HSA_PATH'} // "/opt/rocm/hsa";
+      $HSA_PATH=$ENV{'HSA_PATH'} // "$HIP_PATH/../hsa";
       $HIPCXXFLAGS .= " -isystem $HSA_PATH/include";
     }
 
@@ -224,9 +237,9 @@ if ($HIP_PLATFORM eq "clang") {
     if (! defined $HIP_LIB_PATH) {
         $HIP_LIB_PATH = "$HIP_PATH/lib";
     }
-    $HSA_PATH=$ENV{'HSA_PATH'} // "/opt/rocm/hsa";
+    $HSA_PATH=$ENV{'HSA_PATH'} // "$HIP_PATH/../hsa";
 
-    $HCC_HOME=$ENV{'HCC_HOME'} // $hipConfig{'HCC_HOME'} // "/opt/rocm/hcc";
+    $HCC_HOME=$ENV{'HCC_HOME'} // $hipConfig{'HCC_HOME'} // "$HIP_PATH/../hcc";
 
     $HCC_VERSION=`${HCC_HOME}/bin/hcc --version`;
     $HCC_VERSION=~/.*based on HCC ([^ ]+).*/;
@@ -234,7 +247,7 @@ if ($HIP_PLATFORM eq "clang") {
     $HCC_VERSION_MAJOR=$HCC_VERSION;
     $HCC_VERSION_MAJOR=~s/\..*//;
 
-    $ROCM_PATH=$ENV{'ROCM_PATH'} // "/opt/rocm";
+    $ROCM_PATH=$ENV{'ROCM_PATH'} // "$ROCM_ROOTDIR";
 
     $HIP_ATP_MARKER=$ENV{'HIP_ATP_MARKER'} // 1;
     $marker_path = "$ROCM_PATH/profiler/CXLActivityLogger";


### PR DESCRIPTION
Made changes to the hipcc script to remove default settings to use derived paths based on hipcc location instead of hardcode "/opt/rocm".
Tested it to compile a simple hip code from a non-standard rocm installation.