### PR TITLE
fix for hipcomplex operators failure on g++

### DIFF
--- a/include/hip/hcc_detail/hip_vector_types.h
+++ b/include/hip/hcc_detail/hip_vector_types.h
@@ -41,7 +41,7 @@ THE SOFTWARE.
         #define __NATIVE_VECTOR__(n, ...) [n]
 #endif
 
-#if defined(__cplusplus)
+#if defined(__cplusplus) && defined(__clang__)
     #include <array>
     #include <iosfwd>
     #include <type_traits>


### PR DESCRIPTION
Fixes the failure of few of the operators like unary minus(-) on g++, which resulted in hipSparse compilation failure, as well (SWDEV-216415).  