### PR TITLE
Make CAS loops use the TTAS idiom.

### DIFF
--- a/include/hip/hcc_detail/hip_atomic.h
+++ b/include/hip/hcc_detail/hip_atomic.h
@@ -64,7 +64,7 @@ float atomicAdd(float* address, float val)
     do {
         r = __atomic_load_n(uaddr, __ATOMIC_RELAXED);
 
-        if (r != old) { r = old; continue; }
+        if (r != old) { old = r; continue; }
 
         old = atomicCAS(uaddr, r, __float_as_uint(val + __uint_as_float(r)));
 
@@ -84,7 +84,7 @@ double atomicAdd(double* address, double val)
     do {
         r = __atomic_load_n(uaddr, __ATOMIC_RELAXED);
 
-        if (r != old) { r = old; continue; }
+        if (r != old) { old = r; continue; }
 
         old = atomicCAS(
             uaddr, r, __double_as_longlong(val + __longlong_as_double(r)));

--- a/include/hip/hcc_detail/hip_atomic.h
+++ b/include/hip/hcc_detail/hip_atomic.h
@@ -59,15 +59,17 @@ float atomicAdd(float* address, float val)
 {
     unsigned int* uaddr{reinterpret_cast<unsigned int*>(address)};
     unsigned int old{__atomic_load_n(uaddr, __ATOMIC_RELAXED)};
+
     unsigned int r;
-
     do {
-        r = old;
-        old = __atomic_load_n(uaddr, __ATOMIC_RELAXED);
+        r = __atomic_load_n(uaddr, __ATOMIC_RELAXED);
 
-        if (r != old) continue;
-    } while (
-        atomicCAS(uaddr, r, __float_as_uint(val + __uint_as_float(r))) != r);
+        if (r != old) { r = old; continue; }
+
+        old = atomicCAS(uaddr, r, __float_as_uint(val + __uint_as_float(r)));
+
+        if (r == old) break;
+    } while (true);
 
     return __uint_as_float(r);
 }
@@ -77,15 +79,18 @@ double atomicAdd(double* address, double val)
 {
     unsigned long long* uaddr{reinterpret_cast<unsigned long long*>(address)};
     unsigned long long old{__atomic_load_n(uaddr, __ATOMIC_RELAXED)};
+
     unsigned long long r;
-
     do {
-        r = old;
-        old = __atomic_load_n(uaddr, __ATOMIC_RELAXED);
+        r = __atomic_load_n(uaddr, __ATOMIC_RELAXED);
 
-        if (r != old) continue;
-    } while (atomicCAS(
-        uaddr, r, __double_as_longlong(val + __longlong_as_double(r))) != r);
+        if (r != old) { r = old; continue; }
+
+        old = atomicCAS(
+            uaddr, r, __double_as_longlong(val + __longlong_as_double(r)));
+
+        if (r == old) break;
+    } while (true);
 
     return __longlong_as_double(r);
 }

--- a/include/hip/hcc_detail/hip_atomic.h
+++ b/include/hip/hcc_detail/hip_atomic.h
@@ -64,7 +64,7 @@ float atomicAdd(float* address, float val)
     do {
         r = __atomic_load_n(uaddr, __ATOMIC_RELAXED);
 
-        if (r != old) { old = r; continue; }
+        if (r != old) { r = old; continue; }
 
         old = atomicCAS(uaddr, r, __float_as_uint(val + __uint_as_float(r)));
 
@@ -84,7 +84,7 @@ double atomicAdd(double* address, double val)
     do {
         r = __atomic_load_n(uaddr, __ATOMIC_RELAXED);
 
-        if (r != old) { old = r; continue; }
+        if (r != old) { r = old; continue; }
 
         old = atomicCAS(
             uaddr, r, __double_as_longlong(val + __longlong_as_double(r)));


### PR DESCRIPTION
For certain atomic ops which lack hardware support we use CAS loops as the implementation. At the moment these loops are TAS, which makes them even more awful than they need to be. This takes the trivial step of using TTAS, which is notably cheaper for us since the first T boils down to a trivial read.