### PR TITLE
[HIPIFY][tests] Set max clang's CudaArch for corresponding CUDA major…

### DIFF
--- a/tests/hipify-clang/lit.cfg
+++ b/tests/hipify-clang/lit.cfg
@@ -111,12 +111,18 @@ if config.pointer_size == 8:
 # Set max clang's CudaArch for corresponding CUDA version
 # to support maximum CUDA features in offline tests
 if config.cuda_version_major == 7:
-    clang_arguments += " --cuda-gpu-arch=sm_52"
-if config.cuda_version_major == 8:
+    if config.cuda_version_minor == 5:
+        clang_arguments += " --cuda-gpu-arch=sm_53"
+    else:
+        clang_arguments += " --cuda-gpu-arch=sm_52"
+elif config.cuda_version_major == 8:
     clang_arguments += " --cuda-gpu-arch=sm_62"
-if config.cuda_version_major == 9:
-    clang_arguments += " --cuda-gpu-arch=sm_70"
-if config.cuda_version_major == 10:
+elif config.cuda_version_major == 9:
+    if config.cuda_version_minor == 2:
+        clang_arguments += " --cuda-gpu-arch=sm_72"
+    else:
+        clang_arguments += " --cuda-gpu-arch=sm_70"
+elif config.cuda_version_major == 10:
     clang_arguments += " --cuda-gpu-arch=sm_75"
 
 # cuDNN ROOT

--- a/tests/hipify-clang/unit_tests/device/atomics.cu
+++ b/tests/hipify-clang/unit_tests/device/atomics.cu
@@ -276,7 +276,7 @@ int main(int argc, char** argv) {
     runTest<unsigned int>();
     runTest<unsigned long long>();
     runTest<float>();
-#if CUDA_VERSION >= 8000
+#if CUDA_VERSION >= 8000 && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 600
     runTest<double>();
 #endif
     // CHECK: hipDeviceReset();


### PR DESCRIPTION
….minor version

[Reason] To support maximum CUDA features in offline tests

+ Add defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 600 restriction for atomicAdd on doubles in atomics.cu. So if LLVM < 7 and --cuda-gpu-arch doesn't work, __CUDA_ARCH__ is unset too (350 by default in clang); if LLVM >= 7 --cuda-gpu-arch is used and __CUDA_ARCH__ is set based on it.