### PR TITLE
[HIPIFY] Introduce --cuda-compile-host-device for LLVM >= 9

### DIFF
--- a/hipify-clang/src/LLVMCompat.cpp
+++ b/hipify-clang/src/LLVMCompat.cpp
@@ -127,6 +127,14 @@ bool pragma_once_outside_header() {
 #endif
 }
 
+bool canCompileHostAndDeviceInOneJob() {
+#if LLVM_VERSION_MAJOR < 9
+  return false;
+#else
+  return true;
+#endif
+}
+
 void RetainExcludedConditionalBlocks(clang::CompilerInstance &CI) {
 #if LLVM_VERSION_MAJOR > 9
   clang::PreprocessorOptions &PPOpts = CI.getPreprocessorOpts();

--- a/hipify-clang/src/LLVMCompat.h
+++ b/hipify-clang/src/LLVMCompat.h
@@ -85,6 +85,8 @@ std::error_code real_path(const Twine &path, SmallVectorImpl<char> &output,
 
 bool pragma_once_outside_header();
 
+bool canCompileHostAndDeviceInOneJob();
+
 void RetainExcludedConditionalBlocks(clang::CompilerInstance &CI);
 
 bool CheckCompatibility();

--- a/hipify-clang/src/main.cpp
+++ b/hipify-clang/src/main.cpp
@@ -198,7 +198,11 @@ int main(int argc, const char **argv) {
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(sInclude.c_str(), ct::ArgumentInsertPosition::BEGIN));
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("cuda", ct::ArgumentInsertPosition::BEGIN));
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-x", ct::ArgumentInsertPosition::BEGIN));
-    Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("--cuda-host-only", ct::ArgumentInsertPosition::BEGIN));
+    if (llcompat::canCompileHostAndDeviceInOneJob()) {
+      Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("--cuda-compile-host-device", ct::ArgumentInsertPosition::BEGIN));
+    } else {
+      Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("--cuda-host-only", ct::ArgumentInsertPosition::BEGIN));
+    }
     Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-fno-delayed-template-parsing", ct::ArgumentInsertPosition::BEGIN));
     if (!CudaPath.empty()) {
       std::string sCudaPath = "--cuda-path=" + CudaPath;


### PR DESCRIPTION
[Reason] clang starting from 9.0.0 can compile Host and Device code in a single job.
LLVM < 9 continues using `--cuda-host-only`.