### PR TITLE
[HIPIFY][perl] Start to generate hipify-perl under an option -perl

### DIFF
--- a/hipify-clang/src/ArgParse.cpp
+++ b/hipify-clang/src/ArgParse.cpp
@@ -44,13 +44,8 @@ cl::opt<bool> GeneratePython("python",
   cl::value_desc("python"),
   cl::cat(ToolTemplateCategory));
 
-cl::opt<std::string> OutputPerlMapFilename("o-perl-map",
-  cl::desc("Output filename for Perl map"),
-  cl::value_desc("filename"),
-  cl::cat(ToolTemplateCategory));
-
-cl::opt<std::string> OutputPerlMapDir("o-perl-map-dir",
-  cl::desc("Output direcory for Perl map"),
+cl::opt<std::string> OutputHipifyPerlDir("o-hipify-perl-dir",
+  cl::desc("Output direcory for hipify-perl script"),
   cl::value_desc("directory"),
   cl::cat(ToolTemplateCategory));
 

--- a/hipify-clang/src/ArgParse.h
+++ b/hipify-clang/src/ArgParse.h
@@ -30,8 +30,7 @@ namespace ct = clang::tooling;
 
 extern cl::OptionCategory ToolTemplateCategory;
 extern cl::opt<std::string> OutputFilename;
-extern cl::opt<std::string> OutputPerlMapFilename;
-extern cl::opt<std::string> OutputPerlMapDir;
+extern cl::opt<std::string> OutputHipifyPerlDir;
 extern cl::opt<std::string> OutputPythonMapDir;
 extern cl::opt<std::string> OutputDir;
 extern cl::opt<std::string> TemporaryDir;

--- a/hipify-clang/src/CUDA2HIP_Perl.cpp
+++ b/hipify-clang/src/CUDA2HIP_Perl.cpp
@@ -327,17 +327,16 @@ namespace perl {
 
   bool generate(bool Generate) {
     if (!Generate) return true;
-    std::string dstPerlMap = OutputPerlMapFilename, dstPerlMapDir = OutputPerlMapDir;
-    if (dstPerlMap.empty()) dstPerlMap = "hipify-perl-map";
+    std::string dstHipifyPerl = "hipify-perl", dstHipifyPerlDir = OutputHipifyPerlDir;
     std::error_code EC;
-    if (!dstPerlMapDir.empty()) {
-      std::string sOutputPerlMapDirAbsPath = getAbsoluteDirectoryPath(OutputPerlMapDir, EC, "output hipify-perl map");
+    if (!dstHipifyPerlDir.empty()) {
+      std::string sOutputHipifyPerlDirAbsPath = getAbsoluteDirectoryPath(OutputHipifyPerlDir, EC, "output hipify-perl");
       if (EC) return false;
-      dstPerlMap = sOutputPerlMapDirAbsPath + "/" + dstPerlMap;
+      dstHipifyPerl = sOutputHipifyPerlDirAbsPath + "/" + dstHipifyPerl;
     }
     SmallString<128> tmpFile;
-    StringRef ext = "hipify-tmp";
-    EC = sys::fs::createTemporaryFile(dstPerlMap, ext, tmpFile);
+    StringRef ext = "hipify-perl-tmp";
+    EC = sys::fs::createTemporaryFile(dstHipifyPerl, ext, tmpFile);
     if (EC) {
       llvm::errs() << "\n" << sHipify << sError << EC.message() << ": " << tmpFile << "\n";
       return false;
@@ -490,9 +489,9 @@ namespace perl {
     *streamPtr.get() << tab << "}" << std::endl << "}" << std::endl;
     streamPtr.get()->flush();
     bool ret = true;
-    EC = sys::fs::copy_file(tmpFile, dstPerlMap);
+    EC = sys::fs::copy_file(tmpFile, dstHipifyPerl);
     if (EC) {
-      llvm::errs() << "\n" << sHipify << sError << EC.message() << ": while copying " << tmpFile << " to " << dstPerlMap << "\n";
+      llvm::errs() << "\n" << sHipify << sError << EC.message() << ": while copying " << tmpFile << " to " << dstHipifyPerl << "\n";
       ret = false;
     }
     if (!SaveTemps) sys::fs::remove(tmpFile);


### PR DESCRIPTION
+ Get rid of --o-perl-map option for Perl output filename: the output name now is always hipify-perl
+ Option --o-perl-map-dir renamed to --o-hipify-perl-dir

Cmd example for generating hipify-perl script to the particular directory:
hipify-clang -perl --o-hipify-perl-dir=../../bin