### PR TITLE
Add support for extended launch syntax.

### DIFF
--- a/include/hip/hcc_detail/functional_grid_launch.hpp
+++ b/include/hip/hcc_detail/functional_grid_launch.hpp
@@ -124,30 +124,6 @@ void hipLaunchKernelGGLImpl(
                           dimBlocks.x, dimBlocks.y, dimBlocks.z, sharedMemBytes,
                           stream, nullptr, kernarg);
 }
-
-inline
-__attribute__((visibility("hidden")))
-void hipExtLaunchKernelGGLImpl(
-    std::uintptr_t function_address,
-    const dim3& numBlocks,
-    const dim3& dimBlocks,
-    std::uint32_t sharedMemBytes,
-    hipStream_t stream,
-    hipEvent_t startEvent,
-    hipEvent_t stopEvent,
-    std::uint32_t flags,
-    void** kernarg) {
-
-    const auto& kd = hip_impl::get_program_state()
-        .kernel_descriptor(function_address, target_agent(stream));
-
-    hipExtModuleLaunchKernel(kd, numBlocks.x * dimBlocks.x,
-                             numBlocks.y * dimBlocks.y,
-                             numBlocks.z * dimBlocks.z,
-                             dimBlocks.x, dimBlocks.y, dimBlocks.z,
-                             sharedMemBytes, stream, nullptr, kernarg,
-                             startEvent, stopEvent, flags);
-}
 } // Namespace hip_impl.
 
 
@@ -200,30 +176,4 @@ void hipLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& dimBlocks,
                                      numBlocks, dimBlocks, sharedMemBytes,
                                      stream, &config[0]);
 }
-
-template <typename... Args, typename F = void (*)(Args...)>
-inline
-void hipExtLaunchKernelGGL(F kernel, const dim3& numBlocks,
-                           const dim3& dimBlocks, std::uint32_t sharedMemBytes,
-                           hipStream_t stream, hipEvent_t startEvent,
-                           hipEvent_t stopEvent, std::uint32_t flags,
-                           Args... args) {
-    hip_impl::hip_init();
-    auto kernarg =
-        hip_impl::make_kernarg(kernel, std::tuple<Args...>{std::move(args)...});
-    std::size_t kernarg_size = kernarg.size();
-
-    void* config[]{
-        HIP_LAUNCH_PARAM_BUFFER_POINTER,
-        kernarg.data(),
-        HIP_LAUNCH_PARAM_BUFFER_SIZE,
-        &kernarg_size,
-        HIP_LAUNCH_PARAM_END};
-
-    hip_impl::hipExtLaunchKernelGGLImpl(reinterpret_cast<std::uintptr_t>(kernel),
-                                        numBlocks, dimBlocks, sharedMemBytes,
-                                        stream, startEvent, stopEvent, flags,
-                                        &config[0]);
-}
-
 #pragma GCC visibility pop

--- a/include/hip/hcc_detail/hip_runtime_api.h
+++ b/include/hip/hcc_detail/hip_runtime_api.h
@@ -2846,6 +2846,18 @@ hipError_t hipModuleLaunchKernel(hipFunction_t f, unsigned int gridDimX, unsigne
                                  unsigned int sharedMemBytes, hipStream_t stream,
                                  void** kernelParams, void** extra);
 
+// TODO: add spammy description
+hipError_t hipExtModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,
+                                    uint32_t globalWorkSizeY,
+                                    uint32_t globalWorkSizeZ,
+                                    uint32_t localWorkSizeX,
+                                    uint32_t localWorkSizeY,
+                                    uint32_t localWorkSizeZ,
+                                    size_t sharedMemBytes,
+                                    hipStream_t hStream, void** kernelParams,
+                                    void** extra, hipEvent_t startEvent,
+                                    hipEvent_t stopEvent, uint32_t flags);
+
 /**
  * @brief launches kernel f with launch parameters and shared memory on stream with arguments passed
  * to kernelparams or extra, where thread blocks can cooperate and synchronize as they execute

--- a/include/hip/hcc_detail/hip_runtime_api.h
+++ b/include/hip/hcc_detail/hip_runtime_api.h
@@ -2885,17 +2885,6 @@ hipError_t hipModuleLaunchKernel(hipFunction_t f, unsigned int gridDimX, unsigne
                                  unsigned int sharedMemBytes, hipStream_t stream,
                                  void** kernelParams, void** extra);
 
-// TODO: add spammy description
-hipError_t hipExtModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,
-                                    uint32_t globalWorkSizeY,
-                                    uint32_t globalWorkSizeZ,
-                                    uint32_t localWorkSizeX,
-                                    uint32_t localWorkSizeY,
-                                    uint32_t localWorkSizeZ,
-                                    size_t sharedMemBytes,
-                                    hipStream_t hStream, void** kernelParams,
-                                    void** extra, hipEvent_t startEvent,
-                                    hipEvent_t stopEvent, uint32_t flags);
 
 /**
  * @brief launches kernel f with launch parameters and shared memory on stream with arguments passed

--- a/tests/src/kernel/hipExtLaunchKernelGGL.cpp
+++ b/tests/src/kernel/hipExtLaunchKernelGGL.cpp
@@ -25,6 +25,7 @@ THE SOFTWARE.
  */
 
 #include "hip/hip_runtime.h"
+#include "hip/hip_ext.h"
 #include "test_common.h"
 
 void test(size_t N) {
@@ -43,7 +44,7 @@ void test(size_t N) {
 
     hipExtLaunchKernelGGL(HipTest::vectorADD, dim3(blocks),
                           dim3(threadsPerBlock), 0, 0, nullptr, nullptr, 0,
-                          A_d, B_d, C_d, N);
+                          static_cast<const int*>(A_d), static_cast<const int*>(B_d), C_d, N);
 
     HIPCHECK(hipMemcpy(C_h, C_d, Nbytes, hipMemcpyDeviceToHost));
 

--- a/tests/src/kernel/hipExtLaunchKernelGGL.cpp
+++ b/tests/src/kernel/hipExtLaunchKernelGGL.cpp
@@ -1,0 +1,61 @@
+/*
+Copyright (c) 2015-2017 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+// Test the Grid_Launch syntax.
+
+/* HIT_START
+ * BUILD: %t %s ../test_common.cpp EXCLUDE_HIP_PLATFORM nvcc
+ * TEST: %t
+ * HIT_END
+ */
+
+#include "hip/hip_runtime.h"
+#include "test_common.h"
+
+void test(size_t N) {
+    size_t Nbytes = N * sizeof(int);
+
+    int *A_d, *B_d, *C_d;
+    int *A_h, *B_h, *C_h;
+
+    HipTest::initArrays(&A_d, &B_d, &C_d, &A_h, &B_h, &C_h, N);
+
+
+    unsigned blocks = HipTest::setNumBlocks(blocksPerCU, threadsPerBlock, N);
+
+    HIPCHECK(hipMemcpy(A_d, A_h, Nbytes, hipMemcpyHostToDevice));
+    HIPCHECK(hipMemcpy(B_d, B_h, Nbytes, hipMemcpyHostToDevice));
+
+    hipExtLaunchKernelGGL(HipTest::vectorADD, dim3(blocks),
+                          dim3(threadsPerBlock), 0, 0, nullptr, nullptr, 0,
+                          A_d, B_d, C_d, N);
+
+    HIPCHECK(hipMemcpy(C_h, C_d, Nbytes, hipMemcpyDeviceToHost));
+
+    HIPCHECK(hipDeviceSynchronize());
+
+    HipTest::checkVectorADD(A_h, B_h, C_h, N);
+}
+
+int main(int argc, char* argv[]) {
+    HipTest::parseStandardArguments(argc, argv, true);
+
+    test_gl2(N);
+
+    passed();
+}

--- a/tests/src/kernel/hipExtLaunchKernelGGL.cpp
+++ b/tests/src/kernel/hipExtLaunchKernelGGL.cpp
@@ -55,7 +55,7 @@ void test(size_t N) {
 int main(int argc, char* argv[]) {
     HipTest::parseStandardArguments(argc, argv, true);
 
-    test_gl2(N);
+    test(N);
 
     passed();
 }

--- a/tests/src/runtimeApi/module/hipModuleGetGlobal.cpp
+++ b/tests/src/runtimeApi/module/hipModuleGetGlobal.cpp
@@ -32,7 +32,6 @@ THE SOFTWARE.
 #include <iostream>
 #include <fstream>
 #include <vector>
-#include <hip/hip_ext.h>
 
 #define LEN 64
 #define SIZE LEN * sizeof(float)


### PR DESCRIPTION
This depends on https://github.com/RadeonOpenCompute/hcc-clang-upgrade/pull/183. It supersedes https://github.com/ROCm-Developer-Tools/HIP/pull/1523.