### PR TITLE
[HIP] Unify hipError_t (Step 1)

### DIFF
--- a/hipify-clang/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/hipify-clang/src/CUDA2HIP_Runtime_API_types.cpp
@@ -597,8 +597,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // cudaError enum values
   // CUDA_SUCCESS
   {"cudaSuccess",                                                      {"hipSuccess",                                               "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 0
-  // cudaErrorInvalidValue = 1, CUDA_ERROR_INVALID_VALUE = 1, hipErrorInvalidValue = 1011
-  // TODO [HIP]: make hipErrorInvalidValue = 1
   // CUDA_ERROR_INVALID_VALUE
   {"cudaErrorInvalidValue",                                            {"hipErrorInvalidValue",                                     "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 1
   // cudaErrorMemoryAllocation = 2, CUDA_ERROR_OUT_OF_MEMORY = 2, hipErrorOutOfMemory = 2, hipErrorMemoryAllocation = 1002
@@ -624,21 +622,15 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // Deprecated since CUDA 5.0
   // CUDA_ERROR_PROFILER_ALREADY_STOPPED
   {"cudaErrorProfilerAlreadyStopped",                                  {"hipErrorProfilerAlreadyStopped",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 8
-  // cudaErrorInvalidConfiguration = 9, hipErrorInvalidConfiguration = 1009
-  // TODO [HIP]: make hipErrorInvalidConfiguration = 9
   // no analogue
   {"cudaErrorInvalidConfiguration",                                    {"hipErrorInvalidConfiguration",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 9
   // no analogue
   {"cudaErrorInvalidPitchValue",                                       {"hipErrorInvalidPitchValue",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 12
-  // cudaErrorInvalidSymbol = 13, hipErrorInvalidSymbol = 701, but also cudaErrorLaunchOutOfResources = CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES = 701
-  // TODO [HIP]: make hipErrorInvalidSymbol = 13
   // no analogue
   {"cudaErrorInvalidSymbol",                                           {"hipErrorInvalidSymbol",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 13
   // Deprecated since CUDA 10.1
   // no analogue
   {"cudaErrorInvalidHostPointer",                                      {"hipErrorInvalidHostPointer",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 16
-  // cudaErrorInvalidDevicePointer = 17, hipErrorInvalidDevicePointer = 1017
-  // TODO [HIP]: make hipErrorInvalidDevicePointer = 17
   // Deprecated since CUDA 10.1
   // no analogue
   {"cudaErrorInvalidDevicePointer",                                    {"hipErrorInvalidDevicePointer",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 17
@@ -648,8 +640,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaErrorInvalidTextureBinding",                                   {"hipErrorInvalidTextureBinding",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 19
   // no analogue
   {"cudaErrorInvalidChannelDescriptor",                                {"hipErrorInvalidChannelDescriptor",                         "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 20
-  // cudaErrorInvalidMemcpyDirection = 21, hipErrorInvalidMemcpyDirection = 1021
-  // TODO [HIP]: make hipErrorInvalidMemcpyDirection = 21
   // no analogue
   {"cudaErrorInvalidMemcpyDirection",                                  {"hipErrorInvalidMemcpyDirection",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 21
   // no analogue
@@ -686,12 +676,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaErrorDevicesUnavailable",                                      {"hipErrorDevicesUnavailable",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 46
   // no analogue
   {"cudaErrorIncompatibleDriverContext",                               {"hipErrorIncompatibleDriverContext",                        "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 49
-  // cudaErrorMissingConfiguration = 52, hipErrorMissingConfiguration = 1001
-  // TODO [HIP]: make hipErrorMissingConfiguration = 52
   // no analogue
   {"cudaErrorMissingConfiguration",                                    {"hipErrorMissingConfiguration",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 52
-  // cudaErrorPriorLaunchFailure = 53, hipErrorPriorLaunchFailure = 1005
-  // TODO [HIP]: make hipErrorPriorLaunchFailure = 53
   // no analogue
   {"cudaErrorPriorLaunchFailure",                                      {"hipErrorPriorLaunchFailure",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 53
   // no analogue
@@ -704,16 +690,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaErrorSyncDepthExceeded",                                       {"hipErrorSyncDepthExceeded",                                "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 68
   // no analogue
   {"cudaErrorLaunchPendingCountExceeded",                              {"hipErrorLaunchPendingCountExceeded",                       "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 69
-  // cudaErrorInvalidDeviceFunction = 98, hipErrorInvalidDeviceFunction = 1008
-  // TODO [HIP]: make hipErrorInvalidDeviceFunction = 98
   // no analogue
   {"cudaErrorInvalidDeviceFunction",                                   {"hipErrorInvalidDeviceFunction",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 98
-  // cudaErrorNoDevice = 100, CUDA_ERROR_NO_DEVICE = 100, hipErrorNoDevice = 1038
-  // TODO [HIP]: make hipErrorNoDevice = 100
   // CUDA_ERROR_NO_DEVICE
   {"cudaErrorNoDevice",                                                {"hipErrorNoDevice",                                         "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 100
-  // cudaErrorInvalidDevice = 101, CUDA_ERROR_INVALID_DEVICE = 101, hipErrorInvalidDevice = 1010
-  // TODO [HIP]: make hipErrorInvalidDevice = 101
   // CUDA_ERROR_INVALID_DEVICE
   {"cudaErrorInvalidDevice",                                           {"hipErrorInvalidDevice",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 101
   // no analogue
@@ -781,48 +761,30 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaErrorIllegalState",                                            {"hipErrorIllegalState",                                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 401
   // CUDA_ERROR_NOT_FOUND
   {"cudaErrorSymbolNotFound",                                          {"hipErrorNotFound",                                         "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 500
-  // cudaErrorNotReady = 600, CUDA_ERROR_NOT_READY = 600, hipErrorNotReady = 1034
-  // TODO [HIP]: make hipErrorNotReady = 600
   // CUDA_ERROR_NOT_READY
   {"cudaErrorNotReady",                                                {"hipErrorNotReady",                                         "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 600
  // CUDA_ERROR_ILLEGAL_ADDRESS
   {"cudaErrorIllegalAddress",                                          {"hipErrorIllegalAddress",                                   "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 700
-  // cudaErrorLaunchOutOfResources = 701, CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES = 701, hipErrorLaunchOutOfResources = 1007
-  // TODO [HIP]: make hipErrorLaunchOutOfResources = 701
   // CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES
   {"cudaErrorLaunchOutOfResources",                                    {"hipErrorLaunchOutOfResources",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 701
-  // cudaErrorLaunchTimeout = 702, CUDA_ERROR_LAUNCH_TIMEOUT = 702, hipErrorLaunchTimeOut = 1006
-  // TODO [HIP]: make hipErrorLaunchTimeOut = 702
   // CUDA_ERROR_LAUNCH_TIMEOUT
   {"cudaErrorLaunchTimeout",                                           {"hipErrorLaunchTimeOut",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 702
   // CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING
   {"cudaErrorLaunchIncompatibleTexturing",                             {"hipErrorLaunchIncompatibleTexturing",                      "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 703
-  // cudaErrorPeerAccessAlreadyEnabled = 704, CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED = 704, hipErrorPeerAccessAlreadyEnabled = 1050
-  // TODO [HIP]: make hipErrorPeerAccessAlreadyEnabled = 704
   // CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED
   {"cudaErrorPeerAccessAlreadyEnabled",                                {"hipErrorPeerAccessAlreadyEnabled",                         "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 704
-  // cudaErrorPeerAccessNotEnabled = 705, CUDA_ERROR_PEER_ACCESS_NOT_ENABLED = 705, hipErrorPeerAccessNotEnabled = 1051
-  // TODO [HIP]: make hipErrorPeerAccessNotEnabled = 705
   // CUDA_ERROR_PEER_ACCESS_NOT_ENABLED
   {"cudaErrorPeerAccessNotEnabled",                                    {"hipErrorPeerAccessNotEnabled",                             "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 705
-  // cudaErrorSetOnActiveProcess = 708, CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE = 708, hipErrorSetOnActiveProcess = 305
-  // TODO [HIP]: make hipErrorSetOnActiveProcess = 708
   // CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE
   {"cudaErrorSetOnActiveProcess",                                      {"hipErrorSetOnActiveProcess",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 708
   // CUDA_ERROR_CONTEXT_IS_DESTROYED
   {"cudaErrorContextIsDestroyed",                                      {"hipErrorContextIsDestroyed",                               "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 709
-  // cudaErrorAssert = 710, CUDA_ERROR_ASSERT = 710, hipErrorAssert = 1081
-  // TODO [HIP]: make hipErrorAssert = 710
   // CUDA_ERROR_ASSERT
   {"cudaErrorAssert",                                                  {"hipErrorAssert",                                           "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 710
   // CUDA_ERROR_TOO_MANY_PEERS
   {"cudaErrorTooManyPeers",                                            {"hipErrorTooManyPeers",                                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 711
-  // cudaErrorHostMemoryAlreadyRegistered = 712, CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED = 712, hipErrorHostMemoryAlreadyRegistered = 1061
-  // TODO [HIP]: make hipErrorHostMemoryAlreadyRegistered = 712
   // CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED
   {"cudaErrorHostMemoryAlreadyRegistered",                             {"hipErrorHostMemoryAlreadyRegistered",                      "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 712
-  // cudaErrorHostMemoryNotRegistered = 713, CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED = 713, hipErrorHostMemoryNotRegistered = 1062
-  // TODO [HIP]: make hipErrorHostMemoryNotRegistered = 713
   // CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED
   {"cudaErrorHostMemoryNotRegistered",                                 {"hipErrorHostMemoryNotRegistered",                          "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 713
   // CUDA_ERROR_HARDWARE_STACK_ERROR
@@ -835,16 +797,12 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaErrorInvalidAddressSpace",                                     {"hipErrorInvalidAddressSpace",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 717
   // CUDA_ERROR_INVALID_PC
   {"cudaErrorInvalidPc",                                               {"hipErrorInvalidPc",                                        "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 718
-  // cudaErrorLaunchFailure = 719, CUDA_ERROR_LAUNCH_FAILED = 719, hipErrorLaunchFailure = 1004
-  // TODO [HIP]: make hipErrorSetOnActiveProcess = 719
   // CUDA_ERROR_LAUNCH_FAILED
   {"cudaErrorLaunchFailure",                                           {"hipErrorLaunchFailure",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 719
   // no analogue
   {"cudaErrorCooperativeLaunchTooLarge",                               {"hipErrorCooperativeLaunchTooLarge",                        "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 720
   // CUDA_ERROR_NOT_PERMITTED
   {"cudaErrorNotPermitted",                                            {"hipErrorNotPermitted",                                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 800
-  // cudaErrorNotSupported = 801, CUDA_ERROR_NOT_SUPPORTED = 801, hipErrorNotSupported = 1082
-  // TODO [HIP]: make hipErrorNotSupported = 801
   // CUDA_ERROR_NOT_SUPPORTED
   {"cudaErrorNotSupported",                                            {"hipErrorNotSupported",                                     "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 801
   // CUDA_ERROR_SYSTEM_NOT_READY
@@ -875,8 +833,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaErrorTimeout",                                                 {"hipErrorTimeout",                                          "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 909
   // CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE
   {"cudaErrorGraphExecUpdateFailure",                                  {"hipErrorGraphExecUpdateFailure",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 910
-  // cudaErrorUnknown = 999, CUDA_ERROR_UNKNOWN = 999, hipErrorUnknown = 1030
-  // TODO [HIP]: make hipErrorUnknown = 999
   // CUDA_ERROR_UNKNOWN
   {"cudaErrorUnknown",                                                 {"hipErrorUnknown",                                          "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 999
   // Deprecated since CUDA 4.1

--- a/include/hip/hip_runtime_api.h
+++ b/include/hip/hip_runtime_api.h
@@ -183,6 +183,8 @@ typedef struct hipPointerAttribute_t {
 
 typedef enum __HIP_NODISCARD hipError_t {
     hipSuccess = 0,  ///< Successful completion.
+    hipErrorInvalidValue = 1,  ///< One or more of the parameters passed to the API call is NULL
+                               ///< or not in an acceptable range.
     hipErrorOutOfMemory = 2,
     hipErrorNotInitialized = 3,
     hipErrorDeinitialized = 4,
@@ -190,7 +192,16 @@ typedef enum __HIP_NODISCARD hipError_t {
     hipErrorProfilerNotInitialized = 6,
     hipErrorProfilerAlreadyStarted = 7,
     hipErrorProfilerAlreadyStopped = 8,
+    hipErrorInvalidConfiguration = 9,
+    hipErrorInvalidSymbol = 13,
+    hipErrorInvalidDevicePointer = 17,  ///< Invalid Device Pointer
+    hipErrorInvalidMemcpyDirection = 21,  ///< Invalid memory copy direction
     hipErrorInsufficientDriver = 35,
+    hipErrorMissingConfiguration = 52,
+    hipErrorPriorLaunchFailure = 53,
+    hipErrorInvalidDeviceFunction = 98,
+    hipErrorNoDevice = 100,  ///< Call to hipGetDeviceCount returned 0 devices
+    hipErrorInvalidDevice = 101,  ///< DeviceID must be in range 0...#compute-devices.
     hipErrorInvalidImage = 200,
     hipErrorInvalidContext = 201,  ///< Produced when input context is invalid.
     hipErrorContextAlreadyCurrent = 202,
@@ -214,53 +225,40 @@ typedef enum __HIP_NODISCARD hipError_t {
     hipErrorSharedObjectSymbolNotFound = 302,
     hipErrorSharedObjectInitFailed = 303,
     hipErrorOperatingSystem = 304,
-    hipErrorSetOnActiveProcess = 305,
     hipErrorInvalidHandle = 400,
     hipErrorNotFound = 500,
+    hipErrorNotReady = 600,  ///< Indicates that asynchronous operations enqueued earlier are not
+                             ///< ready.  This is not actually an error, but is used to distinguish
+                             ///< from hipSuccess (which indicates completion).  APIs that return
+                             ///< this error include hipEventQuery and hipStreamQuery.
     hipErrorIllegalAddress = 700,
-    hipErrorInvalidSymbol = 701,
-    // Runtime Error Codes start here.
-    hipErrorMissingConfiguration = 1001,
-    hipErrorMemoryAllocation = 1002,     ///< Memory allocation error.
-    hipErrorInitializationError = 1003,  ///< TODO comment from hipErrorInitializationError
-    hipErrorLaunchFailure =
-        1004,  ///< An exception occurred on the device while executing a kernel.
-    hipErrorPriorLaunchFailure = 1005,
-    hipErrorLaunchTimeOut = 1006,
-    hipErrorLaunchOutOfResources = 1007,  ///< Out of resources error.
-    hipErrorInvalidDeviceFunction = 1008,
-    hipErrorInvalidConfiguration = 1009,
-    hipErrorInvalidDevice = 1010,  ///< DeviceID must be in range 0...#compute-devices.
-    hipErrorInvalidValue = 1011,   ///< One or more of the parameters passed to the API call is NULL
-                                   ///< or not in an acceptable range.
-    hipErrorInvalidDevicePointer = 1017,    ///< Invalid Device Pointer
-    hipErrorInvalidMemcpyDirection = 1021,  ///< Invalid memory copy direction
-    hipErrorUnknown = 1030,                 ///< Unknown error.
-    hipErrorInvalidResourceHandle = 1033,  ///< Resource handle (hipEvent_t or hipStream_t) invalid.
-    hipErrorNotReady = 1034,  ///< Indicates that asynchronous operations enqueued earlier are not
-                              ///< ready.  This is not actually an error, but is used to distinguish
-                              ///< from hipSuccess (which indicates completion).  APIs that return
-                              ///< this error include hipEventQuery and hipStreamQuery.
-    hipErrorNoDevice = 1038,  ///< Call to hipGetDeviceCount returned 0 devices
+    hipErrorLaunchOutOfResources = 701,  ///< Out of resources error.
+    hipErrorLaunchTimeOut = 702,
     hipErrorPeerAccessAlreadyEnabled =
-        1050,  ///< Peer access was already enabled from the current device.
-
+        704,  ///< Peer access was already enabled from the current device.
     hipErrorPeerAccessNotEnabled =
-        1051,                      ///< Peer access was never enabled from the current device.
+        705,  ///< Peer access was never enabled from the current device.
+    hipErrorSetOnActiveProcess = 708,
+    hipErrorAssert = 710,  ///< Produced when the kernel calls assert.
+    hipErrorHostMemoryAlreadyRegistered =
+        712,  ///< Produced when trying to lock a page-locked memory.
+    hipErrorHostMemoryNotRegistered =
+        713,  ///< Produced when trying to unlock a non-page-locked memory.
+    hipErrorLaunchFailure =
+        719,  ///< An exception occurred on the device while executing a kernel.
+    hipErrorNotSupported = 801,  ///< Produced when the hip API is not supported/implemented
+    hipErrorUnknown = 999,  //< Unknown error.
+
+    // Runtime Error Codes start here.
+    hipErrorMemoryAllocation = 1002,  ///< Memory allocation error.
+    hipErrorInitializationError = 1003,  ///< TODO comment from hipErrorInitializationError
+    hipErrorInvalidResourceHandle = 1033,  ///< Resource handle (hipEvent_t or hipStream_t) invalid.
     hipErrorRuntimeMemory = 1052,  ///< HSA runtime memory call returned error.  Typically not seen
                                    ///< in production systems.
     hipErrorRuntimeOther = 1053,  ///< HSA runtime call other than memory returned error.  Typically
                                   ///< not seen in production systems.
-    hipErrorHostMemoryAlreadyRegistered =
-        1061,  ///< Produced when trying to lock a page-locked memory.
-    hipErrorHostMemoryNotRegistered =
-        1062,  ///< Produced when trying to unlock a non-page-locked memory.
     hipErrorMapBufferObjectFailed =
-        1071,    ///< Produced when the IPC memory attach failed from ROCr.
-    hipErrorAssert =
-        1081,    ///< Produced when the kernel calls assert.
-    hipErrorNotSupported = 
-        1082,    ///< Produced when the hip API is not supported/implemented 
+        1071,  ///< Produced when the IPC memory attach failed from ROCr.
     hipErrorTbd  ///< Marker that more error codes are needed.
 } hipError_t;
 


### PR DESCRIPTION
Step 1. Set the same values for RT error codes as for analogous Driver's

[Reason] RT's and Driver's error codes unification in CUDA 10.2