### PR TITLE
Remove redundant declarations.

### DIFF
--- a/include/hip/hcc_detail/hip_runtime.h
+++ b/include/hip/hcc_detail/hip_runtime.h
@@ -518,25 +518,6 @@ hc_get_workitem_absolute_id(int dim)
 #pragma pop_macro("__CUDA__")
 #endif // ndef _OPENMP
 
-#if __HIP_VDI__
-hipError_t hipExtModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,
-                                    uint32_t globalWorkSizeY, uint32_t globalWorkSizeZ,
-                                    uint32_t localWorkSizeX, uint32_t localWorkSizeY,
-                                    uint32_t localWorkSizeZ, size_t sharedMemBytes,
-                                    hipStream_t hStream, void** kernelParams, void** extra,
-                                    hipEvent_t startEvent = nullptr,
-                                    hipEvent_t stopEvent = nullptr,
-                                    uint32_t flags = 0);
-
-hipError_t hipHccModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,
-                                    uint32_t globalWorkSizeY, uint32_t globalWorkSizeZ,
-                                    uint32_t localWorkSizeX, uint32_t localWorkSizeY,
-                                    uint32_t localWorkSizeZ, size_t sharedMemBytes,
-                                    hipStream_t hStream, void** kernelParams, void** extra,
-                                    hipEvent_t startEvent = nullptr,
-                                    hipEvent_t stopEvent = nullptr)
-                                    __attribute__((deprecated("use hipExtModuleLaunchKernel instead")));
-#endif // __HIP_VDI__
 #endif // defined(__clang__) && defined(__HIP__)
 
 #include <hip/hcc_detail/hip_memory.h>


### PR DESCRIPTION
- The revised `hip/hip_ext.h` have that declarations.