### PR TITLE
[dtest] Fix hipMemset2D test

### DIFF
--- a/tests/src/runtimeApi/memory/hipMemset2D.cpp
+++ b/tests/src/runtimeApi/memory/hipMemset2D.cpp
@@ -45,7 +45,7 @@ bool testhipMemset2D(int memsetval,int p_gpuDevice)
     char *A_d;
     char *A_h;
     bool testResult = true;
-    HIPCHECK(hipMemAllocPitch((hipDeviceptr_t*)&A_d, &pitch_A, width , numH,16));
+    HIPCHECK (hipMallocPitch((void**)&A_d, &pitch_A, width , numH));
     A_h = (char*)malloc(sizeElements);
     HIPASSERT(A_h != NULL);
     for (size_t i=0; i<elements; i++) {
@@ -81,7 +81,7 @@ bool testhipMemset2DAsync(int memsetval,int p_gpuDevice)
     char *A_h;
     bool testResult = true;
 
-    HIPCHECK ( hipMallocPitch((void**)&A_d, &pitch_A, width , numH) );
+    HIPCHECK (hipMallocPitch((void**)&A_d, &pitch_A, width , numH));
     A_h = (char*)malloc(sizeElements);
     HIPASSERT(A_h != NULL);
     for (size_t i=0; i<elements; i++) {
@@ -110,13 +110,9 @@ int main(int argc, char *argv[])
 {
     HipTest::parseStandardArguments(argc, argv, true);
     HIPCHECK(hipSetDevice(p_gpuDevice));
-    hipCtx_t context;
-    hipCtxCreate(&context, 0, p_gpuDevice);
-
     bool testResult = true;
     testResult &= testhipMemset2D(memsetval, p_gpuDevice);
     testResult &= testhipMemset2DAsync(memsetval, p_gpuDevice);
-    hipCtxDestroy(context);
     if(testResult){
        passed();
     }


### PR DESCRIPTION
Reverts changes made in #1399. This is a RT api test. For testing hipMemAllocPitch , a new test should be written and that should use correct memset API.