### PR TITLE
Reimplement hipMemGetInfo

### DIFF
--- a/include/hip/hcc_detail/device_functions.h
+++ b/include/hip/hcc_detail/device_functions.h
@@ -690,12 +690,7 @@ extern "C" uint64_t __clock_u64()  __HC__;
 __device__
 inline  __attribute((always_inline))
 long long int __clock64() {
-// ToDo: Unify HCC and HIP implementation.
-#if __HCC__
-    return (long long int) __clock_u64();
-#else
-    return (long long int) __builtin_amdgcn_s_memrealtime();
-#endif
+    return (long long int)  __builtin_readcyclecounter();
 }
 
 __device__

--- a/include/hip/hcc_detail/device_functions.h
+++ b/include/hip/hcc_detail/device_functions.h
@@ -690,7 +690,12 @@ extern "C" uint64_t __clock_u64()  __HC__;
 __device__
 inline  __attribute((always_inline))
 long long int __clock64() {
-    return (long long int)  __builtin_readcyclecounter();
+// ToDo: Unify HCC and HIP implementation.
+#if __HCC__
+    return (long long int) __clock_u64();
+#else
+    return (long long int) __builtin_amdgcn_s_memrealtime();
+#endif
 }
 
 __device__

--- a/include/hip/hcc_detail/device_functions.h
+++ b/include/hip/hcc_detail/device_functions.h
@@ -690,12 +690,7 @@ extern "C" uint64_t __clock_u64()  __HC__;
 __device__
 inline  __attribute((always_inline))
 long long int __clock64() {
-// ToDo: Unify HCC and HIP implementation.
-#if __HCC__
-    return (long long int) __clock_u64();
-#else
-    return (long long int) __builtin_amdgcn_s_memrealtime();
-#endif
+return (long long int)  __builtin_readcyclecounter();
 }
 
 __device__

--- a/include/hip/hcc_detail/device_functions.h
+++ b/include/hip/hcc_detail/device_functions.h
@@ -690,7 +690,12 @@ extern "C" uint64_t __clock_u64()  __HC__;
 __device__
 inline  __attribute((always_inline))
 long long int __clock64() {
-return (long long int)  __builtin_readcyclecounter();
+// ToDo: Unify HCC and HIP implementation.
+#if __HCC__
+    return (long long int) __clock_u64();
+#else
+    return (long long int) __builtin_amdgcn_s_memrealtime();
+#endif
 }
 
 __device__

--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -512,9 +512,9 @@ ihipDevice_t::ihipDevice_t(unsigned deviceId, unsigned deviceCnt, hc::accelerato
             _computeUnits = 1;
         }
         err = hsa_agent_get_info(
-	    *agent, (hsa_agent_info_t) HSA_AMD_AGENT_INFO_DRIVER_NODE_ID, &internal_node_id);
+	    *agent, (hsa_agent_info_t) HSA_AMD_AGENT_INFO_DRIVER_NODE_ID, &_driver_node_id);
 	if (err != HSA_STATUS_SUCCESS){
-	   internal_node_id = 0;
+	   _driver_node_id = 0;
 	}
         
 	_hsaAgent = *agent;

--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -505,13 +505,19 @@ ihipDevice_t::ihipDevice_t(unsigned deviceId, unsigned deviceCnt, hc::accelerato
     : _deviceId(deviceId), _acc(acc), _state(0), _criticalData(this) {
     hsa_agent_t* agent = static_cast<hsa_agent_t*>(acc.get_hsa_agent());
     if (agent) {
-        int err = hsa_agent_get_info(
+	int err;
+        err = hsa_agent_get_info(
             *agent, (hsa_agent_info_t)HSA_AMD_AGENT_INFO_COMPUTE_UNIT_COUNT, &_computeUnits);
         if (err != HSA_STATUS_SUCCESS) {
             _computeUnits = 1;
         }
-
-        _hsaAgent = *agent;
+        err = hsa_agent_get_info(
+	    *agent, (hsa_agent_info_t) HSA_AMD_AGENT_INFO_DRIVER_NODE_ID, &internal_node_id);
+	if (err != HSA_STATUS_SUCCESS){
+	   internal_node_id = 0;
+	}
+        
+	_hsaAgent = *agent;
     } else {
         _hsaAgent.handle = static_cast<uint64_t>(-1);
     }

--- a/src/hip_hcc_internal.h
+++ b/src/hip_hcc_internal.h
@@ -804,7 +804,7 @@ class ihipDevice_t {
     int _isLargeBar;
    
     // Node id reported by kfd for this device
-    uint32_t internal_node_id;
+    uint32_t _driver_node_id;
 
     ihipCtx_t* _primaryCtx;
 

--- a/src/hip_hcc_internal.h
+++ b/src/hip_hcc_internal.h
@@ -802,6 +802,9 @@ class ihipDevice_t {
 
     // TODO - report this through device properties, base on HCC API call.
     int _isLargeBar;
+   
+    // Node id reported by kfd for this device
+    uint32_t internal_node_id;
 
     ihipCtx_t* _primaryCtx;
 

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -19,7 +19,6 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-
 #include <hc_am.hpp>
 #include "hsa/hsa.h"
 #include "hsa/hsa_ext_amd.h"
@@ -27,6 +26,8 @@ THE SOFTWARE.
 #include "hip/hip_runtime.h"
 #include "hip_hcc_internal.h"
 #include "trace_helper.h"
+
+#include <fstream>
 
 __device__ char __hip_device_heap[__HIP_SIZE_OF_HEAP];
 __device__ uint32_t __hip_device_page_flag[__HIP_NUM_PAGES];
@@ -1969,14 +1970,27 @@ hipError_t hipMemGetInfo(size_t* free, size_t* total) {
         }
 
         if (free) {
-            // TODO - replace with kernel-level for reporting free memory:
-            size_t deviceMemSize, hostMemSize, userMemSize;
-            hc::am_memtracker_sizeinfo(device->_acc, &deviceMemSize, &hostMemSize, &userMemSize);
-
-            *free = device->_props.totalGlobalMem - deviceMemSize;
-
-            // Deduct the amount of memory from the free memory reported from the system
-            if (HIP_HIDDEN_FREE_MEM) *free -= (size_t)HIP_HIDDEN_FREE_MEM * 1024 * 1024;
+            hsa_agent_t* agent = static_cast<hsa_agent_t*>(device->_acc.get_hsa_agent());
+            if (!agent){
+		return ihipLogStatus(hipErrorInvalidResourceHandle);
+            } else {
+		uint32_t internal_node_id;
+		hsa_status_t err = hsa_agent_get_info(*agent, (hsa_agent_info_t) HSA_AMD_AGENT_INFO_DRIVER_NODE_ID, &internal_node_id);
+		if(err != HSA_STATUS_SUCCESS) return hipErrorInvalidDevice;
+		
+		size_t deviceMemSize;
+		std::string fileName = std::string("/sys/class/kfd/kfd/topology/nodes/") + std::to_string(internal_node_id) + std::string("/mem_banks/0/used_memory");  
+                
+		std::ifstream file;
+		file.open(fileName);
+		if(!file) return ihipLogStatus(hipErrorFileNotFound);
+		
+		file >> deviceMemSize;    
+		*free = device->_props.totalGlobalMem - deviceMemSize;
+		file.close();                 
+            	// Deduct the amount of memory from the free memory reported from the system
+		if (HIP_HIDDEN_FREE_MEM) *free -= (size_t)HIP_HIDDEN_FREE_MEM * 1024 * 1024;
+           }
         } else {
             e = hipErrorInvalidValue;
         }

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1970,9 +1970,9 @@ hipError_t hipMemGetInfo(size_t* free, size_t* total) {
         }
 	
         if (free) {
-		if (!device->internal_node_id) return ihipLogStatus(hipErrorInvalidDevice);
+		if (!device->_driver_node_id) return ihipLogStatus(hipErrorInvalidDevice);
 			
-		std::string fileName = std::string("/sys/class/kfd/kfd/topology/nodes/") + std::to_string(device->internal_node_id) + std::string("/mem_banks/0/used_memory");  
+		std::string fileName = std::string("/sys/class/kfd/kfd/topology/nodes/") + std::to_string(device->_driver_node_id) + std::string("/mem_banks/0/used_memory");  
 		std::ifstream file;
 		file.open(fileName);
 		if (!file) return ihipLogStatus(hipErrorFileNotFound);


### PR DESCRIPTION
Addresses SWDEV-136570. hipMemGetInfo changed to compute free memory based on information from kfd instead of relying on hc::am_tracker.