### PR TITLE
Fix build failure of PyTorch/Caffe2 for hip-clang

### DIFF
--- a/include/hip/hcc_detail/hip_complex.h
+++ b/include/hip/hcc_detail/hip_complex.h
@@ -24,7 +24,9 @@ THE SOFTWARE.
 #define HIP_INCLUDE_HIP_HCC_DETAIL_HIP_COMPLEX_H
 
 #include "hip/hcc_detail/hip_vector_types.h"
+#if !__HIP__
 #include "hip/math_functions.h"
+#endif
 
 // TODO: Clang has a bug which allows device functions to call std functions
 // when std functions are introduced into default namespace by using statement.


### PR DESCRIPTION
we need this urgently to unblock pytorch/caffe2 builds