### PR TITLE
Replacment of RENAME command in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -485,9 +485,12 @@ if(POLICY CMP0037)
     cmake_policy(PUSH)
     cmake_policy(SET CMP0037 OLD)
 endif()
+file(GENERATE OUTPUT ${PROJECT_BINARY_DIR}/fixnames
+        CONTENT "pwd; for i in *.deb; do mv \"\$i\" \"\${i/.deb/-amd64.deb}\" ; done
+for i in *.rpm ; do mv \$i \${i/.rpm/.x86_64.rpm} ; done
+")
 add_custom_target(package
-    COMMAND rename -v "'s/([a-z0-9_.\-]).deb/$1-amd64.deb/'" *.deb
-    COMMAND rename -v "'s/([a-z0-9_.\-]).rpm/$1.x86_64.rpm/'" *.rpm
+    COMMAND bash ${PROJECT_BINARY_DIR}/fixnames
     WORKING_DIRECTORY ${PROJECT_BINARY_DIR}
     DEPENDS pkg_hip_base pkg_hip_hcc pkg_hip_nvcc pkg_hip_doc pkg_hip_samples)
 if(POLICY CMP0037)


### PR DESCRIPTION
The reason to introduce this is that RENAME fails on SLES and CentOS systems.

