### PR TITLE
Fix for hip*Complex operator overload issue

### DIFF
--- a/include/hip/hcc_detail/hip_complex.h
+++ b/include/hip/hcc_detail/hip_complex.h
@@ -34,6 +34,8 @@ THE SOFTWARE.
 #include "math.h"
 #endif
 
+namespace hip_cmplx{
+
 #if __cplusplus
 #define COMPLEX_NEG_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator-(const type& op) {                             \
@@ -317,4 +319,6 @@ __device__ __host__ inline hipDoubleComplex func(const hipDoubleComplex& z) { re
 
 __DEFINE_HIP_COMPLEX_FUN(conj, hipConj)
 
-#endif
+}//hip_cmplx
+
+#endif //HIP_INCLUDE_HIP_HCC_DETAIL_HIP_COMPLEX_H

--- a/include/hip/hcc_detail/hip_complex.h
+++ b/include/hip/hcc_detail/hip_complex.h
@@ -38,14 +38,14 @@ THE SOFTWARE.
 #define COMPLEX_NEG_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator-(const type& op) {                             \
         type ret;                                                                                  \
-        ret.CmplxNum.x = -op.CmplxNum.x;                                                           \
-        ret.CmplxNum.y = -op.CmplxNum.y;                                                           \
+        ret.x = -op.x;                                                                             \
+        ret.y = -op.y;                                                                             \
         return ret;                                                                                \
     }
 
 #define COMPLEX_EQ_OP_OVERLOAD(type)                                                               \
     __device__ __host__ static inline bool operator==(const type& lhs, const type& rhs) {          \
-        return lhs.CmplxNum.x == rhs.CmplxNum.x && lhs.CmplxNum.y == rhs.CmplxNum.y;               \
+        return lhs.x == rhs.x && lhs.y == rhs.y;                                                   \
     }
 
 #define COMPLEX_NE_OP_OVERLOAD(type)                                                               \
@@ -56,48 +56,48 @@ THE SOFTWARE.
 #define COMPLEX_ADD_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator+(const type& lhs, const type& rhs) {           \
         type ret;                                                                                  \
-        ret.CmplxNum.x = lhs.CmplxNum.x + rhs.CmplxNum.x;                                          \
-        ret.CmplxNum.y = lhs.CmplxNum.y + rhs.CmplxNum.y;                                          \
+        ret.x = lhs.x + rhs.x;                                                                     \
+        ret.y = lhs.y + rhs.y;                                                                     \
         return ret;                                                                                \
     }
 
 #define COMPLEX_SUB_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator-(const type& lhs, const type& rhs) {           \
         type ret;                                                                                  \
-        ret.CmplxNum.x = lhs.CmplxNum.x - rhs.CmplxNum.x;                                          \
-        ret.CmplxNum.y = lhs.CmplxNum.y - rhs.CmplxNum.y;                                          \
+        ret.x = lhs.x - rhs.x;                                                                     \
+        ret.y = lhs.y - rhs.y;                                                                     \
         return ret;                                                                                \
     }
 
 #define COMPLEX_MUL_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator*(const type& lhs, const type& rhs) {           \
         type ret;                                                                                  \
-        ret.CmplxNum.x = lhs.CmplxNum.x * rhs.CmplxNum.x - lhs.CmplxNum.y * rhs.CmplxNum.y;        \
-        ret.CmplxNum.y = lhs.CmplxNum.x * rhs.CmplxNum.y + lhs.CmplxNum.y * rhs.CmplxNum.x;        \
+        ret.x = lhs.x * rhs.x - lhs.y * rhs.y;                                                     \
+        ret.y = lhs.x * rhs.y + lhs.y * rhs.x;                                                     \
         return ret;                                                                                \
     }
 
 #define COMPLEX_DIV_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator/(const type& lhs, const type& rhs) {           \
         type ret;                                                                                  \
-        ret.CmplxNum.x = (lhs.CmplxNum.x * rhs.CmplxNum.x + lhs.CmplxNum.y * rhs.CmplxNum.y);      \
-        ret.CmplxNum.y = (rhs.CmplxNum.x * lhs.CmplxNum.y - lhs.CmplxNum.x * rhs.CmplxNum.y);      \
-        ret.CmplxNum.x = ret.CmplxNum.x / (rhs.CmplxNum.x * rhs.CmplxNum.x + rhs.CmplxNum.y * rhs.CmplxNum.y);                                           \
-        ret.CmplxNum.y = ret.CmplxNum.y / (rhs.CmplxNum.x * rhs.CmplxNum.x + rhs.CmplxNum.y * rhs.CmplxNum.y);                                           \
+        ret.x = (lhs.x * rhs.x + lhs.y * rhs.y);                                                   \
+        ret.y = (rhs.x * lhs.y - lhs.x * rhs.y);                                                   \
+        ret.x = ret.x / (rhs.x * rhs.x + rhs.y * rhs.y);                                           \
+        ret.y = ret.y / (rhs.x * rhs.x + rhs.y * rhs.y);                                           \
         return ret;                                                                                \
     }
 
 #define COMPLEX_ADD_PREOP_OVERLOAD(type)                                                           \
     __device__ __host__ static inline type& operator+=(type& lhs, const type& rhs) {               \
-        lhs.CmplxNum.x += rhs.CmplxNum.x;                                                          \
-        lhs.CmplxNum.y += rhs.CmplxNum.y;                                                          \
+        lhs.x += rhs.x;                                                                            \
+        lhs.y += rhs.y;                                                                            \
         return lhs;                                                                                \
     }
 
 #define COMPLEX_SUB_PREOP_OVERLOAD(type)                                                           \
     __device__ __host__ static inline type& operator-=(type& lhs, const type& rhs) {               \
-        lhs.CmplxNum.x -= rhs.CmplxNum.x;                                                          \
-        lhs.CmplxNum.y -= rhs.CmplxNum.y;                                                          \
+        lhs.x -= rhs.x;                                                                            \
+        lhs.y -= rhs.y;                                                                            \
         return lhs;                                                                                \
     }
 
@@ -116,109 +116,135 @@ THE SOFTWARE.
 #define COMPLEX_SCALAR_PRODUCT(type, type1)                                                        \
     __device__ __host__ static inline type operator*(const type& lhs, type1 rhs) {                 \
         type ret;                                                                                  \
-        ret.CmplxNum.x = lhs.CmplxNum.x * rhs;                                                     \
-        ret.CmplxNum.y = lhs.CmplxNum.y * rhs;                                                     \
+        ret.x = lhs.x * rhs;                                                                       \
+        ret.y = lhs.y * rhs;                                                                       \
         return ret;                                                                                \
     }
 
 #endif
 
-typedef struct hipFloatComplex
+#ifdef __cplusplus
+struct hipFloatComplex : public float2
 {
-   float2 CmplxNum;
-}hipFloatComplex;
+     hipFloatComplex()
+     {
+         x = 0.0;
+         y = 0.0;
+     }
+     hipFloatComplex(float2 f)
+     {
+         x = f.x;
+         y = f.y;
+     }
+};
+#else
+typedef float2 hipFloatComplex;
+#endif
 
-__device__ __host__ static inline float hipCrealf(hipFloatComplex z) { return z.CmplxNum.x; }
+__device__ __host__ static inline float hipCrealf(hipFloatComplex z) { return z.x; }
 
-__device__ __host__ static inline float hipCimagf(hipFloatComplex z) { return z.CmplxNum.y; }
+__device__ __host__ static inline float hipCimagf(hipFloatComplex z) { return z.y; }
 
 __device__ __host__ static inline hipFloatComplex make_hipFloatComplex(float a, float b) {
     hipFloatComplex z;
-    z.CmplxNum.x = a;
-    z.CmplxNum.y = b;
+    z.x = a;
+    z.y = b;
     return z;
 }
 
 __device__ __host__ static inline hipFloatComplex hipConjf(hipFloatComplex z) {
     hipFloatComplex ret;
-    ret.CmplxNum.x = z.CmplxNum.x;
-    ret.CmplxNum.y = -z.CmplxNum.y;
+    ret.x = z.x;
+    ret.y = -z.y;
     return ret;
 }
 
 __device__ __host__ static inline float hipCsqabsf(hipFloatComplex z) {
-    return z.CmplxNum.x * z.CmplxNum.x + z.CmplxNum.y * z.CmplxNum.y;
+    return z.x * z.x + z.y * z.y;
 }
 
 __device__ __host__ static inline hipFloatComplex hipCaddf(hipFloatComplex p, hipFloatComplex q) {
-    return make_hipFloatComplex(p.CmplxNum.x + q.CmplxNum.x, p.CmplxNum.y + q.CmplxNum.y);
+    return make_hipFloatComplex(p.x + q.x, p.y + q.y);
 }
 
 __device__ __host__ static inline hipFloatComplex hipCsubf(hipFloatComplex p, hipFloatComplex q) {
-    return make_hipFloatComplex(p.CmplxNum.x - q.CmplxNum.x, p.CmplxNum.y - q.CmplxNum.y);
+    return make_hipFloatComplex(p.x - q.x, p.y - q.y);
 }
 
 __device__ __host__ static inline hipFloatComplex hipCmulf(hipFloatComplex p, hipFloatComplex q) {
-    return make_hipFloatComplex(p.CmplxNum.x * q.CmplxNum.x - p.CmplxNum.y * q.CmplxNum.y, p.CmplxNum.y * q.CmplxNum.x + p.CmplxNum.x * q.CmplxNum.y);
+    return make_hipFloatComplex(p.x * q.x - p.y * q.y, p.y * q.x + p.x * q.y);
 }
 
 __device__ __host__ static inline hipFloatComplex hipCdivf(hipFloatComplex p, hipFloatComplex q) {
     float sqabs = hipCsqabsf(q);
     hipFloatComplex ret;
-    ret.CmplxNum.x = (p.CmplxNum.x * q.CmplxNum.x + p.CmplxNum.y * q.CmplxNum.y) / sqabs;
-    ret.CmplxNum.y = (p.CmplxNum.y * q.CmplxNum.x - p.CmplxNum.x * q.CmplxNum.y) / sqabs;
+    ret.x = (p.x * q.x + p.y * q.y) / sqabs;
+    ret.y = (p.y * q.x - p.x * q.y) / sqabs;
     return ret;
 }
 
 __device__ __host__ static inline float hipCabsf(hipFloatComplex z) { return sqrtf(hipCsqabsf(z)); }
 
 
-typedef struct hipDoubleComplex
+#ifdef __cplusplus
+struct hipDoubleComplex:public double2
 {
-    double2 CmplxNum; 
-}hipDoubleComplex;
+  hipDoubleComplex()
+  {
+      x = 0;
+      y = 0;
+  }
 
-//typedef double2 hipDoubleComplex;
+  hipDoubleComplex(double2 d)
+  {
+     x=d.x;
+     y=d.y;
+  }
 
-__device__ __host__ static inline double hipCreal(hipDoubleComplex z) { return z.CmplxNum.x; }
+};
+#else
+typedef double2 hipDoubleComplex;
+#endif
 
-__device__ __host__ static inline double hipCimag(hipDoubleComplex z) { return z.CmplxNum.y; }
+__device__ __host__ static inline double hipCreal(hipDoubleComplex z) { return z.x; }
+
+__device__ __host__ static inline double hipCimag(hipDoubleComplex z) { return z.y; }
 
 __device__ __host__ static inline hipDoubleComplex make_hipDoubleComplex(double a, double b) {
     hipDoubleComplex z;
-    z.CmplxNum.x = a;
-    z.CmplxNum.y = b;
+    z.x = a;
+    z.y = b;
     return z;
 }
 
 __device__ __host__ static inline hipDoubleComplex hipConj(hipDoubleComplex z) {
     hipDoubleComplex ret;
-    ret.CmplxNum.x = z.CmplxNum.x;
-    ret.CmplxNum.y = z.CmplxNum.y;
+    ret.x = z.x;
+    ret.y = z.y;
     return ret;
 }
 
 __device__ __host__ static inline double hipCsqabs(hipDoubleComplex z) {
-    return z.CmplxNum.x * z.CmplxNum.x + z.CmplxNum.y * z.CmplxNum.y;
+    return z.x * z.x + z.y * z.y;
 }
 
 __device__ __host__ static inline hipDoubleComplex hipCadd(hipDoubleComplex p, hipDoubleComplex q) {
-    return make_hipDoubleComplex(p.CmplxNum.x + q.CmplxNum.x, p.CmplxNum.y + q.CmplxNum.y);
+    return make_hipDoubleComplex(p.x + q.x, p.y + q.y);
 }
 
 __device__ __host__ static inline hipDoubleComplex hipCsub(hipDoubleComplex p, hipDoubleComplex q) {
-    return make_hipDoubleComplex(p.CmplxNum.x - q.CmplxNum.x, p.CmplxNum.y - q.CmplxNum.y);
+    return make_hipDoubleComplex(p.x - q.x, p.y - q.y);
 }
 
 __device__ __host__ static inline hipDoubleComplex hipCmul(hipDoubleComplex p, hipDoubleComplex q) {
-    return make_hipDoubleComplex(p.CmplxNum.x * q.CmplxNum.x - p.CmplxNum.y * q.CmplxNum.y, p.CmplxNum.y * q.CmplxNum.x + p.CmplxNum.x * q.CmplxNum.y);
+    return make_hipDoubleComplex(p.x * q.x - p.y * q.y, p.y * q.x + p.x * q.y);
 }
 
 __device__ __host__ static inline hipDoubleComplex hipCdiv(hipDoubleComplex p, hipDoubleComplex q) {
     double sqabs = hipCsqabs(q);
     hipDoubleComplex ret;
-    ret.CmplxNum.x = (p.CmplxNum.x * q.CmplxNum.x + p.CmplxNum.y * q.CmplxNum.y) / sqabs;
-    ret.CmplxNum.y = (p.CmplxNum.y * q.CmplxNum.x - p.CmplxNum.x * q.CmplxNum.y) / sqabs;
+    ret.x = (p.x * q.x + p.y * q.y) / sqabs;
+    ret.y = (p.y * q.x - p.x * q.y) / sqabs;
     return ret;
 }
 
@@ -281,30 +307,30 @@ __device__ __host__ static inline hipComplex make_hipComplex(float x, float y) {
 }
 
 __device__ __host__ static inline hipFloatComplex hipComplexDoubleToFloat(hipDoubleComplex z) {
-    return make_hipFloatComplex((float)z.CmplxNum.x, (float)z.CmplxNum.y);
+    return make_hipFloatComplex((float)z.x, (float)z.y);
 }
 
 __device__ __host__ static inline hipDoubleComplex hipComplexFloatToDouble(hipFloatComplex z) {
-    return make_hipDoubleComplex((double)z.CmplxNum.x, (double)z.CmplxNum.y);
+    return make_hipDoubleComplex((double)z.x, (double)z.y);
 }
 
 __device__ __host__ static inline hipComplex hipCfmaf(hipComplex p, hipComplex q, hipComplex r) {
-    float real = (p.CmplxNum.x * q.CmplxNum.x) + r.CmplxNum.x;
-    float imag = (q.CmplxNum.x * p.CmplxNum.y) + r.CmplxNum.y;
+    float real = (p.x * q.x) + r.x;
+    float imag = (q.x * p.y) + r.y;
 
-    real = -(p.CmplxNum.y * q.CmplxNum.y) + real;
-    imag = (p.CmplxNum.x * q.CmplxNum.y) + imag;
+    real = -(p.y * q.y) + real;
+    imag = (p.x * q.y) + imag;
 
     return make_hipComplex(real, imag);
 }
 
 __device__ __host__ static inline hipDoubleComplex hipCfma(hipDoubleComplex p, hipDoubleComplex q,
                                                            hipDoubleComplex r) {
-    double real = (p.CmplxNum.x * q.CmplxNum.x) + r.CmplxNum.x;
-    double imag = (q.CmplxNum.x * p.CmplxNum.y) + r.CmplxNum.y;
+    double real = (p.x * q.x) + r.x;
+    double imag = (q.x * p.y) + r.y;
 
-    real = -(p.CmplxNum.y * q.CmplxNum.y) + real;
-    imag = (p.CmplxNum.x * q.CmplxNum.x) + imag;
+    real = -(p.y * q.y) + real;
+    imag = (p.x * q.y) + imag;
 
     return make_hipDoubleComplex(real, imag);
 }

--- a/include/hip/hcc_detail/hip_complex.h
+++ b/include/hip/hcc_detail/hip_complex.h
@@ -34,8 +34,6 @@ THE SOFTWARE.
 #include "math.h"
 #endif
 
-namespace hip_cmplx{
-
 #if __cplusplus
 #define COMPLEX_NEG_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator-(const type& op) {                             \
@@ -302,23 +300,5 @@ __device__ __host__ static inline hipDoubleComplex hipCfma(hipDoubleComplex p, h
 
     return make_hipDoubleComplex(real, imag);
 }
-
-// Complex functions returning real numbers.
-#define __DEFINE_HIP_COMPLEX_REAL_FUN(func, hipFun) \
-__device__ __host__ inline float func(const hipFloatComplex& z) { return hipFun##f(z); } \
-__device__ __host__ inline double func(const hipDoubleComplex& z) { return hipFun(z); }
-
-__DEFINE_HIP_COMPLEX_REAL_FUN(abs, hipCabs)
-__DEFINE_HIP_COMPLEX_REAL_FUN(real, hipCreal)
-__DEFINE_HIP_COMPLEX_REAL_FUN(imag, hipCimag)
-
-// Complex functions returning complex numbers.
-#define __DEFINE_HIP_COMPLEX_FUN(func, hipFun) \
-__device__ __host__ inline hipFloatComplex func(const hipFloatComplex& z) { return hipFun##f(z); } \
-__device__ __host__ inline hipDoubleComplex func(const hipDoubleComplex& z) { return hipFun(z); }
-
-__DEFINE_HIP_COMPLEX_FUN(conj, hipConj)
-
-}//hip_cmplx
 
 #endif //HIP_INCLUDE_HIP_HCC_DETAIL_HIP_COMPLEX_H

--- a/include/hip/hcc_detail/hip_complex.h
+++ b/include/hip/hcc_detail/hip_complex.h
@@ -38,14 +38,14 @@ THE SOFTWARE.
 #define COMPLEX_NEG_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator-(const type& op) {                             \
         type ret;                                                                                  \
-        ret.x = -op.x;                                                                             \
-        ret.y = -op.y;                                                                             \
+        ret.CmplxNum.x = -op.CmplxNum.x;                                                           \
+        ret.CmplxNum.y = -op.CmplxNum.y;                                                           \
         return ret;                                                                                \
     }
 
 #define COMPLEX_EQ_OP_OVERLOAD(type)                                                               \
     __device__ __host__ static inline bool operator==(const type& lhs, const type& rhs) {          \
-        return lhs.x == rhs.x && lhs.y == rhs.y;                                                   \
+        return lhs.CmplxNum.x == rhs.CmplxNum.x && lhs.CmplxNum.y == rhs.CmplxNum.y;               \
     }
 
 #define COMPLEX_NE_OP_OVERLOAD(type)                                                               \
@@ -56,48 +56,48 @@ THE SOFTWARE.
 #define COMPLEX_ADD_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator+(const type& lhs, const type& rhs) {           \
         type ret;                                                                                  \
-        ret.x = lhs.x + rhs.x;                                                                     \
-        ret.y = lhs.y + rhs.y;                                                                     \
+        ret.CmplxNum.x = lhs.CmplxNum.x + rhs.CmplxNum.x;                                          \
+        ret.CmplxNum.y = lhs.CmplxNum.y + rhs.CmplxNum.y;                                          \
         return ret;                                                                                \
     }
 
 #define COMPLEX_SUB_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator-(const type& lhs, const type& rhs) {           \
         type ret;                                                                                  \
-        ret.x = lhs.x - rhs.x;                                                                     \
-        ret.y = lhs.y - rhs.y;                                                                     \
+        ret.CmplxNum.x = lhs.CmplxNum.x - rhs.CmplxNum.x;                                          \
+        ret.CmplxNum.y = lhs.CmplxNum.y - rhs.CmplxNum.y;                                          \
         return ret;                                                                                \
     }
 
 #define COMPLEX_MUL_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator*(const type& lhs, const type& rhs) {           \
         type ret;                                                                                  \
-        ret.x = lhs.x * rhs.x - lhs.y * rhs.y;                                                     \
-        ret.y = lhs.x * rhs.y + lhs.y * rhs.x;                                                     \
+        ret.CmplxNum.x = lhs.CmplxNum.x * rhs.CmplxNum.x - lhs.CmplxNum.y * rhs.CmplxNum.y;        \
+        ret.CmplxNum.y = lhs.CmplxNum.x * rhs.CmplxNum.y + lhs.CmplxNum.y * rhs.CmplxNum.x;        \
         return ret;                                                                                \
     }
 
 #define COMPLEX_DIV_OP_OVERLOAD(type)                                                              \
     __device__ __host__ static inline type operator/(const type& lhs, const type& rhs) {           \
         type ret;                                                                                  \
-        ret.x = (lhs.x * rhs.x + lhs.y * rhs.y);                                                   \
-        ret.y = (rhs.x * lhs.y - lhs.x * rhs.y);                                                   \
-        ret.x = ret.x / (rhs.x * rhs.x + rhs.y * rhs.y);                                           \
-        ret.y = ret.y / (rhs.x * rhs.x + rhs.y * rhs.y);                                           \
+        ret.CmplxNum.x = (lhs.CmplxNum.x * rhs.CmplxNum.x + lhs.CmplxNum.y * rhs.CmplxNum.y);      \
+        ret.CmplxNum.y = (rhs.CmplxNum.x * lhs.CmplxNum.y - lhs.CmplxNum.x * rhs.CmplxNum.y);      \
+        ret.CmplxNum.x = ret.CmplxNum.x / (rhs.CmplxNum.x * rhs.CmplxNum.x + rhs.CmplxNum.y * rhs.CmplxNum.y);                                           \
+        ret.CmplxNum.y = ret.CmplxNum.y / (rhs.CmplxNum.x * rhs.CmplxNum.x + rhs.CmplxNum.y * rhs.CmplxNum.y);                                           \
         return ret;                                                                                \
     }
 
 #define COMPLEX_ADD_PREOP_OVERLOAD(type)                                                           \
     __device__ __host__ static inline type& operator+=(type& lhs, const type& rhs) {               \
-        lhs.x += rhs.x;                                                                            \
-        lhs.y += rhs.y;                                                                            \
+        lhs.CmplxNum.x += rhs.CmplxNum.x;                                                          \
+        lhs.CmplxNum.y += rhs.CmplxNum.y;                                                          \
         return lhs;                                                                                \
     }
 
 #define COMPLEX_SUB_PREOP_OVERLOAD(type)                                                           \
     __device__ __host__ static inline type& operator-=(type& lhs, const type& rhs) {               \
-        lhs.x -= rhs.x;                                                                            \
-        lhs.y -= rhs.y;                                                                            \
+        lhs.CmplxNum.x -= rhs.CmplxNum.x;                                                          \
+        lhs.CmplxNum.y -= rhs.CmplxNum.y;                                                          \
         return lhs;                                                                                \
     }
 
@@ -116,101 +116,109 @@ THE SOFTWARE.
 #define COMPLEX_SCALAR_PRODUCT(type, type1)                                                        \
     __device__ __host__ static inline type operator*(const type& lhs, type1 rhs) {                 \
         type ret;                                                                                  \
-        ret.x = lhs.x * rhs;                                                                       \
-        ret.y = lhs.y * rhs;                                                                       \
+        ret.CmplxNum.x = lhs.CmplxNum.x * rhs;                                                     \
+        ret.CmplxNum.y = lhs.CmplxNum.y * rhs;                                                     \
         return ret;                                                                                \
     }
 
 #endif
 
-typedef float2 hipFloatComplex;
+typedef struct hipFloatComplex
+{
+   float2 CmplxNum;
+}hipFloatComplex;
 
-__device__ __host__ static inline float hipCrealf(hipFloatComplex z) { return z.x; }
+__device__ __host__ static inline float hipCrealf(hipFloatComplex z) { return z.CmplxNum.x; }
 
-__device__ __host__ static inline float hipCimagf(hipFloatComplex z) { return z.y; }
+__device__ __host__ static inline float hipCimagf(hipFloatComplex z) { return z.CmplxNum.y; }
 
 __device__ __host__ static inline hipFloatComplex make_hipFloatComplex(float a, float b) {
     hipFloatComplex z;
-    z.x = a;
-    z.y = b;
+    z.CmplxNum.x = a;
+    z.CmplxNum.y = b;
     return z;
 }
 
 __device__ __host__ static inline hipFloatComplex hipConjf(hipFloatComplex z) {
     hipFloatComplex ret;
-    ret.x = z.x;
-    ret.y = -z.y;
+    ret.CmplxNum.x = z.CmplxNum.x;
+    ret.CmplxNum.y = -z.CmplxNum.y;
     return ret;
 }
 
 __device__ __host__ static inline float hipCsqabsf(hipFloatComplex z) {
-    return z.x * z.x + z.y * z.y;
+    return z.CmplxNum.x * z.CmplxNum.x + z.CmplxNum.y * z.CmplxNum.y;
 }
 
 __device__ __host__ static inline hipFloatComplex hipCaddf(hipFloatComplex p, hipFloatComplex q) {
-    return make_hipFloatComplex(p.x + q.x, p.y + q.y);
+    return make_hipFloatComplex(p.CmplxNum.x + q.CmplxNum.x, p.CmplxNum.y + q.CmplxNum.y);
 }
 
 __device__ __host__ static inline hipFloatComplex hipCsubf(hipFloatComplex p, hipFloatComplex q) {
-    return make_hipFloatComplex(p.x - q.x, p.y - q.y);
+    return make_hipFloatComplex(p.CmplxNum.x - q.CmplxNum.x, p.CmplxNum.y - q.CmplxNum.y);
 }
 
 __device__ __host__ static inline hipFloatComplex hipCmulf(hipFloatComplex p, hipFloatComplex q) {
-    return make_hipFloatComplex(p.x * q.x - p.y * q.y, p.y * q.x + p.x * q.y);
+    return make_hipFloatComplex(p.CmplxNum.x * q.CmplxNum.x - p.CmplxNum.y * q.CmplxNum.y, p.CmplxNum.y * q.CmplxNum.x + p.CmplxNum.x * q.CmplxNum.y);
 }
 
 __device__ __host__ static inline hipFloatComplex hipCdivf(hipFloatComplex p, hipFloatComplex q) {
     float sqabs = hipCsqabsf(q);
     hipFloatComplex ret;
-    ret.x = (p.x * q.x + p.y * q.y) / sqabs;
-    ret.y = (p.y * q.x - p.x * q.y) / sqabs;
+    ret.CmplxNum.x = (p.CmplxNum.x * q.CmplxNum.x + p.CmplxNum.y * q.CmplxNum.y) / sqabs;
+    ret.CmplxNum.y = (p.CmplxNum.y * q.CmplxNum.x - p.CmplxNum.x * q.CmplxNum.y) / sqabs;
     return ret;
 }
 
 __device__ __host__ static inline float hipCabsf(hipFloatComplex z) { return sqrtf(hipCsqabsf(z)); }
 
 
-typedef double2 hipDoubleComplex;
+typedef struct hipDoubleComplex
+{
+    double2 CmplxNum; 
+}hipDoubleComplex;
 
-__device__ __host__ static inline double hipCreal(hipDoubleComplex z) { return z.x; }
+//typedef double2 hipDoubleComplex;
 
-__device__ __host__ static inline double hipCimag(hipDoubleComplex z) { return z.y; }
+__device__ __host__ static inline double hipCreal(hipDoubleComplex z) { return z.CmplxNum.x; }
+
+__device__ __host__ static inline double hipCimag(hipDoubleComplex z) { return z.CmplxNum.y; }
 
 __device__ __host__ static inline hipDoubleComplex make_hipDoubleComplex(double a, double b) {
     hipDoubleComplex z;
-    z.x = a;
-    z.y = b;
+    z.CmplxNum.x = a;
+    z.CmplxNum.y = b;
     return z;
 }
 
 __device__ __host__ static inline hipDoubleComplex hipConj(hipDoubleComplex z) {
     hipDoubleComplex ret;
-    ret.x = z.x;
-    ret.y = z.y;
+    ret.CmplxNum.x = z.CmplxNum.x;
+    ret.CmplxNum.y = z.CmplxNum.y;
     return ret;
 }
 
 __device__ __host__ static inline double hipCsqabs(hipDoubleComplex z) {
-    return z.x * z.x + z.y * z.y;
+    return z.CmplxNum.x * z.CmplxNum.x + z.CmplxNum.y * z.CmplxNum.y;
 }
 
 __device__ __host__ static inline hipDoubleComplex hipCadd(hipDoubleComplex p, hipDoubleComplex q) {
-    return make_hipDoubleComplex(p.x + q.x, p.y + q.y);
+    return make_hipDoubleComplex(p.CmplxNum.x + q.CmplxNum.x, p.CmplxNum.y + q.CmplxNum.y);
 }
 
 __device__ __host__ static inline hipDoubleComplex hipCsub(hipDoubleComplex p, hipDoubleComplex q) {
-    return make_hipDoubleComplex(p.x - q.x, p.y - q.y);
+    return make_hipDoubleComplex(p.CmplxNum.x - q.CmplxNum.x, p.CmplxNum.y - q.CmplxNum.y);
 }
 
 __device__ __host__ static inline hipDoubleComplex hipCmul(hipDoubleComplex p, hipDoubleComplex q) {
-    return make_hipDoubleComplex(p.x * q.x - p.y * q.y, p.y * q.x + p.x * q.y);
+    return make_hipDoubleComplex(p.CmplxNum.x * q.CmplxNum.x - p.CmplxNum.y * q.CmplxNum.y, p.CmplxNum.y * q.CmplxNum.x + p.CmplxNum.x * q.CmplxNum.y);
 }
 
 __device__ __host__ static inline hipDoubleComplex hipCdiv(hipDoubleComplex p, hipDoubleComplex q) {
     double sqabs = hipCsqabs(q);
     hipDoubleComplex ret;
-    ret.x = (p.x * q.x + p.y * q.y) / sqabs;
-    ret.y = (p.y * q.x - p.x * q.y) / sqabs;
+    ret.CmplxNum.x = (p.CmplxNum.x * q.CmplxNum.x + p.CmplxNum.y * q.CmplxNum.y) / sqabs;
+    ret.CmplxNum.y = (p.CmplxNum.y * q.CmplxNum.x - p.CmplxNum.x * q.CmplxNum.y) / sqabs;
     return ret;
 }
 
@@ -273,30 +281,30 @@ __device__ __host__ static inline hipComplex make_hipComplex(float x, float y) {
 }
 
 __device__ __host__ static inline hipFloatComplex hipComplexDoubleToFloat(hipDoubleComplex z) {
-    return make_hipFloatComplex((float)z.x, (float)z.y);
+    return make_hipFloatComplex((float)z.CmplxNum.x, (float)z.CmplxNum.y);
 }
 
 __device__ __host__ static inline hipDoubleComplex hipComplexFloatToDouble(hipFloatComplex z) {
-    return make_hipDoubleComplex((double)z.x, (double)z.y);
+    return make_hipDoubleComplex((double)z.CmplxNum.x, (double)z.CmplxNum.y);
 }
 
 __device__ __host__ static inline hipComplex hipCfmaf(hipComplex p, hipComplex q, hipComplex r) {
-    float real = (p.x * q.x) + r.x;
-    float imag = (q.x * p.y) + r.y;
+    float real = (p.CmplxNum.x * q.CmplxNum.x) + r.CmplxNum.x;
+    float imag = (q.CmplxNum.x * p.CmplxNum.y) + r.CmplxNum.y;
 
-    real = -(p.y * q.y) + real;
-    imag = (p.x * q.y) + imag;
+    real = -(p.CmplxNum.y * q.CmplxNum.y) + real;
+    imag = (p.CmplxNum.x * q.CmplxNum.y) + imag;
 
     return make_hipComplex(real, imag);
 }
 
 __device__ __host__ static inline hipDoubleComplex hipCfma(hipDoubleComplex p, hipDoubleComplex q,
                                                            hipDoubleComplex r) {
-    double real = (p.x * q.x) + r.x;
-    double imag = (q.x * p.y) + r.y;
+    double real = (p.CmplxNum.x * q.CmplxNum.x) + r.CmplxNum.x;
+    double imag = (q.CmplxNum.x * p.CmplxNum.y) + r.CmplxNum.y;
 
-    real = -(p.y * q.y) + real;
-    imag = (p.x * q.y) + imag;
+    real = -(p.CmplxNum.y * q.CmplxNum.y) + real;
+    imag = (p.CmplxNum.x * q.CmplxNum.x) + imag;
 
     return make_hipDoubleComplex(real, imag);
 }

--- a/include/hip/nvcc_detail/hip_complex.h
+++ b/include/hip/nvcc_detail/hip_complex.h
@@ -25,6 +25,8 @@ THE SOFTWARE.
 
 #include "cuComplex.h"
 
+namespace hip_cmplx{
+
 typedef cuFloatComplex hipFloatComplex;
 
 __device__ __host__ static inline float hipCrealf(hipFloatComplex z) { return cuCrealf(z); }
@@ -116,4 +118,5 @@ __device__ __host__ static inline hipDoubleComplex hipCfma(hipDoubleComplex p, h
     return cuCfma(p, q, r);
 }
 
+}//hip_cmplx
 #endif

--- a/include/hip/nvcc_detail/hip_complex.h
+++ b/include/hip/nvcc_detail/hip_complex.h
@@ -25,8 +25,6 @@ THE SOFTWARE.
 
 #include "cuComplex.h"
 
-namespace hip_cmplx{
-
 typedef cuFloatComplex hipFloatComplex;
 
 __device__ __host__ static inline float hipCrealf(hipFloatComplex z) { return cuCrealf(z); }
@@ -118,5 +116,4 @@ __device__ __host__ static inline hipDoubleComplex hipCfma(hipDoubleComplex p, h
     return cuCfma(p, q, r);
 }
 
-}//hip_cmplx
 #endif

--- a/tests/src/deviceLib/hipComplexOps.cpp
+++ b/tests/src/deviceLib/hipComplexOps.cpp
@@ -18,8 +18,8 @@
  */
  
 /* HIT_START
- * BUILD: %t %s ../test_common.cpp
- * TEST: %t
+ * BUILD: %t %s ../test_common.cpp EXCLUDE_HIP_PLATFORM nvcc
+ * TEST: %t EXCLUDE_HIP_PLATFORM nvcc
  * HIT_END
  */
 

--- a/tests/src/deviceLib/hipComplexOps.cpp
+++ b/tests/src/deviceLib/hipComplexOps.cpp
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+ 
+/* HIT_START
+ * BUILD: %t %s ../test_common.cpp
+ * TEST: %t
+ * HIT_END
+ */
+
+#include "test_common.h"
+#include "hip/hip_complex.h"
+#include <stdio.h>
+
+template<typename T>
+void validateResult(T a, T r)
+{
+   if( a != r)
+   {  
+      failed("Result did not match!");
+   }
+}
+
+int main(int argc, char ** argv) {
+   hipDoubleComplex x = make_hipDoubleComplex(2.0, 3.0);
+   hipDoubleComplex y = make_hipDoubleComplex(4.0, 2.0);
+
+   // Test all operations for doubleComplex
+   validateResult(x+y, make_hipDoubleComplex(6.0, 5.0));
+   validateResult(y-x, make_hipDoubleComplex(2.0, -1.0));
+   validateResult(x*y, make_hipDoubleComplex(2.0, 16.0));
+   validateResult(x/y, make_hipDoubleComplex(0.700000, 0.400000));
+
+   hipDoubleComplex a,b,c;
+   a=b=c=y;
+   validateResult(a += x, make_hipDoubleComplex(6.0, 5.0));
+   validateResult(b -= x, make_hipDoubleComplex(2.0, -1.0));
+   validateResult(c *= x, make_hipDoubleComplex(2.0, 16.0));
+
+   
+   // Test all operations for floatComplex
+   hipFloatComplex f_x = make_hipFloatComplex(2.0, 3.0);
+   hipFloatComplex f_y = make_hipFloatComplex(4.0, 2.0);
+
+   validateResult(f_x+f_y, make_hipFloatComplex(6.0, 5.0));
+   validateResult(f_y-f_x, make_hipFloatComplex(2.0, -1.0));
+   validateResult(f_x*f_y, make_hipFloatComplex(2.0, 16.0));
+   validateResult(f_x/f_y, make_hipFloatComplex(0.700000, 0.400000));
+
+   hipFloatComplex f_a,f_b,f_c;
+   f_a = f_b = f_c = f_y;
+   validateResult(f_a += f_x, make_hipFloatComplex(6.0, 5.0));
+   validateResult(f_b -= f_x, make_hipFloatComplex(2.0, -1.0));
+   validateResult(f_c *= f_x, make_hipFloatComplex(2.0, 16.0));
+
+   passed();         
+   return 0;               
+}
+

--- a/tests/src/deviceLib/hipComplexOps.cpp
+++ b/tests/src/deviceLib/hipComplexOps.cpp
@@ -36,7 +36,75 @@ void validateResult(T a, T r)
    }
 }
 
+//Intension here to add compile time check to make sure all casting/constructs are fine.
+void hipDoubleComplexConstruct()
+{
+   // Default construct
+   hipDoubleComplex dc1;
+   hipDoubleComplex dc2 = make_hipDoubleComplex(2.0, 3.0);
+
+   // Casting
+   double2 dVar; dVar.x = 4.0; dVar.y = 5.0;
+   hipDoubleComplex dc3 = (hipDoubleComplex)dVar; // c style casting
+   hipDoubleComplex dc4 = static_cast<hipDoubleComplex>(dVar); // c++ casting
+
+   // copy constructor & assignment
+   hipDoubleComplex dc5 = hipDoubleComplex(dVar);
+   hipDoubleComplex dc6; dc6 = dc2;
+
+   // pointer construct
+   double2 *ptrDVar = new double2;
+   ptrDVar->x = 2.0;
+   ptrDVar->y = 3.0;
+
+   hipDoubleComplex *ptrDC = new hipDoubleComplex;
+   hipDoubleComplex *ptrDC1 = (hipDoubleComplex*)ptrDVar;// c casting
+   hipDoubleComplex *ptrDC2 = static_cast<hipDoubleComplex *>(ptrDVar); // c++ casting
+   hipDoubleComplex *ptrDC3;
+   ptrDC3 = ptrDC1;
+
+   // Casting hipDoubleComplex -> double2
+   double2 dd1 = (double2)dc2;
+   double2 dd2 = static_cast<double2>(dc2);
+}
+
+//Intension here to add compile time check to make sure all casting/constructs are fine.
+void hipFloatComplexConstruct()
+{
+   // Default construct
+   hipFloatComplex fc1;
+   hipFloatComplex fc2 = make_hipFloatComplex(2.0, 3.0);
+
+   //Casting
+   float2 fVar; fVar.x = 4.0; fVar.y = 5.0;
+   hipFloatComplex fc3 = (hipFloatComplex)fVar; // c style casting
+   hipFloatComplex fc4 = static_cast<hipFloatComplex>(fVar); // c++ casting
+
+   // copy constructor & assignment
+   hipFloatComplex fc5 = hipFloatComplex(fVar);
+   hipFloatComplex fc6; fc6 = fc2;
+
+   // pointer construct
+   float2 *ptrfVar = new float2;
+   ptrfVar->x = 2.0;
+   ptrfVar->y = 3.0;
+
+   hipFloatComplex *ptrfc = new hipFloatComplex;
+   hipFloatComplex *ptrfc1 = (hipFloatComplex*)ptrfVar;// c casting
+   hipFloatComplex *ptrfc2 = static_cast<hipFloatComplex *>(ptrfVar); // c++ casting
+   hipFloatComplex *ptrfc3;
+   ptrfc3 = ptrfc1;
+
+   // Casting hipFloatComplex -> float2
+   float2 dd1 = (float2)fc2;
+   float2 dd2 = static_cast<float2>(fc2);
+}
+
 int main(int argc, char ** argv) {
+
+   // Test casting and constructs
+   hipDoubleComplexConstruct();
+
    hipDoubleComplex x = make_hipDoubleComplex(2.0, 3.0);
    hipDoubleComplex y = make_hipDoubleComplex(4.0, 2.0);
 
@@ -52,7 +120,9 @@ int main(int argc, char ** argv) {
    validateResult(b -= x, make_hipDoubleComplex(2.0, -1.0));
    validateResult(c *= x, make_hipDoubleComplex(2.0, 16.0));
 
-   
+   // Test casting and constructs
+   hipFloatComplexConstruct();
+
    // Test all operations for floatComplex
    hipFloatComplex f_x = make_hipFloatComplex(2.0, 3.0);
    hipFloatComplex f_y = make_hipFloatComplex(4.0, 2.0);


### PR DESCRIPTION
1. Added dtests for hipFloatComplex and hipDoubleComplex operations 
2. Fixed broken operators '*=' and '+=' for hip*Complex  

More details about the issue can be found #1575 