### PR TITLE
hipStreamSynchronize can skip marker if stream is empty

### DIFF
--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -310,6 +310,8 @@ void ihipStream_t::locked_wait() {
     hc::completion_future marker;
     {
         LockedAccessor_StreamCrit_t crit(_criticalData);
+        // skipping marker since stream is empty
+        if (crit->_av.get_is_empty()) return;
         marker = crit->_av.create_marker(hc::no_scope);
     }
 


### PR DESCRIPTION
This follows the convention established elsewhere for checking `_av.get_is_empty()` before creating a marker.

- https://github.com/ROCm-Developer-Tools/HIP/blob/ebe0c56f4f700863a85984ccfbaf4c4d53e2805c/src/hip_hcc.cpp#L1059
- https://github.com/ROCm-Developer-Tools/HIP/blob/ebe0c56f4f700863a85984ccfbaf4c4d53e2805c/src/hip_hcc.cpp#L1550