### PR TITLE
[HIP]Fixed redefinition of real() & imag() [SWDEV#201461]

### DIFF
--- a/include/hip/hcc_detail/hip_complex.h
+++ b/include/hip/hcc_detail/hip_complex.h
@@ -34,6 +34,8 @@ THE SOFTWARE.
 #include "math.h"
 #endif
 
+namespace hip_cmplx{
+
 #if __cplusplus
 #define COMPLEX_NEG_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator-(const type& op) {                             \
@@ -317,4 +319,6 @@ __device__ __host__ inline hipDoubleComplex func(const hipDoubleComplex& z) { re
 
 __DEFINE_HIP_COMPLEX_FUN(conj, hipConj)
 
-#endif
+}//hip_cmplx
+
+#endif //HIP_INCLUDE_HIP_HCC_DETAIL_HIP_COMPLEX_H

--- a/include/hip/hcc_detail/hip_complex.h
+++ b/include/hip/hcc_detail/hip_complex.h
@@ -34,8 +34,6 @@ THE SOFTWARE.
 #include "math.h"
 #endif
 
-namespace hip_cmplx{
-
 #if __cplusplus
 #define COMPLEX_NEG_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator-(const type& op) {                             \
@@ -302,23 +300,5 @@ __device__ __host__ static inline hipDoubleComplex hipCfma(hipDoubleComplex p, h
 
     return make_hipDoubleComplex(real, imag);
 }
-
-// Complex functions returning real numbers.
-#define __DEFINE_HIP_COMPLEX_REAL_FUN(func, hipFun) \
-__device__ __host__ inline float func(const hipFloatComplex& z) { return hipFun##f(z); } \
-__device__ __host__ inline double func(const hipDoubleComplex& z) { return hipFun(z); }
-
-__DEFINE_HIP_COMPLEX_REAL_FUN(abs, hipCabs)
-__DEFINE_HIP_COMPLEX_REAL_FUN(real, hipCreal)
-__DEFINE_HIP_COMPLEX_REAL_FUN(imag, hipCimag)
-
-// Complex functions returning complex numbers.
-#define __DEFINE_HIP_COMPLEX_FUN(func, hipFun) \
-__device__ __host__ inline hipFloatComplex func(const hipFloatComplex& z) { return hipFun##f(z); } \
-__device__ __host__ inline hipDoubleComplex func(const hipDoubleComplex& z) { return hipFun(z); }
-
-__DEFINE_HIP_COMPLEX_FUN(conj, hipConj)
-
-}//hip_cmplx
 
 #endif //HIP_INCLUDE_HIP_HCC_DETAIL_HIP_COMPLEX_H

--- a/include/hip/nvcc_detail/hip_complex.h
+++ b/include/hip/nvcc_detail/hip_complex.h
@@ -25,6 +25,8 @@ THE SOFTWARE.
 
 #include "cuComplex.h"
 
+namespace hip_cmplx{
+
 typedef cuFloatComplex hipFloatComplex;
 
 __device__ __host__ static inline float hipCrealf(hipFloatComplex z) { return cuCrealf(z); }
@@ -116,4 +118,5 @@ __device__ __host__ static inline hipDoubleComplex hipCfma(hipDoubleComplex p, h
     return cuCfma(p, q, r);
 }
 
+}//hip_cmplx
 #endif

--- a/include/hip/nvcc_detail/hip_complex.h
+++ b/include/hip/nvcc_detail/hip_complex.h
@@ -25,8 +25,6 @@ THE SOFTWARE.
 
 #include "cuComplex.h"
 
-namespace hip_cmplx{
-
 typedef cuFloatComplex hipFloatComplex;
 
 __device__ __host__ static inline float hipCrealf(hipFloatComplex z) { return cuCrealf(z); }
@@ -118,5 +116,4 @@ __device__ __host__ static inline hipDoubleComplex hipCfma(hipDoubleComplex p, h
     return cuCfma(p, q, r);
 }
 
-}//hip_cmplx
 #endif


### PR DESCRIPTION
hip_complex.h has real() and imag() which was conflicting with std:real and std:imag hence build failure observed in HPC app. 