### PR TITLE
[dtest] Fix hipModuleGetGlobal

### DIFF
--- a/tests/src/runtimeApi/module/hipModuleGetGlobal.cpp
+++ b/tests/src/runtimeApi/module/hipModuleGetGlobal.cpp
@@ -32,7 +32,6 @@ THE SOFTWARE.
 #include <iostream>
 #include <fstream>
 #include <vector>
-#include <hip/hip_ext.h>
 
 #define LEN 64
 #define SIZE LEN * sizeof(float)


### PR DESCRIPTION
No idea why did #1150 include hip/hip_hcc.h in this test and then why did it get unnoticed in #1341 .
@mangupta merging this should help #1530 CI build.