### PR TITLE
[HIPIFY][#1439] Add reinterpret_cast to args of some functions

### DIFF
--- a/hipify-clang/src/HipifyAction.h
+++ b/hipify-clang/src/HipifyAction.h
@@ -72,6 +72,8 @@ public:
   bool cudaSharedIncompleteArrayVar(const clang::ast_matchers::MatchFinder::MatchResult& Result);
   bool cudaDeviceFuncCall(const clang::ast_matchers::MatchFinder::MatchResult& Result);
   bool cudaSymbolFuncCall(const clang::ast_matchers::MatchFinder::MatchResult& Result);
+  bool cudaReinterpretCastArgFuncCall(const clang::ast_matchers::MatchFinder::MatchResult& Result);
+
   // Called by the preprocessor for each include directive during the non-raw lexing pass.
   void InclusionDirective(clang::SourceLocation hash_loc,
                           const clang::Token &include_token,

--- a/tests/hipify-clang/unit_tests/samples/reinterpret_cast.cu
+++ b/tests/hipify-clang/unit_tests/samples/reinterpret_cast.cu
@@ -1,0 +1,53 @@
+// RUN: %run_test hipify "%s" "%t" %hipify_args %clang_args
+
+/*
+Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <stdio.h>
+// CHECK: #include <hip/hip_runtime.h>
+#include <cuda_runtime.h>
+
+__global__
+void fn(float* px, float* py) {
+  bool a[42];
+  __shared__ double b[69];
+  for (auto&& x : b) x = *py++;
+  for (auto&& x : a) x = *px++ > 0.0;
+  for (auto&& x : a) if (x)* --py = *--px;
+}
+
+int main() {
+  // CHECK: hipFuncCache_t cacheConfig;
+  cudaFuncCache cacheConfig;
+  void* func;
+  // CHECK: hipFuncSetCacheConfig(reinterpret_cast<const void*>(func), cacheConfig);
+  cudaFuncSetCacheConfig(func, cacheConfig);
+  // CHECK: hipFuncAttributes attr{};
+  cudaFuncAttributes attr{};
+  // CHECK: auto r = hipFuncGetAttributes(&attr, reinterpret_cast<const void*>(&fn));
+  auto r = cudaFuncGetAttributes(&attr, &fn);
+  // CHECK: if (r != hipSuccess || attr.maxThreadsPerBlock == 0) {
+  if (r != cudaSuccess || attr.maxThreadsPerBlock == 0) {
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
+ Affected functions: hipFuncSetCacheConfig, hipFuncGetAttributes
+ Add a corresponding Matcher cudaReinterpretCastArgFuncCall
+ Add reinterpret_cast.cu test

TODO: Do the same for hipify-perl