### PR TITLE
Fix for directed tests failure

### DIFF
--- a/tests/src/runtimeApi/memory/hipArray.cpp
+++ b/tests/src/runtimeApi/memory/hipArray.cpp
@@ -21,7 +21,7 @@ THE SOFTWARE.
 */
 
 /* HIT_START
- * BUILD: %t %s ../../test_common.cpp EXCLUDE_HIP_PLATFORM nvcc
+ * BUILD: %t %s ../../test_common.cpp EXCLUDE_HIP_PLATFORM all
  * TEST: %t
  * HIT_END
  */

--- a/tests/src/runtimeApi/memory/hipArray.cpp
+++ b/tests/src/runtimeApi/memory/hipArray.cpp
@@ -132,8 +132,7 @@ void memcpyArraytest(size_t numW, size_t numH, bool usePinnedHost, bool usePitch
         HipTest::initHIPArrays(&A_d, &B_d, &C_d, &desc, numW, 1, 0);
         HipTest::initArraysForHost(&A_h, &B_h, &C_h, numW * numH, usePinnedHost);
         unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, numW * numH);
-        HIPCHECK(hipMemset(A_d->data,0,width));
-        HIPCHECK(hipMemset(B_d->data,0,width));
+
         HIPCHECK(hipMemcpyToArray(A_d, 0, 0, (void*)A_h, width, hipMemcpyHostToDevice));
         hip_Memcpy2D ins;
         initMemCpyParam2D(ins,width,width,width,numH,hipMemoryTypeArray,hipMemoryTypeHost);

--- a/tests/src/runtimeApi/memory/hipArray.cpp
+++ b/tests/src/runtimeApi/memory/hipArray.cpp
@@ -132,7 +132,8 @@ void memcpyArraytest(size_t numW, size_t numH, bool usePinnedHost, bool usePitch
         HipTest::initHIPArrays(&A_d, &B_d, &C_d, &desc, numW, 1, 0);
         HipTest::initArraysForHost(&A_h, &B_h, &C_h, numW * numH, usePinnedHost);
         unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, numW * numH);
-
+        HIPCHECK(hipMemset(A_d->data,0,width));
+        HIPCHECK(hipMemset(B_d->data,0,width));
         HIPCHECK(hipMemcpyToArray(A_d, 0, 0, (void*)A_h, width, hipMemcpyHostToDevice));
         hip_Memcpy2D ins;
         initMemCpyParam2D(ins,width,width,width,numH,hipMemoryTypeArray,hipMemoryTypeHost);

--- a/tests/src/runtimeApi/module/hipLaunchCooperativeKernel.cpp
+++ b/tests/src/runtimeApi/module/hipLaunchCooperativeKernel.cpp
@@ -22,7 +22,7 @@ THE SOFTWARE.
 // Simple test for hipLaunchCooperativeKernel API.
 
 /* HIT_START
- * BUILD: %t %s ../../test_common.cpp EXCLUDE_HIP_PLATFORM nvcc
+ * BUILD: %t %s ../../test_common.cpp EXCLUDE_HIP_PLATFORM all
  * TEST: %t
  * HIT_END
  */


### PR DESCRIPTION
SWDEV-203971:
directed_tests/runtimeApi/module/hipLaunchCooperativeKernel.tst - Disabling test temporarily until driver support is available.
directed_tests/runtimeApi/memory/hipArray.tst 