### PR TITLE
Only add `hipExtLaunchMultiKernelMultiDevice` for non-HCC compilers.

### DIFF
--- a/include/hip/hcc_detail/hip_runtime_api.h
+++ b/include/hip/hcc_detail/hip_runtime_api.h
@@ -2956,7 +2956,7 @@ hipError_t hipOccupancyMaxActiveBlocksPerMultiprocessor(
 hipError_t hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(
    uint32_t* numBlocks, hipFunction_t f, uint32_t blockSize, size_t dynSharedMemPerBlk, unsigned int flags);
 
-#if __HIP_VDI__
+#if __HIP_VDI__ && !defined(__HCC__)
 /**
  * @brief Launches kernels on multiple devices and guarantees all specified kernels are dispatched
  * on respective streams before enqueuing any other work on the specified streams from any other threads


### PR DESCRIPTION
rocBLAS still compile part of code using HCC. With the headers shipped with HIP-Clang, __HIP_VDI__ is turned on unconditionally, that cause a conflict linkage definition for `hipExtLaunchMultiKernelMultiDevice` between the one defined here and the other one defined in `include/hip/hcc_detail/functional_grid_launch.hpp`