### PR TITLE
[HIPIFY][perl][fix] Treat ::device_function as a device function

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1956,11 +1956,13 @@ sub warnUnsupportedDeviceFunctions
         "umul24"
     )
     {
-        # match math at the beginning of a word, but not if it already has a namespace qualifier ('::') :
-        my $mt = m/[:]?[:]?\b($func)\b(\w*\()/g;
-        if ($mt) {
+        # match device function from the list of unsupported, except those, which have a namespace prefix (aka somenamespace::umin(...));
+        # function with only global namespace qualifier '::' (aka ::umin(...)) should be treated as a device function (and warned as well as without such qualifier);
+        my $mt_namespace = m/(\w+)::($func)\s*\(\s*.*\s*\)/g;
+        my $mt = m/($func)\s*\(\s*.*\s*\)/g;
+        if ($mt && !$mt_namespace) {
             $m += $mt;
-            print STDERR "  warning: $fileName:#$line_num : unsupported device function : $_\n";
+            print STDERR "  warning: $fileName:$line_num: unsupported device function \"$func\": $_\n";
         }
     }
     return $m;

--- a/hipify-clang/src/CUDA2HIP_Perl.cpp
+++ b/hipify-clang/src/CUDA2HIP_Perl.cpp
@@ -53,11 +53,13 @@ namespace perl {
       *perlStreamPtr.get() << "\nsub warnUnsupportedDeviceFunctions\n" << "{\n" << space << "my $line_num = shift;\n" << space << "my $m = 0;\n" << space << "foreach $func (\n";
       *perlStreamPtr.get() << sUnsupported.str() << "\n" << space << ")\n";
       *perlStreamPtr.get() << space << "{\n";
-      *perlStreamPtr.get() << double_space << "# match math at the beginning of a word, but not if it already has a namespace qualifier ('::') :\n";
-      *perlStreamPtr.get() << double_space << "my $mt = m/[:]?[:]?\\b($func)\\b(\\w*\\()/g;\n";
-      *perlStreamPtr.get() << double_space << "if ($mt) {\n";
+      *perlStreamPtr.get() << double_space << "# match device function from the list of unsupported, except those, which have a namespace prefix (aka somenamespace::umin(...));\n";
+      *perlStreamPtr.get() << double_space << "# function with only global namespace qualifier '::' (aka ::umin(...)) should be treated as a device function (and warned as well as without such qualifier);\n";
+      *perlStreamPtr.get() << double_space << "my $mt_namespace = m/(\\w+)::($func)\\s*\\(\\s*.*\\s*\\)/g;\n";
+      *perlStreamPtr.get() << double_space << "my $mt = m/($func)\\s*\\(\\s*.*\\s*\\)/g;\n";
+      *perlStreamPtr.get() << double_space << "if ($mt && !$mt_namespace) {\n";
       *perlStreamPtr.get() << triple_space << "$m += $mt;\n";
-      *perlStreamPtr.get() << triple_space << "print STDERR \"  warning: $fileName:#$line_num : unsupported device function : $_\\n\";\n";
+      *perlStreamPtr.get() << triple_space << "print STDERR \"  warning: $fileName:$line_num: unsupported device function \\\"$func\\\": $_\\n\";\n";
       *perlStreamPtr.get() << double_space << "}\n";
       *perlStreamPtr.get() << space << "}\n";
       *perlStreamPtr.get() << space << "return $m;\n";


### PR DESCRIPTION
+ Do not treat somenamespace::device_function_name as a device function
+ Fix generation of warnUnsupportedDeviceFunctions function in hipify-clang
+ Update hipify-perl based on hipify-clang -perl generation
+ Update device test math_functions.cu for hipify-perl

[Restrictions]
- hipify-perl is yet unable to handle function declarations in user namespaces
- hipify-perl is yet unable to handle using directive