### PR TITLE
Cleaned up error messages for HipEnvVarDriver test

### DIFF
--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -70,7 +70,7 @@ int getDeviceNumber(bool print_err=true) {
         }
     }
     if (print_err) {
-		std::cout << buff;
+        std::cout << buff;
     }
     return atoi(buff);
 }

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -38,23 +38,22 @@ const string directed_dir = string(".") + PATH_SEPERATOR_STR + "directed_tests" 
 const string dir = string(".") + PATH_SEPERATOR_STR + "hipEnvVar";
 
 int readHipEnvVar(string flags, char* buff){
-    //Don't print errors if popen is missing file
-    int fd = dup(fileno(stderr));
-    freopen(NULL_DEVICE, "w", stderr);
+
+    std::cout << "\nFinding hipEnvVar in " << directed_dir << "...\n";
     FILE* directed_in = popen((directed_dir + flags).c_str(), "r");
-    FILE* in = popen((dir + flags).c_str(), "r");
-    dup2(fd, fileno(stderr));
-    close(fd);
     
     if(fgets(buff, 512, directed_in) == NULL){
+        std::cout << "Finding hipEnvVar in " << dir << "...\n";
+        FILE* in = popen((dir + flags).c_str(), "r");
         if(fgets(buff, 512, in) == NULL){
             pclose(directed_in);
             pclose(in);
             return 1;
         }
+        pclose(in);
     }
+    std::cout << "hipEnvVar Found!\n";
     pclose(directed_in);
-    pclose(in);
     return 0;
 }
 

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -21,6 +21,7 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
  * HIT_END
  */
 
+#include <io.h>
 #include <iostream>
 #include <vector>
 #include <stdio.h>
@@ -34,23 +35,34 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
 
 using namespace std;
 
-const string directed_dir = "directed_tests" + string(PATH_SEPERATOR_STR) + "hipEnvVar";
+const string directed_dir = "." + string(PATH_SEPERATOR_STR) + "directed_tests" + string(PATH_SEPERATOR_STR) + "hipEnvVar";
 const string dir = "." + string(PATH_SEPERATOR_STR) + "hipEnvVar";
 
-int getDeviceNumber() {
+int getDeviceNumber(bool print_cout=true) {
     char buff[512];
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+	//Don't print error if missing directed_dir file
+    int fd = dup(fileno(stderr));
+    freopen(NULL_DEVICE, "w", stderr);
     FILE* in = popen((directed_dir + " -c").c_str(), "r");
     if(fgets(buff, 512, in) == NULL){
+        dup2(fd, fileno(stderr));
+        close(fd);
         pclose(in);
-        //Check at same level
+        //Check at same level, and print error if missing both files
         in = popen((dir + " -c").c_str(), "r");
         if(fgets(buff, 512, in) == NULL){
             pclose(in);
             return 1;
         }
+    } else {
+		dup2(fd, fileno(stderr));
+		close(fd);
+	}
+    if (print_cout) {
+		cout << buff;
     }
-    cout << buff;
     pclose(in);
     return atoi(buff);
 }
@@ -58,16 +70,23 @@ int getDeviceNumber() {
 // Query the current device ID remotely to hipEnvVar
 void getDevicePCIBusNumRemote(int deviceID, char* pciBusID) {    
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
+	int fd = dup(fileno(stderr));
+	freopen(NULL_DEVICE, "w", stderr);
     FILE* in = popen((directed_dir + " -d " + std::to_string(deviceID)).c_str(), "r");
     if(fgets(pciBusID, 100, in) == NULL){
+		dup2(fd, fileno(stderr));
+		close(fd);
         pclose(in);
         //Check at same level
-        in = popen((dir + " -d").c_str(), "r");
+        in = popen((dir + " -d " + std::to_string(deviceID)).c_str(), "r");
         if(fgets(pciBusID, 100, in) == NULL){
             pclose(in);
             return;
         }
-    }
+    } else {
+		dup2(fd, fileno(stderr));
+		close(fd);
+	}
     cout << pciBusID;
     pclose(in);
     return;
@@ -116,7 +135,7 @@ int main() {
     // check when set an invalid device number
     setenv("HIP_VISIBLE_DEVICES", "1000,0,1", 1);
     setenv("CUDA_VISIBLE_DEVICES", "1000,0,1", 1);
-    assert(getDeviceNumber() == 0);
+    assert(getDeviceNumber(false) == 0);
 
     if (totalDeviceNum > 2) {
         setenv("HIP_VISIBLE_DEVICES", "0,1,1000,2", 1);
@@ -135,7 +154,7 @@ int main() {
 
     setenv("HIP_VISIBLE_DEVICES", "-100,0,1", 1);
     setenv("CUDA_VISIBLE_DEVICES", "-100,0,1", 1);
-    assert(getDeviceNumber() == 0);
+    assert(getDeviceNumber(false) == 0);
 
     std::cout << "PASSED" << std::endl;
     return 0;

--- a/tests/src/hipEnvVarDriver.cpp
+++ b/tests/src/hipEnvVarDriver.cpp
@@ -21,7 +21,6 @@ OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWA
  * HIT_END
  */
 
-#include <io.h>
 #include <iostream>
 #include <vector>
 #include <stdio.h>

--- a/tests/src/test_common.cpp
+++ b/tests/src/test_common.cpp
@@ -37,10 +37,12 @@ int p_tests = -1; /*which tests to run. Interpretation is left to each test.  de
 const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES=";
 const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES=";
 const char* PATH_SEPERATOR_STR = "\\";
+const char* NULL_DEVICE = "NUL:";
 #else
 const char* HIP_VISIBLE_DEVICES_STR = "HIP_VISIBLE_DEVICES";
 const char* CUDA_VISIBLE_DEVICES_STR = "CUDA_VISIBLE_DEVICES";
 const char* PATH_SEPERATOR_STR = "/";
+const char* NULL_DEVICE = "/dev/null";
 #endif
 
 namespace HipTest {

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -105,6 +105,10 @@ THE SOFTWARE.
 #define pclose(x) _pclose(x)
 #define setenv(x,y,z) _putenv_s(x,y)
 #define unsetenv _putenv
+#define fileno(x) _fileno(x)
+#define dup(x) _dup(x)
+#define dup2(x,y) _dup2(x,y)
+#define close(x) _close(x)
 #else
 #define aligned_free(x) free(x)
 #endif
@@ -124,6 +128,7 @@ extern int p_tests;
 extern const char* HIP_VISIBLE_DEVICES_STR;
 extern const char* CUDA_VISIBLE_DEVICES_STR;
 extern const char* PATH_SEPERATOR_STR;
+extern const char* NULL_DEVICE;
 
 // ********************* CPP section *********************
 #ifdef __cplusplus

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -99,7 +99,6 @@ THE SOFTWARE.
 
 #ifdef _WIN64
 #include <tchar.h>
-#include <io.h>
 #define aligned_alloc(x,y) _aligned_malloc(y,x)
 #define aligned_free(x) _aligned_free(x)
 #define popen(x,y) _popen(x,y)

--- a/tests/src/test_common.h
+++ b/tests/src/test_common.h
@@ -99,6 +99,7 @@ THE SOFTWARE.
 
 #ifdef _WIN64
 #include <tchar.h>
+#include <io.h>
 #define aligned_alloc(x,y) _aligned_malloc(y,x)
 #define aligned_free(x) _aligned_free(x)
 #define popen(x,y) _popen(x,y)


### PR DESCRIPTION
There were several error messages that appeared even if the hipEnvVarDriver.exe test passes and executes successfully. Now it is cleaned up. The following are those instances:
- When popen searches for directed_test directory but does not find it, it outputs an error, then finds the hipEnvVar at the same level. Currently the fix will prompt the test to only output an error if both searches for hipEnvVar fails.
- When assertion is used towards the later half of the test, conditions were set to specifically hide the devices, resulting in No Hip Device detected in the latter half of the test. The fix will make these errors not appear as they are intended to not find any devices. Assertions themselves are untouched.

HipEnvVarDriver.cpp has also been refactored. Reading HipEnvVar will now happen in a helper function for getDeviceNumber and getDevicePCIBusNumRemote, as the code to read HipEnvVar were really similar in them.