### PR TITLE
Clear `HIP_PATH` before version detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ endmacro()
 # Setup version information
 #############################
 # Determine HIP_BASE_VERSION
+set(ENV{HIP_PATH} "")
 execute_process(COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/bin/hipconfig --version
     OUTPUT_VARIABLE HIP_BASE_VERSION
     OUTPUT_STRIP_TRAILING_WHITESPACE)


### PR DESCRIPTION
Don't allow `HIP_PATH` to be propagated to `hipconfig`, when run by CMake to detect the package version, as it leads to the wrong version is detected: when there's already HIP of some different version installed in the system and `HIP_PATH` points to its location, `hipconfig` tends to return the version of the installed HIP, rather than the value defined for the distribution. The compiled results report wrong version and spoils the rest of the stack in this case.

First found during the testing of the ebuild for HIP at https://github.com/justxi/rocm/pull/120 and fixed there with clearing `HIP_PATH` just before calling `cmake` as the first measure. But it looks, that the proper fix is like in this request.