### PR TITLE
fix a minor bug while computing this.grid()::thread_rank()

### DIFF
--- a/include/hip/hcc_detail/hip_cooperative_groups_helper.h
+++ b/include/hip/hcc_detail/hip_cooperative_groups_helper.h
@@ -106,10 +106,10 @@ __CG_STATIC_QUALIFIER__ uint32_t size() {
 }
 
 __CG_STATIC_QUALIFIER__ uint32_t thread_rank() {
-  // Compute global id of the workgroup to which the current threads belongs to
+  // Compute global id of the workgroup to which the current thread belongs to
   uint32_t blkIdx =
            (uint32_t)((hipBlockIdx_z * hipGridDim_y * hipGridDim_x) +
-                      (hipBlockIdx_y * hipGridDim_x) +
+                      (hipBlockIdx_x * hipGridDim_y) +
                       (hipBlockIdx_x));
 
   // Compute total number of threads being passed to reach current workgroup
@@ -120,7 +120,7 @@ __CG_STATIC_QUALIFIER__ uint32_t thread_rank() {
   // Compute thread local rank within current workgroup
   uint32_t local_thread_rank =
            (uint32_t)((hipThreadIdx_z * hipBlockDim_y * hipBlockDim_x) +
-                      (hipThreadIdx_y * hipBlockDim_x) +
+                      (hipThreadIdx_x * hipBlockDim_y) +
                       (hipThreadIdx_x));
 
   return (num_threads_till_current_workgroup + local_thread_rank);


### PR DESCRIPTION
* There was a bug while computing this_grid().thread_rank(), fixed it.
* The semantics of this_grid().thread_rank() computation is as follows.
   1. Compute number of work-groups to be passed before arriving at current work-group
   2. Using above, compute total number of threads being passed till current work-group
   3. Computer local thread-rank (of current thread) within current work-group
   4. Return sum of above 2 and 3.