### PR TITLE
Map clock64() to __builtin_readcyclecounter()

### DIFF
--- a/include/hip/hcc_detail/device_functions.h
+++ b/include/hip/hcc_detail/device_functions.h
@@ -690,12 +690,7 @@ extern "C" uint64_t __clock_u64()  __HC__;
 __device__
 inline  __attribute((always_inline))
 long long int __clock64() {
-// ToDo: Unify HCC and HIP implementation.
-#if __HCC__
-    return (long long int) __clock_u64();
-#else
-    return (long long int) __builtin_amdgcn_s_memrealtime();
-#endif
+return (long long int)  __builtin_readcyclecounter();
 }
 
 __device__


### PR DESCRIPTION
Fixes SWDEV-203215.