### PR TITLE
Revert "Cooperative groups match with cuda SWDEV-205006"

### DIFF
--- a/include/hip/hcc_detail/functional_grid_launch.hpp
+++ b/include/hip/hcc_detail/functional_grid_launch.hpp
@@ -127,6 +127,35 @@ void hipLaunchKernelGGLImpl(
 } // Namespace hip_impl.
 
 
+template <typename F>
+inline
+hipError_t hipOccupancyMaxPotentialBlockSize(uint32_t* gridSize, uint32_t* blockSize,
+    F kernel, size_t dynSharedMemPerBlk, uint32_t blockSizeLimit) {
+
+    using namespace hip_impl;
+
+    hip_impl::hip_init();
+    auto f = get_program_state().kernel_descriptor(reinterpret_cast<std::uintptr_t>(kernel),
+                                                   target_agent(0));
+
+    return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, f,
+                                      dynSharedMemPerBlk, blockSizeLimit);
+}
+
+template <typename F>
+inline
+hipError_t hipOccupancyMaxActiveBlocksPerMultiprocessor(uint32_t* numBlocks, F kernel,
+    uint32_t blockSize, size_t dynSharedMemPerBlk) {
+
+    using namespace hip_impl;
+
+    hip_impl::hip_init();
+    auto f = get_program_state().kernel_descriptor(reinterpret_cast<std::uintptr_t>(kernel),
+                                                   target_agent(0));
+
+    return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f, blockSize, dynSharedMemPerBlk);
+}
+
 template <typename... Args, typename F = void (*)(Args...)>
 inline
 void hipLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& dimBlocks,

--- a/include/hip/hcc_detail/hip_runtime_api.h
+++ b/include/hip/hcc_detail/hip_runtime_api.h
@@ -2923,14 +2923,14 @@ hipError_t hipLaunchCooperativeKernelMultiDevice(hipLaunchParams* launchParamsLi
  * @param [out] gridSize           minimum grid size for maximum potential occupancy
  * @param [out] blockSize          block size for maximum potential occupancy
  * @param [in]  f                  kernel function for which occupancy is calulated
- * @param [in]  dynamicSMemSize    Per - block dynamic shared memory usage intended, in bytes
+ * @param [in]  dynSharedMemPerBlk dynamic shared memory usage (in bytes) intended for each block
  * @param [in]  blockSizeLimit     the maximum block size for the kernel, use 0 for no limit
  *
  * @returns hipSuccess, hipInvalidDevice, hipErrorInvalidValue
  */
-hipError_t hipOccupancyMaxPotentialBlockSize(int* gridSize, int* blockSize,
-                                             const void* f, size_t dynamicSMemSize,
-                                             int blockSizeLimit);
+hipError_t hipOccupancyMaxPotentialBlockSize(uint32_t* gridSize, uint32_t* blockSize,
+                                             hipFunction_t f, size_t dynSharedMemPerBlk,
+                                             uint32_t blockSizeLimit);
 
 /**
  * @brief Returns occupancy for a device function.
@@ -2938,10 +2938,10 @@ hipError_t hipOccupancyMaxPotentialBlockSize(int* gridSize, int* blockSize,
  * @param [out] numBlocks        Returned occupancy
  * @param [in]  func             Kernel function for which occupancy is calulated
  * @param [in]  blockSize        Block size the kernel is intended to be launched with
- * @param [in]  dynamicSMemSize  Per - block dynamic shared memory usage intended, in bytes
+ * @param [in]  dynSharedMemPerBlk dynamic shared memory usage (in bytes) intended for each block
  */
 hipError_t hipOccupancyMaxActiveBlocksPerMultiprocessor(
-   int* numBlocks, const void* f, int blockSize, size_t dynamicSMemSize);
+   uint32_t* numBlocks, hipFunction_t f, uint32_t blockSize, size_t dynSharedMemPerBlk);
 
 /**
  * @brief Returns occupancy for a device function.
@@ -2949,11 +2949,11 @@ hipError_t hipOccupancyMaxActiveBlocksPerMultiprocessor(
  * @param [out] numBlocks        Returned occupancy
  * @param [in]  func             Kernel function for which occupancy is calulated
  * @param [in]  blockSize        Block size the kernel is intended to be launched with
- * @param [in]  dynamicSMemSize  Per - block dynamic shared memory usage intended, in bytes
+ * @param [in]  dynSharedMemPerBlk dynamic shared memory usage (in bytes) intended for each block
  * @param [in]  flags            Extra flags for occupancy calculation (currently ignored)
  */
 hipError_t hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(
-   int* numBlocks, const void* f, int blockSize, size_t dynamicSMemSize, unsigned int flags);
+   uint32_t* numBlocks, hipFunction_t f, uint32_t blockSize, size_t dynSharedMemPerBlk, unsigned int flags);
 
 /**
  * @brief Launches kernels on multiple devices and guarantees all specified kernels are dispatched
@@ -3359,27 +3359,7 @@ hipError_t hipBindTextureToMipmappedArray(const texture<T, dim, readMode>& tex,
     return hipSuccess;
 }
 
-template <class T>
-inline hipError_t hipOccupancyMaxActiveBlocksPerMultiprocessor(
-    int* numBlocks, T f, int blockSize, size_t dynamicSMemSize) {
-    return hipOccupancyMaxActiveBlocksPerMultiprocessor(
-        numBlocks, reinterpret_cast<const void*>(f), blockSize, dynamicSMemSize);
-}
 
-template <class T>
-inline hipError_t hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(
-    int* numBlocks, T f, int blockSize, size_t dynamicSMemSize, unsigned int flags) {
-    return hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(
-        numBlocks, reinterpret_cast<const void*>(f), blockSize, dynamicSMemSize, flags);
-}
-
-template <class T>
-inline hipError_t hipOccupancyMaxPotentialBlockSize(int* gridSize, int* blockSize,
-    T f, size_t dynamicSMemSize, int blockSizeLimit) {
-    return hipOccupancyMaxPotentialBlockSize(
-    gridSize, blockSize, reinterpret_cast<const void*>(f), dynamicSMemSize, blockSizeLimit);
-}
- 
 template <class T>
 inline hipError_t hipLaunchCooperativeKernel(T f, dim3 gridDim, dim3 blockDim,
                                              void** kernelParams, unsigned int sharedMemBytes, hipStream_t stream) {

--- a/samples/2_Cookbook/13_occupancy/occupancy.cpp
+++ b/samples/2_Cookbook/13_occupancy/occupancy.cpp
@@ -56,9 +56,9 @@ void launchKernel(float* C, float* A, float* B, bool manual){
      const unsigned threadsperblock = 32;
      const unsigned blocks = (NUM/threadsperblock)+1;
 
-     int mingridSize = 0;
-     int gridSize = 0;
-     int blockSize = 0;
+     uint32_t mingridSize = 0;
+     uint32_t gridSize = 0;
+     uint32_t blockSize = 0;
      
      if (manual){
 	blockSize = threadsperblock; 
@@ -86,7 +86,7 @@ void launchKernel(float* C, float* A, float* B, bool manual){
      printf("kernel Execution time = %6.3fms\n", eventMs);
 
      //Calculate Occupancy
-     int numBlock = 0;
+     uint32_t numBlock = 0;
      HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, multiply, blockSize, 0));
      
      if(devProp.maxThreadsPerMultiProcessor){

--- a/tests/src/runtimeApi/module/hipLaunchCooperativeKernel.cpp
+++ b/tests/src/runtimeApi/module/hipLaunchCooperativeKernel.cpp
@@ -116,7 +116,7 @@ int main() {
 
     dimBlock.x = workgroups[i];
     // Calculate the device occupancy to know how many blocks can be run concurrently
-    hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocks,
+    hipOccupancyMaxActiveBlocksPerMultiprocessor(reinterpret_cast<uint32_t*>(&numBlocks),
         test_gws, dimBlock.x * dimBlock.y * dimBlock.z, dimBlock.x * sizeof(long));
 
     dimGrid.x = deviceProp.multiProcessorCount * std::min(numBlocks, 32);

--- a/tests/src/runtimeApi/module/hipOccupancyMaxActiveBlocksPerMultiprocessor.cpp
+++ b/tests/src/runtimeApi/module/hipOccupancyMaxActiveBlocksPerMultiprocessor.cpp
@@ -30,6 +30,10 @@ THE SOFTWARE.
 #include "hip/hip_runtime.h"
 #include "test_common.h"
 
+#define fileName "vcpy_kernel.code"
+#define kernel_name "hello_world"
+
+
 __global__ void f1(float *a) { *a = 1.0; }
 
 template <typename T>
@@ -40,14 +44,15 @@ __global__ void f2(T *a) { *a = 1; }
 int main(int argc, char* argv[]) {
 
     // test case for using kernel function pointer
-    int gridSize = 0;
-    int blockSize = 0;
+    uint32_t gridSize = 0;
+    uint32_t blockSize = 0;
     hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, 0, 0);
     assert(gridSize != 0 && blockSize != 0);
 
-    int numBlock = 0;
+    uint32_t numBlock = 0;
     hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, f1, blockSize, 0);
     assert(numBlock != 0);
+
 
     // test case for using kernel function pointer with template
     gridSize = 0;
@@ -57,6 +62,16 @@ int main(int argc, char* argv[]) {
 
     numBlock = 0;
     hipOccupancyMaxActiveBlocksPerMultiprocessor<void(*)(int *)>(&numBlock, f2, blockSize, 0);
+    assert(numBlock != 0);
+
+
+    // test case for using kernel with hipFunction_t type
+    numBlock = 0;
+    hipModule_t Module;
+    hipFunction_t Function;
+    HIPCHECK(hipModuleLoad(&Module, fileName));
+    HIPCHECK(hipModuleGetFunction(&Function, Module, kernel_name));
+    HIPCHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, Function, blockSize, 0));
     assert(numBlock != 0);
 
     passed();

--- a/tests/src/runtimeApi/module/hipOccupancyMaxPotentialBlockSize.cpp
+++ b/tests/src/runtimeApi/module/hipOccupancyMaxPotentialBlockSize.cpp
@@ -30,16 +30,22 @@ THE SOFTWARE.
 #include "hip/hip_runtime.h"
 #include "test_common.h"
 
+#define fileName "vcpy_kernel.code"
+#define kernel_name "hello_world"
+
+
 __global__ void f1(float *a) { *a = 1.0; }
 
 template <typename T>
 __global__ void f2(T *a) { *a = 1; }
 
+
+
 int main(int argc, char* argv[]) {
 
     // test case for using kernel function pointer 
-    int gridSize = 0;
-    int blockSize = 0;
+    uint32_t gridSize = 0;
+    uint32_t blockSize = 0;
     hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, 0, 0);
     assert(gridSize != 0 && blockSize != 0);
 
@@ -47,6 +53,16 @@ int main(int argc, char* argv[]) {
     gridSize = 0;
     blockSize = 0;
     hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(&gridSize, &blockSize, f2, 0, 0);
+    assert(gridSize != 0 && blockSize != 0);
+
+    // test case for using kernel with hipFunction_t type
+    gridSize = 0;
+    blockSize = 0;
+    hipModule_t Module;
+    hipFunction_t Function;
+    HIPCHECK(hipModuleLoad(&Module, fileName));
+    HIPCHECK(hipModuleGetFunction(&Function, Module, kernel_name));
+    HIPCHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, Function, 0, 0));
     assert(gridSize != 0 && blockSize != 0);
 
     passed();


### PR DESCRIPTION
Reverts ROCm-Developer-Tools/HIP#1560.

Reverting this for HIP-Clang/ VDI builds for 2.10. 