### PR TITLE
Fix hipMemcpy3D

### DIFF
--- a/include/hip/hcc_detail/driver_types.h
+++ b/include/hip/hcc_detail/driver_types.h
@@ -254,14 +254,14 @@ typedef struct hipMemcpy3DParms {
     hipArray_t srcArray;
     struct hipPos srcPos;
     struct hipPitchedPtr srcPtr;
-
     hipArray_t dstArray;
     struct hipPos dstPos;
     struct hipPitchedPtr dstPtr;
-
     struct hipExtent extent;
     enum hipMemcpyKind kind;
+} hipMemcpy3DParms;
 
+typedef struct HIP_MEMCPY3D {
     size_t Depth;
     size_t Height;
     size_t WidthInBytes;
@@ -282,10 +282,7 @@ typedef struct hipMemcpy3DParms {
     size_t srcLOD;
     hipMemoryType srcMemoryType;
     size_t srcPitch;
-    size_t srcXInBytes;
-    size_t srcY;
-    size_t srcZ;
-}hipMemcpy3DParms;
+} HIP_MEMCPY3D;
 
 static inline struct hipPitchedPtr make_hipPitchedPtr(void* d, size_t p, size_t xsz,
                                                           size_t ysz) {

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1602,7 +1602,7 @@ hipError_t ihipMemcpy3D(const struct hipMemcpy3DParms* p, hipStream_t stream, bo
         void* srcPtr;void* dstPtr;
         copyDepth = p->extent.depth;
         copyHeight = p->extent.height;
-        copyWidth =  p->extent.width; // in bytes
+        copyWidth =  p->extent.width; // in bytes ?
         dstXoffset = p->dstPos.x;
         dstYoffset = p->dstPos.y;
         dstZoffset = p->dstPos.z;
@@ -1622,6 +1622,7 @@ hipError_t ihipMemcpy3D(const struct hipMemcpy3DParms* p, hipStream_t stream, bo
             dstHeight = p->dstArray->height;
             dstDepth = p->dstArray->depth;
             dstPitch = dstWidth * dstByteSize;
+            copyWidth = copyWidth * dstByteSize; //TODO check ?
         } else {
             //Non Array destination
             dstPtr = p->dstPtr.ptr;

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1599,7 +1599,8 @@ hipError_t ihipMemcpy3D(const struct hipMemcpy3DParms* p, hipStream_t stream, bo
         size_t srcXoffset, srcYoffset, srcZoffset, dstXoffset, dstYoffset, dstZoffset;
         size_t srcWidth, srcHeight, srcDepth, dstWidth, dstHeight, dstDepth;
 
-        void* srcPtr;void* dstPtr;
+        void* srcPtr, *dstPtr;
+        bool copyWidthUpdate= false;
         copyDepth = p->extent.depth;
         copyHeight = p->extent.height;
         copyWidth =  p->extent.width; // in bytes ?
@@ -1622,7 +1623,10 @@ hipError_t ihipMemcpy3D(const struct hipMemcpy3DParms* p, hipStream_t stream, bo
             dstHeight = p->dstArray->height;
             dstDepth = p->dstArray->depth;
             dstPitch = dstWidth * dstByteSize;
-            copyWidth = copyWidth * dstByteSize; //TODO check ?
+            if(!copyWidthUpdate) {
+                copyWidth = copyWidth * dstByteSize;
+                copyWidthUpdate = true;
+            }
         } else {
             //Non Array destination
             dstPtr = p->dstPtr.ptr;
@@ -1644,6 +1648,10 @@ hipError_t ihipMemcpy3D(const struct hipMemcpy3DParms* p, hipStream_t stream, bo
             srcHeight = p->srcArray->height;
             srcDepth = p->srcArray->depth;
             srcPitch = srcWidth * srcByteSize;
+            if(!copyWidthUpdate) {
+                copyWidth = copyWidth * srcByteSize;
+                copyWidthUpdate = true;
+            }
         } else {
             //Non Array source
             srcPtr = p->srcPtr.ptr;

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1622,11 +1622,7 @@ hipError_t ihipMemcpy3D(const struct hipMemcpy3DParms* p, hipStream_t stream, bo
             dstWidth = p->dstArray->width;
             dstHeight = p->dstArray->height;
             dstDepth = p->dstArray->depth;
-            if(hipMemcpyHostToDevice == p->kind || hipMemcpyDeviceToDevice == p->kind){
-                dstPitch = dstByteSize * alignUp(dstWidth, IMAGE_PITCH_ALIGNMENT);
-            }else {
-                dstPitch = dstByteSize * dstWidth;
-            }
+            dstPitch = dstByteSize * alignUp(dstWidth, IMAGE_PITCH_ALIGNMENT);
             if(!copyWidthUpdate) {
                 copyWidth = copyWidth * dstByteSize;
                 copyWidthUpdate = true;
@@ -1651,11 +1647,7 @@ hipError_t ihipMemcpy3D(const struct hipMemcpy3DParms* p, hipStream_t stream, bo
             srcWidth = p->srcArray->width;
             srcHeight = p->srcArray->height;
             srcDepth = p->srcArray->depth;
-            if(hipMemcpyDeviceToHost == p->kind || hipMemcpyDeviceToDevice == p->kind){
-                srcPitch = alignUp(srcWidth, IMAGE_PITCH_ALIGNMENT) * srcByteSize;
-            }else {
-                srcPitch = srcWidth * srcByteSize;
-            }
+            srcPitch = srcByteSize * alignUp(srcWidth, IMAGE_PITCH_ALIGNMENT);
             if(!copyWidthUpdate) {
                 copyWidth = copyWidth * srcByteSize;
                 copyWidthUpdate = true;

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1540,132 +1540,135 @@ hipError_t hipMemcpyAtoH(void* dst, hipArray* srcArray, size_t srcOffset, size_t
     return ihipLogStatus(e);
 }
 
+int getByteSizeFromFormat(const hipChannelFormatDesc& desc){
+    int byteSize =0;
+    switch (desc.f) {
+        case hipChannelFormatKindUnsigned:
+            switch (desc.x) {
+                case 32:
+                    byteSize = sizeof(uint32_t);
+                    break;
+                case 16:
+                    byteSize = sizeof(uint16_t);
+                    break;
+                case 8:
+                    byteSize = sizeof(uint8_t);
+                    break;
+                default:
+                    byteSize = sizeof(uint32_t);
+            }
+            break;
+        case hipChannelFormatKindSigned:
+            switch (desc.x) {
+                case 32:
+                    byteSize = sizeof(int32_t);
+                    break;
+                case 16:
+                    byteSize = sizeof(int16_t);
+                    break;
+                case 8:
+                    byteSize = sizeof(int8_t);
+                    break;
+                default:
+                    byteSize = sizeof(int32_t);
+            }
+            break;
+        case hipChannelFormatKindFloat:
+            switch (desc.x) {
+                case 32:
+                    byteSize = sizeof(float);
+                    break;
+                case 16:
+                    byteSize = sizeof(_Float16);
+                    break;
+                default:
+                    byteSize = sizeof(float);
+            }
+            break;
+        case hipChannelFormatKindNone:
+        default:
+            break;
+    }
+    return byteSize;
+}
+
 hipError_t ihipMemcpy3D(const struct hipMemcpy3DParms* p, hipStream_t stream, bool isAsync) {
     hipError_t e = hipSuccess;
     if(p) {
-        size_t byteSize, width, height, depth, widthInBytes, srcPitch, dstPitch, srcYsize, dstYsize;
+        size_t dstByteSize, srcByteSize, copyWidth, copyHeight, copyDepth, widthInBytes, srcPitch, dstPitch, srcYsize, dstYsize;
         size_t srcXoffset, srcYoffset, srcZoffset, dstXoffset, dstYoffset, dstZoffset;
-        hipChannelFormatDesc desc;
+        size_t srcWidth, srcHeight, srcDepth, dstWidth, dstHeight, dstDepth;
+
         void* srcPtr;void* dstPtr;
+        copyDepth = p->extent.depth;
+        copyHeight = p->extent.height;
+        copyWidth =  p->extent.width; // in bytes
+        dstXoffset = p->dstPos.x;
+        dstYoffset = p->dstPos.y;
+        dstZoffset = p->dstPos.z;
+        srcXoffset = p->srcPos.x;
+        srcYoffset = p->srcPos.y;
+        srcZoffset = p->srcPos.z;
         if (p->dstArray != nullptr) {
-            if (p->dstArray->isDrv == false) {
-                switch (p->dstArray->desc.f) {
-                    case hipChannelFormatKindSigned:
-                        byteSize = sizeof(int);
-                        break;
-                    case hipChannelFormatKindUnsigned:
-                        byteSize = sizeof(unsigned int);
-                        break;
-                    case hipChannelFormatKindFloat:
-                        byteSize = sizeof(float);
-                        break;
-                    case hipChannelFormatKindNone:
-                        byteSize = sizeof(size_t);
-                        break;
-                    default:
-                        byteSize = 0;
-                        break;
-                }
-                depth = p->extent.depth;
-                height = p->extent.height;
-                width =  p->extent.width;
-                widthInBytes = p->extent.width * byteSize;
-                srcPitch = p->srcPtr.pitch;
-                srcPtr = p->srcPtr.ptr;
-                srcYsize = p->srcPtr.ysize;
-                dstYsize = p->dstPtr.ysize;
-                desc = p->dstArray->desc;
-                dstPtr = p->dstArray->data;
-                dstXoffset = p->dstPos.x;
-                dstYoffset = p->dstPos.y;
-                dstZoffset = p->dstPos.z;
-                srcXoffset = p->srcPos.x;
-                srcYoffset = p->srcPos.y;
-                srcZoffset = p->srcPos.z;
-                hsa_ext_image_data_info_t imageInfo;
-                if(hipTextureType2DLayered == p->dstArray->textureType)
-                    GetImageInfo(HSA_EXT_IMAGE_GEOMETRY_2DA, width, height, 0, desc, imageInfo, depth);
-                else
-                    GetImageInfo(HSA_EXT_IMAGE_GEOMETRY_3D, width, height, depth, desc, imageInfo);
-                dstPitch = imageInfo.size/(height == 0 ? 1 : height)/(depth == 0 ? 1 : depth);
-            } else {
-                depth = p->Depth;
-                height = p->Height;
-                widthInBytes = p->WidthInBytes;
-                width =  p->dstArray->width;
-                dstXoffset = p->dstXInBytes;
-                dstYoffset = p->dstY;
-                dstZoffset = p->dstZ;
-                srcXoffset = p->srcXInBytes;
-                srcYoffset = p->srcY;
-                srcZoffset = p->srcZ;
-                hsa_ext_image_channel_order_t channelOrder;
-                switch(p->dstArray->NumChannels) {
-                    case 2:
-                       channelOrder = HSA_EXT_IMAGE_CHANNEL_ORDER_RG;
-                       break;
-                    case 3:
-                       channelOrder = HSA_EXT_IMAGE_CHANNEL_ORDER_RGB;
-                       break;
-                    case 4:
-                       channelOrder = HSA_EXT_IMAGE_CHANNEL_ORDER_RGBA;
-                       break;
-                    case 1:
-                    default:
-                       channelOrder = HSA_EXT_IMAGE_CHANNEL_ORDER_R;
-                       break;
-                }
-                hsa_ext_image_channel_type_t channelType;
-                e = ihipArrayToImageFormat(p->dstArray->Format,channelType);
-                srcPitch = p->srcPitch;
-                srcPtr = (void*)p->srcHost;
-                srcYsize = p->srcHeight;
-                dstYsize = p->dstHeight;
-                dstPtr = p->dstArray->data;
-                hsa_ext_image_data_info_t imageInfo;
-                if(hipTextureType2DLayered == p->dstArray->textureType)
-                    GetImageInfo(HSA_EXT_IMAGE_GEOMETRY_2DA, width, height, 0, channelOrder, channelType, imageInfo, depth);
-                else
-                    GetImageInfo(HSA_EXT_IMAGE_GEOMETRY_3D, width, height, depth, channelOrder, channelType, imageInfo);
-                dstPitch = imageInfo.size/(height == 0 ? 1 : height)/(depth == 0 ? 1 : depth);
+            if ((p->dstArray->isDrv == true) ||( p->dstPtr.ptr!= nullptr)){
+                return hipErrorInvalidValue;
             }
+            // Array destination
+            dstByteSize = getByteSizeFromFormat(p->dstArray->desc);
+            hipChannelFormatDesc desc;
+            desc = p->dstArray->desc;
+            dstPtr = p->dstArray->data;
+            dstWidth = p->dstArray->width;
+            dstHeight = p->dstArray->height;
+            dstDepth = p->dstArray->depth;
+            dstPitch = dstWidth * dstByteSize;
         } else {
-            // Non array destination
-            depth = p->extent.depth;
-            height = p->extent.height;
-            widthInBytes = p->extent.width;
-            srcPitch = p->srcPtr.pitch;
-            srcPtr = p->srcPtr.ptr;
+            //Non Array destination
             dstPtr = p->dstPtr.ptr;
-            srcYsize = p->srcPtr.ysize;
-            dstYsize = p->dstPtr.ysize;
+            dstWidth = p->dstPtr.xsize;
+            dstHeight = p->dstPtr.ysize;
             dstPitch = p->dstPtr.pitch;
-            dstXoffset = p->dstPos.x;
-            dstYoffset = p->dstPos.y;
-            dstZoffset = p->dstPos.z;
-            srcXoffset = p->srcPos.x;
-            srcYoffset = p->srcPos.y;
-            srcZoffset = p->srcPos.z;
+        }
+
+        if (p->srcArray != nullptr) {
+            if ((p->srcArray->isDrv == true) ||( p->srcPtr.ptr!= nullptr)){
+                return hipErrorInvalidValue;
+            }
+            // Array source
+            srcByteSize = getByteSizeFromFormat(p->srcArray->desc);
+            hipChannelFormatDesc desc;
+            desc = p->srcArray->desc;
+            srcPtr = p->srcArray->data;
+            srcWidth = p->srcArray->width;
+            srcHeight = p->srcArray->height;
+            srcDepth = p->srcArray->depth;
+            srcPitch = srcWidth * srcByteSize;
+        } else {
+            //Non Array source
+            srcPtr = p->srcPtr.ptr;
+            srcWidth = p->srcPtr.xsize;
+            srcHeight = p->srcPtr.ysize;
+            srcPitch = p->srcPtr.pitch;
         }
 
         stream = ihipSyncAndResolveStream(stream);
         try {
-            if((widthInBytes == dstPitch) && (widthInBytes == srcPitch)) {
+            if((copyWidth == dstPitch) && (copyWidth == srcPitch)&& (copyHeight == dstHeight) &&(copyHeight == srcHeight)) {
                 if(isAsync)
-                    stream->locked_copyAsync((void*)dstPtr, (void*)srcPtr, widthInBytes*height*depth, p->kind);
+                    stream->locked_copyAsync((void*)dstPtr, (void*)srcPtr, copyWidth*copyHeight*copyDepth, p->kind);
                 else
-                    stream->locked_copySync((void*)dstPtr, (void*)srcPtr, widthInBytes*height*depth, p->kind, false);
+                    stream->locked_copySync((void*)dstPtr, (void*)srcPtr, copyWidth*copyHeight*copyDepth, p->kind, false);
             } else {
-                for (int i = 0; i < depth; i++) {
-                    for (int j = 0; j < height; j++) {
+                for (int i = 0; i < copyDepth; i++) {
+                    for (int j = 0; j < copyHeight; j++) {
                         unsigned char* src =
-                             (unsigned char*)srcPtr + (i + srcZoffset) * srcYsize * srcPitch + (j + srcYoffset) * srcPitch + srcXoffset;
+                             (unsigned char*)srcPtr + (i + srcZoffset) * srcHeight * srcPitch + (j + srcYoffset) * srcPitch + srcXoffset;
                         unsigned char* dst =
-                             (unsigned char*)dstPtr + (i + dstZoffset) * dstYsize * dstPitch + (j + dstYoffset) * dstPitch + dstXoffset;
+                             (unsigned char*)dstPtr + (i + dstZoffset) * dstHeight * dstPitch + (j + dstYoffset) * dstPitch + dstXoffset;
                         if(isAsync)
-                            stream->locked_copyAsync(dst, src, widthInBytes, p->kind);
+                            stream->locked_copyAsync(dst, src, copyWidth, p->kind);
                         else
-                            stream->locked_copySync(dst, src, widthInBytes, p->kind);
+                            stream->locked_copySync(dst, src, copyWidth, p->kind);
                      }
                 }
            }

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -1622,7 +1622,11 @@ hipError_t ihipMemcpy3D(const struct hipMemcpy3DParms* p, hipStream_t stream, bo
             dstWidth = p->dstArray->width;
             dstHeight = p->dstArray->height;
             dstDepth = p->dstArray->depth;
-            dstPitch = dstWidth * dstByteSize;
+            if(hipMemcpyHostToDevice == p->kind || hipMemcpyDeviceToDevice == p->kind){
+                dstPitch = dstByteSize * alignUp(dstWidth, IMAGE_PITCH_ALIGNMENT);
+            }else {
+                dstPitch = dstByteSize * dstWidth;
+            }
             if(!copyWidthUpdate) {
                 copyWidth = copyWidth * dstByteSize;
                 copyWidthUpdate = true;
@@ -1647,7 +1651,11 @@ hipError_t ihipMemcpy3D(const struct hipMemcpy3DParms* p, hipStream_t stream, bo
             srcWidth = p->srcArray->width;
             srcHeight = p->srcArray->height;
             srcDepth = p->srcArray->depth;
-            srcPitch = srcWidth * srcByteSize;
+            if(hipMemcpyDeviceToHost == p->kind || hipMemcpyDeviceToDevice == p->kind){
+                srcPitch = alignUp(srcWidth, IMAGE_PITCH_ALIGNMENT) * srcByteSize;
+            }else {
+                srcPitch = srcWidth * srcByteSize;
+            }
             if(!copyWidthUpdate) {
                 copyWidth = copyWidth * srcByteSize;
                 copyWidthUpdate = true;

--- a/tests/src/runtimeApi/memory/hipMemcpy3D.cpp
+++ b/tests/src/runtimeApi/memory/hipMemcpy3D.cpp
@@ -18,7 +18,7 @@ THE SOFTWARE.
 */
 
 /* HIT_START
- * BUILD: %t %s ../../test_common.cpp EXCLUDE_HIP_PLATFORM nvcc
+ * BUILD: %t %s ../../test_common.cpp
  * TEST: %t
  * HIT_END
  */
@@ -54,9 +54,15 @@ void runTest(int width,int height,int depth)
     myparms.kind = hipMemcpyHostToDevice;
     HIPCHECK(hipMemcpy3D(&myparms));
     HIPCHECK(hipDeviceSynchronize());
-    HipTest::checkArray(hData,(T*)arr->data,width,height,depth);
+    T *hOutputData = (T*) malloc(size);
+    memset(hOutputData, 0,  size);
+
+    // copy result from device to host
+    HIPCHECK(hipMemcpyFromArray(hOutputData, arr, 0, 0, size, hipMemcpyDeviceToHost));
+    HipTest::checkArray(hData,hOutputData,width,height,depth);
     hipFreeArray(arr);
     free(hData);
+    free(hOutputData);
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/tests/src/runtimeApi/memory/hipMemcpy3D.cpp
+++ b/tests/src/runtimeApi/memory/hipMemcpy3D.cpp
@@ -51,7 +51,11 @@ void runTest(int width,int height,int depth, hipChannelFormatKind formatKind)
     myparms.srcPtr = make_hipPitchedPtr(hData, width * sizeof(T), width, height);
     myparms.dstArray = arr;
     myparms.extent = make_hipExtent(width , height, depth);
+#ifdef __HIP_PLATFORM_NVCC__
+    myparms.kind = cudaMemcpyHostToDevice;
+#else
     myparms.kind = hipMemcpyHostToDevice;
+#endif
     HIPCHECK(hipMemcpy3D(&myparms));
     HIPCHECK(hipDeviceSynchronize());
     //Array to Array
@@ -61,7 +65,11 @@ void runTest(int width,int height,int depth, hipChannelFormatKind formatKind)
     myparms.srcArray = arr;
     myparms.dstArray = arr1;
     myparms.extent = make_hipExtent(width, height, depth);
+#ifdef __HIP_PLATFORM_NVCC__
+    myparms.kind = cudaMemcpyDeviceToDevice;
+#else
     myparms.kind = hipMemcpyDeviceToDevice;
+#endif
     HIPCHECK(hipMemcpy3D(&myparms));
     HIPCHECK(hipDeviceSynchronize());
 
@@ -74,7 +82,11 @@ void runTest(int width,int height,int depth, hipChannelFormatKind formatKind)
     myparms.dstPtr = make_hipPitchedPtr(hOutputData, width * sizeof(T), width, height);
     myparms.srcArray = arr1;
     myparms.extent = make_hipExtent(width, height, depth);
+#ifdef __HIP_PLATFORM_NVCC__
+    myparms.kind = cudaMemcpyDeviceToHost;
+#else
     myparms.kind = hipMemcpyDeviceToHost;
+#endif
     HIPCHECK(hipMemcpy3D(&myparms));
     HIPCHECK(hipDeviceSynchronize());
 

--- a/tests/src/runtimeApi/memory/hipMemcpy3D.cpp
+++ b/tests/src/runtimeApi/memory/hipMemcpy3D.cpp
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2015 - present Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/* HIT_START
+ * BUILD: %t %s ../../test_common.cpp EXCLUDE_HIP_PLATFORM nvcc
+ * TEST: %t
+ * HIT_END
+ */
+
+#include "test_common.h"
+
+template <typename T>
+void runTest(int width,int height,int depth)
+{
+    unsigned int size = width * height * depth * sizeof(T);
+    T* hData = (T*) malloc(size);
+    memset(hData, 0, size);
+
+    for (int i = 0; i < depth; i++) {
+        for (int j = 0; j < height; j++) {
+            for (int k = 0; k < width; k++) {
+                hData[i*width*height + j*width +k] = i*width*height + j*width + k;
+            }
+        }
+    }
+    printf("test- sizeof(T) =%d\n", sizeof(T));
+    // Allocate array and copy image data
+    hipChannelFormatDesc channelDesc = hipCreateChannelDesc(sizeof(T)*8, 0, 0, 0, hipChannelFormatKindSigned);
+    hipArray *arr;
+
+    HIPCHECK(hipMalloc3DArray(&arr, &channelDesc, make_hipExtent(width, height, depth), hipArrayCubemap));
+    hipMemcpy3DParms myparms = {0};
+    myparms.srcPos = make_hipPos(0,0,0);
+    myparms.dstPos = make_hipPos(0,0,0);
+    myparms.srcPtr = make_hipPitchedPtr(hData, width * sizeof(T), width, height);
+    myparms.dstArray = arr;
+    myparms.extent = make_hipExtent(width * sizeof(T), height, depth);
+    myparms.kind = hipMemcpyHostToDevice;
+    HIPCHECK(hipMemcpy3D(&myparms));
+    HIPCHECK(hipDeviceSynchronize());
+    HipTest::checkArray(hData,(T*)arr->data,width,height,depth);
+    hipFreeArray(arr);
+    free(hData);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Program main
+////////////////////////////////////////////////////////////////////////////////
+int main(int argc, char **argv)
+{
+    for(int i=1;i<25;i++)
+    {
+        runTest<float>(i,i,i);
+        runTest<int>(i+1,i,i);
+        runTest<char>(i,i+1,i);
+    }
+    passed();
+}

--- a/tests/src/texture/simpleTexture2DLayered.cpp
+++ b/tests/src/texture/simpleTexture2DLayered.cpp
@@ -59,7 +59,7 @@ void runTest(int width,int height,int num_layers,texture<T, hipTextureType2DLaye
     myparms.dstPos = make_hipPos(0,0,0);
     myparms.srcPtr = make_hipPitchedPtr(hData, width * sizeof(T), width, height);
     myparms.dstArray = arr;
-    myparms.extent = make_hipExtent(width, height, num_layers);
+    myparms.extent = make_hipExtent(width * sizeof(T), height, num_layers);
     //myparms.kind = hipMemcpyHostToDevice;
     HIPCHECK(hipMemcpy3D(&myparms));
 

--- a/tests/src/texture/simpleTexture2DLayered.cpp
+++ b/tests/src/texture/simpleTexture2DLayered.cpp
@@ -53,7 +53,7 @@ void runTest(int width,int height,int num_layers,texture<T, hipTextureType2DLaye
     channelDesc = hipCreateChannelDesc(sizeof(T)*8, 0, 0, 0, hipChannelFormatKindFloat);
     hipArray *arr;
 
-    HIPCHECK(hipMalloc3DArray(&arr, &channelDesc, make_hipExtent(width, height, num_layers), hipArrayLayered));
+    HIPCHECK(hipMalloc3DArray(&arr, &channelDesc, make_hipExtent(width* sizeof(T), height, num_layers), hipArrayLayered));
     hipMemcpy3DParms myparms = {0};
     myparms.srcPos = make_hipPos(0,0,0);
     myparms.dstPos = make_hipPos(0,0,0);

--- a/tests/src/texture/simpleTexture2DLayered.cpp
+++ b/tests/src/texture/simpleTexture2DLayered.cpp
@@ -53,13 +53,13 @@ void runTest(int width,int height,int num_layers,texture<T, hipTextureType2DLaye
     channelDesc = hipCreateChannelDesc(sizeof(T)*8, 0, 0, 0, hipChannelFormatKindFloat);
     hipArray *arr;
 
-    HIPCHECK(hipMalloc3DArray(&arr, &channelDesc, make_hipExtent(width* sizeof(T), height, num_layers), hipArrayLayered));
+    HIPCHECK(hipMalloc3DArray(&arr, &channelDesc, make_hipExtent(width, height, num_layers), hipArrayLayered));
     hipMemcpy3DParms myparms = {0};
     myparms.srcPos = make_hipPos(0,0,0);
     myparms.dstPos = make_hipPos(0,0,0);
     myparms.srcPtr = make_hipPitchedPtr(hData, width * sizeof(T), width, height);
     myparms.dstArray = arr;
-    myparms.extent = make_hipExtent(width * sizeof(T), height, num_layers);
+    myparms.extent = make_hipExtent(width , height, num_layers);
     //myparms.kind = hipMemcpyHostToDevice;
     HIPCHECK(hipMemcpy3D(&myparms));
 

--- a/tests/src/texture/simpleTexture3D.cpp
+++ b/tests/src/texture/simpleTexture3D.cpp
@@ -21,14 +21,11 @@ THE SOFTWARE.
 */
 
 /* HIT_START
- * BUILD: %t %s ../test_common.cpp EXCLUDE_HIP_PLATFORM nvcc
+ * BUILD: %t %s ../test_common.cpp
  * TEST: %t
  * HIT_END
  */
 #include "test_common.h"
-
-//typedef char T;
-const char *sampleName = "simpleTexture3D";
 
 // Texture reference for 3D texture
 texture<float, hipTextureType3D, hipReadModeElementType> texf;
@@ -36,7 +33,7 @@ texture<int, hipTextureType3D, hipReadModeElementType> texi;
 texture<char, hipTextureType3D, hipReadModeElementType> texc;
 
 template <typename T>
-__global__ void simpleKernel3DArray(T* outputData, 
+__global__ void simpleKernel3DArray(T* outputData,
                                     int width,
                                     int height,int depth)
 {
@@ -44,21 +41,18 @@ __global__ void simpleKernel3DArray(T* outputData,
        for (int j = 0; j < height; j++) {
            for (int k = 0; k < width; k++) {
                if(std::is_same<T, float>::value)
-                   outputData[i*width*height + j*width + k] = tex3D(texf, texf.textureObject, k, j, i);
+                   outputData[i*width*height + j*width + k] = tex3D(texf, k, j, i);
                else if(std::is_same<T, int>::value)
-                   outputData[i*width*height + j*width + k] = tex3D(texi, texi.textureObject, k, j, i);
+                   outputData[i*width*height + j*width + k] = tex3D(texi, k, j, i);
                else if(std::is_same<T, char>::value)
-                   outputData[i*width*height + j*width + k] = tex3D(texc, texc.textureObject, k, j, i);
+                   outputData[i*width*height + j*width + k] = tex3D(texc, k, j, i);
            }
        }
     }
 }
 
-////////////////////////////////////////////////////////////////////////////////
-//! Run a simple test for tex3D
-////////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void runTest(int width,int height,int depth,texture<T, hipTextureType3D, hipReadModeElementType> *tex)
+void runTest(int width,int height,int depth,texture<T, hipTextureType3D, hipReadModeElementType> *tex, hipChannelFormatKind formatKind)
 {
     unsigned int size = width * height * depth * sizeof(T);
     T* hData = (T*) malloc(size);
@@ -73,17 +67,21 @@ void runTest(int width,int height,int depth,texture<T, hipTextureType3D, hipRead
     }
 
     // Allocate array and copy image data
-    hipChannelFormatDesc channelDesc = hipCreateChannelDesc(sizeof(T)*8, 0, 0, 0, hipChannelFormatKindSigned);
+    hipChannelFormatDesc channelDesc = hipCreateChannelDesc(sizeof(T)*8, 0, 0, 0, formatKind);
     hipArray *arr;
 
-    HIPCHECK(hipMalloc3DArray(&arr, &channelDesc, make_hipExtent(width, height, depth), hipArrayCubemap));
+    HIPCHECK(hipMalloc3DArray(&arr, &channelDesc, make_hipExtent(width, height, depth), hipArrayDefault));
     hipMemcpy3DParms myparms = {0};
     myparms.srcPos = make_hipPos(0,0,0);
     myparms.dstPos = make_hipPos(0,0,0);
     myparms.srcPtr = make_hipPitchedPtr(hData, width * sizeof(T), width, height);
     myparms.dstArray = arr;
     myparms.extent = make_hipExtent(width, height, depth);
+#ifdef __HIP_PLATFORM_NVCC__
+    myparms.kind = cudaMemcpyHostToDevice;
+#else
     myparms.kind = hipMemcpyHostToDevice;
+#endif
     HIPCHECK(hipMemcpy3D(&myparms));
 
     // set texture parameters
@@ -108,7 +106,7 @@ void runTest(int width,int height,int depth,texture<T, hipTextureType3D, hipRead
 
     // copy result from device to host
     HIPCHECK(hipMemcpy(hOutputData, dData, size, hipMemcpyDeviceToHost));
-    HipTest::checkArray(hData,hOutputData,width,height,depth); 
+    HipTest::checkArray(hData,hOutputData,width,height,depth);
 
     hipFree(dData);
     hipFreeArray(arr);
@@ -116,18 +114,13 @@ void runTest(int width,int height,int depth,texture<T, hipTextureType3D, hipRead
     free(hOutputData);
 }
 
-////////////////////////////////////////////////////////////////////////////////
-// Program main
-////////////////////////////////////////////////////////////////////////////////
 int main(int argc, char **argv)
 {
-    printf("%s starting...\n", sampleName);
     for(int i=1;i<25;i++)
     {
-        runTest<float>(i,i,i,&texf);
-        runTest<int>(i+1,i,i,&texi);
-        runTest<char>(i,i+1,i,&texc);
+        runTest<float>(i,i,i,&texf, hipChannelFormatKindFloat);
+        runTest<int>(i+1,i,i,&texi, hipChannelFormatKindSigned);
+        runTest<char>(i,i+1,i,&texc, hipChannelFormatKindSigned);
     }
     passed();
 }
-

--- a/tests/src/texture/simpleTexture3D.cpp
+++ b/tests/src/texture/simpleTexture3D.cpp
@@ -21,7 +21,7 @@ THE SOFTWARE.
 */
 
 /* HIT_START
- * BUILD: %t %s ../test_common.cpp
+ * BUILD: %t %s ../test_common.cpp NVCC_OPTIONS -std=c++11
  * TEST: %t
  * HIT_END
  */

--- a/tests/src/texture/simpleTexture3D.cpp
+++ b/tests/src/texture/simpleTexture3D.cpp
@@ -76,7 +76,7 @@ void runTest(int width,int height,int depth,texture<T, hipTextureType3D, hipRead
     hipChannelFormatDesc channelDesc = hipCreateChannelDesc(sizeof(T)*8, 0, 0, 0, hipChannelFormatKindSigned);
     hipArray *arr;
 
-    HIPCHECK(hipMalloc3DArray(&arr, &channelDesc, make_hipExtent(width, height, depth), hipArrayCubemap));
+    HIPCHECK(hipMalloc3DArray(&arr, &channelDesc, make_hipExtent(width* sizeof(T), height, depth), hipArrayCubemap));
     hipMemcpy3DParms myparms = {0};
     myparms.srcPos = make_hipPos(0,0,0);
     myparms.dstPos = make_hipPos(0,0,0);

--- a/tests/src/texture/simpleTexture3D.cpp
+++ b/tests/src/texture/simpleTexture3D.cpp
@@ -76,13 +76,13 @@ void runTest(int width,int height,int depth,texture<T, hipTextureType3D, hipRead
     hipChannelFormatDesc channelDesc = hipCreateChannelDesc(sizeof(T)*8, 0, 0, 0, hipChannelFormatKindSigned);
     hipArray *arr;
 
-    HIPCHECK(hipMalloc3DArray(&arr, &channelDesc, make_hipExtent(width* sizeof(T), height, depth), hipArrayCubemap));
+    HIPCHECK(hipMalloc3DArray(&arr, &channelDesc, make_hipExtent(width, height, depth), hipArrayCubemap));
     hipMemcpy3DParms myparms = {0};
     myparms.srcPos = make_hipPos(0,0,0);
     myparms.dstPos = make_hipPos(0,0,0);
     myparms.srcPtr = make_hipPitchedPtr(hData, width * sizeof(T), width, height);
     myparms.dstArray = arr;
-    myparms.extent = make_hipExtent(width * sizeof(T), height, depth);
+    myparms.extent = make_hipExtent(width, height, depth);
     myparms.kind = hipMemcpyHostToDevice;
     HIPCHECK(hipMemcpy3D(&myparms));
 

--- a/tests/src/texture/simpleTexture3D.cpp
+++ b/tests/src/texture/simpleTexture3D.cpp
@@ -82,7 +82,7 @@ void runTest(int width,int height,int depth,texture<T, hipTextureType3D, hipRead
     myparms.dstPos = make_hipPos(0,0,0);
     myparms.srcPtr = make_hipPitchedPtr(hData, width * sizeof(T), width, height);
     myparms.dstArray = arr;
-    myparms.extent = make_hipExtent(width, height, depth);
+    myparms.extent = make_hipExtent(width * sizeof(T), height, depth);
     myparms.kind = hipMemcpyHostToDevice;
     HIPCHECK(hipMemcpy3D(&myparms));
 


### PR DESCRIPTION
Fixes #1790 and #1791. hipMemcpy3D still requires further refactoring for different input and output combinations.