### PR TITLE
[dtest] Avoid resViewDesc for non-array resource in texture creation 

### DIFF
--- a/tests/src/texture/hipTexObjPitch.cpp
+++ b/tests/src/texture/hipTexObjPitch.cpp
@@ -76,8 +76,7 @@ void texture2Dtest()
     texDescr.readMode = hipReadModeElementType;
 
     hipTextureObject_t texObj;
-    hipResourceViewDesc resDesc;
-    HIPCHECK( hipCreateTextureObject(&texObj, &texRes, &texDescr, &resDesc));
+    HIPCHECK( hipCreateTextureObject(&texObj, &texRes, &texDescr, NULL));
 
     HIPCHECK(hipMalloc((void**)&devPtrB, SIZE_W*sizeof(TYPE_t)*SIZE_H)) ;
 


### PR DESCRIPTION
As per CUDA docs pResViewDesc can only be specified if the type of resource is a CUDA array or a CUDA mipmapped array.