### PR TITLE
hipHcc test: do not include hip_ext.h header for hip-clang.

### DIFF
--- a/tests/src/hipHcc.cpp
+++ b/tests/src/hipHcc.cpp
@@ -30,7 +30,9 @@ THE SOFTWARE.
 #include <stdio.h>
 #include <iostream>
 #include "hip/hip_runtime.h"
+#ifdef __HCC__
 #include "hip/hip_ext.h"
+#endif
 #include "test_common.h"
 
 #define CHECK(error)                                                                               \


### PR DESCRIPTION
hip_ext.h header is deprecated in hip-clang.