### PR TITLE
[HIPRTC] Fix hard-coded path to hipcc

### DIFF
--- a/src/hiprtc.cpp
+++ b/src/hiprtc.cpp
@@ -481,7 +481,7 @@ hiprtcResult hiprtcCompileProgram(hiprtcProgram p, int n, const char** o)
 
     static const string hipcc{
         getenv("HIP_PATH") ? (getenv("HIP_PATH") + string{"/bin/hipcc"})
-                           : "/opt/rocm/bin/hipcc"};
+                           : "/opt/rocm/hip/bin/hipcc"};
 
     if (!experimental::filesystem::exists(hipcc)) {
         return HIPRTC_ERROR_INTERNAL_ERROR;


### PR DESCRIPTION
If the environment variable `HIP_PATH` does not exist, HIPRTC searches
for the hipcc executable at `/opt/rocm/bin`, when in fact, hipcc is
located at `/opt/rocm/hip/bin`.
This commit corrects the hard-coded path to hipcc.

---

**Note**
a workaround for this issue is to set `HIP_PATH` in the environment: `export HIP_PATH=/opt/rocm/hip`