### PR TITLE
Adding new test case for the API - hipExtGetLinkTypeAndHopCount

### DIFF
--- a/tests/src/runtimeApi/device/hipExtGetLinkTypeAndHopCount.cpp
+++ b/tests/src/runtimeApi/device/hipExtGetLinkTypeAndHopCount.cpp
@@ -1,0 +1,45 @@
+/*
+Copyright (c) 2015-2017 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANNTY OF ANY KIND, EXPRESS OR
+IMPLIED, INNCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANNY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER INN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/* HIT_START
+ * BUILD: %t %s ../../test_common.cpp
+ * TEST: %t
+ * HIT_END
+ */
+
+#include "test_common.h"
+
+int main() {
+    int numDevices = 0;
+    HIPCHECK(hipGetDeviceCount(&numDevices));
+
+    if (numDevices < 2) {
+      std::cout<<"API not valid for when numDevices < 2. Exiting..."<<std::endl;
+    } else {
+      uint32_t link_type = 0;
+      uint32_t hopcount = 0;
+
+      for (int idx=0; idx<(numDevices-1); ++idx) {
+        //link_type and hopcount is tied to HW, so only checking the API return type.
+        HIPCHECK(hipExtGetLinkTypeAndHopCount(idx, 1+idx, &link_type, &hopcount));
+      }
+    }
+
+    passed();
+}


### PR DESCRIPTION
Implemented the API in VDI and added a new test case. This will be useful to verify on different types of interconnect setups.