### PR TITLE
[hip] Add macro guarding the enum conversion for scalar accessor.

### DIFF
--- a/include/hip/hcc_detail/hip_vector_types.h
+++ b/include/hip/hcc_detail/hip_vector_types.h
@@ -109,7 +109,8 @@ THE SOFTWARE.
             operator T() const noexcept { return data[idx]; }
             __host__ __device__
             operator T() const volatile noexcept { return data[idx]; }
-            
+
+#ifdef __HIP_ENABLE_VECTOR_SCALAR_ACCESSORY_ENUM_CONVERSION__
             // The conversions to enum are fairly ghastly, but unfortunately used in
             // some pre-existing, difficult to modify, code.
             template<
@@ -130,6 +131,7 @@ THE SOFTWARE.
                         T, typename std::enable_if<std::is_enum<U>::value, std::underlying_type<U>>::type::type>{}>::type* = nullptr>
             __host__ __device__
             operator U() const volatile noexcept { return static_cast<U>(data[idx]); }
+#endif
 
             __host__ __device__
             operator T&() noexcept {


### PR DESCRIPTION
- That's a high overhead part, which needs enabling ONLY if necessary.

So far, rocFFT cannot be built due to that overhead. Previous 1m compilation time is increased up to 6+ minutes. For other sources, that overheads are too large to be measurable.