### PR TITLE
Null check of kernelParams

### DIFF
--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -155,9 +155,10 @@ hipError_t ihipModuleLaunchKernel(TlsData *tls, hipFunction_t f, uint32_t global
 
         std::vector<char> kernargs{};
         if (kernelParams) {
-            if (extra || (*kernelParams == nullptr)) return hipErrorInvalidValue;
+            if (extra) return hipErrorInvalidValue;
 
             for (auto&& x : f->_kernarg_layout) {
+                if (*kernelParams == nullptr) return hipErrorInvalidValue;
                 const auto p{static_cast<const char*>(*kernelParams)};
 
                 kernargs.insert(

--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -155,7 +155,7 @@ hipError_t ihipModuleLaunchKernel(TlsData *tls, hipFunction_t f, uint32_t global
 
         std::vector<char> kernargs{};
         if (kernelParams) {
-            if (extra) return hipErrorInvalidValue;
+            if (extra || (*kernelParams == nullptr)) return hipErrorInvalidValue;
 
             for (auto&& x : f->_kernarg_layout) {
                 const auto p{static_cast<const char*>(*kernelParams)};


### PR DESCRIPTION
This avoids seg fault. CUDA too returns error when void* args[2] = {nullptr, nullptr}; is passed to hipModuleLaunchKernel.