### PR TITLE
[HACK] Temporary fix in hipFree for hipManagedMalloc use

### DIFF
--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1989,7 +1989,7 @@ hipError_t hipFree(void* ptr) {
 #endif
         am_status_t status = hc::am_memtracker_getinfo(&amPointerInfo, ptr);
         if (status == AM_SUCCESS) {
-            /*if (amPointerInfo._hostPointer == NULL) */ //TODO Fix this when there is proper Managed memeory support
+            /*if (amPointerInfo._hostPointer == NULL) */ //TODO: Fix it when there is proper managed memory support
             {
                 if (HIP_SYNC_FREE) {
                     // Synchronize all devices, all streams

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1989,7 +1989,8 @@ hipError_t hipFree(void* ptr) {
 #endif
         am_status_t status = hc::am_memtracker_getinfo(&amPointerInfo, ptr);
         if (status == AM_SUCCESS) {
-            if (amPointerInfo._hostPointer == NULL) {
+            /*if (amPointerInfo._hostPointer == NULL) */ //TODO Fix this when there is proper Managed memeory support
+            {
                 if (HIP_SYNC_FREE) {
                     // Synchronize all devices, all streams
                     // to ensure all work has finished on all devices.


### PR DESCRIPTION
This fixes #1412 , #1403 and #1234.

This is temporary fix and has side effects - hipFree will also free pointers which needed hipHostFree calls for freeing.