### PR TITLE
Fix test hip_bitextract.cpp

### DIFF
--- a/tests/src/deviceLib/hip_bitextract.cpp
+++ b/tests/src/deviceLib/hip_bitextract.cpp
@@ -123,6 +123,8 @@ int main() {
         hostSrc032[i] = uint32_src0_dist(rd);
         hostSrc132[i] = uint32_src12_dist(rd);
         hostSrc232[i] = uint32_src12_dist(rd);
+        if (hostSrc132[i] + hostSrc232[i] > 32)
+          hostSrc232[i] = 32 - hostSrc132[i];
         hostOut64[i] = 0;
         hostSrc064[i] = uint64_src0_dist(rd);
         hostSrc164[i] = uint64_src12_dist(rd);


### PR DESCRIPTION
The randomly generated offset+width may exceeds 32, which causes
a left shift operation with 32-offset-width. As an unsigned number
that is greater than 32 and causes undefined behavior. When the
test is compiled without -mavx it is still OK. However when
the test is compiled with -mavx, the undefined behavior causes
wrong results and test failure.

This patch adjusts width so that offset+width<=32 always.