### PR TITLE
Detect when an explicit printf buffer flush is required

### DIFF
--- a/src/hip_hcc_internal.h
+++ b/src/hip_hcc_internal.h
@@ -570,7 +570,7 @@ class ihipStream_t {
     LockedAccessor_StreamCrit_t lockopen_preKernelCommand();
     void lockclose_postKernelCommand(const char* kernelName, hc::accelerator_view* av, bool unlockNotNeeded = 0);
 
-
+    void locked_wait(bool& waited);
     void locked_wait();
 
     hc::accelerator_view* locked_getAv() {

--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -28,6 +28,7 @@ THE SOFTWARE.
 #include "hip/hip_ext.h"
 #include "program_state.inl"
 #include "trace_helper.h"
+#include "hc_am.hpp"
 
 #include <hsa/amd_hsa_kernel_code.h>
 #include <hsa/hsa.h>


### PR DESCRIPTION
Detect when an explicit printf buffer flush is required in a device/stream synchronization function.