### PR TITLE
[HIPIFY][#1437] Fix: cudaFuncGetAttributes to hipFuncGetAttributes is supported

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -363,6 +363,7 @@ while (@ARGV) {
         $ft{'execution'} += s/\bcuFuncGetAttribute\b/hipFuncGetAttribute/g;
         $ft{'execution'} += s/\bcuLaunchKernel\b/hipModuleLaunchKernel/g;
         $ft{'execution'} += s/\bcudaConfigureCall\b/hipConfigureCall/g;
+        $ft{'execution'} += s/\bcudaFuncGetAttributes\b/hipFuncGetAttributes/g;
         $ft{'execution'} += s/\bcudaLaunch\b/hipLaunchByPtr/g;
         $ft{'execution'} += s/\bcudaLaunchCooperativeKernel\b/hipLaunchCooperativeKernel/g;
         $ft{'execution'} += s/\bcudaLaunchCooperativeKernelMultiDevice\b/hipLaunchCooperativeKernelMultiDevice/g;

--- a/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -101,7 +101,7 @@
 
 |   **CUDA**                                                |   **HIP**                             |**CUDA version\***|
 |-----------------------------------------------------------|---------------------------------------|:----------------:|
-| `cudaFuncGetAttributes`                                   |                                       |
+| `cudaFuncGetAttributes`                                   |`hipFuncGetAttributes`                 |
 | `cudaFuncSetAttribute`                                    |                                       | 9.0              |
 | `cudaFuncSetCacheConfig`                                  |`hipFuncSetCacheConfig`                |
 | `cudaFuncSetSharedMemConfig`                              |                                       |

--- a/hipify-clang/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/hipify-clang/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -179,7 +179,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP{
 
   // 5.7. Execution Control
   // no analogue
-  {"cudaFuncGetAttributes",                                   {"hipFuncGetAttributes",                                   "", CONV_EXECUTION, API_RUNTIME, HIP_UNSUPPORTED}},
+  {"cudaFuncGetAttributes",                                   {"hipFuncGetAttributes",                                   "", CONV_EXECUTION, API_RUNTIME}},
   // no analogue
   {"cudaFuncSetAttribute",                                    {"hipFuncSetAttribute",                                    "", CONV_EXECUTION, API_RUNTIME, HIP_UNSUPPORTED}},
   // no analogue


### PR DESCRIPTION
+ Update hipify-perl and CUDA_Runtime_API_functions_supported_by_HIP.md accordingly