### PR TITLE
[HIPIFY] Revise HIP runtime

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -199,9 +199,9 @@ sub simpleSubstitutions {
     $ft{'memory'} += s/\bcuIpcGetMemHandle\b/hipIpcGetMemHandle/g;
     $ft{'memory'} += s/\bcuIpcOpenMemHandle\b/hipIpcOpenMemHandle/g;
     $ft{'memory'} += s/\bcuMemAlloc\b/hipMalloc/g;
-    $ft{'memory'} += s/\bcuMemAllocHost\b/hipMemAllocHost/g;
-    $ft{'memory'} += s/\bcuMemAllocHost_v2\b/hipMemAllocHost/g;
-    $ft{'memory'} += s/\bcuMemAllocManaged\b/hipMemAllocManaged/g;
+    $ft{'memory'} += s/\bcuMemAllocHost\b/hipHostMalloc/g;
+    $ft{'memory'} += s/\bcuMemAllocHost_v2\b/hipHostMalloc/g;
+    $ft{'memory'} += s/\bcuMemAllocManaged\b/hipMallocManaged/g;
     $ft{'memory'} += s/\bcuMemAllocPitch\b/hipMemAllocPitch/g;
     $ft{'memory'} += s/\bcuMemAllocPitch_v2\b/hipMemAllocPitch/g;
     $ft{'memory'} += s/\bcuMemAlloc_v2\b/hipMalloc/g;
@@ -215,7 +215,7 @@ sub simpleSubstitutions {
     $ft{'memory'} += s/\bcuMemHostAlloc\b/hipHostMalloc/g;
     $ft{'memory'} += s/\bcuMemHostGetDevicePointer\b/hipHostGetDevicePointer/g;
     $ft{'memory'} += s/\bcuMemHostGetDevicePointer_v2\b/hipHostGetDevicePointer/g;
-    $ft{'memory'} += s/\bcuMemHostGetFlags\b/hipMemHostGetFlags/g;
+    $ft{'memory'} += s/\bcuMemHostGetFlags\b/hipHostGetFlags/g;
     $ft{'memory'} += s/\bcuMemHostRegister\b/hipHostRegister/g;
     $ft{'memory'} += s/\bcuMemHostRegister_v2\b/hipHostRegister/g;
     $ft{'memory'} += s/\bcuMemHostUnregister\b/hipHostUnregister/g;
@@ -287,6 +287,8 @@ sub simpleSubstitutions {
     $ft{'memory'} += s/\bcudaMemset\b/hipMemset/g;
     $ft{'memory'} += s/\bcudaMemset2D\b/hipMemset2D/g;
     $ft{'memory'} += s/\bcudaMemset2DAsync\b/hipMemset2DAsync/g;
+    $ft{'memory'} += s/\bcudaMemset3D\b/hipMemset3D/g;
+    $ft{'memory'} += s/\bcudaMemset3DAsync\b/hipMemset3DAsync/g;
     $ft{'memory'} += s/\bcudaMemsetAsync\b/hipMemsetAsync/g;
     $ft{'memory'} += s/\bmake_cudaExtent\b/make_hipExtent/g;
     $ft{'memory'} += s/\bmake_cudaPitchedPtr\b/make_hipPitchedPtr/g;
@@ -1706,7 +1708,7 @@ sub simpleSubstitutions {
     $ft{'define'} += s/\bCU_LAUNCH_PARAM_END\b/HIP_LAUNCH_PARAM_END/g;
     $ft{'define'} += s/\bCU_MEMHOSTALLOC_DEVICEMAP\b/hipHostMallocMapped/g;
     $ft{'define'} += s/\bCU_MEMHOSTALLOC_PORTABLE\b/hipHostMallocPortable/g;
-    $ft{'define'} += s/\bCU_MEMHOSTALLOC_WRITECOMBINED\b/hipHostAllocWriteCombined/g;
+    $ft{'define'} += s/\bCU_MEMHOSTALLOC_WRITECOMBINED\b/hipHostMallocWriteCombined/g;
     $ft{'define'} += s/\bCU_MEMHOSTREGISTER_DEVICEMAP\b/hipHostRegisterMapped/g;
     $ft{'define'} += s/\bCU_MEMHOSTREGISTER_IOMEMORY\b/hipHostRegisterIoMemory/g;
     $ft{'define'} += s/\bCU_MEMHOSTREGISTER_PORTABLE\b/hipHostRegisterPortable/g;
@@ -1736,7 +1738,7 @@ sub simpleSubstitutions {
     $ft{'define'} += s/\bcudaHostAllocDefault\b/hipHostMallocDefault/g;
     $ft{'define'} += s/\bcudaHostAllocMapped\b/hipHostMallocMapped/g;
     $ft{'define'} += s/\bcudaHostAllocPortable\b/hipHostMallocPortable/g;
-    $ft{'define'} += s/\bcudaHostAllocWriteCombined\b/hipHostAllocWriteCombined/g;
+    $ft{'define'} += s/\bcudaHostAllocWriteCombined\b/hipHostMallocWriteCombined/g;
     $ft{'define'} += s/\bcudaHostRegisterDefault\b/hipHostRegisterDefault/g;
     $ft{'define'} += s/\bcudaHostRegisterIoMemory\b/hipHostRegisterIoMemory/g;
     $ft{'define'} += s/\bcudaHostRegisterMapped\b/hipHostRegisterMapped/g;

--- a/docs/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -561,7 +561,7 @@
 | define       |`CU_LAUNCH_PARAM_END`                                               |`HIP_LAUNCH_PARAM_END`                                      |
 | define       |`CU_MEMHOSTALLOC_DEVICEMAP`                                         |`hipHostMallocMapped`                                       |
 | define       |`CU_MEMHOSTALLOC_PORTABLE`                                          |`hipHostMallocPortable`                                     |
-| define       |`CU_MEMHOSTALLOC_WRITECOMBINED`                                     |`hipHostAllocWriteCombined`                                 |
+| define       |`CU_MEMHOSTALLOC_WRITECOMBINED`                                     |`hipHostMallocWriteCombined`                                |
 | define       |`CU_MEMHOSTREGISTER_DEVICEMAP`                                      |`hipHostRegisterMapped`                                     |
 | define       |`CU_MEMHOSTREGISTER_IOMEMORY`                                       |`hipHostRegisterIoMemory`                                   | 7.5              |
 | define       |`CU_MEMHOSTREGISTER_PORTABLE`                                       |`hipHostRegisterPortable`                                   |
@@ -916,8 +916,8 @@
 | `cuIpcOpenEventHandle`                                    |                               |
 | `cuIpcOpenMemHandle`                                      | `hipIpcOpenMemHandle`         |
 | `cuMemAlloc`                                              | `hipMalloc`                   |
-| `cuMemAllocHost`                                          | `hipMemAllocHost`             |
-| `cuMemAllocManaged`                                       | `hipMemAllocManaged`          |
+| `cuMemAllocHost`                                          | `hipHostMalloc`               |
+| `cuMemAllocManaged`                                       | `hipMallocManaged`            |
 | `cuMemAllocPitch`                                         | `hipMemAllocPitch`            |
 | `cuMemcpy`                                                |                               |
 | `cuMemcpy2D`                                              | `hipMemcpyParam2D`            |
@@ -944,7 +944,7 @@
 | `cuMemcpyPeer`                                            |                               |
 | `cuMemcpyPeerAsync`                                       |                               |
 | `cuMemFree`                                               | `hipFree`                     |
-| `cuMemFreeHost`                                           | `hipFreeHost`                 |
+| `cuMemFreeHost`                                           | `hipHostFree`                 |
 | `cuMemGetAddressRange`                                    | `hipMemGetAddressRange`       |
 | `cuMemGetInfo`                                            | `hipMemGetInfo`               |
 | `cuMemHostAlloc`                                          | `hipHostMalloc`               |

--- a/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -166,7 +166,7 @@
 | `cudaMemcpy2DToArray`                                     | `hipMemcpy2DToArray`          |
 | `cudaMemcpy2DToArrayAsync`                                |                               |
 | `cudaMemcpy3D`                                            | `hipMemcpy3D`                 |
-| `cudaMemcpy3DAsync`                                       |                               |
+| `cudaMemcpy3DAsync`                                       | `hipMemcpy3DAsync`            |
 | `cudaMemcpy3DPeer`                                        |                               |
 | `cudaMemcpy3DPeerAsync`                                   |                               |
 | `cudaMemcpyAsync`                                         | `hipMemcpyAsync`              |
@@ -179,8 +179,8 @@
 | `cudaMemset`                                              | `hipMemset`                   |
 | `cudaMemset2D`                                            | `hipMemset2D`                 |
 | `cudaMemset2DAsync`                                       | `hipMemset2DAsync`            |
-| `cudaMemset3D`                                            |                               |
-| `cudaMemset3DAsync`                                       |                               |
+| `cudaMemset3D`                                            | `hipMemset3D`                 |
+| `cudaMemset3DAsync`                                       | `hipMemset3DAsync`            |
 | `cudaMemsetAsync`                                         | `hipMemsetAsync`              |
 | `make_cudaExtent`                                         | `make_hipExtent`              |
 | `make_cudaPitchedPtr`                                     | `make_hipPitchedPtr`          |

--- a/hipify-clang/src/CUDA2HIP_Driver_API_functions.cpp
+++ b/hipify-clang/src/CUDA2HIP_Driver_API_functions.cpp
@@ -164,10 +164,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP{
   {"cuMemAlloc",                                           {"hipMalloc",                                               "", CONV_MEMORY, API_DRIVER}},
   {"cuMemAlloc_v2",                                        {"hipMalloc",                                               "", CONV_MEMORY, API_DRIVER}},
   // cudaHostAlloc
-  {"cuMemAllocHost",                                       {"hipMemAllocHost",                                         "", CONV_MEMORY, API_DRIVER}},
-  {"cuMemAllocHost_v2",                                    {"hipMemAllocHost",                                         "", CONV_MEMORY, API_DRIVER}},
+  {"cuMemAllocHost",                                       {"hipHostMalloc",                                           "", CONV_MEMORY, API_DRIVER}},
+  {"cuMemAllocHost_v2",                                    {"hipHostMalloc",                                           "", CONV_MEMORY, API_DRIVER}},
   // cudaMallocManaged
-  {"cuMemAllocManaged",                                    {"hipMemAllocManaged",                                      "", CONV_MEMORY, API_DRIVER}},
+  {"cuMemAllocManaged",                                    {"hipMallocManaged",                                        "", CONV_MEMORY, API_DRIVER}},
   // no analogue
   // NOTE: Not equal to cudaMallocPitch due to different signatures
   {"cuMemAllocPitch",                                      {"hipMemAllocPitch",                                        "", CONV_MEMORY, API_DRIVER}},
@@ -266,7 +266,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP{
   {"cuMemHostGetDevicePointer",                            {"hipHostGetDevicePointer",                                 "", CONV_MEMORY, API_DRIVER}},
   {"cuMemHostGetDevicePointer_v2",                         {"hipHostGetDevicePointer",                                 "", CONV_MEMORY, API_DRIVER}},
   // cudaHostGetFlags
-  {"cuMemHostGetFlags",                                    {"hipMemHostGetFlags",                                      "", CONV_MEMORY, API_DRIVER}},
+  {"cuMemHostGetFlags",                                    {"hipHostGetFlags",                                         "", CONV_MEMORY, API_DRIVER}},
   // cudaHostRegister
   {"cuMemHostRegister",                                    {"hipHostRegister",                                         "", CONV_MEMORY, API_DRIVER}},
   {"cuMemHostRegister_v2",                                 {"hipHostRegister",                                         "", CONV_MEMORY, API_DRIVER}},
@@ -340,7 +340,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_FUNCTION_MAP{
   {"cuPointerGetAttribute",                                {"hipPointerGetAttribute",                                  "", CONV_ADDRESSING, API_DRIVER, HIP_UNSUPPORTED}},
   // no analogue
   // NOTE: Not equal to cudaPointerGetAttributes due to different signatures
-  {"cuPointerGetAttributes",                               {"hipPointerGetAttributes",                                 "", CONV_ADDRESSING, API_DRIVER, HIP_UNSUPPORTED}},
+  {"cuPointerGetAttributes",                               {"hipPointerGetAttributes_",                                "", CONV_ADDRESSING, API_DRIVER, HIP_UNSUPPORTED}},
   // no analogue
   {"cuPointerSetAttribute",                                {"hipPointerSetAttribute",                                  "", CONV_ADDRESSING, API_DRIVER, HIP_UNSUPPORTED}},
 

--- a/hipify-clang/src/CUDA2HIP_Driver_API_types.cpp
+++ b/hipify-clang/src/CUDA2HIP_Driver_API_types.cpp
@@ -1606,7 +1606,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP{
   // cudaHostAllocMapped
   {"CU_MEMHOSTALLOC_DEVICEMAP",                                        {"hipHostMallocMapped",                                      "", CONV_DEFINE, API_DRIVER}}, // 0x02
   // cudaHostAllocWriteCombined
-  {"CU_MEMHOSTALLOC_WRITECOMBINED",                                    {"hipHostAllocWriteCombined",                                "", CONV_DEFINE, API_DRIVER}}, // 0x04
+  {"CU_MEMHOSTALLOC_WRITECOMBINED",                                    {"hipHostMallocWriteCombined",                               "", CONV_DEFINE, API_DRIVER}}, // 0x04
   // cudaHostRegisterPortable
   {"CU_MEMHOSTREGISTER_PORTABLE",                                      {"hipHostRegisterPortable",                                  "", CONV_DEFINE, API_DRIVER}}, // 0x01
   // cudaHostRegisterMapped

--- a/hipify-clang/src/CUDA2HIP_Runtime_API_functions.cpp
+++ b/hipify-clang/src/CUDA2HIP_Runtime_API_functions.cpp
@@ -254,7 +254,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP{
   // no analogue
   {"cudaGetSymbolSize",                                       {"hipGetSymbolSize",                                       "", CONV_MEMORY, API_RUNTIME}},
   // cuMemHostAlloc
-  // NOTE: hipHostAlloc deprecated - use hipHostMalloc instead
   {"cudaHostAlloc",                                           {"hipHostMalloc",                                          "", CONV_MEMORY, API_RUNTIME}},
   // cuMemHostGetDevicePointer
   {"cudaHostGetDevicePointer",                                {"hipHostGetDevicePointer",                                "", CONV_MEMORY, API_RUNTIME}},
@@ -340,16 +339,16 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_FUNCTION_MAP{
   {"cudaMemRangeGetAttribute",                                {"hipMemRangeGetAttribute",                                "", CONV_MEMORY, API_RUNTIME, HIP_UNSUPPORTED}},
   // cuMemRangeGetAttributes
   {"cudaMemRangeGetAttributes",                               {"hipMemRangeGetAttributes",                               "", CONV_MEMORY, API_RUNTIME, HIP_UNSUPPORTED}},
-  // cuMemsetD32
+  // cuMemsetD32 - hipMemsetD32
   {"cudaMemset",                                              {"hipMemset",                                              "", CONV_MEMORY, API_RUNTIME}},
   // no analogue
   {"cudaMemset2D",                                            {"hipMemset2D",                                            "", CONV_MEMORY, API_RUNTIME}},
   // no analogue
   {"cudaMemset2DAsync",                                       {"hipMemset2DAsync",                                       "", CONV_MEMORY, API_RUNTIME}},
   // no analogue
-  {"cudaMemset3D",                                            {"hipMemset3D",                                            "", CONV_MEMORY, API_RUNTIME, HIP_UNSUPPORTED}},
+  {"cudaMemset3D",                                            {"hipMemset3D",                                            "", CONV_MEMORY, API_RUNTIME}},
   // no analogue
-  {"cudaMemset3DAsync",                                       {"hipMemset3DAsync",                                       "", CONV_MEMORY, API_RUNTIME, HIP_UNSUPPORTED}},
+  {"cudaMemset3DAsync",                                       {"hipMemset3DAsync",                                       "", CONV_MEMORY, API_RUNTIME}},
   // cuMemsetD32Async
   {"cudaMemsetAsync",                                         {"hipMemsetAsync",                                         "", CONV_MEMORY, API_RUNTIME}},
   // no analogue

--- a/hipify-clang/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/hipify-clang/src/CUDA2HIP_Runtime_API_types.cpp
@@ -1436,7 +1436,7 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   // CU_MEMHOSTALLOC_DEVICEMAP
   {"cudaHostAllocMapped",                                              {"hipHostMallocMapped",                                      "", CONV_DEFINE, API_RUNTIME}}, // 0x02
   // CU_MEMHOSTALLOC_WRITECOMBINED
-  {"cudaHostAllocWriteCombined",                                       {"hipHostAllocWriteCombined",                                "", CONV_DEFINE, API_RUNTIME}}, // 0x04
+  {"cudaHostAllocWriteCombined",                                       {"hipHostMallocWriteCombined",                               "", CONV_DEFINE, API_RUNTIME}}, // 0x04
   // no analogue
   {"cudaHostRegisterDefault",                                          {"hipHostRegisterDefault",                                   "", CONV_DEFINE, API_RUNTIME}}, // 0x00
   // CU_MEMHOSTREGISTER_PORTABLE


### PR DESCRIPTION
+ hipMemAllocHost is deprecated, use hipHostMalloc instead
+ hipMemAllocManaged -> hipMallocManaged
+ hipFreeHost -> hipHostFree
+ cudaMemset3D(Async) -> hipMemset3D(Async)
+ update docs and hipify-perl accordingly