### PR TITLE
fix linking of vector types with gcc

### DIFF
--- a/include/hip/hcc_detail/hip_vector_types.h
+++ b/include/hip/hcc_detail/hip_vector_types.h
@@ -42,6 +42,7 @@ THE SOFTWARE.
 #endif
 
 #if defined(__cplusplus)
+    #include <array>
     #include <iosfwd>
     #include <type_traits>
 
@@ -464,7 +465,11 @@ THE SOFTWARE.
         inline __host__ __device__
         HIP_vector_type(Us... xs) noexcept
         {
-            new (&data) Native_vec_{static_cast<T>(xs)...};
+            #if __has_extension(ext_vector_type)
+                new (&data) Native_vec_{static_cast<T>(xs)...};
+            #else
+                new (&data) std::array<T, rank>{static_cast<T>(xs)...};
+            #endif
         }
         inline __host__ __device__
         HIP_vector_type(const HIP_vector_type&) = default;

--- a/include/hip/hcc_detail/hip_vector_types.h
+++ b/include/hip/hcc_detail/hip_vector_types.h
@@ -52,9 +52,11 @@ THE SOFTWARE.
     
     namespace std {
         template<typename T, typename U, unsigned int n>
-        struct is_integral<Scalar_accessor<T, U, n>> : is_integral<T> {};
+        struct is_integral<hip_impl::Scalar_accessor<T, U, n>>
+            : is_integral<T> {};
         template<typename T, typename U, unsigned int n>
-        struct is_floating_point<Scalar_accessor<T, U, n>> : is_floating_point<T> {};
+        struct is_floating_point<hip_impl::Scalar_accessor<T, U, n>> 
+            : is_floating_point<T> {};
     } // Namespace std.
     
     namespace hip_impl {

--- a/include/hip/hcc_detail/hip_vector_types.h
+++ b/include/hip/hcc_detail/hip_vector_types.h
@@ -34,17 +34,19 @@ THE SOFTWARE.
 
 #include "hip/hcc_detail/host_defines.h"
 
-#if !defined(_MSC_VER) || __clang__
-#if defined(__clang__)
-    #define __NATIVE_VECTOR__(n, ...) __attribute__((ext_vector_type(n)))
+#if __has_attribute(ext_vector_type) || __has_attribute(vector_size)
+#if __has_attribute(ext_vector_type)
+    #define __NATIVE_VECTOR__(n, T, n_power_of_two) __attribute__((ext_vector_type(n_power_of_two),aligned(n_power_of_two*sizeof(T))))
+#elif __has_attribute(vector_size)
+    #define __NATIVE_VECTOR__(n, T, n_power_of_two) __attribute__((vector_size(n_power_of_two*sizeof(T)),aligned(n_power_of_two*sizeof(T))))
 #endif
 
-#if defined(__cplusplus) && defined(__clang__)
+#if defined(__cplusplus)
     #include <iosfwd>
     #include <type_traits>
 
     namespace hip_impl {
-        template<typename T, typename Vector, unsigned int idx>
+        template<typename T, unsigned int n, unsigned int n_power_of_two, unsigned int idx>
         struct Scalar_accessor {
             struct Address {
                 const Scalar_accessor* p;
@@ -67,6 +69,7 @@ THE SOFTWARE.
                     return &reinterpret_cast<T*>(
                         const_cast<Scalar_accessor*>(p))[idx];
                 }
+
             };
 
             friend
@@ -87,23 +90,14 @@ THE SOFTWARE.
             }
 
             // Idea from https://t0rakka.silvrback.com/simd-scalar-accessor
+            typedef T Vector __NATIVE_VECTOR__(n, T, n_power_of_two);
             Vector data;
 
             __host__ __device__
             operator T() const noexcept { return data[idx]; }
-            __host__ __device__
-            operator T() const volatile noexcept { return data[idx]; }
 
             __host__ __device__
-            operator T&() noexcept {
-                return reinterpret_cast<
-                    T (&)[sizeof(Vector) / sizeof(T)]>(data)[idx];
-            }
-            __host__ __device__
-            operator volatile T&() volatile noexcept {
-                return reinterpret_cast<
-                    volatile T (&)[sizeof(Vector) / sizeof(T)]>(data)[idx];
-            }
+            operator T() const volatile noexcept { return data[idx]; }
 
             __host__ __device__
             Address operator&() const noexcept { return Address{this}; }
@@ -113,7 +107,8 @@ THE SOFTWARE.
                 data[idx] = x;
 
                 return *this;
-            }
+                }
+
             __host__ __device__
             volatile Scalar_accessor& operator=(T x) volatile noexcept {
                 data[idx] = x;
@@ -179,7 +174,7 @@ THE SOFTWARE.
                 typename std::enable_if<
                     std::is_convertible<U, T>{}>::type* = nullptr>
             __host__ __device__
-            Scalar_accessor& operator/=(T x) noexcept {
+            Scalar_accessor& operator/=(U x) noexcept {
                 data[idx] /= x;
                 return *this;
             }
@@ -245,11 +240,14 @@ THE SOFTWARE.
 
     template<typename T>
     struct HIP_vector_base<T, 1> {
-        typedef T Native_vec_ __NATIVE_VECTOR__(1, T);
+        enum { n = 1,
+               n_power_of_two = 1
+        };
+        typedef T Native_vec_ __NATIVE_VECTOR__(n, T, n_power_of_two);
 
         union {
             Native_vec_ data;
-            hip_impl::Scalar_accessor<T, Native_vec_, 0> x;
+            hip_impl::Scalar_accessor<T, n, n_power_of_two, 0> x;
         };
 
         using value_type = T;
@@ -257,12 +255,15 @@ THE SOFTWARE.
 
     template<typename T>
     struct HIP_vector_base<T, 2> {
-        typedef T Native_vec_ __NATIVE_VECTOR__(2, T);
+        enum { n = 2,
+               n_power_of_two = 2
+        };
+        typedef T Native_vec_ __NATIVE_VECTOR__(2, T, n_power_of_two);
 
         union {
             Native_vec_ data;
-            hip_impl::Scalar_accessor<T, Native_vec_, 0> x;
-            hip_impl::Scalar_accessor<T, Native_vec_, 1> y;
+            hip_impl::Scalar_accessor<T, n, n_power_of_two, 0> x;
+            hip_impl::Scalar_accessor<T, n, n_power_of_two, 1> y;
         };
 
         using value_type = T;
@@ -270,174 +271,35 @@ THE SOFTWARE.
 
     template<typename T>
     struct HIP_vector_base<T, 3> {
-        struct Native_vec_ {
-            T d[3];
-
-            __host__ __device__
-            constexpr
-            Native_vec_() = default;
-            __host__ __device__
-            explicit
-            constexpr
-            Native_vec_(T x) noexcept : d{x, x, x} {}
-            __host__ __device__
-            constexpr
-            Native_vec_(T x, T y, T z) noexcept : d{x, y, z} {}
-            __host__ __device__
-            constexpr
-            Native_vec_(const Native_vec_&) = default;
-            __host__ __device__
-            constexpr
-            Native_vec_(Native_vec_&&) = default;
-            __host__ __device__
-            ~Native_vec_() = default;
-
-            __host__ __device__
-            Native_vec_& operator=(const Native_vec_&) = default;
-            __host__ __device__
-            Native_vec_& operator=(Native_vec_&&) = default;
-
-            __host__ __device__
-            T& operator[](unsigned int idx) noexcept { return d[idx]; }
-            __host__ __device__
-            T operator[](unsigned int idx) const noexcept { return d[idx]; }
-
-            __host__ __device__
-            Native_vec_& operator+=(const Native_vec_& x) noexcept
-            {
-                for (auto i = 0u; i != 3u; ++i) d[i] += x.d[i];
-                return *this;
-            }
-            __host__ __device__
-            Native_vec_& operator-=(const Native_vec_& x) noexcept
-            {
-                for (auto i = 0u; i != 3u; ++i) d[i] -= x.d[i];
-                return *this;
-            }
-
-            __host__ __device__
-            Native_vec_& operator*=(const Native_vec_& x) noexcept
-            {
-                for (auto i = 0u; i != 3u; ++i) d[i] *= x.d[i];
-                return *this;
-            }
-            __host__ __device__
-            Native_vec_& operator/=(const Native_vec_& x) noexcept
-            {
-                for (auto i = 0u; i != 3u; ++i) d[i] /= x.d[i];
-                return *this;
-            }
-
-            template<
-                typename U = T,
-                typename std::enable_if<std::is_signed<U>{}>::type* = nullptr>
-            __host__ __device__
-            Native_vec_ operator-() const noexcept
-            {
-                auto r{*this};
-                for (auto&& x : r.d) x = -x;
-                return r;
-            }
-
-            template<
-                typename U = T,
-                typename std::enable_if<std::is_integral<U>{}>::type* = nullptr>
-            __host__ __device__
-            Native_vec_ operator~() const noexcept
-            {
-                auto r{*this};
-                for (auto&& x : r.d) x = ~x;
-                return r;
-            }
-            template<
-                typename U = T,
-                typename std::enable_if<std::is_integral<U>{}>::type* = nullptr>
-            __host__ __device__
-            Native_vec_& operator%=(const Native_vec_& x) noexcept
-            {
-                for (auto i = 0u; i != 3u; ++i) d[i] %= x.d[i];
-                return *this;
-            }
-            template<
-                typename U = T,
-                typename std::enable_if<std::is_integral<U>{}>::type* = nullptr>
-            __host__ __device__
-            Native_vec_& operator^=(const Native_vec_& x) noexcept
-            {
-                for (auto i = 0u; i != 3u; ++i) d[i] ^= x.d[i];
-                return *this;
-            }
-            template<
-                typename U = T,
-                typename std::enable_if<std::is_integral<U>{}>::type* = nullptr>
-            __host__ __device__
-            Native_vec_& operator|=(const Native_vec_& x) noexcept
-            {
-                for (auto i = 0u; i != 3u; ++i) d[i] |= x.d[i];
-                return *this;
-            }
-            template<
-                typename U = T,
-                typename std::enable_if<std::is_integral<U>{}>::type* = nullptr>
-            __host__ __device__
-            Native_vec_& operator&=(const Native_vec_& x) noexcept
-            {
-                for (auto i = 0u; i != 3u; ++i) d[i] &= x.d[i];
-                return *this;
-            }
-            template<
-                typename U = T,
-                typename std::enable_if<std::is_integral<U>{}>::type* = nullptr>
-            __host__ __device__
-            Native_vec_& operator>>=(const Native_vec_& x) noexcept
-            {
-                for (auto i = 0u; i != 3u; ++i) d[i] >>= x.d[i];
-                return *this;
-            }
-            template<
-                typename U = T,
-                typename std::enable_if<std::is_integral<U>{}>::type* = nullptr>
-            __host__ __device__
-            Native_vec_& operator<<=(const Native_vec_& x) noexcept
-            {
-                for (auto i = 0u; i != 3u; ++i) d[i] <<= x.d[i];
-                return *this;
-            }
-
-            using Vec3_cmp = int __NATIVE_VECTOR__(3, int);
-            __host__ __device__
-            Vec3_cmp operator==(const Native_vec_& x) const noexcept
-            {
-                Vec3_cmp r;
-                r[0] = d[0] == x.d[0];
-                r[1] = d[1] == x.d[1];
-                r[2] = d[2] == x.d[2];
-                return r;
-            }
+        enum Enum { n = 3,
+                    n_power_of_two = 4
         };
+        typedef T Native_vec_ __NATIVE_VECTOR__(n, T, n_power_of_two);
 
         union {
             Native_vec_ data;
-            struct {
-                T x;
-                T y;
-                T z;
-            };
+            hip_impl::Scalar_accessor<T, n, n_power_of_two, 0> x;
+            hip_impl::Scalar_accessor<T, n, n_power_of_two, 1> y;
+            hip_impl::Scalar_accessor<T, n, n_power_of_two, 2> z;
         };
 
         using value_type = T;
     };
 
+
     template<typename T>
     struct HIP_vector_base<T, 4> {
-        typedef T Native_vec_ __NATIVE_VECTOR__(4, T);
+        enum Enum { n = 4,
+                    n_power_of_two = 4
+        };
+        typedef T Native_vec_ __NATIVE_VECTOR__(4, T, 4);
 
         union {
             Native_vec_ data;
-            hip_impl::Scalar_accessor<T, Native_vec_, 0> x;
-            hip_impl::Scalar_accessor<T, Native_vec_, 1> y;
-            hip_impl::Scalar_accessor<T, Native_vec_, 2> z;
-            hip_impl::Scalar_accessor<T, Native_vec_, 3> w;
+            hip_impl::Scalar_accessor<T, n, n_power_of_two, 0> x;
+            hip_impl::Scalar_accessor<T, n, n_power_of_two, 1> y;
+            hip_impl::Scalar_accessor<T, n, n_power_of_two, 2> z;
+            hip_impl::Scalar_accessor<T, n, n_power_of_two, 3> w;
         };
 
         using value_type = T;

--- a/include/hip/hcc_detail/hip_vector_types.h
+++ b/include/hip/hcc_detail/hip_vector_types.h
@@ -34,8 +34,12 @@ THE SOFTWARE.
 
 #include "hip/hcc_detail/host_defines.h"
 
-#if __has_attribute(vector_size)
+#if __has_attribute(ext_vector_type) || __has_attribute(vector_size)
+#if __has_attribute(ext_vector_type)
+    #define __NATIVE_VECTOR__(n, T) __attribute__((ext_vector_type(n)))
+#elif __has_attribute(vector_size)
     #define __NATIVE_VECTOR__(n, T) __attribute__((vector_size(n*sizeof(T))))
+#endif
 
 #if defined(__cplusplus)
     #include <iosfwd>
@@ -89,6 +93,11 @@ THE SOFTWARE.
             typedef T Vector __NATIVE_VECTOR__(n, T);
             Vector data;
 
+            __host__ __device__
+            operator T() const noexcept { return data[idx]; }
+            __host__ __device__
+            operator T() const volatile noexcept { return data[idx]; }
+
              __host__ __device__
             operator T&() noexcept {
                 return reinterpret_cast<
@@ -100,17 +109,6 @@ THE SOFTWARE.
                     volatile T (&)[sizeof(Vector) / sizeof(T)]>(data)[idx];
             }
 
-             __host__ __device__
-            operator const T&() const noexcept {
-                return reinterpret_cast<
-                    const T (&)[sizeof(Vector) / sizeof(T)]>(data)[idx];
-            }
-            __host__ __device__
-            operator const volatile T&() const volatile noexcept {
-                return reinterpret_cast<
-                    const volatile T (&)[sizeof(Vector) / sizeof(T)]>(data)[idx];
-            }
- 
             __host__ __device__
             Address operator&() const noexcept { return Address{this}; }
 

--- a/include/hip/hcc_detail/hip_vector_types.h
+++ b/include/hip/hcc_detail/hip_vector_types.h
@@ -142,7 +142,13 @@ THE SOFTWARE.
 
             __host__ __device__
             Address operator&() const noexcept { return Address{this}; }
+            
+            __host__ __device__
+            Scalar_accessor& operator=(const Scalar_accessor& x) noexcept {
+                data[idx] = x.data[idx];
 
+                return *this;
+            }
             __host__ __device__
             Scalar_accessor& operator=(T x) noexcept {
                 data[idx] = x;
@@ -288,6 +294,17 @@ THE SOFTWARE.
         };
 
         using value_type = T;
+        
+        __host__ __device__
+        HIP_vector_base& operator=(const HIP_vector_base& x) noexcept {
+            #if __has_attribute(ext_vector_type)
+                data = x.data;
+            #else
+                data[0] = x.data[0];
+            #endif
+
+            return *this;
+        }
     };
 
     template<typename T>
@@ -301,6 +318,18 @@ THE SOFTWARE.
         };
 
         using value_type = T;
+        
+        __host__ __device__
+        HIP_vector_base& operator=(const HIP_vector_base& x) noexcept {
+            #if __has_attribute(ext_vector_type)
+                data = x.data;
+            #else
+                data[0] = x.data[0];
+                data[1] = x.data[1];
+            #endif
+
+            return *this;
+        }
     };
 
     template<typename T>
@@ -472,6 +501,20 @@ THE SOFTWARE.
         };
 
         using value_type = T;
+        
+        __host__ __device__
+        HIP_vector_base& operator=(const HIP_vector_base& x) noexcept {
+            #if __has_attribute(ext_vector_type)
+                data = x.data;
+            #else
+                data[0] = x.data[0];
+                data[1] = x.data[1];
+                data[2] = x.data[2];
+                data[3] = x.data[3];
+            #endif
+
+            return *this;
+        }
     };
 
     template<typename T, unsigned int rank>

--- a/include/hip/hcc_detail/hip_vector_types.h
+++ b/include/hip/hcc_detail/hip_vector_types.h
@@ -118,7 +118,7 @@ THE SOFTWARE.
                     !std::is_same<U, T>{} &&
                     std::is_enum<U>{} &&
                     std::is_convertible<
-                        T, typename std::underlying_type<U>::type>{}>::type* = nullptr>
+                        T, typename std::enable_if<std::is_enum<U>::value, std::underlying_type<U>>::type::type>{}>::type* = nullptr>
             __host__ __device__
             operator U() const noexcept { return static_cast<U>(data[idx]); }
             template<
@@ -127,7 +127,7 @@ THE SOFTWARE.
                     !std::is_same<U, T>{} &&
                     std::is_enum<U>{} &&
                     std::is_convertible<
-                        T, typename std::underlying_type<U>::type>{}>::type* = nullptr>
+                        T, typename std::enable_if<std::is_enum<U>::value, std::underlying_type<U>>::type::type>{}>::type* = nullptr>
             __host__ __device__
             operator U() const volatile noexcept { return static_cast<U>(data[idx]); }
 

--- a/include/hip/hcc_detail/hip_vector_types.h
+++ b/include/hip/hcc_detail/hip_vector_types.h
@@ -465,7 +465,7 @@ THE SOFTWARE.
         inline __host__ __device__
         HIP_vector_type(Us... xs) noexcept
         {
-            #if __has_extension(ext_vector_type)
+            #if __has_attribute(ext_vector_type)
                 new (&data) Native_vec_{static_cast<T>(xs)...};
             #else
                 new (&data) std::array<T, rank>{static_cast<T>(xs)...};


### PR DESCRIPTION
Fix linker issues where incompatible definitions of the vector types are used in gcc and clang.

Now there is a single consistent data type, which either uses the clang `ext_vector_type` extension, or the equivalent gcc `vector_size`.

Eliminate specialization for size 3 data types and round up to nearest power of two. Likely some code could be saved by automatically computing the next power of two instead of manually specifying it as a template argument.

There still are some issues with these data types and C++ projects which assume that the members of, e.g., `double4` are strictly `double`. Implicit type conversion does not work in all situations. This is the case e.g. for serialization libraries (cereal) applied to the HIP vector types, or python bindings (pybind11). The HIP data types are therefore not strictly compatible to the CUDA ones. However, these issues are pretty localized in our project code (at least) and could be fixed there.

Fixes #1675