### PR TITLE
Fix usage of uninitialized variable in hipDeviceGetAttribute

### DIFF
--- a/include/hip/nvcc_detail/hip_runtime_api.h
+++ b/include/hip/nvcc_detail/hip_runtime_api.h
@@ -968,8 +968,7 @@ inline static hipError_t hipDeviceGetAttribute(int* pi, hipDeviceAttribute_t att
             cdattr = cudaDevAttrEccEnabled;
             break;
         default:
-            cerror = cudaErrorInvalidValue;
-            break;
+            return hipCUDAErrorTohipError(cudaErrorInvalidValue);
     }
 
     cerror = cudaDeviceGetAttribute(pi, cdattr, device);


### PR DESCRIPTION
This fixes the usage of an uninitialized `cdattr` variable in `hipDeviceGetAttribute` for the CUDA backend when taking the switch default, as detailed in #1317.

Note that the `directed_tests/runtimeApi/device/hipGetDeviceAttribute.tst` test fails for me, but it already did before applying this patch. Let's see what CI says!