### PR TITLE
Fix struct declaration for C

### DIFF
--- a/hip_prof_gen.py
+++ b/hip_prof_gen.py
@@ -349,7 +349,7 @@ def generate_prof_header(f, api_map, opts_map):
   # Generating the callbacks data structure
   f.write('\n// HIP API callbacks data structure\n')
   f.write(
-  'struct hip_api_data_t {\n' +
+  'typedef struct hip_api_data_t {\n' +
   '  uint64_t correlation_id;\n' +
   '  uint32_t phase;\n' +
   '  union {\n'
@@ -365,7 +365,7 @@ def generate_prof_header(f, api_map, opts_map):
       f.write('    } ' + name + ';\n')
   f.write(
   '  } args;\n' +
-  '};\n'
+  '} hip_api_data_t;\n'
   )
   
   # Generating the callbacks args data filling macros


### PR DESCRIPTION
This change is necessary for HPCToolkit to use Roctracer to produce code centric profiling view.