### PR TITLE
Temporary add -D_OPENMP to clang options in hipcc to allow using CMak…

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -526,6 +526,13 @@ foreach $arg (@ARGV)
         $optArg = $arg;
     }
 
+    ## This is a temporary workaround for CMake detection of OpenMP support.
+    ## It should be removed when the OpenMP detection c++ test in CMake is updated
+    ## and corrected CMake version is available.
+    if($arg eq '-fopenmp') {
+        $HIPCXXFLAGS .= " -D_OPENMP "
+    }
+
     ## process linker response file for hip-clang
     ## extract object files from static library and pass them directly to
     ## hip-clang in command line.

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -529,7 +529,7 @@ foreach $arg (@ARGV)
     ## This is a temporary workaround for CMake detection of OpenMP support.
     ## It should be removed when the OpenMP detection c++ test in CMake is updated
     ## and corrected CMake version is available.
-    if($arg eq '-fopenmp') {
+    if((defined $HIP_COMPILER) and ($HIP_COMPILER eq "clang") and ($arg eq '-fopenmp')) {
         $HIPCXXFLAGS .= " -D_OPENMP "
     }
 


### PR DESCRIPTION
…e OpenMP detection with hip-clang (until updated CMake version is available).