### PR TITLE
Added check for large blocksize > 256 (SWDEV 201525)

### DIFF
--- a/include/hip/hcc_detail/program_state.hpp
+++ b/include/hip/hcc_detail/program_state.hpp
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include <cstddef>
 #include <cstdint>
 #include <cstdlib>
+#include <string>
 
 #include <hip/hip_common.h>
 
@@ -68,6 +69,8 @@ public:
 
     hipFunction_t kernel_descriptor(std::uintptr_t,
                                     hsa_agent_t);
+
+    std::size_t get_kernattribute(std::string);
 
     kernargs_size_align get_kernargs_size_align(std::uintptr_t);
     hsa_executable_t load_executable(const char*, const size_t,

--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -145,6 +145,12 @@ hipError_t ihipModuleLaunchKernel(TlsData *tls, hipFunction_t f, uint32_t global
     auto ctx = ihipGetTlsDefaultCtx();
     hipError_t ret = hipSuccess;
 
+    std::size_t blockSize = hip_impl::get_program_state().get_kernattribute(f->_name);
+    if (blockSize < (localWorkSizeX * localWorkSizeY * localWorkSizeZ))
+    {
+        return hipErrorLaunchFailure;
+    }
+
     if (ctx == nullptr) {
         ret = hipErrorInvalidDevice;
 

--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -156,14 +156,6 @@ hipError_t ihipModuleLaunchKernel(TlsData *tls, hipFunction_t f, uint32_t global
 
     } else {
 
-        // Kernel launch may fail for (no. of VGPRs X blocksize >= 65536)
-        if(f != nullptr && f->_header != nullptr){
-            uint32_t usedVGPRCount = f->_header->workitem_vgpr_count;
-            if((localWorkSizeX * localWorkSizeY * localWorkSizeZ * usedVGPRCount) >= 65536){
-                return hipErrorInvalidValue;
-            }
-        }
-
         int deviceId = ctx->getDevice()->_deviceId;
         ihipDevice_t* currentDevice = ihipGetDevice(deviceId);
         hsa_agent_t gpuAgent = (hsa_agent_t)currentDevice->_hsaAgent;

--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -149,6 +149,15 @@ hipError_t ihipModuleLaunchKernel(TlsData *tls, hipFunction_t f, uint32_t global
         ret = hipErrorInvalidDevice;
 
     } else {
+
+        // Kernel launch may fail for (no. of VGPRs X blocksize >= 65536)
+        if(f != nullptr && f->_header != nullptr){
+            uint32_t usedVGPRCount = f->_header->workitem_vgpr_count;
+            if((localWorkSizeX * localWorkSizeY * localWorkSizeZ * usedVGPRCount) >= 65536){
+                return hipErrorInvalidValue;
+            }
+        }
+
         int deviceId = ctx->getDevice()->_deviceId;
         ihipDevice_t* currentDevice = ihipGetDevice(deviceId);
         hsa_agent_t gpuAgent = (hsa_agent_t)currentDevice->_hsaAgent;

--- a/src/program_state.cpp
+++ b/src/program_state.cpp
@@ -77,6 +77,11 @@ namespace hip_impl {
         return kd;
     }
 
+    std::size_t program_state::get_kernattribute(std::string kernelName)
+    {
+        return impl->getKernattribute(kernelName);
+    }
+
     kernargs_size_align program_state::get_kernargs_size_align(std::uintptr_t kernel) {
         kernargs_size_align t;
         t.handle = reinterpret_cast<const void*>(&impl->kernargs_size_align(kernel));

--- a/src/program_state.inl
+++ b/src/program_state.inl
@@ -943,7 +943,6 @@ public:
             auto n = kernels_md.substr(m+21, kernels_md.find_first_of("'\n", m) - m - 21);
             size_t block_size = std::stoul(n);
             kernattrib[fn] = block_size;
-            gBlockSize[fn] = block_size;
 
         } while (true);
     }


### PR DESCRIPTION
1. The kernel fails if block size greater than 256 hence added a check to make sure the requested bock size can be launched with given resources.
2. The current check does not cover all the scenarios, I have opened a communication with the compiler team to get more info in order to conclude successful launch of the kernel. 