### PR TITLE
[HIPIFY][cmake] Make CMakeLists use default 3.5.1 for Ubuntu 16.04

### DIFF
--- a/hipify-clang/CMakeLists.txt
+++ b/hipify-clang/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5.2)
+cmake_minimum_required(VERSION 3.5.1)
 
 project(hipify-clang)
 

--- a/hipify-clang/README.md
+++ b/hipify-clang/README.md
@@ -196,7 +196,7 @@ Ubuntu 16-18: LLVM 8.0.0 - 9.0.0, CUDA 8.0 - 10.1, cudnn-5.1.10 - cudnn-7.6.4.38
 
 Minimum build system requirements for the above configurations:
 
-Python 2.7, cmake 3.5.2, GNU C/C++ 5.4.0.
+Python 2.7, cmake 3.5.1, GNU C/C++ 5.4.0.
 
 Here is an example of building `hipify-clang` with testing support on `Ubuntu 16.04`:
 
@@ -346,7 +346,7 @@ LLVM 7.0.0 - 9.0.0, CUDA 7.5 - 10.1, cudnn 7.0.5.15 - 7.6.4.38
 
 Build system requirements for the latest configuration LLVM 9.0.0/CUDA 10.1 Update 2:
 
-Python 3.6.0 - 3.8.0, cmake 3.5.2 - 3.15.5, Visual Studio 2017 (15.5.2) - 2019 (16.3.5).
+Python 3.6.0 - 3.8.0, cmake 3.5.1 - 3.15.5, Visual Studio 2017 (15.5.2) - 2019 (16.3.5).
 
 Here is an example of building `hipify-clang` with testing support on `Windows 10` by `Visual Studio 16 2019`:
 


### PR DESCRIPTION
I've tested HIPIFY in the HIP-Clang CI environment on Ubuntu 16.04 and successfully builds and installs hipify-clang with ROCm LLVM+Clang.

```
root@498447af48dc:/root/HIP/hipify-clang/build# cmake -DCMAKE_INSTALL_PREFIX=../dist -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=/root/llvm-project/build/dist ..
-- The C compiler identification is GNU 5.4.0
-- The CXX compiler identification is GNU 5.4.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found LLVM 10.0.0svn:
--    - CMake module path: /root/llvm-project/build/dist/lib/cmake/llvm
--    - Include path     : /root/llvm-project/build/dist/include
--    - Binary path      : /root/llvm-project/build/dist/bin
-- Linker detection: GNU ld
-- Configuring done
-- Generating done
-- Build files have been written to: /root/HIP/hipify-clang/build
root@498447af48dc:/root/HIP/hipify-clang/build# make -j32 install
Scanning dependencies of target hipify-clang
[  3%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_Complex_API_functions.cpp.o
[  6%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_SPARSE_API_functions.cpp.o
[ 13%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_DNN_API_types.cpp.o
[ 13%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_CUB_API_types.cpp.o
[ 16%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_CAFFE2_API_types.cpp.o
[ 20%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_Runtime_API_types.cpp.o
[ 23%] Building CXX object CMakeFiles/hipify-clang.dir/src/ArgParse.cpp.o
[ 26%] Building CXX object CMakeFiles/hipify-clang.dir/src/HipifyAction.cpp.o
[ 30%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_Driver_API_types.cpp.o
[ 33%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_RAND_API_functions.cpp.o
[ 36%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_Complex_API_types.cpp.o
[ 40%] Building CXX object CMakeFiles/hipify-clang.dir/src/Statistics.cpp.o
[ 43%] Building CXX object CMakeFiles/hipify-clang.dir/src/StringUtils.cpp.o
[ 46%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_Perl.cpp.o
[ 50%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_FFT_API_types.cpp.o
[ 53%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_DNN_API_functions.cpp.o
[ 56%] Building CXX object CMakeFiles/hipify-clang.dir/src/LLVMCompat.cpp.o
[ 60%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_FFT_API_functions.cpp.o
[ 63%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_Device_functions.cpp.o
[ 66%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_Driver_API_functions.cpp.o
[ 73%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_Runtime_API_functions.cpp.o
[ 73%] Building CXX object CMakeFiles/hipify-clang.dir/src/main.cpp.o
[ 80%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_CAFFE2_API_functions.cpp.o
[ 80%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_RAND_API_types.cpp.o
[ 83%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP.cpp.o
[ 86%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_SPARSE_API_types.cpp.o
[ 90%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_BLAS_API_functions.cpp.o
[ 93%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_Python.cpp.o
[ 96%] Building CXX object CMakeFiles/hipify-clang.dir/src/CUDA2HIP_BLAS_API_types.cpp.o
[100%] Linking CXX executable hipify-clang
[100%] Built target hipify-clang
Install the project...
-- Install configuration: "Release"
-- Installing: /root/HIP/hipify-clang/dist/hipify-clang
-- Up-to-date: /root/HIP/hipify-clang/dist
-- Installing: /root/HIP/hipify-clang/dist/include
-- Installing: /root/HIP/hipify-clang/dist/include/clwbintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/tgmath.h
-- Installing: /root/HIP/hipify-clang/dist/include/mwaitxintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/rtmintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/cetintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/wbnoinvdintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512bwintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/stdbool.h
-- Installing: /root/HIP/hipify-clang/dist/include/f16cintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/s390intrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/fma4intrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/vadefs.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512bitalgintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/__clang_cuda_builtin_vars.h
-- Installing: /root/HIP/hipify-clang/dist/include/htmintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vlvp2intersectintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/tbmintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/xsavesintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/limits.h
-- Installing: /root/HIP/hipify-clang/dist/include/smmintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/nmmintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/xtestintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/armintr.h
-- Installing: /root/HIP/hipify-clang/dist/include/iso646.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vlvnniintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/bmi2intrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/htmxlintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/clzerointrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/inttypes.h
-- Installing: /root/HIP/hipify-clang/dist/include/ammintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/fxsrintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/stdatomic.h
-- Installing: /root/HIP/hipify-clang/dist/include/fmaintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/__clang_cuda_intrinsics.h
-- Installing: /root/HIP/hipify-clang/dist/include/vaesintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/lzcntintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/intrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vp2intersectintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/xsaveintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512ifmaintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vpopcntdqvlintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/shaintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/lwpintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/__clang_cuda_runtime_wrapper.h
-- Installing: /root/HIP/hipify-clang/dist/include/xsavecintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/mm_malloc.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vpopcntdqintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/stdarg.h
-- Installing: /root/HIP/hipify-clang/dist/include/vecintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/wmmintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/mmintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/unwind.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512erintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/float.h
-- Installing: /root/HIP/hipify-clang/dist/include/stddef.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vlintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vlbitalgintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/cpuid.h
-- Installing: /root/HIP/hipify-clang/dist/include/__clang_cuda_math_forward_declares.h
-- Installing: /root/HIP/hipify-clang/dist/include/pkuintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vbmivlintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/tmmintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/waitpkgintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512bf16intrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/arm_fp16.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512cdintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/__wmmintrin_aes.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vnniintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/xopintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/ia32intrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/arm64intr.h
-- Installing: /root/HIP/hipify-clang/dist/include/bmiintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vlbwintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vldqintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/__clang_cuda_libdevice_declares.h
-- Installing: /root/HIP/hipify-clang/dist/include/__stddef_max_align_t.h
-- Installing: /root/HIP/hipify-clang/dist/include/arm_neon.h
-- Installing: /root/HIP/hipify-clang/dist/include/opencl-c.h
-- Installing: /root/HIP/hipify-clang/dist/include/sgxintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/gfniintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/__clang_cuda_cmath.h
-- Installing: /root/HIP/hipify-clang/dist/include/cldemoteintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/clflushoptintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vbmiintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/adxintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/cuda_wrappers
-- Installing: /root/HIP/hipify-clang/dist/include/cuda_wrappers/algorithm
-- Installing: /root/HIP/hipify-clang/dist/include/cuda_wrappers/new
-- Installing: /root/HIP/hipify-clang/dist/include/cuda_wrappers/complex
-- Installing: /root/HIP/hipify-clang/dist/include/movdirintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/pmmintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/stdalign.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vlbf16intrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/stdint.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx2intrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/arm_acle.h
-- Installing: /root/HIP/hipify-clang/dist/include/__wmmintrin_pclmul.h
-- Installing: /root/HIP/hipify-clang/dist/include/altivec.h
-- Installing: /root/HIP/hipify-clang/dist/include/ptwriteintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/immintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/xsaveoptintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/module.modulemap
-- Installing: /root/HIP/hipify-clang/dist/include/popcntintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/enqcmdintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vlvbmi2intrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512dqintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/__clang_cuda_device_functions.h
-- Installing: /root/HIP/hipify-clang/dist/include/mm3dnow.h
-- Installing: /root/HIP/hipify-clang/dist/include/stdnoreturn.h
-- Installing: /root/HIP/hipify-clang/dist/include/pconfigintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/emmintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vlcdintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/prfchwintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512ifmavlintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/opencl-c-base.h
-- Installing: /root/HIP/hipify-clang/dist/include/invpcidintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/__clang_cuda_complex_builtins.h
-- Installing: /root/HIP/hipify-clang/dist/include/x86intrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/msa.h
-- Installing: /root/HIP/hipify-clang/dist/include/avxintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/varargs.h
-- Installing: /root/HIP/hipify-clang/dist/include/xmmintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512vbmi2intrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512pfintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/rdseedintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/vpclmulqdqintrin.h
-- Installing: /root/HIP/hipify-clang/dist/include/avx512fintrin.h
```