### PR TITLE
Update the HIP_TRSF_* flags to match their Cuda equivalents.

### DIFF
--- a/include/hip/hcc_detail/driver_types.h
+++ b/include/hip/hcc_detail/driver_types.h
@@ -43,9 +43,10 @@ typedef struct hipChannelFormatDesc {
     enum hipChannelFormatKind f;
 }hipChannelFormatDesc;
 
-#define HIP_TRSF_NORMALIZED_COORDINATES 0x01
-#define HIP_TRSF_READ_AS_INTEGER 0x00
 #define HIP_TRSA_OVERRIDE_FORMAT 0x01
+#define HIP_TRSF_READ_AS_INTEGER 0x01
+#define HIP_TRSF_NORMALIZED_COORDINATES 0x02
+#define HIP_TRSF_SRGB 0x10
 
 typedef enum hipArray_Format {
     HIP_AD_FORMAT_UNSIGNED_INT8 = 0x01,


### PR DESCRIPTION
Currently HIP_TRSF_READ_AS_INTEGER is 0, which makes it impossible via hipTexRefSetFlags() to suppresses the default behavior of having the texture promote integer data to floating point data in the range [0, 1].

Updating these flags to match their Cuda equivalents fixes a lot of potential UB.