### PR TITLE
Add templates for defining the static members in struct Coordinates

### DIFF
--- a/include/hip/hcc_detail/hip_runtime.h
+++ b/include/hip/hcc_detail/hip_runtime.h
@@ -244,6 +244,12 @@ struct Coordinates {
   static constexpr Y y{};
   static constexpr Z z{};
 };
+template<typename F>
+__device__ constexpr typename Coordinates<F>::X Coordinates<F>::x __attribute__((__visibility__("hidden")));
+template<typename F>
+__device__ constexpr typename Coordinates<F>::Y Coordinates<F>::y __attribute__((__visibility__("hidden")));
+template<typename F>
+__device__ constexpr typename Coordinates<F>::Z Coordinates<F>::z __attribute__((__visibility__("hidden")));
 
 inline
 __device__


### PR DESCRIPTION
Static members x,y,z in Coordinates have only been declared by not
defined.  That means that there isn't an object owning the
"storage" of these static member (even though their size is zero).
This works fine when compiling code with optimization since
references and symbols to these static memebers would get
cleaned up by compiler optimizers.  However, this causes
a problem at no-opt since references and symbols to these
static members were not cleaned up and the final code
object would end up having an extern symbol to these
members.