### PR TITLE
[HIPIFY][Linux] Rollback --cuda-compile-host-device on Linux

### DIFF
--- a/hipify-clang/src/LLVMCompat.cpp
+++ b/hipify-clang/src/LLVMCompat.cpp
@@ -128,10 +128,10 @@ bool pragma_once_outside_header() {
 }
 
 bool canCompileHostAndDeviceInOneJob() {
-#if LLVM_VERSION_MAJOR < 9
-  return false;
-#else
+#if LLVM_VERSION_MAJOR >= 9 && defined(_WIN32)
   return true;
+#else
+  return false;
 #endif
 }
 


### PR DESCRIPTION
[Reason] It doesn't work with LLVM 9 and higher; Windows is fine