### PR TITLE
[HIPIFY][tests] Exclude tests for the libs, which are not defined in cmake command line

### DIFF
--- a/tests/hipify-clang/lit.cfg
+++ b/tests/hipify-clang/lit.cfg
@@ -12,18 +12,31 @@ import lit.util
 site_cfg = lit_config.params.get('site_config', None)
 lit_config.load_config(config, site_cfg)
 
-print(str("========================================"))
+config.excludes = ['cmdparser.hpp']
+config.excludes.append('spatial_batch_norm_op.h')
+config.excludes.append('common_cudnn.h')
+
+delimiter = "===============================================================";
+print(delimiter)
 print("CUDA " + config.cuda_version + " - will be used for testing")
 print("LLVM " + config.llvm_version + " - will be used for testing")
 print(platform.machine() + " - Platform architecture")
 print(platform.system() + " " + platform.release() + " - Platform OS")
 print(str(config.pointer_size * 8) + " - hipify-clang binary bitness")
 print(str(struct.calcsize("P") * 8) + " - python " + str(platform.python_version()) + " binary bitness")
-print(str("========================================"))
-
-config.excludes = ['cmdparser.hpp']
-config.excludes.append('spatial_batch_norm_op.h')
-config.excludes.append('common_cudnn.h')
+print(delimiter)
+warns = None
+if not config.cuda_dnn_root:
+    config.excludes.append('cudnn_convolution_forward.cu')
+    config.excludes.append('cudnn_softmax.cu')
+    print("WARN: cuDNN tests are excluded due to unset CUDA_DNN_ROOT_DIR")
+    warns = True
+if not config.cuda_cub_root:
+    config.excludes.append('cub_01.cu')
+    print("WARN: CUB tests are excluded due to unset CUDA_CUB_ROOT_DIR")
+    warns = True
+if warns:
+    print(delimiter)
 
 if config.cuda_version_major == 7 and config.cuda_version_minor == 0:
     config.excludes.append('headers_test_09.cu')
@@ -90,17 +103,26 @@ else:
     run_test_ext = ".sh"
     # CUDA SDK ROOT
     clang_arguments += " -isystem'%s'/samples/common/inc"
-# cuDNN ROOT
-clang_arguments += " -I'%s'/include"
 if config.pointer_size == 8:
     clang_arguments += " -D__LP64__"
 
+# cuDNN ROOT
+if config.cuda_dnn_root:
+    clang_arguments += " -I'%s'/include"
 # CUB ROOT
-clang_arguments += " -I'%s'"
+if config.cuda_cub_root:
+    clang_arguments += " -I'%s'"
+
+if config.cuda_dnn_root and config.cuda_cub_root:
+    config.substitutions.append(("%clang_args", clang_arguments % (config.cuda_sdk_root, config.cuda_dnn_root, config.cuda_cub_root)))
+elif config.cuda_dnn_root:
+    config.substitutions.append(("%clang_args", clang_arguments % (config.cuda_sdk_root, config.cuda_dnn_root)))
+elif config.cuda_cub_root:
+    config.substitutions.append(("%clang_args", clang_arguments % (config.cuda_sdk_root, config.cuda_cub_root)))
+else:
+    config.substitutions.append(("%clang_args", clang_arguments % config.cuda_sdk_root))
 
 hipify_arguments = "--cuda-path='%s'"
-
-config.substitutions.append(("%clang_args", clang_arguments % (config.cuda_sdk_root, config.cuda_dnn_root, config.cuda_cub_root)))
-config.substitutions.append(("%hipify_args", hipify_arguments % (config.cuda_root)))
+config.substitutions.append(("%hipify_args", hipify_arguments % config.cuda_root))
 config.substitutions.append(("hipify", '"' + hipify_path + "/hipify-clang" + '"'))
 config.substitutions.append(("%run_test", '"' + config.test_source_root + "/run_test" + run_test_ext + '"'))


### PR DESCRIPTION
+ affects cuDNN and CUB tests, paths to libraries of which are defined by CUDA_DNN_ROOT_DIR and CUDA_CUB_ROOT_DIR
+ Warn about excluding and why, for instance:
  "WARN: cuDNN tests are excluded due to unset CUDA_DNN_ROOT_DIR"