### PR TITLE
Error messages cleaned up

### DIFF
--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -112,8 +112,6 @@ void getDevicePCIBusNum(int deviceID, char* pciBusID) {
 }
 
 int main() {
-    //extern const char* HIP_VISIBLE_DEVICES_STR;
-    //extern const char* CUDA_VISIBLE_DEVICES_STR;
     unsetenv(HIP_VISIBLE_DEVICES_STR);
     unsetenv(CUDA_VISIBLE_DEVICES_STR);
     

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -140,16 +140,16 @@ int main() {
     if (totalDeviceNum > 2) {
         setenv("HIP_VISIBLE_DEVICES", "0,1,1000,2", 1);
         setenv("CUDA_VISIBLE_DEVICES", "0,1,1000,2", 1);
-        assert(getDeviceNumber(false) == 2);
+        assert(getDeviceNumber() == 2);
 
         setenv("HIP_VISIBLE_DEVICES", "0,1,2", 1);
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
-        assert(getDeviceNumber(false) == 3);
+        assert(getDeviceNumber() == 3);
         // test if CUDA_VISIBLE_DEVICES will be accepted by the runtime
         unsetenv(HIP_VISIBLE_DEVICES_STR);
         unsetenv(CUDA_VISIBLE_DEVICES_STR);
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
-        assert(getDeviceNumber(false) == 3);
+        assert(getDeviceNumber() == 3);
     }
 
     setenv("HIP_VISIBLE_DEVICES", "-100,0,1", 1);

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -20,13 +20,6 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
  * TEST: %t
  * HIT_END
  */
-#ifdef _WIN32
-    #define PLATFORM_NAME "windows"
-#elif __linux__
-    #define PLATFORM_NAME "linux"
-#else
-    #define PLATFORM_NAME "NULL"
-#endif
 
 #include <iostream>
 #include <vector>
@@ -43,13 +36,12 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 using namespace std;
 
 int getDeviceNumber() {
-    FILE* directed_in;
     FILE* in;
-    string directed_dir;
-    string dir;
     char buff[512];
-
-    if (PLATFORM_NAME == "windows"){
+    const char* directed_dir;
+    const char* dir;
+    
+    if (PLATFORM_NAME == "WINDOWS"){
         directed_dir = "directed_tests\\hipEnvVar -c";
         dir = "hipEnvVar -c";
     } else {
@@ -58,33 +50,31 @@ int getDeviceNumber() {
     }
     
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    directed_in = popen(directed_dir.c_str(), "r");
-    if(fgets(buff, 512, directed_in) != NULL){
+    in = popen(directed_dir, "r");
+    if(fgets(buff, 512, in) != NULL){
         cout << buff;
-        pclose(directed_in);
+        pclose(in);
         return atoi(buff);
     }
     //Check at same level
-    in = popen(dir.c_str(), "r");
+    in = popen(dir, "r");
     if(fgets(buff, 512, in) != NULL){
         cout << buff;
         pclose(in);
         return atoi(buff);
     }
     
-    pclose(directed_in);
     pclose(in);
     return 1;
 }
 
 // Query the current device ID remotely to hipEnvVar
 void getDevicePCIBusNumRemote(int deviceID, char* pciBusID) {
-    FILE* directed_in;
     FILE* in;
     
     string directed_dir;
     string dir;
-    if (PLATFORM_NAME == "windows"){
+    if (PLATFORM_NAME == "WINDOWS"){
         directed_dir = "directed_tests\\hipEnvVar -d ";
         dir = "hipEnvVar.exe -d ";
     } else {
@@ -95,10 +85,10 @@ void getDevicePCIBusNumRemote(int deviceID, char* pciBusID) {
     directed_dir += std::to_string(deviceID);
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     
-    directed_in = popen(directed_dir.c_str(), "r");
-    if(fgets(pciBusID, 100, directed_in) != NULL){
+    in = popen(directed_dir.c_str(), "r");
+    if(fgets(pciBusID, 100, in) != NULL){
         cout << pciBusID;
-        pclose(directed_in);
+        pclose(in);
         return;
     }
     //Check at same level
@@ -108,7 +98,6 @@ void getDevicePCIBusNumRemote(int deviceID, char* pciBusID) {
         pclose(in);
         return;
     }
-    pclose(directed_in);
     pclose(in);
     return;
 }
@@ -123,14 +112,9 @@ void getDevicePCIBusNum(int deviceID, char* pciBusID) {
 }
 
 int main() {
-    if (PLATFORM_NAME == "windows"){
-        _putenv("HIP_VISIBLE_DEVICES=");
-        _putenv("CUDA_VISIBLE_DEVICES=");
-    } else {
-        unsetenv("HIP_VISIBLE_DEVICES");
-        unsetenv("CUDA_VISIBLE_DEVICES");
-    }
-
+    unsetenv(HIP_VISIBLE_DEVICES);
+    unsetenv(CUDA_VISIBLE_DEVICES);
+    
     std::vector<std::string> devPCINum;
     char pciBusID[100];
     // collect the device pci bus ID for all device
@@ -173,13 +157,8 @@ int main() {
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
         assert(getDeviceNumber() == 3);
         // test if CUDA_VISIBLE_DEVICES will be accepted by the runtime
-        if (PLATFORM_NAME == "windows"){
-            _putenv("HIP_VISIBLE_DEVICES=");
-            _putenv("CUDA_VISIBLE_DEVICES=");
-        } else {
-            unsetenv("HIP_VISIBLE_DEVICES");
-            unsetenv("CUDA_VISIBLE_DEVICES");
-        }
+        unsetenv(HIP_VISIBLE_DEVICES);
+        unsetenv(CUDA_VISIBLE_DEVICES);
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
         assert(getDeviceNumber() == 3);
     }

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -173,8 +173,13 @@ int main() {
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
         assert(getDeviceNumber() == 3);
         // test if CUDA_VISIBLE_DEVICES will be accepted by the runtime
-        _putenv("HIP_VISIBLE_DEVICES=");
-        _putenv("CUDA_VISIBLE_DEVICES=");
+        if (PLATFORM_NAME == "windows"){
+            _putenv("HIP_VISIBLE_DEVICES=");
+            _putenv("CUDA_VISIBLE_DEVICES=");
+        } else {
+            unsetenv("HIP_VISIBLE_DEVICES");
+            unsetenv("CUDA_VISIBLE_DEVICES");
+        }
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
         assert(getDeviceNumber() == 3);
     }

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -41,7 +41,7 @@ int getDeviceNumber() {
     const char* directed_dir;
     const char* dir;
     
-    if (PLATFORM_NAME == "WINDOWS"){
+    if (_WIN64 == 1){
         directed_dir = "directed_tests\\hipEnvVar -c";
         dir = "hipEnvVar -c";
     } else {
@@ -74,7 +74,7 @@ void getDevicePCIBusNumRemote(int deviceID, char* pciBusID) {
     
     string directed_dir;
     string dir;
-    if (PLATFORM_NAME == "WINDOWS"){
+    if (_WIN64 == 1){
         directed_dir = "directed_tests\\hipEnvVar -d ";
         dir = "hipEnvVar.exe -d ";
     } else {
@@ -112,8 +112,10 @@ void getDevicePCIBusNum(int deviceID, char* pciBusID) {
 }
 
 int main() {
-    unsetenv(HIP_VISIBLE_DEVICES);
-    unsetenv(CUDA_VISIBLE_DEVICES);
+    //extern const char* HIP_VISIBLE_DEVICES_STR;
+    //extern const char* CUDA_VISIBLE_DEVICES_STR;
+    unsetenv(HIP_VISIBLE_DEVICES_STR);
+    unsetenv(CUDA_VISIBLE_DEVICES_STR);
     
     std::vector<std::string> devPCINum;
     char pciBusID[100];
@@ -157,8 +159,8 @@ int main() {
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
         assert(getDeviceNumber() == 3);
         // test if CUDA_VISIBLE_DEVICES will be accepted by the runtime
-        unsetenv(HIP_VISIBLE_DEVICES);
-        unsetenv(CUDA_VISIBLE_DEVICES);
+        unsetenv(HIP_VISIBLE_DEVICES_STR);
+        unsetenv(CUDA_VISIBLE_DEVICES_STR);
         setenv("CUDA_VISIBLE_DEVICES", "0,1,2", 1);
         assert(getDeviceNumber() == 3);
     }

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -45,25 +45,26 @@ using namespace std;
 int getDeviceNumber() {
     FILE* directed_in;
     FILE* in;
-    string directed_test_dir;
+    string directed_dir;
     string dir;
     char buff[512];
 
     if (PLATFORM_NAME == "windows"){
-        directed_test_dir = "directed_tests\\hipEnvVar -c";
+        directed_dir = "directed_tests\\hipEnvVar -c";
         dir = "hipEnvVar -c";
     } else {
-        directed_test_dir = "./directed_tests/hipEnvVar -c";
+        directed_dir = "./directed_tests/hipEnvVar -c";
         dir = "./hipEnvVar -c";
     }
     
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    directed_in = popen(directed_test_dir.c_str(), "r");
+    directed_in = popen(directed_dir.c_str(), "r");
     if(fgets(buff, 512, directed_in) != NULL){
         cout << buff;
         pclose(directed_in);
         return atoi(buff);
     }
+    //Check at same level
     in = popen(dir.c_str(), "r");
     if(fgets(buff, 512, in) != NULL){
         cout << buff;
@@ -81,28 +82,26 @@ void getDevicePCIBusNumRemote(int deviceID, char* pciBusID) {
     FILE* directed_in;
     FILE* in;
     
-    string directed_test_dir;
+    string directed_dir;
     string dir;
     if (PLATFORM_NAME == "windows"){
-        directed_test_dir = "directed_tests\\hipEnvVar -d";
-        dir = "hipEnvVar.exe -d";
+        directed_dir = "directed_tests\\hipEnvVar -d ";
+        dir = "hipEnvVar.exe -d ";
     } else {
-        directed_test_dir = "./directed_tests/hipEnvVar -d";
-        dir = "./hipEnvVar -d";
+        directed_dir = "./directed_tests/hipEnvVar -d ";
+        dir = "./hipEnvVar -d ";
     }
-    //string str = "./directed_tests/hipEnvVar -d ";
-    //str += std::to_string(deviceID);
-    
-    dir += std::to_string(deviceID);
+
+    directed_dir += std::to_string(deviceID);
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
     
-    //Apparently popen on windows does not return NULL on invalid command, nor does it set errno.
-    directed_in = popen(directed_test_dir.c_str(), "r");
+    directed_in = popen(directed_dir.c_str(), "r");
     if(fgets(pciBusID, 100, directed_in) != NULL){
         cout << pciBusID;
         pclose(directed_in);
         return;
     }
+    //Check at same level
     in = popen(dir.c_str(), "r");
     if(fgets(pciBusID, 100, in) != NULL){
         cout << pciBusID;
@@ -124,22 +123,13 @@ void getDevicePCIBusNum(int deviceID, char* pciBusID) {
 }
 
 int main() {
-    //unsetenv("HIP_VISIBLE_DEVICES");
-    //unsetenv("CUDA_VISIBLE_DEVICES");
-
-    _putenv("HIP_VISIBLE_DEVICES=");
-    _putenv("CUDA_VISIBLE_DEVICES=");
-    
-    /* Test for if the Environmental var is set.
-    char* buffer;
-    _dupenv_s(&buffer, NULL, "HIP_VISIBLE_DEVICES"); //Gets the environmental var
-    if(buffer){
-        printf("This environmental var is set");
-        return 0;
+    if (PLATFORM_NAME == "windows"){
+        _putenv("HIP_VISIBLE_DEVICES=");
+        _putenv("CUDA_VISIBLE_DEVICES=");
     } else {
-        printf("This environemntal var is NOT set");
-        return 0;
-	}*/
+        unsetenv("HIP_VISIBLE_DEVICES");
+        unsetenv("CUDA_VISIBLE_DEVICES");
+    }
 
     std::vector<std::string> devPCINum;
     char pciBusID[100];

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -38,26 +38,18 @@ using namespace std;
 int getDeviceNumber() {
     FILE* in;
     char buff[512];
-    const char* directed_dir;
-    const char* dir;
-    
-    if (_WIN64 == 1){
-        directed_dir = "directed_tests\\hipEnvVar -c";
-        dir = "hipEnvVar -c";
-    } else {
-        directed_dir = "./directed_tests/hipEnvVar -c";
-        dir = "./hipEnvVar -c";
-    }
+    string directed_dir = "directed_tests" + string(PATH_SEPERATOR_STR) + "hipEnvVar -c";
+    string dir = "." + string(PATH_SEPERATOR_STR) + "hipEnvVar -c";
     
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
-    in = popen(directed_dir, "r");
+    in = popen(directed_dir.c_str(), "r");
     if(fgets(buff, 512, in) != NULL){
         cout << buff;
         pclose(in);
         return atoi(buff);
     }
     //Check at same level
-    in = popen(dir, "r");
+    in = popen(dir.c_str(), "r");
     if(fgets(buff, 512, in) != NULL){
         cout << buff;
         pclose(in);
@@ -72,15 +64,8 @@ int getDeviceNumber() {
 void getDevicePCIBusNumRemote(int deviceID, char* pciBusID) {
     FILE* in;
     
-    string directed_dir;
-    string dir;
-    if (_WIN64 == 1){
-        directed_dir = "directed_tests\\hipEnvVar -d ";
-        dir = "hipEnvVar.exe -d ";
-    } else {
-        directed_dir = "./directed_tests/hipEnvVar -d ";
-        dir = "./hipEnvVar -d ";
-    }
+    string directed_dir = "directed_tests" + string(PATH_SEPERATOR_STR) + "hipEnvVar -d ";
+    string dir = "." + string(PATH_SEPERATOR_STR) + "hipEnvVar -d";
 
     directed_dir += std::to_string(deviceID);
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -117,7 +102,7 @@ int main() {
     
     std::vector<std::string> devPCINum;
     char pciBusID[100];
-    // collect the device pci bus ID for all device
+    // collect the device pci bus ID for all devices
     int totalDeviceNum = getDeviceNumber();
     std::cout << "The total number of available devices is " << totalDeviceNum << std::endl
               << "Valid index range is 0 - " << totalDeviceNum - 1 << std::endl;

--- a/tests/src/test_common.cpp
+++ b/tests/src/test_common.cpp
@@ -37,10 +37,12 @@ int p_tests = -1; /*which tests to run. Interpretation is left to each test.  de
 const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES=";
 const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES=";
 const char* PATH_SEPERATOR_STR = "\\";
+const char* NULL_DEVICE = "NUL:";
 #else
 const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES";
 const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES";
 const char* PATH_SEPERATOR_STR = "/";
+const char* NULL_DEVICE = "/dev/null";
 #endif
 
 namespace HipTest {

--- a/tests/src/test_common.cpp
+++ b/tests/src/test_common.cpp
@@ -36,9 +36,11 @@ int p_tests = -1; /*which tests to run. Interpretation is left to each test.  de
 #ifdef _WIN64
 const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES=";
 const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES=";
+const char* PATH_SEPERATOR_STR = "\\";
 #else
 const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES";
 const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES";
+const char* PATH_SEPERATOR_STR = "/";
 #endif
 
 namespace HipTest {

--- a/tests/src/test_common.cpp
+++ b/tests/src/test_common.cpp
@@ -33,7 +33,13 @@ unsigned threadsPerBlock = 256;
 int p_gpuDevice = 0;
 unsigned p_verbose = 0;
 int p_tests = -1; /*which tests to run. Interpretation is left to each test.  default:all*/
-
+#ifdef _WIN64
+const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES=";
+const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES=";
+#else
+const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES";
+const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES";
+#endif
 
 namespace HipTest {
 

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -123,6 +123,7 @@ extern unsigned p_verbose;
 extern int p_tests;
 extern const char* HIP_VISIBLE_DEVICES_STR;
 extern const char* CUDA_VISIBLE_DEVICES_STR;
+extern const char* PATH_SEPERATOR_STR;
 
 // ********************* CPP section *********************
 #ifdef __cplusplus

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -105,15 +105,14 @@ THE SOFTWARE.
 #define pclose(x) _pclose(x)
 #define setenv(x,y,z) _putenv_s(x,y)
 #define unsetenv _putenv
-#define PLATFORM_NAME "WINDOWS"
-#define HIP_VISIBLE_DEVICES "HIP_VISIBLE_DEVICES="
-#define CUDA_VISIBLE_DEVICES "CUDA_VISIBLE_DEVICES="
 #else
 #define aligned_free(x) free(x)
-#define PLATFORM_NAME "OTHER"
-#define HIP_VISIBLE_DEVICES "HIP_VISIBLE_DEVICES"
-#define CUDA_VISIBLE_DEVICES "CUDA_VISIBLE_DEVICES"
 #endif
+
+//const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES=";
+//const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES=";
+//const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES";
+//const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES";
 
 // standard command-line variables:
 extern size_t N;
@@ -127,6 +126,8 @@ extern unsigned threadsPerBlock;
 extern int p_gpuDevice;
 extern unsigned p_verbose;
 extern int p_tests;
+extern const char* HIP_VISIBLE_DEVICES_STR;
+extern const char* CUDA_VISIBLE_DEVICES_STR;
 
 // ********************* CPP section *********************
 #ifdef __cplusplus

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -24,13 +24,13 @@ THE SOFTWARE.
  */
 
 #ifdef __cplusplus
-    #include <iostream>
-    #include <iomanip>
-    #if __CUDACC__
-        #include <sys/time.h>
-    #else
-        #include <chrono>
-    #endif
+#include <iostream>
+#include <iomanip>
+#if __CUDACC__
+#include <sys/time.h>
+#else
+#include <chrono>
+#endif
 #endif
 
 // ************************ GCC section **************************
@@ -52,58 +52,62 @@ THE SOFTWARE.
 #define KWHT "\x1B[37m"
 
 #define passed()                                                                                   \
-    printf("%sPASSED!%s\n", KGRN, KNRM);                                                           \
-    exit(0);
+  printf("%sPASSED!%s\n", KGRN, KNRM);                                                             \
+  exit(0);
 
 #define failed(...)                                                                                \
-    printf("%serror: ", KRED);                                                                     \
-    printf(__VA_ARGS__);                                                                           \
-    printf("\n");                                                                                  \
-    printf("error: TEST FAILED\n%s", KNRM);                                                        \
-    abort();
+  printf("%serror: ", KRED);                                                                       \
+  printf(__VA_ARGS__);                                                                             \
+  printf("\n");                                                                                    \
+  printf("error: TEST FAILED\n%s", KNRM);                                                          \
+  abort();
 
 #define warn(...)                                                                                  \
-    printf("%swarn: ", KYEL);                                                                      \
-    printf(__VA_ARGS__);                                                                           \
-    printf("\n");                                                                                  \
-    printf("warn: TEST WARNING\n%s", KNRM);
+  printf("%swarn: ", KYEL);                                                                        \
+  printf(__VA_ARGS__);                                                                             \
+  printf("\n");                                                                                    \
+  printf("warn: TEST WARNING\n%s", KNRM);
 
 #define HIP_PRINT_STATUS(status)                                                                   \
-    std::cout << hipGetErrorName(status) << " at line: " << __LINE__ << std::endl;
+  std::cout << hipGetErrorName(status) << " at line: " << __LINE__ << std::endl;
 
 #define HIPCHECK(error)                                                                            \
-    {                                                                                              \
-        hipError_t localError = error;                                                             \
-        if ((localError != hipSuccess) && (localError != hipErrorPeerAccessAlreadyEnabled)) {      \
-            printf("%serror: '%s'(%d) from %s at %s:%d%s\n", KRED, hipGetErrorString(localError),  \
-                   localError, #error, __FILE__, __LINE__, KNRM);                                  \
-            failed("API returned error code.");                                                    \
-        }                                                                                          \
-    }
+  {                                                                                                \
+    hipError_t localError = error;                                                                 \
+    if ((localError != hipSuccess) && (localError != hipErrorPeerAccessAlreadyEnabled)) {          \
+      printf("%serror: '%s'(%d) from %s at %s:%d%s\n", KRED, hipGetErrorString(localError),        \
+             localError, #error, __FILE__, __LINE__, KNRM);                                        \
+      failed("API returned error code.");                                                          \
+    }                                                                                              \
+  }
 
 #define HIPASSERT(condition)                                                                       \
-    if (!(condition)) {                                                                            \
-        failed("%sassertion %s at %s:%d%s \n", KRED, #condition, __FILE__, __LINE__, KNRM);        \
-    }
+  if (!(condition)) {                                                                              \
+    failed("%sassertion %s at %s:%d%s \n", KRED, #condition, __FILE__, __LINE__, KNRM);            \
+  }
 
 
 #define HIPCHECK_API(API_CALL, EXPECTED_ERROR)                                                     \
-    {                                                                                              \
-        hipError_t _e = (API_CALL);                                                                \
-        if (_e != (EXPECTED_ERROR)) {                                                              \
-            failed("%sAPI '%s' returned %d(%s) but test expected %d(%s) at %s:%d%s \n", KRED,      \
-                   #API_CALL, _e, hipGetErrorName(_e), EXPECTED_ERROR,                             \
-                   hipGetErrorName(EXPECTED_ERROR), __FILE__, __LINE__, KNRM);                     \
-        }                                                                                          \
-    }
+  {                                                                                                \
+    hipError_t _e = (API_CALL);                                                                    \
+    if (_e != (EXPECTED_ERROR)) {                                                                  \
+      failed("%sAPI '%s' returned %d(%s) but test expected %d(%s) at %s:%d%s \n", KRED, #API_CALL, \
+             _e, hipGetErrorName(_e), EXPECTED_ERROR, hipGetErrorName(EXPECTED_ERROR), __FILE__,   \
+             __LINE__, KNRM);                                                                      \
+    }                                                                                              \
+  }
 
 #ifdef _WIN64
 #include <tchar.h>
-#define aligned_alloc(x,y) _aligned_malloc(y,x)
+#define aligned_alloc(x, y) _aligned_malloc(y, x)
 #define aligned_free(x) _aligned_free(x)
-#define popen(x,y) _popen(x,y)
+#define popen(x, y) _popen(x, y)
 #define pclose(x) _pclose(x)
-#define setenv(x,y,z) _putenv_s(x,y)
+#define close(x) _close(x)
+#define dup(x) _dup(x)
+#define dup2(x, y) _dup2(x, y)
+#define fileno(x) _fileno(x)
+#define setenv(x, y, z) _putenv_s(x, y)
 #define unsetenv _putenv
 #else
 #define aligned_free(x) free(x)
@@ -124,6 +128,7 @@ extern int p_tests;
 extern const char* HIP_VISIBLE_DEVICES_STR;
 extern const char* CUDA_VISIBLE_DEVICES_STR;
 extern const char* PATH_SEPERATOR_STR;
+extern const char* NULL_DEVICE;
 
 // ********************* CPP section *********************
 #ifdef __cplusplus
@@ -139,12 +144,12 @@ namespace HipTest {
 // Returns the current system time in microseconds
 inline long long get_time() {
 #if __CUDACC__
-    struct timeval tv;
-    gettimeofday(&tv, 0);
-    return (tv.tv_sec * 1000000) + tv.tv_usec;
+  struct timeval tv;
+  gettimeofday(&tv, 0);
+  return (tv.tv_sec * 1000000) + tv.tv_usec;
 #else
-    return std::chrono::high_resolution_clock::now().time_since_epoch()
-        /std::chrono::microseconds(1);
+  return std::chrono::high_resolution_clock::now().time_since_epoch() /
+      std::chrono::microseconds(1);
 #endif
 }
 
@@ -158,203 +163,197 @@ int parseStandardArguments(int argc, char* argv[], bool failOnUndefinedArg);
 unsigned setNumBlocks(unsigned blocksPerCU, unsigned threadsPerBlock, size_t N);
 
 
-template <typename T>
-__global__ void vectorADD(const T* A_d, const T* B_d, T* C_d, size_t NELEM) {
-    size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
-    size_t stride = blockDim.x * gridDim.x;
+template <typename T> __global__ void vectorADD(const T* A_d, const T* B_d, T* C_d, size_t NELEM) {
+  size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
+  size_t stride = blockDim.x * gridDim.x;
 
+  for (size_t i = offset; i < NELEM; i += stride) {
+    C_d[i] = A_d[i] + B_d[i];
+  }
+}
+
+
+template <typename T>
+__global__ void vectorADDReverse(const T* A_d, const T* B_d, T* C_d, size_t NELEM) {
+  size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
+  size_t stride = blockDim.x * gridDim.x;
+
+  for (int64_t i = NELEM - stride + offset; i >= 0; i -= stride) {
+    C_d[i] = A_d[i] + B_d[i];
+  }
+}
+
+
+template <typename T> __global__ void addCount(const T* A_d, T* C_d, size_t NELEM, int count) {
+  size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
+  size_t stride = blockDim.x * gridDim.x;
+
+  // Deliberately do this in an inefficient way to increase kernel runtime
+  for (int i = 0; i < count; i++) {
     for (size_t i = offset; i < NELEM; i += stride) {
-        C_d[i] = A_d[i] + B_d[i];
+      C_d[i] = A_d[i] + (T)count;
     }
-}
-
-
-template <typename T>
-__global__ void vectorADDReverse(const T* A_d, const T* B_d, T* C_d,
-                                 size_t NELEM) {
-    size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
-    size_t stride = blockDim.x * gridDim.x;
-
-    for (int64_t i = NELEM - stride + offset; i >= 0; i -= stride) {
-        C_d[i] = A_d[i] + B_d[i];
-    }
-}
-
-
-template <typename T>
-__global__ void addCount(const T* A_d, T* C_d, size_t NELEM, int count) {
-    size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
-    size_t stride = blockDim.x * gridDim.x;
-
-    // Deliberately do this in an inefficient way to increase kernel runtime
-    for (int i = 0; i < count; i++) {
-        for (size_t i = offset; i < NELEM; i += stride) {
-            C_d[i] = A_d[i] + (T)count;
-        }
-    }
+  }
 }
 
 
 template <typename T>
 __global__ void addCountReverse(const T* A_d, T* C_d, int64_t NELEM, int count) {
-    size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
-    size_t stride = blockDim.x * gridDim.x;
+  size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
+  size_t stride = blockDim.x * gridDim.x;
 
-    // Deliberately do this in an inefficient way to increase kernel runtime
-    for (int i = 0; i < count; i++) {
-        for (int64_t i = NELEM - stride + offset; i >= 0; i -= stride) {
-            C_d[i] = A_d[i] + (T)count;
-        }
-    }
-}
-
-
-template <typename T>
-__global__ void memsetReverse(T* C_d, T val, int64_t NELEM) {
-    size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
-    size_t stride = blockDim.x * gridDim.x;
-
+  // Deliberately do this in an inefficient way to increase kernel runtime
+  for (int i = 0; i < count; i++) {
     for (int64_t i = NELEM - stride + offset; i >= 0; i -= stride) {
-        C_d[i] = val;
+      C_d[i] = A_d[i] + (T)count;
     }
+  }
 }
 
 
-template <typename T>
-void setDefaultData(size_t numElements, T* A_h, T* B_h, T* C_h) {
-    // Initialize the host data:
-    for (size_t i = 0; i < numElements; i++) {
-        if (A_h) (A_h)[i] = 3.146f + i;  // Pi
-        if (B_h) (B_h)[i] = 1.618f + i;  // Phi
-        if (C_h) (C_h)[i] = 0.0f + i;
-    }
+template <typename T> __global__ void memsetReverse(T* C_d, T val, int64_t NELEM) {
+  size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
+  size_t stride = blockDim.x * gridDim.x;
+
+  for (int64_t i = NELEM - stride + offset; i >= 0; i -= stride) {
+    C_d[i] = val;
+  }
+}
+
+
+template <typename T> void setDefaultData(size_t numElements, T* A_h, T* B_h, T* C_h) {
+  // Initialize the host data:
+  for (size_t i = 0; i < numElements; i++) {
+    if (A_h) (A_h)[i] = 3.146f + i;  // Pi
+    if (B_h) (B_h)[i] = 1.618f + i;  // Phi
+    if (C_h) (C_h)[i] = 0.0f + i;
+  }
 }
 
 
 template <typename T>
 void initArraysForHost(T** A_h, T** B_h, T** C_h, size_t N, bool usePinnedHost = false) {
-    size_t Nbytes = N * sizeof(T);
+  size_t Nbytes = N * sizeof(T);
 
-    if (usePinnedHost) {
-        if (A_h) {
-            HIPCHECK(hipHostMalloc((void**)A_h, Nbytes));
-        }
-        if (B_h) {
-            HIPCHECK(hipHostMalloc((void**)B_h, Nbytes));
-        }
-        if (C_h) {
-            HIPCHECK(hipHostMalloc((void**)C_h, Nbytes));
-        }
-    } else {
-        if (A_h) {
-            *A_h = (T*)malloc(Nbytes);
-            HIPASSERT(*A_h != NULL);
-        }
-
-        if (B_h) {
-            *B_h = (T*)malloc(Nbytes);
-            HIPASSERT(*B_h != NULL);
-        }
-
-        if (C_h) {
-            *C_h = (T*)malloc(Nbytes);
-            HIPASSERT(*C_h != NULL);
-        }
+  if (usePinnedHost) {
+    if (A_h) {
+      HIPCHECK(hipHostMalloc((void**)A_h, Nbytes));
+    }
+    if (B_h) {
+      HIPCHECK(hipHostMalloc((void**)B_h, Nbytes));
+    }
+    if (C_h) {
+      HIPCHECK(hipHostMalloc((void**)C_h, Nbytes));
+    }
+  } else {
+    if (A_h) {
+      *A_h = (T*)malloc(Nbytes);
+      HIPASSERT(*A_h != NULL);
     }
 
-    setDefaultData(N, A_h ? *A_h : NULL, B_h ? *B_h : NULL, C_h ? *C_h : NULL);
+    if (B_h) {
+      *B_h = (T*)malloc(Nbytes);
+      HIPASSERT(*B_h != NULL);
+    }
+
+    if (C_h) {
+      *C_h = (T*)malloc(Nbytes);
+      HIPASSERT(*C_h != NULL);
+    }
+  }
+
+  setDefaultData(N, A_h ? *A_h : NULL, B_h ? *B_h : NULL, C_h ? *C_h : NULL);
 }
 
 
 template <typename T>
 void initArrays(T** A_d, T** B_d, T** C_d, T** A_h, T** B_h, T** C_h, size_t N,
                 bool usePinnedHost = false) {
-    size_t Nbytes = N * sizeof(T);
+  size_t Nbytes = N * sizeof(T);
 
-    if (A_d) {
-        HIPCHECK(hipMalloc(A_d, Nbytes));
-    }
-    if (B_d) {
-        HIPCHECK(hipMalloc(B_d, Nbytes));
-    }
-    if (C_d) {
-        HIPCHECK(hipMalloc(C_d, Nbytes));
-    }
+  if (A_d) {
+    HIPCHECK(hipMalloc(A_d, Nbytes));
+  }
+  if (B_d) {
+    HIPCHECK(hipMalloc(B_d, Nbytes));
+  }
+  if (C_d) {
+    HIPCHECK(hipMalloc(C_d, Nbytes));
+  }
 
-    initArraysForHost(A_h, B_h, C_h, N, usePinnedHost);
+  initArraysForHost(A_h, B_h, C_h, N, usePinnedHost);
 }
 
 
-template <typename T>
-void freeArraysForHost(T* A_h, T* B_h, T* C_h, bool usePinnedHost) {
-    if (usePinnedHost) {
-        if (A_h) {
-            HIPCHECK(hipHostFree(A_h));
-        }
-        if (B_h) {
-            HIPCHECK(hipHostFree(B_h));
-        }
-        if (C_h) {
-            HIPCHECK(hipHostFree(C_h));
-        }
-    } else {
-        if (A_h) {
-            free(A_h);
-        }
-        if (B_h) {
-            free(B_h);
-        }
-        if (C_h) {
-            free(C_h);
-        }
+template <typename T> void freeArraysForHost(T* A_h, T* B_h, T* C_h, bool usePinnedHost) {
+  if (usePinnedHost) {
+    if (A_h) {
+      HIPCHECK(hipHostFree(A_h));
     }
+    if (B_h) {
+      HIPCHECK(hipHostFree(B_h));
+    }
+    if (C_h) {
+      HIPCHECK(hipHostFree(C_h));
+    }
+  } else {
+    if (A_h) {
+      free(A_h);
+    }
+    if (B_h) {
+      free(B_h);
+    }
+    if (C_h) {
+      free(C_h);
+    }
+  }
 }
 
 template <typename T>
 void freeArrays(T* A_d, T* B_d, T* C_d, T* A_h, T* B_h, T* C_h, bool usePinnedHost) {
-    if (A_d) {
-        HIPCHECK(hipFree(A_d));
-    }
-    if (B_d) {
-        HIPCHECK(hipFree(B_d));
-    }
-    if (C_d) {
-        HIPCHECK(hipFree(C_d));
-    }
+  if (A_d) {
+    HIPCHECK(hipFree(A_d));
+  }
+  if (B_d) {
+    HIPCHECK(hipFree(B_d));
+  }
+  if (C_d) {
+    HIPCHECK(hipFree(C_d));
+  }
 
-    freeArraysForHost(A_h, B_h, C_h, usePinnedHost);
+  freeArraysForHost(A_h, B_h, C_h, usePinnedHost);
 }
 
 #if defined(__HIP_PLATFORM_HCC__)
 template <typename T>
 void initArrays2DPitch(T** A_d, T** B_d, T** C_d, size_t* pitch_A, size_t* pitch_B, size_t* pitch_C,
                        size_t numW, size_t numH) {
-    if (A_d) {
-        HIPCHECK(hipMallocPitch((void**)A_d, pitch_A, numW * sizeof(T), numH));
-    }
-    if (B_d) {
-        HIPCHECK(hipMallocPitch((void**)B_d, pitch_B, numW * sizeof(T), numH));
-    }
-    if (C_d) {
-        HIPCHECK(hipMallocPitch((void**)C_d, pitch_C, numW * sizeof(T), numH));
-    }
+  if (A_d) {
+    HIPCHECK(hipMallocPitch((void**)A_d, pitch_A, numW * sizeof(T), numH));
+  }
+  if (B_d) {
+    HIPCHECK(hipMallocPitch((void**)B_d, pitch_B, numW * sizeof(T), numH));
+  }
+  if (C_d) {
+    HIPCHECK(hipMallocPitch((void**)C_d, pitch_C, numW * sizeof(T), numH));
+  }
 
-    HIPASSERT(*pitch_A == *pitch_B);
-    HIPASSERT(*pitch_A == *pitch_C)
+  HIPASSERT(*pitch_A == *pitch_B);
+  HIPASSERT(*pitch_A == *pitch_C)
 }
 
 inline void initHIPArrays(hipArray** A_d, hipArray** B_d, hipArray** C_d,
                           const hipChannelFormatDesc* desc, const size_t numW, const size_t numH,
                           const unsigned int flags) {
-    if (A_d) {
-        HIPCHECK(hipMallocArray(A_d, desc, numW, numH, flags));
-    }
-    if (B_d) {
-        HIPCHECK(hipMallocArray(B_d, desc, numW, numH, flags));
-    }
-    if (C_d) {
-        HIPCHECK(hipMallocArray(C_d, desc, numW, numH, flags));
-    }
+  if (A_d) {
+    HIPCHECK(hipMallocArray(A_d, desc, numW, numH, flags));
+  }
+  if (B_d) {
+    HIPCHECK(hipMallocArray(B_d, desc, numW, numH, flags));
+  }
+  if (C_d) {
+    HIPCHECK(hipMallocArray(C_d, desc, numW, numH, flags));
+  }
 }
 #endif
 
@@ -363,38 +362,38 @@ inline void initHIPArrays(hipArray** A_d, hipArray** B_d, hipArray** C_d,
 template <typename T>
 size_t checkVectorADD(T* A_h, T* B_h, T* result_H, size_t N, bool expectMatch = true,
                       bool reportMismatch = true) {
-    size_t mismatchCount = 0;
-    size_t firstMismatch = 0;
-    size_t mismatchesToPrint = 10;
-    for (size_t i = 0; i < N; i++) {
-        T expected = A_h[i] + B_h[i];
-        if (result_H[i] != expected) {
-            if (mismatchCount == 0) {
-                firstMismatch = i;
-            }
-            mismatchCount++;
-            if ((mismatchCount <= mismatchesToPrint) && expectMatch) {
-                std::cout << std::fixed << std::setprecision(32);
-                std::cout << "At " << i << std::endl;
-                std::cout << "  Computed:" << result_H[i] << std::endl;
-                std::cout << "  Expected:" << expected << std::endl;
-            }
-        }
+  size_t mismatchCount = 0;
+  size_t firstMismatch = 0;
+  size_t mismatchesToPrint = 10;
+  for (size_t i = 0; i < N; i++) {
+    T expected = A_h[i] + B_h[i];
+    if (result_H[i] != expected) {
+      if (mismatchCount == 0) {
+        firstMismatch = i;
+      }
+      mismatchCount++;
+      if ((mismatchCount <= mismatchesToPrint) && expectMatch) {
+        std::cout << std::fixed << std::setprecision(32);
+        std::cout << "At " << i << std::endl;
+        std::cout << "  Computed:" << result_H[i] << std::endl;
+        std::cout << "  Expected:" << expected << std::endl;
+      }
     }
+  }
 
-    if (reportMismatch) {
-        if (expectMatch) {
-            if (mismatchCount) {
-                failed("%zu mismatches ; first at index:%zu\n", mismatchCount, firstMismatch);
-            }
-        } else {
-            if (mismatchCount == 0) {
-                failed("expected mismatches but did not detect any!");
-            }
-        }
+  if (reportMismatch) {
+    if (expectMatch) {
+      if (mismatchCount) {
+        failed("%zu mismatches ; first at index:%zu\n", mismatchCount, firstMismatch);
+      }
+    } else {
+      if (mismatchCount == 0) {
+        failed("expected mismatches but did not detect any!");
+      }
     }
+  }
 
-    return mismatchCount;
+  return mismatchCount;
 }
 
 
@@ -402,92 +401,89 @@ size_t checkVectorADD(T* A_h, T* B_h, T* result_H, size_t N, bool expectMatch = 
 // Calls the test "failed" macro if a mismatch is detected.
 template <typename T>
 void checkTest(T* expected_H, T* result_H, size_t N, bool expectMatch = true) {
-    size_t mismatchCount = 0;
-    size_t firstMismatch = 0;
-    size_t mismatchesToPrint = 10;
-    for (size_t i = 0; i < N; i++) {
-        if (result_H[i] != expected_H[i]) {
-            if (mismatchCount == 0) {
-                firstMismatch = i;
-            }
-            mismatchCount++;
-            if ((mismatchCount <= mismatchesToPrint) && expectMatch) {
-                std::cout << std::fixed << std::setprecision(32);
-                std::cout << "At " << i << std::endl;
-                std::cout << "  Computed:" << result_H[i] << std::endl;
-                std::cout << "  Expected:" << expected_H[i] << std::endl;
-            }
-        }
+  size_t mismatchCount = 0;
+  size_t firstMismatch = 0;
+  size_t mismatchesToPrint = 10;
+  for (size_t i = 0; i < N; i++) {
+    if (result_H[i] != expected_H[i]) {
+      if (mismatchCount == 0) {
+        firstMismatch = i;
+      }
+      mismatchCount++;
+      if ((mismatchCount <= mismatchesToPrint) && expectMatch) {
+        std::cout << std::fixed << std::setprecision(32);
+        std::cout << "At " << i << std::endl;
+        std::cout << "  Computed:" << result_H[i] << std::endl;
+        std::cout << "  Expected:" << expected_H[i] << std::endl;
+      }
     }
+  }
 
-    if (expectMatch) {
-        if (mismatchCount) {
-            fprintf(stderr, "%zu mismatches ; first at index:%zu\n", mismatchCount, firstMismatch);
-            // failed("%zu mismatches ; first at index:%zu\n", mismatchCount, firstMismatch);
-        }
-    } else {
-        if (mismatchCount == 0) {
-            failed("expected mismatches but did not detect any!");
-        }
+  if (expectMatch) {
+    if (mismatchCount) {
+      fprintf(stderr, "%zu mismatches ; first at index:%zu\n", mismatchCount, firstMismatch);
+      // failed("%zu mismatches ; first at index:%zu\n", mismatchCount, firstMismatch);
     }
+  } else {
+    if (mismatchCount == 0) {
+      failed("expected mismatches but did not detect any!");
+    }
+  }
 }
 
 
 //---
 struct Pinned {
-    static const bool isPinned = true;
-    static const char* str() { return "Pinned"; };
+  static const bool isPinned = true;
+  static const char* str() { return "Pinned"; };
 
-    static void* Alloc(size_t sizeBytes) {
-        void* p;
-        HIPCHECK(hipHostMalloc((void**)&p, sizeBytes));
-        return p;
-    };
+  static void* Alloc(size_t sizeBytes) {
+    void* p;
+    HIPCHECK(hipHostMalloc((void**)&p, sizeBytes));
+    return p;
+  };
 };
 
 
 //---
 struct Unpinned {
-    static const bool isPinned = false;
-    static const char* str() { return "Unpinned"; };
+  static const bool isPinned = false;
+  static const char* str() { return "Unpinned"; };
 
-    static void* Alloc(size_t sizeBytes) {
-        void* p = malloc(sizeBytes);
-        HIPASSERT(p);
-        return p;
-    };
+  static void* Alloc(size_t sizeBytes) {
+    void* p = malloc(sizeBytes);
+    HIPASSERT(p);
+    return p;
+  };
 };
 
 
 struct Memcpy {
-    static const char* str() { return "Memcpy"; };
+  static const char* str() { return "Memcpy"; };
 };
 
 struct MemcpyAsync {
-    static const char* str() { return "MemcpyAsync"; };
+  static const char* str() { return "MemcpyAsync"; };
 };
 
 
-template <typename C>
-struct MemTraits;
+template <typename C> struct MemTraits;
 
 
-template <>
-struct MemTraits<Memcpy> {
-    static void Copy(void* dest, const void* src, size_t sizeBytes, hipMemcpyKind kind,
-                     hipStream_t stream) {
-        HIPCHECK(hipMemcpy(dest, src, sizeBytes, kind));
-    }
+template <> struct MemTraits<Memcpy> {
+  static void Copy(void* dest, const void* src, size_t sizeBytes, hipMemcpyKind kind,
+                   hipStream_t stream) {
+    HIPCHECK(hipMemcpy(dest, src, sizeBytes, kind));
+  }
 };
 
 
-template <>
-struct MemTraits<MemcpyAsync> {
-    static void Copy(void* dest, const void* src, size_t sizeBytes, hipMemcpyKind kind,
-                     hipStream_t stream) {
-        HIPCHECK(hipMemcpyAsync(dest, src, sizeBytes, kind, stream));
-    }
+template <> struct MemTraits<MemcpyAsync> {
+  static void Copy(void* dest, const void* src, size_t sizeBytes, hipMemcpyKind kind,
+                   hipStream_t stream) {
+    HIPCHECK(hipMemcpyAsync(dest, src, sizeBytes, kind, stream));
+  }
 };
 
-};  // namespace HipTest
-#endif //__cplusplus
+};      // namespace HipTest
+#endif  //__cplusplus

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -104,8 +104,15 @@ THE SOFTWARE.
 #define popen(x,y) _popen(x,y)
 #define pclose(x) _pclose(x)
 #define setenv(x,y,z) _putenv_s(x,y)
+#define unsetenv _putenv
+#define PLATFORM_NAME "WINDOWS"
+#define HIP_VISIBLE_DEVICES "HIP_VISIBLE_DEVICES="
+#define CUDA_VISIBLE_DEVICES "CUDA_VISIBLE_DEVICES="
 #else
 #define aligned_free(x) free(x)
+#define PLATFORM_NAME "OTHER"
+#define HIP_VISIBLE_DEVICES "HIP_VISIBLE_DEVICES"
+#define CUDA_VISIBLE_DEVICES "CUDA_VISIBLE_DEVICES"
 #endif
 
 // standard command-line variables:

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -109,11 +109,6 @@ THE SOFTWARE.
 #define aligned_free(x) free(x)
 #endif
 
-//const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES=";
-//const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES=";
-//const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES";
-//const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES";
-
 // standard command-line variables:
 extern size_t N;
 extern char memsetval;


### PR DESCRIPTION
There were several error messages that appeared even if the hipEnvVarDriver.exe test passes and executes successfully. Now it is cleaned up. The following are those instances:
- When popen searches for directed_test directory but does not find it, it outputs an error, then finds the hipEnvVar at the same level. Currently the fix will prompt the test to only output an error if both searches for hipEnvVar fails.
- When assertion is used towards the later half of the test, conditions were set to specifically hide the devices, resulting in No Hip Device detected in the latter half of the test. The fix will make these errors not appear as they are intended to not find any devices. Assertions themselves are untouched.