### PR TITLE
fix complex conjugate for double-complex

### DIFF
--- a/include/hip/hcc_detail/hip_complex.h
+++ b/include/hip/hcc_detail/hip_complex.h
@@ -186,7 +186,7 @@ __device__ __host__ static inline hipDoubleComplex make_hipDoubleComplex(double 
 __device__ __host__ static inline hipDoubleComplex hipConj(hipDoubleComplex z) {
     hipDoubleComplex ret;
     ret.x = z.x;
-    ret.y = z.y;
+    ret.y = -z.y;
     return ret;
 }
 


### PR DESCRIPTION
The sign in the y component returned from hipConj incorrect for double-complex.  Fix to match as in hipConjf above