### PR TITLE
hipGetDevice return hipSuccess, return ID if deviceId not null

### DIFF
--- a/src/hip_device.cpp
+++ b/src/hip_device.cpp
@@ -35,16 +35,15 @@ hipError_t hipGetDevice(int* deviceId) {
     hipError_t e = hipSuccess;
 
     auto ctx = ihipGetTlsDefaultCtx();
+    int devid = 0;
 
-    if (deviceId != nullptr) {
-        if (ctx == nullptr) {
-            e = hipErrorInvalidDevice;  // TODO, check error code.
-            *deviceId = -1;
-        } else {
-            *deviceId = ctx->getDevice()->_deviceId;
-        }
+    if (ctx == nullptr) {
+        devid = -1;
     } else {
-        e = hipErrorInvalidValue;
+        devid = ctx->getDevice()->_deviceId;
+    }
+    if (deviceId != nullptr) {
+        *deviceId = devid; /* return only if not NULL */
     }
 
     return ihipLogStatus(e);


### PR DESCRIPTION
The hipGetDevice() will return hipSuccess and use the outgoing argument deviceId to indicate valid device or not (a minus -1 is returned when null device context).
A null outgoing argument, deviceID, will be treated as a dont-care return that can be used in diagnostics/tests.