### PR TITLE
Use the correct return type in runTest in 11_texture_driver sample.

### DIFF
--- a/samples/2_Cookbook/11_texture_driver/texture2dDrv.cpp
+++ b/samples/2_Cookbook/11_texture_driver/texture2dDrv.cpp
@@ -30,7 +30,7 @@ THE SOFTWARE.
 #define fileName "tex2dKernel.code"
 
 texture<float, 2, hipReadModeElementType> tex;
-bool testResult = false;
+bool testResult = true;
 
 #define HIP_CHECK(cmd)                                                                             \
     {                                                                                              \
@@ -126,7 +126,7 @@ bool runTest(int argc, char** argv) {
     }
     hipFree(dData);
     hipFreeArray(array);
-    return true;
+    return testResult;
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Fixes SWDEV-203394.
Currently in runTest() returns true, even if the texture reference copy does not happen. Using the existing testResult Flag to return from runTest().