### PR TITLE
[HIP] Added new hipFreeAll API [Feature]

### DIFF
--- a/include/hip/hcc_detail/functional_grid_launch.hpp
+++ b/include/hip/hcc_detail/functional_grid_launch.hpp
@@ -177,4 +177,19 @@ void hipLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& dimBlocks,
                                      stream, &config[0]);
 }
 
+template<class T>
+hipError_t hipFreeAll(T ptr)
+{
+    return hipFree((void *) ptr);            
+}
+
+template<class T, class... Args>
+hipError_t hipFreeAll(T first, Args... arg)
+{
+    hipError_t status = hipFree(first);
+    if(status == hipSuccess)
+       status = hipFreeAll(arg...);
+    return status;                            
+}
+
 #pragma GCC visibility pop

--- a/tests/src/kernel/hipTestMemKernel.cpp
+++ b/tests/src/kernel/hipTestMemKernel.cpp
@@ -110,9 +110,7 @@ int main() {
     delete[] A;
     delete[] B;
     delete[] C;
-    hipFree(Ad);
-    hipFree(Bd);
-    hipFree(Cd);
+    hipFreeAll(Ad,Bd,Cd);
 
     A = new uint8_t[LEN9];
     B = new uint8_t[LEN9];
@@ -138,9 +136,7 @@ int main() {
     delete[] A;
     delete[] B;
     delete[] C;
-    hipFree(Ad);
-    hipFree(Bd);
-    hipFree(Cd);
+    hipFreeAll(Ad,Bd,Cd);
 
     A = new uint8_t[LEN10];
     B = new uint8_t[LEN10];
@@ -166,9 +162,7 @@ int main() {
     delete[] A;
     delete[] B;
     delete[] C;
-    hipFree(Ad);
-    hipFree(Bd);
-    hipFree(Cd);
+    hipFreeAll(Ad,Bd,Cd);
 
     A = new uint8_t[LEN11];
     B = new uint8_t[LEN11];
@@ -194,9 +188,7 @@ int main() {
     delete[] A;
     delete[] B;
     delete[] C;
-    hipFree(Ad);
-    hipFree(Bd);
-    hipFree(Cd);
+    hipFreeAll(Ad,Bd,Cd);
 
     A = new uint8_t[LEN12];
     B = new uint8_t[LEN12];
@@ -222,9 +214,7 @@ int main() {
     delete[] A;
     delete[] B;
     delete[] C;
-    hipFree(Ad);
-    hipFree(Bd);
-    hipFree(Cd);
+    hipFreeAll(Ad,Bd,Cd);
 
     passed();
 }

--- a/tests/src/kernel/hipTestMemKernel.cpp
+++ b/tests/src/kernel/hipTestMemKernel.cpp
@@ -18,7 +18,7 @@ THE SOFTWARE.
 */
 
 /* HIT_START
- * BUILD: %t %s ../test_common.cpp
+ * BUILD: %t %s ../test_common.cpp EXCLUDE_HIP_PLATFORM nvcc
  * TEST: %t
  * HIT_END
  */


### PR DESCRIPTION
hipFreeAll is a new proposed hip runtime API that takes variable arguments to free all of them. 
e.g. Say at any point in time user wants to free memory allocated in 10 different type of pointers in his program then he/she needs to write something similar mentioned below 
hipFree(varPtr1);
hipFree(varPtr2);
hipFree(varPtr3);
........
hipFree(varPtr10);    
With hipFreeAll API it can be achieved as hipFreeAll(varPtr1,varPtr2,varPtr3........varPtr10);