### PR TITLE
Fix OOM issues with hipMemcpy test on Windows

### DIFF
--- a/tests/src/runtimeApi/memory/hipMemcpy.cpp
+++ b/tests/src/runtimeApi/memory/hipMemcpy.cpp
@@ -292,8 +292,8 @@ void memcpytest2_get_host_memory(size_t& free, size_t& total) {
     MEMORYSTATUSEX status;
     status.dwLength = sizeof(status);
     GlobalMemoryStatusEx(&status);
-    free = status.ullAvailPhys;
-    total = status.ullTotalPhys;
+    free = (0.4 * status.ullAvailPhys);
+    total = (0.4 * status.ullTotalPhys);
 }
 #else
 struct sysinfo memInfo;

--- a/tests/src/runtimeApi/memory/hipMemcpy.cpp
+++ b/tests/src/runtimeApi/memory/hipMemcpy.cpp
@@ -292,8 +292,8 @@ void memcpytest2_get_host_memory(size_t& free, size_t& total) {
     MEMORYSTATUSEX status;
     status.dwLength = sizeof(status);
     GlobalMemoryStatusEx(&status);
-    free = (0.4 * status.ullAvailPhys);
-    total = (0.4 * status.ullTotalPhys);
+    free = static_cast<size_t>(0.4 * status.ullAvailPhys);
+    total = static_cast<size_t>(0.4 * status.ullTotalPhys);
 }
 #else
 struct sysinfo memInfo;

--- a/tests/src/runtimeApi/memory/hipMemcpy.cpp
+++ b/tests/src/runtimeApi/memory/hipMemcpy.cpp
@@ -292,6 +292,10 @@ void memcpytest2_get_host_memory(size_t& free, size_t& total) {
     MEMORYSTATUSEX status;
     status.dwLength = sizeof(status);
     GlobalMemoryStatusEx(&status);
+    // Windows doesn't allow allocating more than half of system memory to the gpu.
+    // Since the runtime also needs space for its internal allocations,
+    // we should not try to allocate more than 40% of reported system memory,
+    // otherwise we can run into OOM issues.
     free = static_cast<size_t>(0.4 * status.ullAvailPhys);
     total = static_cast<size_t>(0.4 * status.ullTotalPhys);
 }


### PR DESCRIPTION
Windows has a complicated way of calculating how much system memory is available for the gpu (see https://docs.microsoft.com/en-us/windows-hardware/drivers/display/calculating-graphics-memory). At most half of system memory is available for the gpu for allocation, however not all of it can be resident on the device at the same time. To calculate that amount it would require a lot of DDI calls to query the aperture sizes and commit limits. That's unreasonable to do in a test, so instead just cap the amount of system memory we report to 40%.