### PR TITLE
[hip] Stop using `noduplicate` and replace it with `convergent`.

### DIFF
--- a/include/hip/hcc_detail/device_functions.h
+++ b/include/hip/hcc_detail/device_functions.h
@@ -970,7 +970,7 @@ static void __barrier(int n)
 
 __device__
 inline
-__attribute__((noduplicate))
+__attribute__((convergent))
 void __syncthreads()
 {
   __barrier(__CLK_LOCAL_MEM_FENCE);


### PR DESCRIPTION
This is a critical change for milestone 1 performance issue.