### PR TITLE
[HIPIFY][#1569] Fix

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -983,7 +983,6 @@ sub simpleSubstitutions {
     $ft{'type'} += s/\bcusparsePointerMode_t\b/hipsparsePointerMode_t/g;
     $ft{'type'} += s/\bcusparseSolvePolicy_t\b/hipsparseSolvePolicy_t/g;
     $ft{'type'} += s/\bcusparseStatus_t\b/hipsparseStatus_t/g;
-    $ft{'type'} += s/\bwarpSize\b/hipWarpSize/g;
     $ft{'numeric_literal'} += s/\bCUBLAS_DIAG_NON_UNIT\b/HIPBLAS_DIAG_NON_UNIT/g;
     $ft{'numeric_literal'} += s/\bCUBLAS_DIAG_UNIT\b/HIPBLAS_DIAG_UNIT/g;
     $ft{'numeric_literal'} += s/\bCUBLAS_FILL_MODE_FULL\b/HIPBLAS_FILL_MODE_FULL/g;

--- a/hipify-clang/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/hipify-clang/src/CUDA2HIP_Runtime_API_types.cpp
@@ -31,8 +31,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaChannelFormatDesc",                                            {"hipChannelFormatDesc",                                     "", CONV_TYPE, API_RUNTIME}},
   // no analogue
   {"cudaDeviceProp",                                                   {"hipDeviceProp_t",                                          "", CONV_TYPE, API_RUNTIME}},
-  // NOTE: int warpSize is a field of cudaDeviceProp
-  {"warpSize",                                                         {"hipWarpSize",                                              "", CONV_TYPE, API_RUNTIME}},
 
   // no analogue
   {"cudaEglFrame",                                                     {"hipEglFrame",                                              "", CONV_TYPE, API_RUNTIME, HIP_UNSUPPORTED}},

--- a/tests/hipify-clang/unit_tests/samples/vec_add.cu
+++ b/tests/hipify-clang/unit_tests/samples/vec_add.cu
@@ -67,7 +67,6 @@ int devcheck(int  gpudevice, int rank)
   cudaError_t cudareturn;
   cudaDeviceProp deviceProp;
   cudaGetDeviceProperties(&deviceProp, gpudevice);
-  // CHECK: if (deviceProp.hipWarpSize <= 1)
   if (deviceProp.warpSize <= 1)
   {
     printf("rank %d: warning, CUDA Device Emulation (CPU) detected, exiting\n", rank);


### PR DESCRIPTION
`hipWarpSize` has been renamed to warpSize in `struct hipDeviceProp_t ` a long ago, thus eliminate it in hipify-clang.