### PR TITLE
[HIP] Unify hipError_t (Step 2)

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1599,7 +1599,7 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bcudaErrorHostMemoryAlreadyRegistered\b/hipErrorHostMemoryAlreadyRegistered/g;
     $ft{'numeric_literal'} += s/\bcudaErrorHostMemoryNotRegistered\b/hipErrorHostMemoryNotRegistered/g;
     $ft{'numeric_literal'} += s/\bcudaErrorIllegalAddress\b/hipErrorIllegalAddress/g;
-    $ft{'numeric_literal'} += s/\bcudaErrorInitializationError\b/hipErrorInitializationError/g;
+    $ft{'numeric_literal'} += s/\bcudaErrorInitializationError\b/hipErrorNotInitialized/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInsufficientDriver\b/hipErrorInsufficientDriver/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidConfiguration\b/hipErrorInvalidConfiguration/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidDevice\b/hipErrorInvalidDevice/g;
@@ -1609,15 +1609,15 @@ sub simpleSubstitutions {
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidKernelImage\b/hipErrorInvalidImage/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidMemcpyDirection\b/hipErrorInvalidMemcpyDirection/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidPtx\b/hipErrorInvalidKernelFile/g;
-    $ft{'numeric_literal'} += s/\bcudaErrorInvalidResourceHandle\b/hipErrorInvalidResourceHandle/g;
+    $ft{'numeric_literal'} += s/\bcudaErrorInvalidResourceHandle\b/hipErrorInvalidHandle/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidSource\b/hipErrorInvalidSource/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidSymbol\b/hipErrorInvalidSymbol/g;
     $ft{'numeric_literal'} += s/\bcudaErrorInvalidValue\b/hipErrorInvalidValue/g;
     $ft{'numeric_literal'} += s/\bcudaErrorLaunchFailure\b/hipErrorLaunchFailure/g;
     $ft{'numeric_literal'} += s/\bcudaErrorLaunchOutOfResources\b/hipErrorLaunchOutOfResources/g;
     $ft{'numeric_literal'} += s/\bcudaErrorLaunchTimeout\b/hipErrorLaunchTimeOut/g;
-    $ft{'numeric_literal'} += s/\bcudaErrorMapBufferObjectFailed\b/hipErrorMapBufferObjectFailed/g;
-    $ft{'numeric_literal'} += s/\bcudaErrorMemoryAllocation\b/hipErrorMemoryAllocation/g;
+    $ft{'numeric_literal'} += s/\bcudaErrorMapBufferObjectFailed\b/hipErrorMapFailed/g;
+    $ft{'numeric_literal'} += s/\bcudaErrorMemoryAllocation\b/hipErrorOutOfMemory/g;
     $ft{'numeric_literal'} += s/\bcudaErrorMissingConfiguration\b/hipErrorMissingConfiguration/g;
     $ft{'numeric_literal'} += s/\bcudaErrorNoDevice\b/hipErrorNoDevice/g;
     $ft{'numeric_literal'} += s/\bcudaErrorNoKernelImageForDevice\b/hipErrorNoBinaryForGpu/g;

--- a/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -716,23 +716,23 @@
 | enum         |***`cudaError`***                                    |                  |***`hipError_t`***                                          |
 | typedef      |***`cudaError_t`***                                  |                  |***`hipError_t`***                                          |
 |            0 |*`cudaSuccess`*                                      |                  |*`hipSuccess`*                                              |
-|            1 |*`cudaErrorInvalidValue`*                            |                  |*`hipErrorInvalidValue`*                                    | 1011                      |
-|            2 |*`cudaErrorMemoryAllocation`*                        |                  |*`hipErrorMemoryAllocation`*                                | 1002                      |
-|            3 |*`cudaErrorInitializationError`*                     |                  |*`hipErrorInitializationError`*                             | 1003                      |
+|            1 |*`cudaErrorInvalidValue`*                            |                  |*`hipErrorInvalidValue`*                                    |
+|            2 |*`cudaErrorMemoryAllocation`*                        |                  |*`hipErrorOutOfMemory`*                                     |
+|            3 |*`cudaErrorInitializationError`*                     |                  |*`hipErrorNotInitialized`*                                  |
 |            4 |*`cudaErrorCudartUnloading`*                         |                  |*`hipErrorDeinitialized`*                                   |
 |            5 |*`cudaErrorProfilerDisabled`*                        |                  |*`hipErrorProfilerDisabled`*                                |
 |            6 |*`cudaErrorProfilerNotInitialized`*                  |                  |*`hipErrorProfilerNotInitialized`*                          |
 |            7 |*`cudaErrorProfilerAlreadyStarted`*                  |                  |*`hipErrorProfilerAlreadyStarted`*                          |
 |            8 |*`cudaErrorProfilerAlreadyStopped`*                  |                  |*`hipErrorProfilerAlreadyStopped`*                          |
-|            9 |*`cudaErrorInvalidConfiguration`*                    |                  |*`hipErrorInvalidConfiguration`*                            | 1009                      |
+|            9 |*`cudaErrorInvalidConfiguration`*                    |                  |*`hipErrorInvalidConfiguration`*                            |
 |           12 |*`cudaErrorInvalidPitchValue`*                       |                  |                                                            |
-|           13 |*`cudaErrorInvalidSymbol`*                           |                  |*`hipErrorInvalidSymbol`*                                   | 701                       |
+|           13 |*`cudaErrorInvalidSymbol`*                           |                  |*`hipErrorInvalidSymbol`*                                   |
 |           16 |*`cudaErrorInvalidHostPointer`*                      |                  |                                                            |
-|           17 |*`cudaErrorInvalidDevicePointer`*                    |                  |*`hipErrorInvalidDevicePointer`*                            | 1017                      |
+|           17 |*`cudaErrorInvalidDevicePointer`*                    |                  |*`hipErrorInvalidDevicePointer`*                            |
 |           18 |*`cudaErrorInvalidTexture`*                          |                  |                                                            |
 |           19 |*`cudaErrorInvalidTextureBinding`*                   |                  |                                                            |
 |           20 |*`cudaErrorInvalidChannelDescriptor`*                |                  |                                                            |
-|           21 |*`cudaErrorInvalidMemcpyDirection`*                  |                  |*`hipErrorInvalidMemcpyDirection`*                          | 1021                      |
+|           21 |*`cudaErrorInvalidMemcpyDirection`*                  |                  |*`hipErrorInvalidMemcpyDirection`*                          |
 |           22 |*`cudaErrorAddressOfConstant`*                       |                  |                                                            |
 |           23 |*`cudaErrorTextureFetchFailed`*                      |                  |                                                            |
 |           24 |*`cudaErrorTextureNotBound`*                         |                  |                                                            |
@@ -749,20 +749,20 @@
 |           45 |*`cudaErrorDuplicateSurfaceName`*                    |                  |                                                            |
 |           46 |*`cudaErrorDevicesUnavailable`*                      |                  |                                                            |
 |           49 |*`cudaErrorIncompatibleDriverContext`*               |                  |                                                            |
-|           52 |*`cudaErrorMissingConfiguration`*                    |                  |*`hipErrorMissingConfiguration`*                            | 1001                      |
-|           53 |*`cudaErrorPriorLaunchFailure`*                      |                  |*`hipErrorPriorLaunchFailure`*                              | 1005                      |
+|           52 |*`cudaErrorMissingConfiguration`*                    |                  |*`hipErrorMissingConfiguration`*                            |
+|           53 |*`cudaErrorPriorLaunchFailure`*                      |                  |*`hipErrorPriorLaunchFailure`*                              |
 |           65 |*`cudaErrorLaunchMaxDepthExceeded`*                  |                  |                                                            |
 |           66 |*`cudaErrorLaunchFileScopedTex`*                     |                  |                                                            |
 |           67 |*`cudaErrorLaunchFileScopedSurf`*                    |                  |                                                            |
 |           68 |*`cudaErrorSyncDepthExceeded`*                       |                  |                                                            |
 |           69 |*`cudaErrorLaunchPendingCountExceeded`*              |                  |                                                            |
-|           98 |*`cudaErrorInvalidDeviceFunction`*                   |                  |*`hipErrorInvalidDeviceFunction`*                           | 1008                      |
-|          100 |*`cudaErrorNoDevice`*                                |                  |*`hipErrorNoDevice`*                                        | 1038                      |
-|          101 |*`cudaErrorInvalidDevice`*                           |                  |*`hipErrorInvalidDevice`*                                   | 1010                      |
+|           98 |*`cudaErrorInvalidDeviceFunction`*                   |                  |*`hipErrorInvalidDeviceFunction`*                           |
+|          100 |*`cudaErrorNoDevice`*                                |                  |*`hipErrorNoDevice`*                                        |
+|          101 |*`cudaErrorInvalidDevice`*                           |                  |*`hipErrorInvalidDevice`*                                   |
 |          127 |*`cudaErrorStartupFailure`*                          | 10.0             |                                                            |
 |          200 |*`cudaErrorInvalidKernelImage`*                      |                  |*`hipErrorInvalidImage`*                                    |
 |          201 |*`cudaErrorDeviceUninitilialized`*                   |                  |*`hipErrorInvalidContext`*                                  |
-|          205 |*`cudaErrorMapBufferObjectFailed`*                   |                  |*`hipErrorMapBufferObjectFailed`*                           | 1071                      |
+|          205 |*`cudaErrorMapBufferObjectFailed`*                   |                  |*`hipErrorMapFailed`*                                       |
 |          206 |*`cudaErrorUnmapBufferObjectFailed`*                 |                  |*`hipErrorUnmapFailed`*                                     |
 |          209 |*`cudaErrorNoKernelImageForDevice`*                  |                  |*`hipErrorNoBinaryForGpu`*                                  |
 |          214 |*`cudaErrorECCUncorrectable`*                        |                  |*`hipErrorECCNotCorrectable`*                               |
@@ -778,31 +778,31 @@
 |          302 |*`cudaErrorSharedObjectSymbolNotFound`*              |                  |*`hipErrorSharedObjectSymbolNotFound`*                      |
 |          303 |*`cudaErrorSharedObjectInitFailed`*                  |                  |*`hipErrorSharedObjectInitFailed`*                          |
 |          304 |*`cudaErrorOperatingSystem`*                         |                  |*`hipErrorOperatingSystem`*                                 |
-|          400 |*`cudaErrorInvalidResourceHandle`*                   |                  |*`hipErrorInvalidResourceHandle`*                           | 1033                      |
+|          400 |*`cudaErrorInvalidResourceHandle`*                   |                  |*`hipErrorInvalidHandle`*                                   |
 |          401 |*`cudaErrorIllegalState`*                            | 10.0             |                                                            |
 |          500 |*`cudaErrorSymbolNotFound`*                          | 10.1             |*`hipErrorNotFound`*                                        |
-|          600 |*`cudaErrorNotReady`*                                |                  |*`hipErrorNotReady`*                                        | 1034                      |
+|          600 |*`cudaErrorNotReady`*                                |                  |*`hipErrorNotReady`*                                        |
 |          700 |*`cudaErrorIllegalAddress`*                          |                  |*`hipErrorIllegalAddress`*                                  |
-|          701 |*`cudaErrorLaunchOutOfResources`*                    |                  |*`hipErrorLaunchOutOfResources`*                            | 1007                      |
-|          702 |*`cudaErrorLaunchTimeout`*                           |                  |*`hipErrorLaunchTimeOut`*                                   | 1006                      |
+|          701 |*`cudaErrorLaunchOutOfResources`*                    |                  |*`hipErrorLaunchOutOfResources`*                            |
+|          702 |*`cudaErrorLaunchTimeout`*                           |                  |*`hipErrorLaunchTimeOut`*                                   |
 |          703 |*`cudaErrorLaunchIncompatibleTexturing`*             |                  |                                                            |
-|          704 |*`cudaErrorPeerAccessAlreadyEnabled`*                |                  |*`hipErrorPeerAccessAlreadyEnabled`*                        | 1050                      |
-|          705 |*`cudaErrorPeerAccessNotEnabled`*                    |                  |*`hipErrorPeerAccessNotEnabled`*                            | 1051                      |
-|          708 |*`cudaErrorSetOnActiveProcess`*                      |                  |*`hipErrorSetOnActiveProcess`*                              | 305                       |
+|          704 |*`cudaErrorPeerAccessAlreadyEnabled`*                |                  |*`hipErrorPeerAccessAlreadyEnabled`*                        |
+|          705 |*`cudaErrorPeerAccessNotEnabled`*                    |                  |*`hipErrorPeerAccessNotEnabled`*                            |
+|          708 |*`cudaErrorSetOnActiveProcess`*                      |                  |*`hipErrorSetOnActiveProcess`*                              |
 |          709 |*`cudaErrorContextIsDestroyed`*                      |                  |                                                            |
-|          710 |*`cudaErrorAssert`*                                  |                  |*`hipErrorAssert`*                                          | 1081                      |
+|          710 |*`cudaErrorAssert`*                                  |                  |*`hipErrorAssert`*                                          |
 |          711 |*`cudaErrorTooManyPeers`*                            |                  |                                                            |
-|          712 |*`cudaErrorHostMemoryAlreadyRegistered`*             |                  |*`hipErrorHostMemoryAlreadyRegistered`*                     | 1061                      |
-|          713 |*`cudaErrorHostMemoryNotRegistered`*                 |                  |*`hipErrorHostMemoryNotRegistered`*                         | 1062                      |
+|          712 |*`cudaErrorHostMemoryAlreadyRegistered`*             |                  |*`hipErrorHostMemoryAlreadyRegistered`*                     |
+|          713 |*`cudaErrorHostMemoryNotRegistered`*                 |                  |*`hipErrorHostMemoryNotRegistered`*                         |
 |          714 |*`cudaErrorHardwareStackError`*                      |                  |                                                            |
 |          715 |*`cudaErrorIllegalInstruction`*                      |                  |                                                            |
 |          716 |*`cudaErrorMisalignedAddress`*                       |                  |                                                            |
 |          717 |*`cudaErrorInvalidAddressSpace`*                     |                  |                                                            |
 |          718 |*`cudaErrorInvalidPc`*                               |                  |                                                            |
-|          719 |*`cudaErrorLaunchFailure`*                           |                  |*`hipErrorLaunchFailure`*                                   | 1004                      |
+|          719 |*`cudaErrorLaunchFailure`*                           |                  |*`hipErrorLaunchFailure`*                                   |
 |          720 |*`cudaErrorCooperativeLaunchTooLarge`*               | 9.0              |                                                            |
 |          800 |*`cudaErrorNotPermitted`*                            |                  |                                                            |
-|          801 |*`cudaErrorNotSupported`*                            |                  |*`hipErrorNotSupported`*                                    | 1082                      |
+|          801 |*`cudaErrorNotSupported`*                            |                  |*`hipErrorNotSupported`*                                    |
 |          802 |*`cudaErrorSystemNotReady`*                          | 10.0             |                                                            |
 |          803 |*`cudaErrorSystemDriverMismatch`*                    | 10.0             |                                                            |
 |          804 |*`cudaErrorCompatNotSupportedOnDevice`*              | 10.0             |                                                            |
@@ -817,7 +817,7 @@
 |          908 |*`cudaErrorStreamCaptureWrongThread`*                | 10.1             |                                                            |
 |          909 |*`cudaErrorTimeout`*                                 | 10.2             |                                                            |
 |          910 |*`cudaErrorGraphExecUpdateFailure`*                  | 10.2             |                                                            |
-|          999 |*`cudaErrorUnknown`*                                 |                  |*`hipErrorUnknown`*                                         | 1030                      |
+|          999 |*`cudaErrorUnknown`*                                 |                  |*`hipErrorUnknown`*                                         |
 |        10000 |*`cudaErrorApiFailureBase`*                          |                  |                                                            |
 | enum         |***`cudaFuncCache`***                                |                  |***`hipFuncCache_t`***                                      |
 |            0 |*`cudaFuncCachePreferNone`*                          |                  |*`hipFuncCachePreferNone`*                                  |

--- a/hipify-clang/src/CUDA2HIP_Driver_API_types.cpp
+++ b/hipify-clang/src/CUDA2HIP_Driver_API_types.cpp
@@ -1166,16 +1166,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP{
   // CUresult enum values
   // cudaSuccess
   {"CUDA_SUCCESS",                                                     {"hipSuccess",                                               "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 0
-  // cudaErrorInvalidValue = 1, CUDA_ERROR_INVALID_VALUE = 1, hipErrorInvalidValue = 1011
-  // TODO [HIP]: make hipErrorInvalidValue = 1
   // cudaErrorInvalidValue
   {"CUDA_ERROR_INVALID_VALUE",                                         {"hipErrorInvalidValue",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 1
-  // cudaErrorMemoryAllocation = 2, CUDA_ERROR_OUT_OF_MEMORY = 2, hipErrorOutOfMemory = 2, hipErrorMemoryAllocation = 1002
-  // TODO [HIP]: remove hipErrorMemoryAllocation
   // cudaErrorMemoryAllocation
   {"CUDA_ERROR_OUT_OF_MEMORY",                                         {"hipErrorOutOfMemory",                                      "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 2
-  // cudaErrorInitializationError = 3, CUDA_ERROR_NOT_INITIALIZED = 3, hipErrorNotInitialized = 3, hipErrorInitializationError = 1003
-  // TODO [HIP]: remove hipErrorInitializationError
   // cudaErrorInitializationError
   {"CUDA_ERROR_NOT_INITIALIZED",                                       {"hipErrorNotInitialized",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 3
   // cudaErrorCudartUnloading
@@ -1191,12 +1185,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP{
   // cudaErrorProfilerAlreadyStopped
   // NOTE: Deprecated since CUDA 5.0
   {"CUDA_ERROR_PROFILER_ALREADY_STOPPED",                              {"hipErrorProfilerAlreadyStopped",                           "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 8
-  // cudaErrorNoDevice = 100, CUDA_ERROR_NO_DEVICE = 100, hipErrorNoDevice = 1038
-  // TODO [HIP]: make hipErrorNoDevice = 100
   // cudaErrorNoDevice
   {"CUDA_ERROR_NO_DEVICE",                                             {"hipErrorNoDevice",                                         "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 100
-  // cudaErrorInvalidDevice = 101, CUDA_ERROR_INVALID_DEVICE = 101, hipErrorInvalidDevice = 1010
-  // TODO [HIP]: make hipErrorInvalidDevice = 101
   // cudaErrorInvalidDevice
   {"CUDA_ERROR_INVALID_DEVICE",                                        {"hipErrorInvalidDevice",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 101
   // cudaErrorInvalidKernelImage
@@ -1206,9 +1196,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP{
   // no analogue
   // NOTE: Deprecated since CUDA 3.2
   {"CUDA_ERROR_CONTEXT_ALREADY_CURRENT",                               {"hipErrorContextAlreadyCurrent",                            "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 202
-  // cudaErrorMapBufferObjectFailed = 205, CUDA_ERROR_MAP_FAILED = 205, hipErrorMapFailed = 205, hipErrorMapBufferObjectFailed = 1071
-  // TODO [HIP]: remove hipErrorMapBufferObjectFailed
-  // TODO [HIPIFY]: rename hipErrorMapBufferObjectFailed to hipErrorMapFailed
   // cudaErrorMapBufferObjectFailed
   {"CUDA_ERROR_MAP_FAILED",                                            {"hipErrorMapFailed",                                        "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 205
   // cudaErrorUnmapBufferObjectFailed
@@ -1253,57 +1240,36 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP{
   {"CUDA_ERROR_SHARED_OBJECT_INIT_FAILED",                             {"hipErrorSharedObjectInitFailed",                           "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 303
   // cudaErrorOperatingSystem
   {"CUDA_ERROR_OPERATING_SYSTEM",                                      {"hipErrorOperatingSystem",                                  "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 304
-  // cudaErrorInvalidResourceHandle = 400, CUDA_ERROR_INVALID_HANDLE = 400, hipErrorInvalidHandle = 400, hipErrorInvalidResourceHandle = 1033
-  // TODO [HIP]: remove hipErrorInvalidResourceHandle
-  // TODO [HIPIFY]: rename hipErrorInvalidResourceHandle to hipErrorInvalidHandle
   // cudaErrorInvalidResourceHandle
   {"CUDA_ERROR_INVALID_HANDLE",                                        {"hipErrorInvalidHandle",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 400
   // cudaErrorIllegalState
   {"CUDA_ERROR_ILLEGAL_STATE",                                         {"hipErrorIllegalState",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER, HIP_UNSUPPORTED}}, // 401
   // cudaErrorSymbolNotFound
   {"CUDA_ERROR_NOT_FOUND",                                             {"hipErrorNotFound",                                         "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 500
-  // cudaErrorNotReady = 600, CUDA_ERROR_NOT_READY = 600, hipErrorNotReady = 1034
-  // TODO [HIP]: make hipErrorNotReady = 600
   // cudaErrorNotReady
   {"CUDA_ERROR_NOT_READY",                                             {"hipErrorNotReady",                                         "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 600
   // cudaErrorIllegalAddress
   {"CUDA_ERROR_ILLEGAL_ADDRESS",                                       {"hipErrorIllegalAddress",                                   "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 700
-  // cudaErrorLaunchOutOfResources = 701, CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES = 701, hipErrorLaunchOutOfResources = 1007
-  // TODO [HIP]: make hipErrorLaunchOutOfResources = 701
   // cudaErrorLaunchOutOfResources
   {"CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES",                               {"hipErrorLaunchOutOfResources",                             "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 701
-  // cudaErrorLaunchTimeout = 702, CUDA_ERROR_LAUNCH_TIMEOUT = 702, hipErrorLaunchTimeOut = 1006
-  // TODO [HIP]: make hipErrorLaunchTimeOut = 702
   // cudaErrorLaunchTimeout
   {"CUDA_ERROR_LAUNCH_TIMEOUT",                                        {"hipErrorLaunchTimeOut",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 702
   // cudaErrorLaunchIncompatibleTexturing
   {"CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING",                         {"hipErrorLaunchIncompatibleTexturing",                      "", CONV_NUMERIC_LITERAL, API_DRIVER, HIP_UNSUPPORTED}}, // 703
-  // cudaErrorPeerAccessAlreadyEnabled = 704, CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED = 704, hipErrorPeerAccessAlreadyEnabled = 1050
-  // TODO [HIP]: make hipErrorPeerAccessAlreadyEnabled = 704
   // cudaErrorPeerAccessAlreadyEnabled
   {"CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED",                           {"hipErrorPeerAccessAlreadyEnabled",                         "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 704
-  // cudaErrorPeerAccessNotEnabled = 705, CUDA_ERROR_PEER_ACCESS_NOT_ENABLED = 705, hipErrorPeerAccessNotEnabled = 1051
-  // TODO [HIP]: make hipErrorPeerAccessNotEnabled = 705
   // cudaErrorPeerAccessNotEnabled
   {"CUDA_ERROR_PEER_ACCESS_NOT_ENABLED",                               {"hipErrorPeerAccessNotEnabled",                             "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 705
-  // cudaErrorSetOnActiveProcess = 708, CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE = 708, hipErrorSetOnActiveProcess = 305
-  // TODO [HIP]: make hipErrorSetOnActiveProcess = 708
   // cudaErrorSetOnActiveProcess
   {"CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE",                                {"hipErrorSetOnActiveProcess",                               "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 708
   // cudaErrorContextIsDestroyed
   {"CUDA_ERROR_CONTEXT_IS_DESTROYED",                                  {"hipErrorContextIsDestroyed",                               "", CONV_NUMERIC_LITERAL, API_DRIVER, HIP_UNSUPPORTED}}, // 709
-  // cudaErrorAssert = 710, CUDA_ERROR_ASSERT = 710, hipErrorAssert = 1081
-  // TODO [HIP]: make hipErrorAssert = 710
   // cudaErrorAssert
   {"CUDA_ERROR_ASSERT",                                                {"hipErrorAssert",                                           "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 710
   // cudaErrorTooManyPeers
   {"CUDA_ERROR_TOO_MANY_PEERS",                                        {"hipErrorTooManyPeers",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER, HIP_UNSUPPORTED}}, // 711
-  // cudaErrorHostMemoryAlreadyRegistered = 712, CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED = 712, hipErrorHostMemoryAlreadyRegistered = 1061
-  // TODO [HIP]: make hipErrorHostMemoryAlreadyRegistered = 712
   // cudaErrorHostMemoryAlreadyRegistered
   {"CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED",                        {"hipErrorHostMemoryAlreadyRegistered",                      "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 712
-  // cudaErrorHostMemoryNotRegistered = 713, CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED = 713, hipErrorHostMemoryNotRegistered = 1062
-  // TODO [HIP]: make hipErrorHostMemoryNotRegistered = 713
   // cudaErrorHostMemoryNotRegistered
   {"CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED",                            {"hipErrorHostMemoryNotRegistered",                          "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 713
   // cudaErrorHardwareStackError
@@ -1316,14 +1282,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP{
   {"CUDA_ERROR_INVALID_ADDRESS_SPACE",                                 {"hipErrorInvalidAddressSpace",                              "", CONV_NUMERIC_LITERAL, API_DRIVER, HIP_UNSUPPORTED}}, // 717
   // cudaErrorInvalidPc
   {"CUDA_ERROR_INVALID_PC",                                            {"hipErrorInvalidPc",                                        "", CONV_NUMERIC_LITERAL, API_DRIVER, HIP_UNSUPPORTED}}, // 718
-  // cudaErrorLaunchFailure = 719, CUDA_ERROR_LAUNCH_FAILED = 719, hipErrorLaunchFailure = 1004
-  // TODO [HIP]: make hipErrorSetOnActiveProcess = 719
   // cudaErrorLaunchFailure
   {"CUDA_ERROR_LAUNCH_FAILED",                                         {"hipErrorLaunchFailure",                                    "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 719
   // cudaErrorNotPermitted
   {"CUDA_ERROR_NOT_PERMITTED",                                         {"hipErrorNotPermitted",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER, HIP_UNSUPPORTED}}, // 800
-  // cudaErrorNotSupported = 801, CUDA_ERROR_NOT_SUPPORTED = 801, hipErrorNotSupported = 1082
-  // TODO [HIP]: make hipErrorNotSupported = 801
   // cudaErrorNotSupported
   {"CUDA_ERROR_NOT_SUPPORTED",                                         {"hipErrorNotSupported",                                     "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 801
   // cudaErrorSystemNotReady
@@ -1354,8 +1316,6 @@ const std::map<llvm::StringRef, hipCounter> CUDA_DRIVER_TYPE_NAME_MAP{
   {"CUDA_ERROR_TIMEOUT",                                               {"hipErrorTimeout",                                          "", CONV_NUMERIC_LITERAL, API_DRIVER, HIP_UNSUPPORTED}}, // 909
   // cudaErrorGraphExecUpdateFailure
   {"CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE",                             {"hipErrorGraphExecUpdateFailure",                           "", CONV_NUMERIC_LITERAL, API_DRIVER, HIP_UNSUPPORTED}}, // 910
-  // cudaErrorUnknown = 999, CUDA_ERROR_UNKNOWN = 999, hipErrorUnknown = 1030
-  // TODO [HIP]: make hipErrorUnknown = 999
   // cudaErrorUnknown
   {"CUDA_ERROR_UNKNOWN",                                               {"hipErrorUnknown",                                          "", CONV_NUMERIC_LITERAL, API_DRIVER}}, // 999
 

--- a/hipify-clang/src/CUDA2HIP_Runtime_API_types.cpp
+++ b/hipify-clang/src/CUDA2HIP_Runtime_API_types.cpp
@@ -599,16 +599,10 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaSuccess",                                                      {"hipSuccess",                                               "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 0
   // CUDA_ERROR_INVALID_VALUE
   {"cudaErrorInvalidValue",                                            {"hipErrorInvalidValue",                                     "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 1
-  // cudaErrorMemoryAllocation = 2, CUDA_ERROR_OUT_OF_MEMORY = 2, hipErrorOutOfMemory = 2, hipErrorMemoryAllocation = 1002
-  // TODO [HIP]: remove hipErrorMemoryAllocation
-  // TODO [HIPIFY]: rename hipErrorMemoryAllocation to hipErrorOutOfMemory
   // CUDA_ERROR_OUT_OF_MEMORY
-  {"cudaErrorMemoryAllocation",                                        {"hipErrorMemoryAllocation",                                 "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 2
-  // cudaErrorInitializationError = 3, CUDA_ERROR_NOT_INITIALIZED = 3, hipErrorNotInitialized = 3, hipErrorInitializationError = 1003
-  // TODO [HIP]: remove hipErrorInitializationError
-  // TODO [HIPIFY]: rename hipErrorInitializationError to hipErrorNotInitialized
+  {"cudaErrorMemoryAllocation",                                        {"hipErrorOutOfMemory",                                      "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 2
   // CUDA_ERROR_NOT_INITIALIZED
-  {"cudaErrorInitializationError",                                     {"hipErrorInitializationError",                              "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 3
+  {"cudaErrorInitializationError",                                     {"hipErrorNotInitialized",                                   "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 3
   // CUDA_ERROR_DEINITIALIZED
   {"cudaErrorCudartUnloading",                                         {"hipErrorDeinitialized",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 4
   // CUDA_ERROR_PROFILER_DISABLED
@@ -705,11 +699,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaErrorDeviceUninitialized",                                     {"hipErrorInvalidContext",                                   "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 201
   // CUDA_ERROR_INVALID_CONTEXT
   {"cudaErrorDeviceUninitilialized",                                   {"hipErrorInvalidContext",                                   "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 201
-  // cudaErrorMapBufferObjectFailed = 205, CUDA_ERROR_MAP_FAILED = 205, hipErrorMapFailed = 205, hipErrorMapBufferObjectFailed = 1071
-  // TODO [HIP]: remove hipErrorMapBufferObjectFailed
-  // TODO [HIPIFY]: rename hipErrorMapBufferObjectFailed to hipErrorMapFailed
   // CUDA_ERROR_MAP_FAILED
-  {"cudaErrorMapBufferObjectFailed",                                   {"hipErrorMapBufferObjectFailed",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 205
+  {"cudaErrorMapBufferObjectFailed",                                   {"hipErrorMapFailed",                                        "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 205
   // CUDA_ERROR_UNMAP_FAILED
   {"cudaErrorUnmapBufferObjectFailed",                                 {"hipErrorUnmapFailed",                                      "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 206
   // CUDA_ERROR_ARRAY_IS_MAPPED
@@ -752,11 +743,8 @@ const std::map<llvm::StringRef, hipCounter> CUDA_RUNTIME_TYPE_NAME_MAP {
   {"cudaErrorSharedObjectInitFailed",                                  {"hipErrorSharedObjectInitFailed",                           "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 303
   // CUDA_ERROR_OPERATING_SYSTEM
   {"cudaErrorOperatingSystem",                                         {"hipErrorOperatingSystem",                                  "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 304
-  // cudaErrorInvalidResourceHandle = 400, CUDA_ERROR_INVALID_HANDLE = 400, hipErrorInvalidHandle = 400, hipErrorInvalidResourceHandle = 1033
-  // TODO [HIP]: remove hipErrorInvalidResourceHandle
-  // TODO [HIPIFY]: rename hipErrorInvalidResourceHandle to hipErrorInvalidHandle
   // CUDA_ERROR_INVALID_HANDLE
-  {"cudaErrorInvalidResourceHandle",                                   {"hipErrorInvalidResourceHandle",                            "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 400
+  {"cudaErrorInvalidResourceHandle",                                   {"hipErrorInvalidHandle",                                    "", CONV_NUMERIC_LITERAL, API_RUNTIME}}, // 400
   // CUDA_ERROR_ILLEGAL_STATE
   {"cudaErrorIllegalState",                                            {"hipErrorIllegalState",                                     "", CONV_NUMERIC_LITERAL, API_RUNTIME, HIP_UNSUPPORTED}}, // 401
   // CUDA_ERROR_NOT_FOUND

--- a/include/hip/hcc_detail/hip_runtime_api.h
+++ b/include/hip/hcc_detail/hip_runtime_api.h
@@ -444,7 +444,7 @@ hipError_t hipGetDeviceProperties(hipDeviceProp_t* prop, int deviceId);
  *
  * @param [in] cacheConfig
  *
- * @returns #hipSuccess, #hipErrorInitializationError
+ * @returns #hipSuccess, #hipErrorNotInitialized
  * Note: AMD devices and some Nvidia GPUS do not support reconfigurable cache.  This hint is ignored
  * on those architectures.
  *
@@ -457,7 +457,7 @@ hipError_t hipDeviceSetCacheConfig(hipFuncCache_t cacheConfig);
  *
  * @param [in] cacheConfig
  *
- * @returns #hipSuccess, #hipErrorInitializationError
+ * @returns #hipSuccess, #hipErrorNotInitialized
  * Note: AMD devices and some Nvidia GPUS do not support reconfigurable cache.  This hint is ignored
  * on those architectures.
  *
@@ -482,7 +482,7 @@ hipError_t hipDeviceGetLimit(size_t* pValue, enum hipLimit_t limit);
  *
  * @param [in] config;
  *
- * @returns #hipSuccess, #hipErrorInitializationError
+ * @returns #hipSuccess, #hipErrorNotInitialized
  * Note: AMD devices and some Nvidia GPUS do not support reconfigurable cache.  This hint is ignored
  * on those architectures.
  *
@@ -494,7 +494,7 @@ hipError_t hipFuncSetCacheConfig(const void* func, hipFuncCache_t config);
  *
  * @param [out] pConfig
  *
- * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorInitializationError
+ * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorNotInitialized
  *
  * Note: AMD devices and some Nvidia GPUS do not support shared cache banking, and the hint is
  * ignored on those architectures.
@@ -508,7 +508,7 @@ hipError_t hipDeviceGetSharedMemConfig(hipSharedMemConfig* pConfig);
  *
  * @param [in] config
  *
- * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorInitializationError
+ * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorNotInitialized
  *
  * Note: AMD devices and some Nvidia GPUS do not support shared cache banking, and the hint is
  * ignored on those architectures.
@@ -727,7 +727,7 @@ hipError_t hipDeviceGetStreamPriorityRange(int* leastPriority, int* greatestPrio
  *
  * @param[in, out] stream Valid pointer to hipStream_t.  This function writes the memory with the
  * newly created stream.
- * @return #hipSuccess #hipErrorInvalidResourceHandle
+ * @return #hipSuccess #hipErrorInvalidHandle
  *
  * Destroys the specified stream.
  *
@@ -749,7 +749,7 @@ hipError_t hipStreamDestroy(hipStream_t stream);
  *
  * @param[in] stream stream to query
  *
- * @return #hipSuccess, #hipErrorNotReady, #hipErrorInvalidResourceHandle
+ * @return #hipSuccess, #hipErrorNotReady, #hipErrorInvalidHandle
  *
  * This is thread-safe and returns a snapshot of the current state of the queue.  However, if other
  * host threads are sending work to the stream, the status may change immediately after the function
@@ -766,7 +766,7 @@ hipError_t hipStreamQuery(hipStream_t stream);
  *
  * @param[in] stream stream identifier.
  *
- * @return #hipSuccess, #hipErrorInvalidResourceHandle
+ * @return #hipSuccess, #hipErrorInvalidHandle
  *
  * This command is host-synchronous : the host will block until the specified stream is empty.
  *
@@ -790,7 +790,7 @@ hipError_t hipStreamSynchronize(hipStream_t stream);
  * @param[in] event event to wait on
  * @param[in] flags control operation [must be 0]
  *
- * @return #hipSuccess, #hipErrorInvalidResourceHandle
+ * @return #hipSuccess, #hipErrorInvalidHandle
  *
  * This function inserts a wait operation into the specified stream.
  * All future work submitted to @p stream will wait until @p event reports completion before
@@ -810,9 +810,9 @@ hipError_t hipStreamWaitEvent(hipStream_t stream, hipEvent_t event, unsigned int
  *
  * @param[in] stream stream to be queried
  * @param[in,out] flags Pointer to an unsigned integer in which the stream's flags are returned
- * @return #hipSuccess, #hipErrorInvalidValue, #hipErrorInvalidResourceHandle
+ * @return #hipSuccess, #hipErrorInvalidValue, #hipErrorInvalidHandle
  *
- * @returns #hipSuccess #hipErrorInvalidValue #hipErrorInvalidResourceHandle
+ * @returns #hipSuccess #hipErrorInvalidValue #hipErrorInvalidHandle
  *
  * Return flags associated with this stream in *@p flags.
  *
@@ -826,9 +826,9 @@ hipError_t hipStreamGetFlags(hipStream_t stream, unsigned int* flags);
  *
  * @param[in] stream stream to be queried
  * @param[in,out] priority Pointer to an unsigned integer in which the stream's priority is returned
- * @return #hipSuccess, #hipErrorInvalidValue, #hipErrorInvalidResourceHandle
+ * @return #hipSuccess, #hipErrorInvalidValue, #hipErrorInvalidHandle
  *
- * @returns #hipSuccess #hipErrorInvalidValue #hipErrorInvalidResourceHandle
+ * @returns #hipSuccess #hipErrorInvalidValue #hipErrorInvalidHandle
  *
  * Query the priority of a stream. The priority is returned in in priority.
  *
@@ -851,7 +851,7 @@ typedef void (*hipStreamCallback_t)(hipStream_t stream, hipError_t status, void*
  * @param[in] callback - The function to call once preceding stream operations are complete
  * @param[in] userData - User specified data to be passed to the callback function
  * @param[in] flags    - Reserved for future use, must be 0
- * @return #hipSuccess, #hipErrorInvalidResourceHandle, #hipErrorNotSupported
+ * @return #hipSuccess, #hipErrorInvalidHandle, #hipErrorNotSupported
  *
  * @see hipStreamCreate, hipStreamCreateWithFlags, hipStreamQuery, hipStreamSynchronize,
  * hipStreamWaitEvent, hipStreamDestroy, hipStreamCreateWithPriority
@@ -893,8 +893,8 @@ hipError_t hipStreamAddCallback(hipStream_t stream, hipStreamCallback_t callback
  * @warning On HCC platform, hipEventInterprocess support is under development.  Use of this flag
  will return an error.
  *
- * @returns #hipSuccess, #hipErrorInitializationError, #hipErrorInvalidValue,
- #hipErrorLaunchFailure, #hipErrorMemoryAllocation
+ * @returns #hipSuccess, #hipErrorNotInitialized, #hipErrorInvalidValue,
+ #hipErrorLaunchFailure, #hipErrorOutOfMemory
  *
  * @see hipEventCreate, hipEventSynchronize, hipEventDestroy, hipEventElapsedTime
  */
@@ -906,8 +906,8 @@ hipError_t hipEventCreateWithFlags(hipEvent_t* event, unsigned flags);
  *
  * @param[in,out] event Returns the newly created event.
  *
- * @returns #hipSuccess, #hipErrorInitializationError, #hipErrorInvalidValue,
- * #hipErrorLaunchFailure, #hipErrorMemoryAllocation
+ * @returns #hipSuccess, #hipErrorNotInitialized, #hipErrorInvalidValue,
+ * #hipErrorLaunchFailure, #hipErrorOutOfMemory
  *
  * @see hipEventCreateWithFlags, hipEventRecord, hipEventQuery, hipEventSynchronize,
  * hipEventDestroy, hipEventElapsedTime
@@ -920,8 +920,8 @@ hipError_t hipEventCreate(hipEvent_t* event);
  *
  * @param[in] event event to record.
  * @param[in] stream stream in which to record event.
- * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorInitializationError,
- * #hipErrorInvalidResourceHandle, #hipErrorLaunchFailure
+ * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorNotInitialized,
+ * #hipErrorInvalidHandle, #hipErrorLaunchFailure
  *
  * hipEventQuery() or hipEventSynchronize() must be used to determine when the event
  * transitions from "recording" (after hipEventRecord() is called) to "recorded"
@@ -952,7 +952,7 @@ hipError_t hipEventRecord(hipEvent_t event, hipStream_t stream);
  *  @brief Destroy the specified event.
  *
  *  @param[in] event Event to destroy.
- *  @returns #hipSuccess, #hipErrorInitializationError, #hipErrorInvalidValue,
+ *  @returns #hipSuccess, #hipErrorNotInitialized, #hipErrorInvalidValue,
  * #hipErrorLaunchFailure
  *
  *  Releases memory associated with the event.  If the event is recording but has not completed
@@ -978,8 +978,8 @@ hipError_t hipEventDestroy(hipEvent_t event);
  *  TODO-hcc - This function needs to support hipEventBlockingSync parameter.
  *
  *  @param[in] event Event on which to wait.
- *  @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorInitializationError,
- * #hipErrorInvalidResourceHandle, #hipErrorLaunchFailure
+ *  @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorNotInitialized,
+ * #hipErrorInvalidHandle, #hipErrorLaunchFailure
  *
  *  @see hipEventCreate, hipEventCreateWithFlags, hipEventQuery, hipEventDestroy, hipEventRecord,
  * hipEventElapsedTime
@@ -993,8 +993,8 @@ hipError_t hipEventSynchronize(hipEvent_t event);
  * @param[out] ms : Return time between start and stop in ms.
  * @param[in]   start : Start event.
  * @param[in]   stop  : Stop event.
- * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorNotReady, #hipErrorInvalidResourceHandle,
- * #hipErrorInitializationError, #hipErrorLaunchFailure
+ * @returns #hipSuccess, #hipErrorInvalidValue, #hipErrorNotReady, #hipErrorInvalidHandle,
+ * #hipErrorNotInitialized, #hipErrorLaunchFailure
  *
  * Computes the elapsed time between two events. Time is computed in ms, with
  * a resolution of approximately 1 us.
@@ -1007,7 +1007,7 @@ hipError_t hipEventSynchronize(hipEvent_t event);
  * commands in that stream have completed executing.  Thus the time that
  * the event recorded may be significantly after the host calls hipEventRecord().
  *
- * If hipEventRecord() has not been called on either event, then #hipErrorInvalidResourceHandle is
+ * If hipEventRecord() has not been called on either event, then #hipErrorInvalidHandle is
  * returned. If hipEventRecord() has been called on both events, but the timestamp has not yet been
  * recorded on one or both events (that is, hipEventQuery() would return #hipErrorNotReady on at
  * least one of the events), then #hipErrorNotReady is returned.
@@ -1022,8 +1022,8 @@ hipError_t hipEventElapsedTime(float* ms, hipEvent_t start, hipEvent_t stop);
  * @brief Query event status
  *
  * @param[in] event Event to query.
- * @returns #hipSuccess, #hipErrorNotReady, #hipErrorInvalidResourceHandle, #hipErrorInvalidValue,
- * #hipErrorInitializationError, #hipErrorLaunchFailure
+ * @returns #hipSuccess, #hipErrorNotReady, #hipErrorInvalidHandle, #hipErrorInvalidValue,
+ * #hipErrorNotInitialized, #hipErrorLaunchFailure
  *
  * Query the status of the specified event.  This function will return #hipErrorNotReady if all
  * commands in the appropriate stream (specified to hipEventRecord()) have completed.  If that work
@@ -1077,7 +1077,7 @@ hipError_t hipPointerGetAttributes(hipPointerAttribute_t* attributes, const void
  *
  *  If size is 0, no memory is allocated, *ptr returns nullptr, and hipSuccess is returned.
  *
- *  @return #hipSuccess, #hipErrorMemoryAllocation, #hipErrorInvalidValue (bad context, null *ptr)
+ *  @return #hipSuccess, #hipErrorOutOfMemory, #hipErrorInvalidValue (bad context, null *ptr)
  *
  *  @see hipMallocPitch, hipFree, hipMallocArray, hipFreeArray, hipMalloc3D, hipMalloc3DArray,
  * hipHostFree, hipHostMalloc
@@ -1093,7 +1093,7 @@ hipError_t hipMalloc(void** ptr, size_t size);
  *
  *  If size is 0, no memory is allocated, *ptr returns nullptr, and hipSuccess is returned.
  *
- *  @return #hipSuccess, #hipErrorMemoryAllocation, #hipErrorInvalidValue (bad context, null *ptr)
+ *  @return #hipSuccess, #hipErrorOutOfMemory, #hipErrorInvalidValue (bad context, null *ptr)
  *
  *  @see hipMallocPitch, hipFree, hipMallocArray, hipFreeArray, hipMalloc3D, hipMalloc3DArray,
  * hipHostFree, hipHostMalloc
@@ -1108,7 +1108,7 @@ hipError_t hipExtMallocWithFlags(void** ptr, size_t sizeBytes, unsigned int flag
  *
  *  If size is 0, no memory is allocated, *ptr returns nullptr, and hipSuccess is returned.
  *
- *  @return #hipSuccess, #hipErrorMemoryAllocation
+ *  @return #hipSuccess, #hipErrorOutOfMemory
  *
  *  @deprecated use hipHostMalloc() instead
  */
@@ -1123,7 +1123,7 @@ hipError_t hipMallocHost(void** ptr, size_t size);
  *
  *  If size is 0, no memory is allocated, *ptr returns nullptr, and hipSuccess is returned.
  *
- *  @return #hipSuccess, #hipErrorMemoryAllocation
+ *  @return #hipSuccess, #hipErrorOutOfMemory
  *
  *  @deprecated use hipHostMalloc() instead
  */
@@ -1139,7 +1139,7 @@ hipError_t hipMemAllocHost(void** ptr, size_t size);
  *
  *  If size is 0, no memory is allocated, *ptr returns nullptr, and hipSuccess is returned.
  *
- *  @return #hipSuccess, #hipErrorMemoryAllocation
+ *  @return #hipSuccess, #hipErrorOutOfMemory
  *
  *  @see hipSetDeviceFlags, hipHostFree
  */
@@ -1152,7 +1152,7 @@ hipError_t hipHostMalloc(void** ptr, size_t size, unsigned int flags);
  *  @param[in]  size Requested memory size
  *  @param[in]  flags must be either hipMemAttachGlobal/hipMemAttachHost
  *
- *  @return #hipSuccess, #hipErrorMemoryAllocation
+ *  @return #hipSuccess, #hipErrorOutOfMemory
  */
 hipError_t hipMallocManaged(void** devPtr, size_t size, unsigned int flags __dparm(0));
 
@@ -1165,7 +1165,7 @@ hipError_t hipMallocManaged(void** devPtr, size_t size, unsigned int flags __dpa
  *
  *  If size is 0, no memory is allocated, *ptr returns nullptr, and hipSuccess is returned.
  *
- *  @return #hipSuccess, #hipErrorMemoryAllocation
+ *  @return #hipSuccess, #hipErrorOutOfMemory
  *
  *  @deprecated use hipHostMalloc() instead
  */
@@ -1179,7 +1179,7 @@ hipError_t hipHostAlloc(void** ptr, size_t size, unsigned int flags);
  *  @param[in]  hstPtr Host Pointer allocated through hipHostMalloc
  *  @param[in]  flags Flags to be passed for extension
  *
- *  @return #hipSuccess, #hipErrorInvalidValue, #hipErrorMemoryAllocation
+ *  @return #hipSuccess, #hipErrorInvalidValue, #hipErrorOutOfMemory
  *
  *  @see hipSetDeviceFlags, hipHostMalloc
  */
@@ -1228,7 +1228,7 @@ hipError_t hipHostGetFlags(unsigned int* flagsPtr, void* hostPtr);
  * typically one of the writes will "win" and overwrite data from the other registered memory
  * region.
  *
- *  @return #hipSuccess, #hipErrorMemoryAllocation
+ *  @return #hipSuccess, #hipErrorOutOfMemory
  *
  *  @see hipHostUnregister, hipHostGetFlags, hipHostGetDevicePointer
  */
@@ -1909,7 +1909,7 @@ hipError_t hipMemPtrGetInfo(void* ptr, size_t* size);
  *  @param[in]   width  Requested array allocation width
  *  @param[in]   height Requested array allocation height
  *  @param[in]   flags  Requested properties of allocated array
- *  @return      #hipSuccess, #hipErrorMemoryAllocation
+ *  @return      #hipSuccess, #hipErrorOutOfMemory
  *
  *  @see hipMalloc, hipMallocPitch, hipFree, hipFreeArray, hipHostMalloc, hipHostFree
  */
@@ -1925,7 +1925,7 @@ hipError_t hipMalloc3D(hipPitchedPtr* pitchedDevPtr, hipExtent extent);
  *  @brief Frees an array on the device.
  *
  *  @param[in]  array  Pointer to array to free
- *  @return     #hipSuccess, #hipErrorInvalidValue, #hipErrorInitializationError
+ *  @return     #hipSuccess, #hipErrorInvalidValue, #hipErrorNotInitialized
  *
  *  @see hipMalloc, hipMallocPitch, hipFree, hipMallocArray, hipHostMalloc, hipHostFree
  */
@@ -1938,7 +1938,7 @@ hipError_t hipFreeArray(hipArray* array);
  *  @param[in]   desc   Requested channel format
  *  @param[in]   extent Requested array allocation width, height and depth
  *  @param[in]   flags  Requested properties of allocated array
- *  @return      #hipSuccess, #hipErrorMemoryAllocation
+ *  @return      #hipSuccess, #hipErrorOutOfMemory
  *
  *  @see hipMalloc, hipMallocPitch, hipFree, hipFreeArray, hipHostMalloc, hipHostFree
  */
@@ -3036,9 +3036,9 @@ hipError_t hipProfilerStop();
  *
  * @returns
  * hipSuccess,
- * hipErrorInvalidResourceHandle,
- * hipErrorMemoryAllocation,
- * hipErrorMapBufferObjectFailed,
+ * hipErrorInvalidHandle,
+ * hipErrorOutOfMemory,
+ * hipErrorMapFailed,
  *
  */
 hipError_t hipIpcGetMemHandle(hipIpcMemHandle_t* handle, void* devPtr);
@@ -3071,8 +3071,8 @@ hipError_t hipIpcGetMemHandle(hipIpcMemHandle_t* handle, void* devPtr);
  *
  * @returns
  * hipSuccess,
- * hipErrorMapBufferObjectFailed,
- * hipErrorInvalidResourceHandle,
+ * hipErrorMapFailed,
+ * hipErrorInvalidHandle,
  * hipErrorTooManyPeers
  *
  * @note No guarantees are made about the address returned in @p *devPtr.
@@ -3095,8 +3095,8 @@ hipError_t hipIpcOpenMemHandle(void** devPtr, hipIpcMemHandle_t handle, unsigned
  *
  * @returns
  * hipSuccess,
- * hipErrorMapBufferObjectFailed,
- * hipErrorInvalidResourceHandle,
+ * hipErrorMapFailed,
+ * hipErrorInvalidHandle,
  *
  */
 hipError_t hipIpcCloseMemHandle(void* devPtr);

--- a/include/hip/hip_runtime_api.h
+++ b/include/hip/hip_runtime_api.h
@@ -211,7 +211,7 @@ typedef enum __HIP_NODISCARD hipError_t {
     hipErrorContextAlreadyCurrent = 202,
     hipErrorMapFailed = 205,
     // Deprecated
-    hipErrorMapBufferObjectFailed = 205  ///< Produced when the IPC memory attach failed from ROCr.
+    hipErrorMapBufferObjectFailed = 205,  ///< Produced when the IPC memory attach failed from ROCr.
     hipErrorUnmapFailed = 206,
     hipErrorArrayIsMapped = 207,
     hipErrorAlreadyMapped = 208,

--- a/include/hip/hip_runtime_api.h
+++ b/include/hip/hip_runtime_api.h
@@ -186,7 +186,11 @@ typedef enum __HIP_NODISCARD hipError_t {
     hipErrorInvalidValue = 1,  ///< One or more of the parameters passed to the API call is NULL
                                ///< or not in an acceptable range.
     hipErrorOutOfMemory = 2,
+    // Deprecated
+    hipErrorMemoryAllocation = 2,  ///< Memory allocation error.
     hipErrorNotInitialized = 3,
+    // Deprecated
+    hipErrorInitializationError = 3,
     hipErrorDeinitialized = 4,
     hipErrorProfilerDisabled = 5,
     hipErrorProfilerNotInitialized = 6,
@@ -206,6 +210,8 @@ typedef enum __HIP_NODISCARD hipError_t {
     hipErrorInvalidContext = 201,  ///< Produced when input context is invalid.
     hipErrorContextAlreadyCurrent = 202,
     hipErrorMapFailed = 205,
+    // Deprecated
+    hipErrorMapBufferObjectFailed = 205  ///< Produced when the IPC memory attach failed from ROCr.
     hipErrorUnmapFailed = 206,
     hipErrorArrayIsMapped = 207,
     hipErrorAlreadyMapped = 208,
@@ -226,6 +232,8 @@ typedef enum __HIP_NODISCARD hipError_t {
     hipErrorSharedObjectInitFailed = 303,
     hipErrorOperatingSystem = 304,
     hipErrorInvalidHandle = 400,
+    // Deprecated
+    hipErrorInvalidResourceHandle = 400,  ///< Resource handle (hipEvent_t or hipStream_t) invalid.
     hipErrorNotFound = 500,
     hipErrorNotReady = 600,  ///< Indicates that asynchronous operations enqueued earlier are not
                              ///< ready.  This is not actually an error, but is used to distinguish
@@ -248,17 +256,11 @@ typedef enum __HIP_NODISCARD hipError_t {
         719,  ///< An exception occurred on the device while executing a kernel.
     hipErrorNotSupported = 801,  ///< Produced when the hip API is not supported/implemented
     hipErrorUnknown = 999,  //< Unknown error.
-
-    // Runtime Error Codes start here.
-    hipErrorMemoryAllocation = 1002,  ///< Memory allocation error.
-    hipErrorInitializationError = 1003,  ///< TODO comment from hipErrorInitializationError
-    hipErrorInvalidResourceHandle = 1033,  ///< Resource handle (hipEvent_t or hipStream_t) invalid.
+    // HSA Runtime Error Codes start here.
     hipErrorRuntimeMemory = 1052,  ///< HSA runtime memory call returned error.  Typically not seen
                                    ///< in production systems.
     hipErrorRuntimeOther = 1053,  ///< HSA runtime call other than memory returned error.  Typically
                                   ///< not seen in production systems.
-    hipErrorMapBufferObjectFailed =
-        1071,  ///< Produced when the IPC memory attach failed from ROCr.
     hipErrorTbd  ///< Marker that more error codes are needed.
 } hipError_t;
 

--- a/include/hip/nvcc_detail/hip_runtime_api.h
+++ b/include/hip/nvcc_detail/hip_runtime_api.h
@@ -262,9 +262,9 @@ inline static hipError_t hipCUDAErrorTohipError(cudaError_t cuError) {
         case cudaErrorMissingConfiguration:
             return hipErrorMissingConfiguration;
         case cudaErrorMemoryAllocation:
-            return hipErrorMemoryAllocation;
+            return hipErrorOutOfMemory;
         case cudaErrorInitializationError:
-            return hipErrorInitializationError;
+            return hipErrorNotInitialized;
         case cudaErrorLaunchFailure:
             return hipErrorLaunchFailure;
         case cudaErrorPriorLaunchFailure:
@@ -286,7 +286,7 @@ inline static hipError_t hipCUDAErrorTohipError(cudaError_t cuError) {
         case cudaErrorUnknown:
             return hipErrorUnknown;
         case cudaErrorInvalidResourceHandle:
-            return hipErrorInvalidResourceHandle;
+            return hipErrorInvalidHandle;
         case cudaErrorNotReady:
             return hipErrorNotReady;
         case cudaErrorNoDevice:
@@ -300,7 +300,7 @@ inline static hipError_t hipCUDAErrorTohipError(cudaError_t cuError) {
         case cudaErrorHostMemoryNotRegistered:
             return hipErrorHostMemoryNotRegistered;
         case cudaErrorMapBufferObjectFailed:
-            return hipErrorMapBufferObjectFailed;
+            return hipErrorMapFailed;
         case cudaErrorAssert:
             return hipErrorAssert;
         case cudaErrorNotSupported:
@@ -315,7 +315,7 @@ inline static hipError_t hipCUResultTohipError(CUresult cuError) {  // TODO Popu
         case CUDA_SUCCESS:
             return hipSuccess;
         case CUDA_ERROR_OUT_OF_MEMORY:
-            return hipErrorMemoryAllocation;
+            return hipErrorOutOfMemory;
         case CUDA_ERROR_INVALID_VALUE:
             return hipErrorInvalidValue;
         case CUDA_ERROR_INVALID_DEVICE:
@@ -328,6 +328,10 @@ inline static hipError_t hipCUResultTohipError(CUresult cuError) {  // TODO Popu
             return hipErrorInvalidContext;
         case CUDA_ERROR_NOT_INITIALIZED:
             return hipErrorNotInitialized;
+        case CUDA_ERROR_INVALID_HANDLE:
+          return hipErrorInvalidHandle;
+        case CUDA_ERROR_MAP_FAILED:
+          return hipErrorMapFailed;
         default:
             return hipErrorUnknown;  // Note - translated error.
     }
@@ -338,13 +342,13 @@ inline static cudaError_t hipErrorToCudaError(hipError_t hError) {
     switch (hError) {
         case hipSuccess:
             return cudaSuccess;
-        case hipErrorMemoryAllocation:
+        case hipErrorOutOfMemory:
             return cudaErrorMemoryAllocation;
         case hipErrorLaunchOutOfResources:
             return cudaErrorLaunchOutOfResources;
         case hipErrorInvalidValue:
             return cudaErrorInvalidValue;
-        case hipErrorInvalidResourceHandle:
+        case hipErrorInvalidHandle:
             return cudaErrorInvalidResourceHandle;
         case hipErrorInvalidDevice:
             return cudaErrorInvalidDevice;
@@ -352,7 +356,7 @@ inline static cudaError_t hipErrorToCudaError(hipError_t hError) {
             return cudaErrorInvalidMemcpyDirection;
         case hipErrorInvalidDevicePointer:
             return cudaErrorInvalidDevicePointer;
-        case hipErrorInitializationError:
+        case hipErrorNotInitialized:
             return cudaErrorInitializationError;
         case hipErrorNoDevice:
             return cudaErrorNoDevice;

--- a/samples/0_Intro/bit_extract/bit_extract.cpp
+++ b/samples/0_Intro/bit_extract/bit_extract.cpp
@@ -63,9 +63,9 @@ int main(int argc, char* argv[]) {
 
     printf("info: allocate host mem (%6.2f MB)\n", 2 * Nbytes / 1024.0 / 1024.0);
     A_h = (uint32_t*)malloc(Nbytes);
-    CHECK(A_h == 0 ? hipErrorMemoryAllocation : hipSuccess);
+    CHECK(A_h == 0 ? hipErrorOutOfMemory : hipSuccess);
     C_h = (uint32_t*)malloc(Nbytes);
-    CHECK(C_h == 0 ? hipErrorMemoryAllocation : hipSuccess);
+    CHECK(C_h == 0 ? hipErrorOutOfMemory : hipSuccess);
 
     for (size_t i = 0; i < N; i++) {
         A_h[i] = i;

--- a/samples/0_Intro/square/square.hipref.cpp
+++ b/samples/0_Intro/square/square.hipref.cpp
@@ -62,9 +62,9 @@ int main(int argc, char* argv[]) {
 #endif
     printf("info: allocate host mem (%6.2f MB)\n", 2 * Nbytes / 1024.0 / 1024.0);
     A_h = (float*)malloc(Nbytes);
-    CHECK(A_h == 0 ? hipErrorMemoryAllocation : hipSuccess);
+    CHECK(A_h == 0 ? hipErrorOutOfMemory : hipSuccess);
     C_h = (float*)malloc(Nbytes);
-    CHECK(C_h == 0 ? hipErrorMemoryAllocation : hipSuccess);
+    CHECK(C_h == 0 ? hipErrorOutOfMemory : hipSuccess);
     // Fill with Phi + i
     for (size_t i = 0; i < N; i++) {
         A_h[i] = 1.618f + i;

--- a/src/hip_event.cpp
+++ b/src/hip_event.cpp
@@ -103,10 +103,10 @@ hipError_t hipEventCreate(hipEvent_t* event) {
 
 hipError_t hipEventRecord(hipEvent_t event, hipStream_t stream) {
     HIP_INIT_SPECIAL_API(hipEventRecord, TRACE_SYNC, event, stream);
-    if (!event) return ihipLogStatus(hipErrorInvalidResourceHandle);
+    if (!event) return ihipLogStatus(hipErrorInvalidHandle);
     stream = ihipSyncAndResolveStream(stream);
     LockedAccessor_EventCrit_t eCrit(event->criticalData());
-    if (eCrit->_eventData._state == hipEventStatusUnitialized) return ihipLogStatus(hipErrorInvalidResourceHandle);
+    if (eCrit->_eventData._state == hipEventStatusUnitialized) return ihipLogStatus(hipErrorInvalidHandle);
     if (HIP_SYNC_NULL_STREAM && stream->isDefaultStream()) {
         // TODO-HIP_SYNC_NULL_STREAM : can remove this code when HIP_SYNC_NULL_STREAM = 0
         // If default stream , then wait on all queues.
@@ -136,7 +136,7 @@ hipError_t hipEventDestroy(hipEvent_t event) {
 
         return ihipLogStatus(hipSuccess);
     } else {
-        return ihipLogStatus(hipErrorInvalidResourceHandle);
+        return ihipLogStatus(hipErrorInvalidHandle);
     }
 }
 
@@ -152,7 +152,7 @@ hipError_t hipEventSynchronize(hipEvent_t event) {
         auto ecd = event->locked_copyCrit();
 
         if (ecd._state == hipEventStatusUnitialized) {
-            return ihipLogStatus(hipErrorInvalidResourceHandle);
+            return ihipLogStatus(hipErrorInvalidHandle);
         } else if (ecd._state == hipEventStatusCreated) {
             // Created but not actually recorded on any device:
             return ihipLogStatus(hipSuccess);
@@ -167,7 +167,7 @@ hipError_t hipEventSynchronize(hipEvent_t event) {
             return ihipLogStatus(hipSuccess);
         }
     } else {
-        return ihipLogStatus(hipErrorInvalidResourceHandle);
+        return ihipLogStatus(hipErrorInvalidHandle);
     }
 }
 
@@ -175,7 +175,7 @@ hipError_t hipEventElapsedTime(float* ms, hipEvent_t start, hipEvent_t stop) {
     HIP_INIT_API(hipEventElapsedTime, ms, start, stop);
 
     if (ms == nullptr) return ihipLogStatus(hipErrorInvalidValue);
-    if ((start == nullptr) || (stop == nullptr)) return ihipLogStatus(hipErrorInvalidResourceHandle);
+    if ((start == nullptr) || (stop == nullptr)) return ihipLogStatus(hipErrorInvalidHandle);
 
     *ms = 0.0f;
     auto startEcd = start->locked_copyCrit();
@@ -187,8 +187,8 @@ hipError_t hipEventElapsedTime(float* ms, hipEvent_t start, hipEvent_t stop) {
         (stop->_flags & hipEventDisableTiming) ||
         (stopEcd._state == hipEventStatusUnitialized) ||
         (stopEcd._state == hipEventStatusCreated)) {
-        // Both events must be at least recorded else return hipErrorInvalidResourceHandle
-        return ihipLogStatus(hipErrorInvalidResourceHandle);
+        // Both events must be at least recorded else return hipErrorInvalidHandle
+        return ihipLogStatus(hipErrorInvalidHandle);
     }
 
     // Refresh status, if still recording...
@@ -222,7 +222,7 @@ hipError_t hipEventElapsedTime(float* ms, hipEvent_t start, hipEvent_t stop) {
 hipError_t hipEventQuery(hipEvent_t event) {
     HIP_INIT_SPECIAL_API(hipEventQuery, TRACE_QUERY, event);
  
-    if (!event) return ihipLogStatus(hipErrorInvalidResourceHandle);
+    if (!event) return ihipLogStatus(hipErrorInvalidHandle);
 
     if (!(event->_flags & hipEventReleaseToSystem)) {
         tprintf(DB_WARN,

--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -1756,13 +1756,8 @@ const char* ihipErrorString(hipError_t hip_error) {
             return "hipErrorIllegalAddress";
         case hipErrorInvalidSymbol:
             return "hipErrorInvalidSymbol";
-
         case hipErrorMissingConfiguration:
             return "hipErrorMissingConfiguration";
-        case hipErrorMemoryAllocation:
-            return "hipErrorMemoryAllocation";
-        case hipErrorInitializationError:
-            return "hipErrorInitializationError";
         case hipErrorLaunchFailure:
             return "hipErrorLaunchFailure";
         case hipErrorPriorLaunchFailure:
@@ -1785,15 +1780,12 @@ const char* ihipErrorString(hipError_t hip_error) {
             return "hipErrorInvalidMemcpyDirection";
         case hipErrorUnknown:
             return "hipErrorUnknown";
-        case hipErrorInvalidResourceHandle:
-            return "hipErrorInvalidResourceHandle";
         case hipErrorNotReady:
             return "hipErrorNotReady";
         case hipErrorNoDevice:
             return "hipErrorNoDevice";
         case hipErrorPeerAccessAlreadyEnabled:
             return "hipErrorPeerAccessAlreadyEnabled";
-
         case hipErrorPeerAccessNotEnabled:
             return "hipErrorPeerAccessNotEnabled";
         case hipErrorRuntimeMemory:
@@ -1804,8 +1796,6 @@ const char* ihipErrorString(hipError_t hip_error) {
             return "hipErrorHostMemoryAlreadyRegistered";
         case hipErrorHostMemoryNotRegistered:
             return "hipErrorHostMemoryNotRegistered";
-        case hipErrorMapBufferObjectFailed:
-            return "hipErrorMapBufferObjectFailed";
         case hipErrorAssert:
             return "hipErrorAssert";
         case hipErrorNotSupported:

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -199,7 +199,7 @@ hipError_t ihipHostMalloc(TlsData *tls, void** ptr, size_t sizeBytes, unsigned i
                 true  /*shareWithAll*/, amFlags, flags, 0);
 
             if (sizeBytes && (*ptr == NULL)) {
-                hip_status = hipErrorMemoryAllocation;
+                hip_status = hipErrorOutOfMemory;
             }
         }
     }
@@ -328,7 +328,7 @@ hipError_t hipHostGetDevicePointer(void** devicePointer, void* hostPointer, unsi
             tprintf(DB_MEM, " host_ptr=%p returned device_pointer=%p\n", hostPointer,
                     *devicePointer);
         } else {
-            e = hipErrorMemoryAllocation;
+            e = hipErrorOutOfMemory;
         }
     }
     return ihipLogStatus(e);
@@ -354,7 +354,7 @@ hipError_t hipMalloc(void** ptr, size_t sizeBytes) {
                                               0 /*amFlags*/, 0 /*hipFlags*/, 0);
 
         if (sizeBytes && (*ptr == NULL)) {
-            hip_status = hipErrorMemoryAllocation;
+            hip_status = hipErrorOutOfMemory;
         }
     }
 
@@ -389,11 +389,11 @@ hipError_t hipExtMallocWithFlags(void** ptr, size_t sizeBytes, unsigned int flag
                                               amFlags /*amFlags*/, 0 /*hipFlags*/, 0);
 
         if (sizeBytes && (*ptr == NULL)) {
-            hip_status = hipErrorMemoryAllocation;
+            hip_status = hipErrorOutOfMemory;
         }
     }
 #else
-    hipError_t hip_status = hipErrorMemoryAllocation;
+    hipError_t hip_status = hipErrorOutOfMemory;
 #endif
 
     return ihipLogStatus(hip_status);
@@ -436,7 +436,7 @@ hipError_t allocImage(TlsData* tls,hsa_ext_image_geometry_t geometry, int width,
       hc::accelerator acc = ctx->getDevice()->_acc;
       hsa_agent_t* agent = static_cast<hsa_agent_t*>(acc.get_hsa_agent());
       if (!agent)
-         return hipErrorInvalidResourceHandle;
+         return hipErrorInvalidHandle;
       size_t allocGranularity = 0;
       hsa_amd_memory_pool_t* allocRegion = static_cast<hsa_amd_memory_pool_t*>(acc.get_hsa_am_region());
       hsa_amd_memory_pool_get_info(*allocRegion, HSA_AMD_MEMORY_POOL_INFO_RUNTIME_ALLOC_GRANULE, &allocGranularity);
@@ -461,12 +461,12 @@ hipError_t allocImage(TlsData* tls,hsa_ext_image_geometry_t geometry, int width,
       *ptr = hip_internal::allocAndSharePtr("device_array", imageInfo.size, ctx,
                                                                           false /*shareWithAll*/, am_flags, 0, alignment);
       if (*ptr == NULL) {
-         return hipErrorMemoryAllocation;
+         return hipErrorOutOfMemory;
       }
       return hipSuccess;
    }
    else {
-      return hipErrorMemoryAllocation;
+      return hipErrorOutOfMemory;
    }
 }
 
@@ -565,7 +565,7 @@ hipError_t GetImageInfo(hsa_ext_image_geometry_t geometry,int width, int height,
     hc::accelerator acc;
     hsa_agent_t* agent = static_cast<hsa_agent_t*>(acc.get_hsa_agent());
     if (!agent)
-        return hipErrorInvalidResourceHandle;
+        return hipErrorInvalidHandle;
     hsa_status_t status =
         hsa_ext_image_data_get_info_with_layout(*agent, &imageDescriptor, permission, HSA_EXT_IMAGE_DATA_LAYOUT_LINEAR, 0, 0, &imageInfo);
     if(HSA_STATUS_SUCCESS != status){
@@ -860,7 +860,7 @@ hipError_t hipHostRegister(void* hostPtr, size_t sizeBytes, unsigned int flags) 
                 if (am_status == AM_SUCCESS) {
                     hip_status = hipSuccess;
                 } else {
-                    hip_status = hipErrorMemoryAllocation;
+                    hip_status = hipErrorOutOfMemory;
                 }
             } else {
                 hip_status = hipErrorInvalidValue;
@@ -2083,7 +2083,7 @@ hipError_t hipIpcGetMemHandle(hipIpcMemHandle_t* handle, void* devPtr) {
     size_t psize = 0u;
     hc::accelerator acc;
     if ((handle == NULL) || (devPtr == NULL)) {
-        hipStatus = hipErrorInvalidResourceHandle;
+        hipStatus = hipErrorInvalidHandle;
     } else {
 #if (__hcc_workweek__ >= 17332)
         hc::AmPointerInfo amPointerInfo(NULL, NULL, NULL, 0, acc, 0, 0);
@@ -2094,7 +2094,7 @@ hipError_t hipIpcGetMemHandle(hipIpcMemHandle_t* handle, void* devPtr) {
         if (status == AM_SUCCESS) {
             psize = (size_t)amPointerInfo._sizeBytes;
         } else {
-            hipStatus = hipErrorInvalidResourceHandle;
+            hipStatus = hipErrorInvalidHandle;
         }
         ihipIpcMemHandle_t* iHandle = (ihipIpcMemHandle_t*)handle;
         // Save the size of the pointer to hipIpcMemHandle
@@ -2104,7 +2104,7 @@ hipError_t hipIpcGetMemHandle(hipIpcMemHandle_t* handle, void* devPtr) {
         // Create HSA ipc memory
         hsa_status_t hsa_status =
             hsa_amd_ipc_memory_create(devPtr, psize, (hsa_amd_ipc_memory_t*)&(iHandle->ipc_handle));
-        if (hsa_status != HSA_STATUS_SUCCESS) hipStatus = hipErrorMemoryAllocation;
+        if (hsa_status != HSA_STATUS_SUCCESS) hipStatus = hipErrorOutOfMemory;
 #else
         hipStatus = hipErrorRuntimeOther;
 #endif
@@ -2123,7 +2123,7 @@ hipError_t hipIpcOpenMemHandle(void** devPtr, hipIpcMemHandle_t handle, unsigned
     hc::accelerator acc;
     hsa_agent_t* agent = static_cast<hsa_agent_t*>(acc.get_hsa_agent());
     if (!agent)
-        return ihipLogStatus(hipErrorInvalidResourceHandle);
+        return ihipLogStatus(hipErrorInvalidHandle);
 
     ihipIpcMemHandle_t* iHandle = (ihipIpcMemHandle_t*)&handle;
     // Attach ipc memory
@@ -2140,7 +2140,7 @@ hipError_t hipIpcOpenMemHandle(void** devPtr, hipIpcMemHandle_t handle, unsigned
         hc::AmPointerInfo ampi(NULL, *devPtr, *devPtr, sizeof(*devPtr), acc, true, true);
         am_status_t am_status = hc::am_memtracker_add(*devPtr,ampi);
         if (am_status != AM_SUCCESS)
-            return ihipLogStatus(hipErrorMapBufferObjectFailed);
+            return ihipLogStatus(hipErrorMapFailed);
 
 #if USE_APP_PTR_FOR_CTX
         am_status = hc::am_memtracker_update(*devPtr, device->_deviceId, 0, ctx);
@@ -2148,7 +2148,7 @@ hipError_t hipIpcOpenMemHandle(void** devPtr, hipIpcMemHandle_t handle, unsigned
         am_status = hc::am_memtracker_update(*devPtr, device->_deviceId, 0);
 #endif
         if(am_status != AM_SUCCESS)
-            return ihipLogStatus(hipErrorMapBufferObjectFailed);
+            return ihipLogStatus(hipErrorMapFailed);
     }
 #else
     hipStatus = hipErrorRuntimeOther;
@@ -2168,7 +2168,7 @@ hipError_t hipIpcCloseMemHandle(void* devPtr) {
         return ihipLogStatus(hipErrorInvalidValue);
 
     if (hsa_amd_ipc_memory_detach(devPtr) != HSA_STATUS_SUCCESS)
-        return ihipLogStatus(hipErrorInvalidResourceHandle);
+        return ihipLogStatus(hipErrorInvalidHandle);
 #else
     hipStatus = hipErrorRuntimeOther;
 #endif

--- a/src/hip_stream.cpp
+++ b/src/hip_stream.cpp
@@ -133,7 +133,7 @@ hipError_t hipStreamWaitEvent(hipStream_t stream, hipEvent_t event, unsigned int
     hipError_t e = hipSuccess;
 
     if (event == nullptr) {
-        e = hipErrorInvalidResourceHandle;
+        e = hipErrorInvalidHandle;
 
     } else {
         auto ecd = event->locked_copyCrit(); 
@@ -189,7 +189,7 @@ hipError_t hipStreamSynchronize(hipStream_t stream) {
 
 //---
 /**
- * @return #hipSuccess, #hipErrorInvalidResourceHandle
+ * @return #hipSuccess, #hipErrorInvalidHandle
  */
 hipError_t hipStreamDestroy(hipStream_t stream) {
     HIP_INIT_API(hipStreamDestroy, stream);
@@ -199,7 +199,7 @@ hipError_t hipStreamDestroy(hipStream_t stream) {
     //--- Drain the stream:
     if (stream == NULL) {
         if (!HIP_FORCE_NULL_STREAM) {
-            e = hipErrorInvalidResourceHandle;
+            e = hipErrorInvalidHandle;
         }
     } else {
         stream->locked_wait();
@@ -210,7 +210,7 @@ hipError_t hipStreamDestroy(hipStream_t stream) {
             ctx->locked_removeStream(stream);
             delete stream;
         } else {
-            e = hipErrorInvalidResourceHandle;
+            e = hipErrorInvalidHandle;
         }
     }
 
@@ -225,7 +225,7 @@ hipError_t hipStreamGetFlags(hipStream_t stream, unsigned int* flags) {
     if (flags == NULL) {
         return ihipLogStatus(hipErrorInvalidValue);
     } else if (stream == hipStreamNull) {
-        return ihipLogStatus(hipErrorInvalidResourceHandle);
+        return ihipLogStatus(hipErrorInvalidHandle);
     } else {
         *flags = stream->_flags;
         return ihipLogStatus(hipSuccess);
@@ -240,7 +240,7 @@ hipError_t hipStreamGetPriority(hipStream_t stream, int* priority) {
     if (priority == NULL) {
         return ihipLogStatus(hipErrorInvalidValue);
     } else if (stream == hipStreamNull) {
-        return ihipLogStatus(hipErrorInvalidResourceHandle);
+        return ihipLogStatus(hipErrorInvalidHandle);
     } else {
 #if defined(__HCC__) && (__hcc_major__ < 3) && (__hcc_minor__ < 3)
         *priority = 0;

--- a/tests/hipify-clang/unit_tests/samples/square.cu
+++ b/tests/hipify-clang/unit_tests/samples/square.cu
@@ -67,11 +67,11 @@ int main(int argc, char *argv[])
     printf ("info: allocate host mem (%6.2f MB)\n", 2*Nbytes/1024.0/1024.0);
     A_h = (float*)malloc(Nbytes);
 
-    // CHECK: CHECK(A_h == 0 ? hipErrorMemoryAllocation : hipSuccess );
+    // CHECK: CHECK(A_h == 0 ? hipErrorOutOfMemory : hipSuccess );
     CHECK(A_h == 0 ? cudaErrorMemoryAllocation : cudaSuccess );
     C_h = (float*)malloc(Nbytes);
 
-    // CHECK: CHECK(C_h == 0 ? hipErrorMemoryAllocation : hipSuccess );
+    // CHECK: CHECK(C_h == 0 ? hipErrorOutOfMemory : hipSuccess );
     CHECK(C_h == 0 ? cudaErrorMemoryAllocation : cudaSuccess );
     // Fill with Phi + i
     for (size_t i=0; i<N; i++)

--- a/tests/src/dynamicLoading/complex_loading_behavior.cpp
+++ b/tests/src/dynamicLoading/complex_loading_behavior.cpp
@@ -62,11 +62,11 @@ int launch_local_kernel() {
     hipDeviceProp_t props;
     CHECK(hipGetDeviceProperties(&props, device /*deviceID*/));
     A_h = (float*)malloc(Nbytes);
-    CHECK(A_h == 0 ? hipErrorMemoryAllocation : hipSuccess);
+    CHECK(A_h == 0 ? hipErrorOutOfMemory : hipSuccess);
     B_h = (float*)malloc(Nbytes);
-    CHECK(B_h == 0 ? hipErrorMemoryAllocation : hipSuccess);
+    CHECK(B_h == 0 ? hipErrorOutOfMemory : hipSuccess);
     C_h = (float*)malloc(Nbytes);
-    CHECK(C_h == 0 ? hipErrorMemoryAllocation : hipSuccess);
+    CHECK(C_h == 0 ? hipErrorOutOfMemory : hipSuccess);
     // Fill with Phi + i
     for (size_t i = 0; i < N; i++) {
         A_h[i] = 1.618f + i;
@@ -174,11 +174,11 @@ extern "C" int foo() {
     hipDeviceProp_t props;
     CHECK(hipGetDeviceProperties(&props, device /*deviceID*/));
     A_h = (float*)malloc(Nbytes);
-    CHECK(A_h == 0 ? hipErrorMemoryAllocation : hipSuccess);
+    CHECK(A_h == 0 ? hipErrorOutOfMemory : hipSuccess);
     B_h = (float*)malloc(Nbytes);
-    CHECK(B_h == 0 ? hipErrorMemoryAllocation : hipSuccess);
+    CHECK(B_h == 0 ? hipErrorOutOfMemory : hipSuccess);
     C_h = (float*)malloc(Nbytes);
-    CHECK(C_h == 0 ? hipErrorMemoryAllocation : hipSuccess);
+    CHECK(C_h == 0 ? hipErrorOutOfMemory : hipSuccess);
     // Fill with Phi + i
     for (size_t i = 0; i < N; i++) {
         A_h[i] = 1.618f + i;

--- a/tests/src/runtimeApi/event/record_event.cpp
+++ b/tests/src/runtimeApi/event/record_event.cpp
@@ -133,14 +133,14 @@ void test(unsigned testMask, int* C_d, int* C_h, int64_t numElements, hipStream_
 
     {
         // Check some error conditions for incomplete events:
-        HIPCHECK_API(hipEventElapsedTime(&t, timingDisabled, stop), hipErrorInvalidResourceHandle);
-        HIPCHECK_API(hipEventElapsedTime(&t, start, timingDisabled), hipErrorInvalidResourceHandle);
+        HIPCHECK_API(hipEventElapsedTime(&t, timingDisabled, stop), hipErrorInvalidHandle);
+        HIPCHECK_API(hipEventElapsedTime(&t, start, timingDisabled), hipErrorInvalidHandle);
 
-        HIPCHECK_API(hipEventElapsedTime(&t, neverCreated, stop), hipErrorInvalidResourceHandle);
-        HIPCHECK_API(hipEventElapsedTime(&t, start, neverCreated), hipErrorInvalidResourceHandle);
+        HIPCHECK_API(hipEventElapsedTime(&t, neverCreated, stop), hipErrorInvalidHandle);
+        HIPCHECK_API(hipEventElapsedTime(&t, start, neverCreated), hipErrorInvalidHandle);
 
-        HIPCHECK_API(hipEventElapsedTime(&t, neverRecorded, stop), hipErrorInvalidResourceHandle);
-        HIPCHECK_API(hipEventElapsedTime(&t, start, neverRecorded), hipErrorInvalidResourceHandle);
+        HIPCHECK_API(hipEventElapsedTime(&t, neverRecorded, stop), hipErrorInvalidHandle);
+        HIPCHECK_API(hipEventElapsedTime(&t, start, neverRecorded), hipErrorInvalidHandle);
     }
 
     HIPCHECK(hipEventDestroy(start));

--- a/tests/src/runtimeApi/module/hipExtLaunchMultiKernelMultiDevice.cpp
+++ b/tests/src/runtimeApi/module/hipExtLaunchMultiKernelMultiDevice.cpp
@@ -67,9 +67,9 @@ int main(int argc, char *argv[])
 
     printf ("info: allocate host mem (%6.2f MB)\n", 2*Nbytes/1024.0/1024.0);
     A_h = (float*)malloc(Nbytes);
-    HIPCHECK(A_h == 0 ? hipErrorMemoryAllocation : hipSuccess );
+    HIPCHECK(A_h == 0 ? hipErrorOutOfMemory : hipSuccess );
     C_h = (float*)malloc(Nbytes);
-    HIPCHECK(C_h == 0 ? hipErrorMemoryAllocation : hipSuccess );
+    HIPCHECK(C_h == 0 ? hipErrorOutOfMemory : hipSuccess );
     // Fill with Phi + i
     for (size_t i = 0; i < N; i++)
     {

--- a/tests/src/runtimeApi/stream/hipStreamAddCallback.cpp
+++ b/tests/src/runtimeApi/stream/hipStreamAddCallback.cpp
@@ -60,9 +60,9 @@ int main(int argc, char* argv[]) {
     size_t Nbytes = N * sizeof(float);
 
     A_h = (float*)malloc(Nbytes);
-    HIPCHECK(A_h == 0 ? hipErrorMemoryAllocation : hipSuccess);
+    HIPCHECK(A_h == 0 ? hipErrorOutOfMemory : hipSuccess);
     C_h = (float*)malloc(Nbytes);
-    HIPCHECK(C_h == 0 ? hipErrorMemoryAllocation : hipSuccess);
+    HIPCHECK(C_h == 0 ? hipErrorOutOfMemory : hipSuccess);
 
     // Fill with Phi + i
     for (size_t i = 0; i < N; i++) {

--- a/tests/src/runtimeApi/stream/hipStreamSync2.cpp
+++ b/tests/src/runtimeApi/stream/hipStreamSync2.cpp
@@ -201,7 +201,7 @@ void runTests(int64_t numElements) {
 
 int main(int argc, char* argv[]) {
     // Can' destroy the default stream:// TODO - move to another test
-    HIPCHECK_API(hipStreamDestroy(0), hipErrorInvalidResourceHandle);
+    HIPCHECK_API(hipStreamDestroy(0), hipErrorInvalidHandle);
 
     HipTest::parseStandardArguments(argc, argv, true /*failOnUndefinedArg*/);
 


### PR DESCRIPTION
Step 2. Make a few hipError codes deprecated
Update hipify-clang, hipify-perl, docs and samples accordingly