### PR TITLE
Updated hipEnvVarDriver to work with Windows

### DIFF
--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -112,8 +112,6 @@ void getDevicePCIBusNum(int deviceID, char* pciBusID) {
 }
 
 int main() {
-    //extern const char* HIP_VISIBLE_DEVICES_STR;
-    //extern const char* CUDA_VISIBLE_DEVICES_STR;
     unsetenv(HIP_VISIBLE_DEVICES_STR);
     unsetenv(CUDA_VISIBLE_DEVICES_STR);
     

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -20,13 +20,6 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
  * TEST: %t
  * HIT_END
  */
-#ifdef _WIN32
-    #define PLATFORM_NAME "windows"
-#elif __linux__
-    #define PLATFORM_NAME "linux"
-#else
-    #define PLATFORM_NAME "NULL"
-#endif
 
 #include <iostream>
 #include <vector>
@@ -43,13 +36,12 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 using namespace std;
 
 int getDeviceNumber() {
-    FILE* directed_in;
     FILE* in;
-    string directed_dir;
-    string dir;
     char buff[512];
-
-    if (PLATFORM_NAME == "windows"){
+    const char* directed_dir;
+    const char* dir;
+    
+    if (PLATFORM_NAME == "WINDOWS"){
         directed_dir = "directed_tests\\hipEnvVar -c";
         dir = "hipEnvVar -c";
     } else {
@@ -58,33 +50,31 @@ int getDeviceNumber() {
     }
     
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    directed_in = popen(directed_dir.c_str(), "r");
-    if(fgets(buff, 512, directed_in) != NULL){
+    in = popen(directed_dir, "r");
+    if(fgets(buff, 512, in) != NULL){
         cout << buff;
-        pclose(directed_in);
+        pclose(in);
         return atoi(buff);
     }
     //Check at same level
-    in = popen(dir.c_str(), "r");
+    in = popen(dir, "r");
     if(fgets(buff, 512, in) != NULL){
         cout << buff;
         pclose(in);
         return atoi(buff);
     }
     
-    pclose(directed_in);
     pclose(in);
     return 1;
 }
 
 // Query the current device ID remotely to hipEnvVar
 void getDevicePCIBusNumRemote(int deviceID, char* pciBusID) {
-    FILE* directed_in;
     FILE* in;
     
     string directed_dir;
     string dir;
-    if (PLATFORM_NAME == "windows"){
+    if (PLATFORM_NAME == "WINDOWS"){
         directed_dir = "directed_tests\\hipEnvVar -d ";
         dir = "hipEnvVar.exe -d ";
     } else {
@@ -95,10 +85,10 @@ void getDevicePCIBusNumRemote(int deviceID, char* pciBusID) {
     directed_dir += std::to_string(deviceID);
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     
-    directed_in = popen(directed_dir.c_str(), "r");
-    if(fgets(pciBusID, 100, directed_in) != NULL){
+    in = popen(directed_dir.c_str(), "r");
+    if(fgets(pciBusID, 100, in) != NULL){
         cout << pciBusID;
-        pclose(directed_in);
+        pclose(in);
         return;
     }
     //Check at same level
@@ -108,7 +98,6 @@ void getDevicePCIBusNumRemote(int deviceID, char* pciBusID) {
         pclose(in);
         return;
     }
-    pclose(directed_in);
     pclose(in);
     return;
 }
@@ -123,14 +112,9 @@ void getDevicePCIBusNum(int deviceID, char* pciBusID) {
 }
 
 int main() {
-    if (PLATFORM_NAME == "windows"){
-        _putenv("HIP_VISIBLE_DEVICES=");
-        _putenv("CUDA_VISIBLE_DEVICES=");
-    } else {
-        unsetenv("HIP_VISIBLE_DEVICES");
-        unsetenv("CUDA_VISIBLE_DEVICES");
-    }
-
+    unsetenv(HIP_VISIBLE_DEVICES);
+    unsetenv(CUDA_VISIBLE_DEVICES);
+    
     std::vector<std::string> devPCINum;
     char pciBusID[100];
     // collect the device pci bus ID for all device
@@ -173,13 +157,8 @@ int main() {
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
         assert(getDeviceNumber() == 3);
         // test if CUDA_VISIBLE_DEVICES will be accepted by the runtime
-        if (PLATFORM_NAME == "windows"){
-            _putenv("HIP_VISIBLE_DEVICES=");
-            _putenv("CUDA_VISIBLE_DEVICES=");
-        } else {
-            unsetenv("HIP_VISIBLE_DEVICES");
-            unsetenv("CUDA_VISIBLE_DEVICES");
-        }
+        unsetenv(HIP_VISIBLE_DEVICES);
+        unsetenv(CUDA_VISIBLE_DEVICES);
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
         assert(getDeviceNumber() == 3);
     }

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -173,8 +173,13 @@ int main() {
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
         assert(getDeviceNumber() == 3);
         // test if CUDA_VISIBLE_DEVICES will be accepted by the runtime
-        _putenv("HIP_VISIBLE_DEVICES=");
-        _putenv("CUDA_VISIBLE_DEVICES=");
+        if (PLATFORM_NAME == "windows"){
+            _putenv("HIP_VISIBLE_DEVICES=");
+            _putenv("CUDA_VISIBLE_DEVICES=");
+        } else {
+            unsetenv("HIP_VISIBLE_DEVICES");
+            unsetenv("CUDA_VISIBLE_DEVICES");
+        }
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
         assert(getDeviceNumber() == 3);
     }

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -41,7 +41,7 @@ int getDeviceNumber() {
     const char* directed_dir;
     const char* dir;
     
-    if (PLATFORM_NAME == "WINDOWS"){
+    if (_WIN64 == 1){
         directed_dir = "directed_tests\\hipEnvVar -c";
         dir = "hipEnvVar -c";
     } else {
@@ -74,7 +74,7 @@ void getDevicePCIBusNumRemote(int deviceID, char* pciBusID) {
     
     string directed_dir;
     string dir;
-    if (PLATFORM_NAME == "WINDOWS"){
+    if (_WIN64 == 1){
         directed_dir = "directed_tests\\hipEnvVar -d ";
         dir = "hipEnvVar.exe -d ";
     } else {
@@ -112,8 +112,10 @@ void getDevicePCIBusNum(int deviceID, char* pciBusID) {
 }
 
 int main() {
-    unsetenv(HIP_VISIBLE_DEVICES);
-    unsetenv(CUDA_VISIBLE_DEVICES);
+    //extern const char* HIP_VISIBLE_DEVICES_STR;
+    //extern const char* CUDA_VISIBLE_DEVICES_STR;
+    unsetenv(HIP_VISIBLE_DEVICES_STR);
+    unsetenv(CUDA_VISIBLE_DEVICES_STR);
     
     std::vector<std::string> devPCINum;
     char pciBusID[100];
@@ -157,8 +159,8 @@ int main() {
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
         assert(getDeviceNumber() == 3);
         // test if CUDA_VISIBLE_DEVICES will be accepted by the runtime
-        unsetenv(HIP_VISIBLE_DEVICES);
-        unsetenv(CUDA_VISIBLE_DEVICES);
+        unsetenv(HIP_VISIBLE_DEVICES_STR);
+        unsetenv(CUDA_VISIBLE_DEVICES_STR);
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
         assert(getDeviceNumber() == 3);
     }

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -45,25 +45,26 @@ using namespace std;
 int getDeviceNumber() {
     FILE* directed_in;
     FILE* in;
-    string directed_test_dir;
+    string directed_dir;
     string dir;
     char buff[512];
 
     if (PLATFORM_NAME == "windows"){
-        directed_test_dir = "directed_tests\\hipEnvVar -c";
+        directed_dir = "directed_tests\\hipEnvVar -c";
         dir = "hipEnvVar -c";
     } else {
-        directed_test_dir = "./directed_tests/hipEnvVar -c";
+        directed_dir = "./directed_tests/hipEnvVar -c";
         dir = "./hipEnvVar -c";
     }
     
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    directed_in = popen(directed_test_dir.c_str(), "r");
+    directed_in = popen(directed_dir.c_str(), "r");
     if(fgets(buff, 512, directed_in) != NULL){
         cout << buff;
         pclose(directed_in);
         return atoi(buff);
     }
+    //Check at same level
     in = popen(dir.c_str(), "r");
     if(fgets(buff, 512, in) != NULL){
         cout << buff;
@@ -81,28 +82,26 @@ void getDevicePCIBusNumRemote(int deviceID, char* pciBusID) {
     FILE* directed_in;
     FILE* in;
     
-    string directed_test_dir;
+    string directed_dir;
     string dir;
     if (PLATFORM_NAME == "windows"){
-        directed_test_dir = "directed_tests\\hipEnvVar -d";
-        dir = "hipEnvVar.exe -d";
+        directed_dir = "directed_tests\\hipEnvVar -d ";
+        dir = "hipEnvVar.exe -d ";
     } else {
-        directed_test_dir = "./directed_tests/hipEnvVar -d";
-        dir = "./hipEnvVar -d";
+        directed_dir = "./directed_tests/hipEnvVar -d ";
+        dir = "./hipEnvVar -d ";
     }
-    //string str = "./directed_tests/hipEnvVar -d ";
-    //str += std::to_string(deviceID);
-    
-    dir += std::to_string(deviceID);
+
+    directed_dir += std::to_string(deviceID);
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     
-    //Apparently popen on windows does not return NULL on invalid command, nor does it set errno.
-    directed_in = popen(directed_test_dir.c_str(), "r");
+    directed_in = popen(directed_dir.c_str(), "r");
     if(fgets(pciBusID, 100, directed_in) != NULL){
         cout << pciBusID;
         pclose(directed_in);
         return;
     }
+    //Check at same level
     in = popen(dir.c_str(), "r");
     if(fgets(pciBusID, 100, in) != NULL){
         cout << pciBusID;
@@ -124,22 +123,13 @@ void getDevicePCIBusNum(int deviceID, char* pciBusID) {
 }
 
 int main() {
-    //unsetenv("HIP_VISIBLE_DEVICES");
-    //unsetenv("CUDA_VISIBLE_DEVICES");
-
-    _putenv("HIP_VISIBLE_DEVICES=");
-    _putenv("CUDA_VISIBLE_DEVICES=");
-    
-    /* Test for if the Environmental var is set.
-    char* buffer;
-    _dupenv_s(&buffer, NULL, "HIP_VISIBLE_DEVICES"); //Gets the environmental var
-    if(buffer){
-        printf("This environmental var is set");
-        return 0;
+    if (PLATFORM_NAME == "windows"){
+        _putenv("HIP_VISIBLE_DEVICES=");
+        _putenv("CUDA_VISIBLE_DEVICES=");
     } else {
-        printf("This environemntal var is NOT set");
-        return 0;
-	}*/
+        unsetenv("HIP_VISIBLE_DEVICES");
+        unsetenv("CUDA_VISIBLE_DEVICES");
+    }
 
     std::vector<std::string> devPCINum;
     char pciBusID[100];

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -38,26 +38,18 @@ using namespace std;
 int getDeviceNumber() {
     FILE* in;
     char buff[512];
-    const char* directed_dir;
-    const char* dir;
-    
-    if (_WIN64 == 1){
-        directed_dir = "directed_tests\\hipEnvVar -c";
-        dir = "hipEnvVar -c";
-    } else {
-        directed_dir = "./directed_tests/hipEnvVar -c";
-        dir = "./hipEnvVar -c";
-    }
+    string directed_dir = "directed_tests" + string(PATH_SEPERATOR_STR) + "hipEnvVar -c";
+    string dir = "." + string(PATH_SEPERATOR_STR) + "hipEnvVar -c";
     
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    in = popen(directed_dir, "r");
+    in = popen(directed_dir.c_str(), "r");
     if(fgets(buff, 512, in) != NULL){
         cout << buff;
         pclose(in);
         return atoi(buff);
     }
     //Check at same level
-    in = popen(dir, "r");
+    in = popen(dir.c_str(), "r");
     if(fgets(buff, 512, in) != NULL){
         cout << buff;
         pclose(in);
@@ -72,15 +64,8 @@ int getDeviceNumber() {
 void getDevicePCIBusNumRemote(int deviceID, char* pciBusID) {
     FILE* in;
     
-    string directed_dir;
-    string dir;
-    if (_WIN64 == 1){
-        directed_dir = "directed_tests\\hipEnvVar -d ";
-        dir = "hipEnvVar.exe -d ";
-    } else {
-        directed_dir = "./directed_tests/hipEnvVar -d ";
-        dir = "./hipEnvVar -d ";
-    }
+    string directed_dir = "directed_tests" + string(PATH_SEPERATOR_STR) + "hipEnvVar -d ";
+    string dir = "." + string(PATH_SEPERATOR_STR) + "hipEnvVar -d";
 
     directed_dir += std::to_string(deviceID);
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -117,7 +102,7 @@ int main() {
     
     std::vector<std::string> devPCINum;
     char pciBusID[100];
-    // collect the device pci bus ID for all device
+    // collect the device pci bus ID for all devices
     int totalDeviceNum = getDeviceNumber();
     std::cout << "The total number of available devices is " << totalDeviceNum << std::endl
               << "Valid index range is 0 - " << totalDeviceNum - 1 << std::endl;

--- a/tests/src/test_common.cpp
+++ b/tests/src/test_common.cpp
@@ -36,9 +36,11 @@ int p_tests = -1; /*which tests to run. Interpretation is left to each test.  de
 #ifdef _WIN64
 const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES=";
 const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES=";
+const char* PATH_SEPERATOR_STR = "\\";
 #else
 const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES";
 const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES";
+const char* PATH_SEPERATOR_STR = "/";
 #endif
 
 namespace HipTest {

--- a/tests/src/test_common.cpp
+++ b/tests/src/test_common.cpp
@@ -33,7 +33,13 @@ unsigned threadsPerBlock = 256;
 int p_gpuDevice = 0;
 unsigned p_verbose = 0;
 int p_tests = -1; /*which tests to run. Interpretation is left to each test.  default:all*/
-
+#ifdef _WIN64
+const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES=";
+const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES=";
+#else
+const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES";
+const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES";
+#endif
 
 namespace HipTest {
 

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -123,6 +123,7 @@ extern unsigned p_verbose;
 extern int p_tests;
 extern const char* HIP_VISIBLE_DEVICES_STR;
 extern const char* CUDA_VISIBLE_DEVICES_STR;
+extern const char* PATH_SEPERATOR_STR;
 
 // ********************* CPP section *********************
 #ifdef __cplusplus

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -105,15 +105,14 @@ THE SOFTWARE.
 #define pclose(x) _pclose(x)
 #define setenv(x,y,z) _putenv_s(x,y)
 #define unsetenv _putenv
-#define PLATFORM_NAME "WINDOWS"
-#define HIP_VISIBLE_DEVICES "HIP_VISIBLE_DEVICES="
-#define CUDA_VISIBLE_DEVICES "CUDA_VISIBLE_DEVICES="
 #else
 #define aligned_free(x) free(x)
-#define PLATFORM_NAME "OTHER"
-#define HIP_VISIBLE_DEVICES "HIP_VISIBLE_DEVICES"
-#define CUDA_VISIBLE_DEVICES "CUDA_VISIBLE_DEVICES"
 #endif
+
+//const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES=";
+//const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES=";
+//const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES";
+//const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES";
 
 // standard command-line variables:
 extern size_t N;
@@ -127,6 +126,8 @@ extern unsigned threadsPerBlock;
 extern int p_gpuDevice;
 extern unsigned p_verbose;
 extern int p_tests;
+extern const char* HIP_VISIBLE_DEVICES_STR;
+extern const char* CUDA_VISIBLE_DEVICES_STR;
 
 // ********************* CPP section *********************
 #ifdef __cplusplus

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -104,8 +104,15 @@ THE SOFTWARE.
 #define popen(x,y) _popen(x,y)
 #define pclose(x) _pclose(x)
 #define setenv(x,y,z) _putenv_s(x,y)
+#define unsetenv _putenv
+#define PLATFORM_NAME "WINDOWS"
+#define HIP_VISIBLE_DEVICES "HIP_VISIBLE_DEVICES="
+#define CUDA_VISIBLE_DEVICES "CUDA_VISIBLE_DEVICES="
 #else
 #define aligned_free(x) free(x)
+#define PLATFORM_NAME "OTHER"
+#define HIP_VISIBLE_DEVICES "HIP_VISIBLE_DEVICES"
+#define CUDA_VISIBLE_DEVICES "CUDA_VISIBLE_DEVICES"
 #endif
 
 // standard command-line variables:

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -109,11 +109,6 @@ THE SOFTWARE.
 #define aligned_free(x) free(x)
 #endif
 
-//const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES=";
-//const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES=";
-//const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES";
-//const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES";
-
 // standard command-line variables:
 extern size_t N;
 extern char memsetval;


### PR DESCRIPTION
hipEnvVarDriver would not run with windows because of the following:

1. Windows didn't recognize unsetenv(). Windows use _putenv.
2. Path to hipEnvVar used forward slashes (/) while windows only recognizes back slashes (\)
3. _popen on windows does not actually return NULL on invalid command, therefore after checking for directed_test/hipEnvVar, it doesn't go to check hipEnvVar at the same level.

Changes have been made to fix these.
