### PR TITLE
Fixes for hipMemcpy_simple on Windows

### DIFF
--- a/tests/src/runtimeApi/memory/hipMemcpy_simple.cpp
+++ b/tests/src/runtimeApi/memory/hipMemcpy_simple.cpp
@@ -120,8 +120,8 @@ void simpleTest2(size_t numElements, bool usePinnedHost) {
         HIPCHECK(hipHostFree(A_h1));
         HIPCHECK(hipHostFree(A_h2));
     } else {
-        free(A_h1);
-        free(A_h2);
+        aligned_free(A_h1);
+        aligned_free(A_h2);
     }
 }
 

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -99,10 +99,14 @@ THE SOFTWARE.
 
 #ifdef _WIN64
 #include <tchar.h>
-#define aligned_alloc _aligned_malloc
+#define aligned_alloc(x,y) _aligned_malloc(y,x)
+#define aligned_free(x) _aligned_free(x)
 #define popen(x,y) _popen(x,y)
 #define pclose(x) _pclose(x)
 #define setenv(x,y,z) _putenv_s(x,y)
+#endif
+#else
+#define aligned_free(x) free(x)
 #endif
 
 // standard command-line variables:

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -104,7 +104,6 @@ THE SOFTWARE.
 #define popen(x,y) _popen(x,y)
 #define pclose(x) _pclose(x)
 #define setenv(x,y,z) _putenv_s(x,y)
-#endif
 #else
 #define aligned_free(x) free(x)
 #endif


### PR DESCRIPTION
_aligned_malloc() on Windows first takes size, then alignment, which is the opposite of how the similar function behaves on Linux. Memory allocated by it also has to be freed using _aligned_free(), unlike Linux where we can use regular free().

Edit aligned_alloc() macro and add a aligned_free() one to align with the above behaviour.