### PR TITLE
SWDEV-202043 hipMemcpyDtoD() issue

### DIFF
--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1166,6 +1166,11 @@ hipError_t hipMemcpyHtoD(hipDeviceptr_t dst, void* src, size_t sizeBytes) {
 
     hipError_t e = hipSuccess;
 
+    if(dst==NULL || src==NULL)
+	{
+	e=hipErrorInvalidValue;
+	return ihipLogStatus(e);
+	}
     try {
         stream->locked_copySync((void*)dst, (void*)src, sizeBytes, hipMemcpyHostToDevice, false);
     } catch (ihipException& ex) {
@@ -1185,6 +1190,11 @@ hipError_t hipMemcpyDtoH(void* dst, hipDeviceptr_t src, size_t sizeBytes) {
 
     hipError_t e = hipSuccess;
 
+    if(dst==NULL || src==NULL)
+	{
+	e=hipErrorInvalidValue;
+	return ihipLogStatus(e);
+	}
     try {
         stream->locked_copySync((void*)dst, (void*)src, sizeBytes, hipMemcpyDeviceToHost, false);
     } catch (ihipException& ex) {
@@ -1204,6 +1214,11 @@ hipError_t hipMemcpyDtoD(hipDeviceptr_t dst, hipDeviceptr_t src, size_t sizeByte
 
     hipError_t e = hipSuccess;
 
+    if(dst==NULL || src==NULL)
+	{
+	e=hipErrorInvalidValue;
+	return ihipLogStatus(e);
+	}
     try {
         stream->locked_copySync((void*)dst, (void*)src, sizeBytes, hipMemcpyDeviceToDevice, false);
     } catch (ihipException& ex) {
@@ -1222,6 +1237,11 @@ hipError_t hipMemcpyHtoH(void* dst, void* src, size_t sizeBytes) {
 
     hipError_t e = hipSuccess;
 
+    if(dst==NULL || src==NULL)
+	{
+	e=hipErrorInvalidValue;
+	return ihipLogStatus(e);
+	}
     try {
         stream->locked_copySync((void*)dst, (void*)src, sizeBytes, hipMemcpyHostToHost, false);
     } catch (ihipException& ex) {

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1160,15 +1160,17 @@ hipError_t hipMemcpy(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind
 hipError_t hipMemcpyHtoD(hipDeviceptr_t dst, void* src, size_t sizeBytes) {
     HIP_INIT_SPECIAL_API(hipMemcpyHtoD, (TRACE_MCMD), dst, src, sizeBytes);
 
+    hipError_t e = hipSuccess;
+    if (sizeBytes == 0) return ihipLogStatus(e);
+
+    if(dst==NULL || src==NULL){
+	return ihipLogStatus(hipErrorInvalidValue);
+    }
+     
     hipStream_t stream = ihipSyncAndResolveStream(hipStreamNull);
 
     hc::completion_future marker;
 
-    hipError_t e = hipSuccess;
-
-    if(dst==NULL || src==NULL){
-	return ihipLogStatus(hipErrorInvalidValue);
-	}
     try {
         stream->locked_copySync((void*)dst, (void*)src, sizeBytes, hipMemcpyHostToDevice, false);
     } catch (ihipException& ex) {
@@ -1182,15 +1184,17 @@ hipError_t hipMemcpyHtoD(hipDeviceptr_t dst, void* src, size_t sizeBytes) {
 hipError_t hipMemcpyDtoH(void* dst, hipDeviceptr_t src, size_t sizeBytes) {
     HIP_INIT_SPECIAL_API(hipMemcpyDtoH, (TRACE_MCMD), dst, src, sizeBytes);
 
+    hipError_t e = hipSuccess;
+    if (sizeBytes == 0) return ihipLogStatus(e);
+
+    if(dst==NULL || src==NULL){
+	return ihipLogStatus(hipErrorInvalidValue);
+    }
+
     hipStream_t stream = ihipSyncAndResolveStream(hipStreamNull);
 
     hc::completion_future marker;
 
-    hipError_t e = hipSuccess;
-
-    if(dst==NULL || src==NULL){
-	return ihipLogStatus(hipErrorInvalidValue);
-	}
     try {
         stream->locked_copySync((void*)dst, (void*)src, sizeBytes, hipMemcpyDeviceToHost, false);
     } catch (ihipException& ex) {
@@ -1204,15 +1208,17 @@ hipError_t hipMemcpyDtoH(void* dst, hipDeviceptr_t src, size_t sizeBytes) {
 hipError_t hipMemcpyDtoD(hipDeviceptr_t dst, hipDeviceptr_t src, size_t sizeBytes) {
     HIP_INIT_SPECIAL_API(hipMemcpyDtoD, (TRACE_MCMD), dst, src, sizeBytes);
 
+    hipError_t e = hipSuccess;
+    if (sizeBytes == 0) return ihipLogStatus(e);
+
+    if(dst==NULL || src==NULL){
+	return ihipLogStatus(hipErrorInvalidValue);
+    }
+
     hipStream_t stream = ihipSyncAndResolveStream(hipStreamNull);
 
     hc::completion_future marker;
 
-    hipError_t e = hipSuccess;
-
-    if(dst==NULL || src==NULL){
-	return ihipLogStatus(hipErrorInvalidValue);
-	}
     try {
         stream->locked_copySync((void*)dst, (void*)src, sizeBytes, hipMemcpyDeviceToDevice, false);
     } catch (ihipException& ex) {
@@ -1225,15 +1231,17 @@ hipError_t hipMemcpyDtoD(hipDeviceptr_t dst, hipDeviceptr_t src, size_t sizeByte
 hipError_t hipMemcpyHtoH(void* dst, void* src, size_t sizeBytes) {
     HIP_INIT_SPECIAL_API(hipMemcpyHtoH, (TRACE_MCMD), dst, src, sizeBytes);
 
+    hipError_t e = hipSuccess;
+    if (sizeBytes == 0) return ihipLogStatus(e);
+    
+    if(dst==NULL || src==NULL){
+	return ihipLogStatus(hipErrorInvalidValue);
+    }
+
     hipStream_t stream = ihipSyncAndResolveStream(hipStreamNull);
 
     hc::completion_future marker;
 
-    hipError_t e = hipSuccess;
-
-    if(dst==NULL || src==NULL){
-	return ihipLogStatus(hipErrorInvalidValue);
-	}
     try {
         stream->locked_copySync((void*)dst, (void*)src, sizeBytes, hipMemcpyHostToHost, false);
     } catch (ihipException& ex) {

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1166,10 +1166,8 @@ hipError_t hipMemcpyHtoD(hipDeviceptr_t dst, void* src, size_t sizeBytes) {
 
     hipError_t e = hipSuccess;
 
-    if(dst==NULL || src==NULL)
-	{
-	e=hipErrorInvalidValue;
-	return ihipLogStatus(e);
+    if(dst==NULL || src==NULL){
+	return ihipLogStatus(hipErrorInvalidValue);
 	}
     try {
         stream->locked_copySync((void*)dst, (void*)src, sizeBytes, hipMemcpyHostToDevice, false);
@@ -1190,10 +1188,8 @@ hipError_t hipMemcpyDtoH(void* dst, hipDeviceptr_t src, size_t sizeBytes) {
 
     hipError_t e = hipSuccess;
 
-    if(dst==NULL || src==NULL)
-	{
-	e=hipErrorInvalidValue;
-	return ihipLogStatus(e);
+    if(dst==NULL || src==NULL){
+	return ihipLogStatus(hipErrorInvalidValue);
 	}
     try {
         stream->locked_copySync((void*)dst, (void*)src, sizeBytes, hipMemcpyDeviceToHost, false);
@@ -1214,10 +1210,8 @@ hipError_t hipMemcpyDtoD(hipDeviceptr_t dst, hipDeviceptr_t src, size_t sizeByte
 
     hipError_t e = hipSuccess;
 
-    if(dst==NULL || src==NULL)
-	{
-	e=hipErrorInvalidValue;
-	return ihipLogStatus(e);
+    if(dst==NULL || src==NULL){
+	return ihipLogStatus(hipErrorInvalidValue);
 	}
     try {
         stream->locked_copySync((void*)dst, (void*)src, sizeBytes, hipMemcpyDeviceToDevice, false);
@@ -1237,10 +1231,8 @@ hipError_t hipMemcpyHtoH(void* dst, void* src, size_t sizeBytes) {
 
     hipError_t e = hipSuccess;
 
-    if(dst==NULL || src==NULL)
-	{
-	e=hipErrorInvalidValue;
-	return ihipLogStatus(e);
+    if(dst==NULL || src==NULL){
+	return ihipLogStatus(hipErrorInvalidValue);
 	}
     try {
         stream->locked_copySync((void*)dst, (void*)src, sizeBytes, hipMemcpyHostToHost, false);


### PR DESCRIPTION
Added Null check in hipMemcpyDtoD(), hipMemcpyHtoD(), hipMemcpyDtoH(), hipMemcpyHtoH() to avoid seg fault when src or dest is passed as NULL.