### PR TITLE
Use portable macro for deprecation message.

### DIFF
--- a/include/hip/hcc_detail/hip_runtime_api.h
+++ b/include/hip/hcc_detail/hip_runtime_api.h
@@ -2994,7 +2994,8 @@ hipError_t hipExtLaunchMultiKernelMultiDevice(hipLaunchParams* launchParamsList,
  * When using this API, start the profiler with profiling disabled.  (--startdisabled)
  * @warning : hipProfilerStart API is under development.
  */
-hipError_t hipProfilerStart() __attribute__((deprecated("use roctracer/rocTX instead")));
+DEPRECATED("use roctracer/rocTX instead")
+hipError_t hipProfilerStart();
 
 
 /**
@@ -3002,7 +3003,8 @@ hipError_t hipProfilerStart() __attribute__((deprecated("use roctracer/rocTX ins
  * When using this API, start the profiler with profiling disabled.  (--startdisabled)
  * @warning : hipProfilerStop API is under development.
  */
-hipError_t hipProfilerStop() __attribute__((deprecated("use roctracer/rocTX instead")));
+DEPRECATED("use roctracer/rocTX instead")
+hipError_t hipProfilerStop();
 
 
 /**


### PR DESCRIPTION
Please review, approve, and merge this ASAP as it breaks the Windows builds.