### PR TITLE
[HIPIFY][tests] Set max clang's CudaArch for corresponding CUDA version

### DIFF
--- a/tests/hipify-clang/lit.cfg
+++ b/tests/hipify-clang/lit.cfg
@@ -108,6 +108,17 @@ else:
 if config.pointer_size == 8:
     clang_arguments += " -D__LP64__"
 
+# Set max clang's CudaArch for corresponding CUDA version
+# to support maximum CUDA features in offline tests
+if config.cuda_version_major == 7:
+    clang_arguments += " --cuda-gpu-arch=sm_52"
+if config.cuda_version_major == 8:
+    clang_arguments += " --cuda-gpu-arch=sm_62"
+if config.cuda_version_major == 9:
+    clang_arguments += " --cuda-gpu-arch=sm_70"
+if config.cuda_version_major == 10:
+    clang_arguments += " --cuda-gpu-arch=sm_75"
+
 # cuDNN ROOT
 if config.cuda_dnn_root:
     clang_arguments += " -I'%s'/include"

--- a/tests/hipify-clang/unit_tests/device/atomics.cu
+++ b/tests/hipify-clang/unit_tests/device/atomics.cu
@@ -276,7 +276,9 @@ int main(int argc, char** argv) {
     runTest<unsigned int>();
     runTest<unsigned long long>();
     runTest<float>();
+#if CUDA_VERSION >= 8000
     runTest<double>();
+#endif
     // CHECK: hipDeviceReset();
     cudaDeviceReset();
     printf("%s completed, returned %s\n", sampleName, testResult ? "OK" : "ERROR!");


### PR DESCRIPTION
[Reason] To support maximum CUDA features in offline tests

+ Add CUDA_VERSION >= 800 restriction for atomics.cu

[TODO] Find a way to use or exclude atomicAdd for doubles if LLVM < 7, because
LLVM 6.0.1 and older do not use --cuda-gpu-arch in clang's Driver code at all (option is only declared)