### PR TITLE
Adding code object manager to rtc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,7 +289,7 @@ if(HIP_PLATFORM STREQUAL "hcc")
         target_link_libraries(hip_hcc PRIVATE hc_am)
         target_link_libraries(hip_hcc_static PRIVATE hc_am)
 
-        add_library(hiprtc SHARED src/hiprtc.cpp)
+        add_library(hiprtc SHARED src/hiprtc.cpp src/code_object_bundle.cpp)
         target_include_directories(
             hiprtc SYSTEM
                 PRIVATE ${PROJECT_SOURCE_DIR}/include ${HSA_PATH}/include)


### PR DESCRIPTION
Adding Code Object Manager file to rtc to resolve address of Bundled_code_object in libhiprtc.so