### PR TITLE
[HIPIFY][#1439] Add reinterpret_cast to args of some functions

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1757,7 +1757,7 @@ while (@ARGV) {
             $ft{'kernel_func'} += countSupportedDeviceFunctions();
         }
 
-        $ft{'memory'} += transformSymbolFunctions();
+        transformHostFunctions();
 
         # Print it!
         # TODO - would like to move this code outside loop but it uses $_ which contains the whole file.
@@ -1813,7 +1813,7 @@ if ($count_conversions) {
     }
 }
 
-sub transformSymbolFunctions
+sub transformHostFunctions
 {
     my $m = 0;
     foreach $func (
@@ -1831,6 +1831,18 @@ sub transformSymbolFunctions
     )
     {
         $m += s/(?<!\/\/ CHECK: )($func)\s*\(\s*([^,]+)\s*,\s*([^,\)]+)\s*(,\s*|\))\s*/$func\($2, HIP_SYMBOL\($3\)$4/g;
+    }
+    foreach $func (
+        "hipFuncSetCacheConfig"
+    )
+    {
+        $m += s/(?<!\/\/ CHECK: )($func)\s*\(\s*([^,]+)\s*,/$func\(reinterpret_cast<const void*>\($2\),/g
+    }
+    foreach $func (
+        "hipFuncGetAttributes"
+    )
+    {
+        $m += s/(?<!\/\/ CHECK: )($func)\s*\(\s*([^,]+)\s*,\s*([^,\)]+)\s*(,\s*|\))\s*/$func\($2, reinterpret_cast<const void*>\($3\)$4/g;
     }
     return $m;
 }

--- a/hipify-clang/src/CUDA2HIP_Scripting.h
+++ b/hipify-clang/src/CUDA2HIP_Scripting.h
@@ -24,6 +24,11 @@ THE SOFTWARE.
 
 extern std::set<std::string> DeviceSymbolFunctions0;
 extern std::set<std::string> DeviceSymbolFunctions1;
+extern std::set<std::string> ReinterpretFunctions0;
+extern std::set<std::string> ReinterpretFunctions1;
+
+extern std::string sHIP_SYMBOL;
+extern std::string s_reinterpret_cast;
 
 namespace perl {
 

--- a/hipify-clang/src/HipifyAction.cpp
+++ b/hipify-clang/src/HipifyAction.cpp
@@ -37,8 +37,8 @@ namespace ct = clang::tooling;
 namespace mat = clang::ast_matchers;
 
 const std::string sHIP_DYNAMIC_SHARED = "HIP_DYNAMIC_SHARED";
-const std::string sHIP_SYMBOL = "HIP_SYMBOL";
-const std::string s_reinterpret_cast = "reinterpret_cast<const void*>";
+std::string sHIP_SYMBOL = "HIP_SYMBOL";
+std::string s_reinterpret_cast = "reinterpret_cast<const void*>";
 const std::string sHipLaunchKernelGGL = "hipLaunchKernelGGL(";
 const std::string sDim3 = "dim3(";
 
@@ -65,6 +65,14 @@ std::set<std::string> DeviceSymbolFunctions1 {
 
 std::set<std::string> ReinterpretFunctions{
   {sCudaFuncSetCacheConfig},
+  {sCudaFuncGetAttributes}
+};
+
+std::set<std::string> ReinterpretFunctions0{
+  {sCudaFuncSetCacheConfig}
+};
+
+std::set<std::string> ReinterpretFunctions1{
   {sCudaFuncGetAttributes}
 };
 

--- a/tests/hipify-clang/unit_tests/casts/reinterpret_cast.cu
+++ b/tests/hipify-clang/unit_tests/casts/reinterpret_cast.cu
@@ -22,7 +22,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 
-#include <stdio.h>
 // CHECK: #include <hip/hip_runtime.h>
 #include <cuda_runtime.h>
 
@@ -32,7 +31,7 @@ void fn(float* px, float* py) {
   __shared__ double b[69];
   for (auto&& x : b) x = *py++;
   for (auto&& x : a) x = *px++ > 0.0;
-  for (auto&& x : a) if (x)* --py = *--px;
+  for (auto&& x : a) if (x) *--py = *--px;
 }
 
 int main() {


### PR DESCRIPTION
+ Perl part of [#1458]
+ Affected functions: hipFuncSetCacheConfig, hipFuncGetAttributes
+ Implement function generateHostFunctions() in hipify-clang for that purposes
+ Update hipify-perl accordingly