### PR TITLE
optimize `atomicAdd` for float/double

### DIFF
--- a/include/hip/hcc_detail/hip_atomic.h
+++ b/include/hip/hcc_detail/hip_atomic.h
@@ -59,17 +59,16 @@ float atomicAdd(float* address, float val)
 {
     unsigned int* uaddr{reinterpret_cast<unsigned int*>(address)};
     unsigned int r{__atomic_load_n(uaddr, __ATOMIC_RELAXED)};
-
-    unsigned int old;
-    do {
-        old = __atomic_load_n(uaddr, __ATOMIC_RELAXED);
-
-        if (r != old) { r = old; continue; }
-
-        r = atomicCAS(uaddr, r, __float_as_uint(val + __uint_as_float(r)));
-
-        if (r == old) break;
-    } while (true);
+    unsigned  int assumed;
+    do
+    {
+        assumed = r;
+        r = atomicCAS(
+            uaddr,
+            r,
+            __float_as_uint(val + __uint_as_float(r)));
+    }
+    while(assumed != r);
 
     return __uint_as_float(r);
 }
@@ -79,18 +78,16 @@ double atomicAdd(double* address, double val)
 {
     unsigned long long* uaddr{reinterpret_cast<unsigned long long*>(address)};
     unsigned long long r{__atomic_load_n(uaddr, __ATOMIC_RELAXED)};
-
-    unsigned long long old;
-    do {
-        old = __atomic_load_n(uaddr, __ATOMIC_RELAXED);
-
-        if (r != old) { r = old; continue; }
-
+    unsigned long long assumed;
+    do
+    {
+        assumed = r;
         r = atomicCAS(
-            uaddr, r, __double_as_longlong(val + __longlong_as_double(r)));
-
-        if (r == old) break;
-    } while (true);
+            uaddr,
+            r,
+            __double_as_longlong(val + __longlong_as_double(r)));
+    }
+    while(assumed != r);
 
     return __longlong_as_double(r);
 }


### PR DESCRIPTION
Reduce the number of atomic operations performed to emulate `atomicAdd`
for data type `float` and `double`.

The optimization is also mentioned, since a few years, in the [CUDA programming guide](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#atomic-functions).

The way to implement `atomicAdd` with `atomicCAS` is common but I like to point to older implementations with `atomicExch` too and some old comparisons from 2010. [ref](https://devtalk.nvidia.com/default/topic/458062/atomicadd)


I did a integration test of this implementation vs. the old together with [PIConGPU](https://github.com/ComputationalRadiationPhysics/picongpu/issues). PIConGPU is doing in one kernel a scatter with N threads to a chunk of shared memory with `atomicAdd(float*,float)`.
The improvement for single precision float data (time to solution) on a Radeon VII was **>10%** and and on MI50 **>12%**.

Doing the scatter directly on global memory instead of shared results in a improvement of **>25%**.