### PR TITLE
Remove filesystem dependency in hipRTC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,7 @@ if(HIP_PLATFORM STREQUAL "hcc")
         target_include_directories(
             hiprtc SYSTEM
                 PRIVATE ${PROJECT_SOURCE_DIR}/include ${HSA_PATH}/include)
-        target_link_libraries(hiprtc PUBLIC stdc++fs)
+        target_link_libraries(hiprtc PUBLIC stdc++)
     endif()
     set_target_properties(hip_hcc PROPERTIES CXX_VISIBILITY_PRESET hidden)
     set_target_properties(hip_hcc PROPERTIES VISIBILITY_INLINES_HIDDEN 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,7 +304,6 @@ if(HIP_PLATFORM STREQUAL "hcc")
         target_include_directories(
             hiprtc SYSTEM
                 PRIVATE ${PROJECT_SOURCE_DIR}/include ${HSA_PATH}/include)
-        target_link_libraries(hiprtc PUBLIC stdc++)
     endif()
     set_target_properties(hip_hcc PROPERTIES CXX_VISIBILITY_PRESET hidden)
     set_target_properties(hip_hcc PROPERTIES VISIBILITY_INLINES_HIDDEN 1)

--- a/src/hiprtc.cpp
+++ b/src/hiprtc.cpp
@@ -307,6 +307,17 @@ struct _hiprtcProgram {
         return true;
     }
 
+    void replaceExtension(std::string& fileName, std::string ext) const {
+        auto res = std::find(fileName.begin(), fileName.end(), '.');
+        if(res == std::end(fileName)) {
+            fileName += ext;
+        } else {
+            std::string s(fileName.begin(), res);
+            s += ext;
+            fileName = s;
+        }
+    }
+
     // ACCESSORS
     std::string writeTemporaryFiles(
         const std::string& programFolder) const
@@ -323,7 +334,7 @@ struct _hiprtcProgram {
         });
 
         auto tmp{(programFolder + '/' + name)};
-        tmp += ".cpp"; // Just add extension for now.
+        replaceExtension(tmp, ".cpp");
         ofstream{tmp}.write(source.data(), source.size());
 
         return tmp;

--- a/src/hiprtc.cpp
+++ b/src/hiprtc.cpp
@@ -48,12 +48,7 @@ THE SOFTWARE.
 #include <vector>
 
 #include <iostream>
-
 #include <sys/stat.h>
-
-#if defined(_WIN32)
-#include <direct.h>
-#endif
 
 const char* hiprtcGetErrorString(hiprtcResult x)
 {
@@ -88,28 +83,16 @@ const char* hiprtcGetErrorString(hiprtcResult x)
 
 namespace hip_impl {
 bool exists(const std::string& path) {
-#if defined(_WIN32)
-    struct _stat info;
-    if (_stat(path.c_str(), &info) != 0) {
-        return false;
-    }
-    return (info.st_mode & _S_IFDIR) != 0;
-#else
     struct stat info;
     if (stat(path.c_str(), &info) != 0) {
         return false;
     }
     return (info.st_mode & S_IFDIR) != 0;
-#endif
 }
 
 bool create_directory(const std::string& path) {
-#if defined(_WIN32)
-    int ret = _mkdir(path.c_str());
-#else
     mode_t mode = 0755;
     int ret = mkdir(path.c_str(), mode);
-#endif
     if (ret == 0) return true;
     return false;
 }
@@ -408,12 +391,8 @@ namespace
 
         ~Unique_temporary_path() noexcept
         {
-#if defined(_WIN32)
-            _rmdir(path_.c_str());
-#else
             std::string s("rm -r " + path_);
             system(s.c_str());
-#endif
         }
 
         // MANIPULATORS

--- a/src/hiprtc.cpp
+++ b/src/hiprtc.cpp
@@ -302,8 +302,8 @@ struct _hiprtcProgram {
 
     void replaceExtension(std::string& fileName, const std::string &ext) const {
         auto res = fileName.rfind('.');
-        auto sloc = fileName.rfind('/');
-        if (res != std::string::npos && res > sloc) {
+        auto sloc = fileName.rfind('/'); // slash location
+        if (res != std::string::npos && (res > sloc || sloc == std::string::npos)) {
             fileName.replace(fileName.begin() + res, fileName.end(), ext);
         } else {
             fileName += ext;

--- a/src/hiprtc.cpp
+++ b/src/hiprtc.cpp
@@ -301,12 +301,12 @@ struct _hiprtcProgram {
     }
 
     void replaceExtension(std::string& fileName, const std::string &ext) const {
-        auto res = std::find(fileName.rbegin(), fileName.rend(), '.');
-        auto sloc = std::find(fileName.rbegin(), fileName.rend(), '/');
-        if(res == fileName.rend() || res > sloc) {
-            fileName += ext;
+        auto res = fileName.rfind('.');
+        auto sloc = fileName.rfind('/');
+        if (res != std::string::npos && res > sloc) {
+            fileName.replace(fileName.begin() + res, fileName.end(), ext);
         } else {
-            fileName.replace(res.base(), fileName.end(), ext);
+            fileName += ext;
         }
     }
 
@@ -326,7 +326,7 @@ struct _hiprtcProgram {
         });
 
         auto tmp{(programFolder + '/' + name)};
-        replaceExtension(tmp, "cpp");
+        replaceExtension(tmp, ".cpp");
         ofstream{tmp}.write(source.data(), source.size());
 
         return tmp;

--- a/src/hiprtc.cpp
+++ b/src/hiprtc.cpp
@@ -403,7 +403,9 @@ namespace
         ~Unique_temporary_path() noexcept
         {
             std::string s("rm -r " + path_);
-            system(s.c_str());
+            if (path_.substr(0, 5) == "/tmp/") {
+                system(s.c_str());
+            }
         }
 
         // MANIPULATORS


### PR DESCRIPTION
Removing dependency on filesystem, so libstdc++fs is no longer required to link