### PR TITLE
replace array designator C99

### DIFF
--- a/include/hip/hcc_detail/texture_functions.h
+++ b/include/hip/hcc_detail/texture_functions.h
@@ -168,7 +168,20 @@ union TData {
 extern "C" {
 
 // this is really a sparse array with only valid values being the ones indexed by the enum hipArray_Format(e.g. texFormatToSize[HIP_AD_FORMAT_UNSIGNED_INT8] = UCHAR_MAX)
-__device__ __constant__ static int texFormatToSize[] = {1,UCHAR_MAX,USHRT_MAX,1,1,1,1,1,SCHAR_MAX,SHRT_MAX,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};
+__device__ __constant__ static int texFormatToSize[] = {
+    1, /* HIP_AD_FORMAT_NOT_INITIALIZED */
+    UCHAR_MAX, /* HIP_AD_FORMAT_UNSIGNED_INT8 */
+    USHRT_MAX, /* HIP_AD_FORMAT_UNSIGNED_INT16 */
+    1, /* HIP_AD_FORMAT_UNSIGNED_INT32 */
+    1,1,1,1, /* Invalid values */
+    SCHAR_MAX, /* HIP_AD_FORMAT_SIGNED_INT8 */
+    SHRT_MAX, /* HIP_AD_FORMAT_SIGNED_INT16 */
+    1, /* HIP_AD_FORMAT_SIGNED_INT32 */
+    1,1,1,1,1, /* Invalid values */
+    1, /* HIP_AD_FORMAT_HALF */
+    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1, /* Invalid values */
+    1 /* HIP_AD_FORMAT_FLOAT */
+};
 
 __device__
 __hip_float4_vector_value_type __ockl_image_sample_1D(

--- a/include/hip/hcc_detail/texture_functions.h
+++ b/include/hip/hcc_detail/texture_functions.h
@@ -157,8 +157,6 @@ union TData {
 
 #define TEXTURE_RETURN_UINT_XYZW return make_uint4(texel.u.x, texel.u.y, texel.u.z, texel.u.w);
 
-#define HIP_AD_FORMAT_NOT_INITIALIZED 0
-
 #define TEXTURE_RETURN_FLOAT return (texFormatToSize[texRef.format] == 1)? texel.f.x : (float)texel.u.x/texFormatToSize[texRef.format];
 
 #define TEXTURE_RETURN_FLOAT_X return (texFormatToSize[texRef.format] == 1)? make_float1(texel.f.x) : make_float1((float)texel.u.x/texFormatToSize[texRef.format]);
@@ -169,17 +167,8 @@ union TData {
 
 extern "C" {
 
- __device__ __constant__ static int texFormatToSize[] = {
-    [HIP_AD_FORMAT_NOT_INITIALIZED] = 1  ,
-    [HIP_AD_FORMAT_UNSIGNED_INT8] = UCHAR_MAX ,
-    [HIP_AD_FORMAT_UNSIGNED_INT16]= USHRT_MAX,
-    [HIP_AD_FORMAT_UNSIGNED_INT32]= 1    ,
-    [HIP_AD_FORMAT_SIGNED_INT8]   = SCHAR_MAX,
-    [HIP_AD_FORMAT_SIGNED_INT16]  = SHRT_MAX,
-    [HIP_AD_FORMAT_SIGNED_INT32]  = 1    ,
-    [HIP_AD_FORMAT_HALF]          = 1    ,
-    [HIP_AD_FORMAT_FLOAT]         = 1
-};
+// this is really a sparse array with only valid values being the ones indexed by the enum hipArray_Format(e.g. texFormatToSize[HIP_AD_FORMAT_UNSIGNED_INT8] = UCHAR_MAX)
+__device__ __constant__ static int texFormatToSize[] = {1,UCHAR_MAX,USHRT_MAX,1,1,1,1,1,SCHAR_MAX,SHRT_MAX,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};
 
 __device__
 __hip_float4_vector_value_type __ockl_image_sample_1D(


### PR DESCRIPTION
SWDEV-213602
Fixed compilation warning: array designators are a C99 extension [-Wc99-designator]