### PR TITLE
bump version to 3.1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -295,13 +295,13 @@ def docker_upload_dockerhub( String local_org, String image_name, String remote_
 String build_config = 'Release'
 String job_name = env.JOB_NAME.toLowerCase( )
 
-// The following launches 3 builds in parallel: rocm-head, rocm-2.9.x and cuda-10.x
-parallel rocm_2_9:
+// The following launches 3 builds in parallel: rocm-head, rocm-3.0.x and cuda-10.x
+parallel rocm_3_0:
 {
   node('hip-rocm')
   {
-    String hcc_ver = 'rocm-2.9.x'
-    String from_image = 'ci_test_nodes/rocm-2.9.x/ubuntu-16.04:latest'
+    String hcc_ver = 'rocm-3.0.x'
+    String from_image = 'ci_test_nodes/rocm-3.0.x/ubuntu-16.04:latest'
     String inside_args = '--device=/dev/kfd --device=/dev/dri --group-add=video'
 
     // Checkout source code, dependencies and version files

--- a/bin/hipconfig
+++ b/bin/hipconfig
@@ -1,7 +1,7 @@
 #!/usr/bin/perl -w
 
 $HIP_BASE_VERSION_MAJOR = "3";
-$HIP_BASE_VERSION_MINOR = "0";
+$HIP_BASE_VERSION_MINOR = "1";
 
 # Need perl > 5.10 to use logic-defined or
 use 5.006; use v5.10.1;


### PR DESCRIPTION
- Bump version HIP version to 3.1
- Switch HIP tests to run on top of ROCm 3.0