### PR TITLE
[HIPIFY] Fix build failure against ToT trunk LLVM 11.0.0

### DIFF
--- a/hipify-clang/src/HipifyAction.cpp
+++ b/hipify-clang/src/HipifyAction.cpp
@@ -213,7 +213,7 @@ StringRef readSourceText(clang::SourceManager &SM, const clang::SourceRange &exp
   */
 std::string stringifyZeroDefaultedArg(clang::SourceManager &SM, const clang::Expr *arg) {
   if (clang::isa<clang::CXXDefaultArgExpr>(arg)) return "0";
-  else return readSourceText(SM, arg->getSourceRange());
+  else return std::string(readSourceText(SM, arg->getSourceRange()));
 }
 
 } // anonymous namespace
@@ -427,7 +427,7 @@ bool HipifyAction::cudaSharedIncompleteArrayVar(const mat::MatchFinder::MatchRes
         clang::LangOptions LO;
         LO.CUDA = true;
         clang::PrintingPolicy policy(LO);
-        typeName = BT->getName(policy);
+        typeName = std::string(BT->getName(policy));
       }
     } else {
       typeName = QT.getAsString();

--- a/hipify-clang/src/LLVMCompat.cpp
+++ b/hipify-clang/src/LLVMCompat.cpp
@@ -44,7 +44,7 @@ ct::Replacements &getReplacements(ct::RefactoringTool &Tool, StringRef file) {
 #if LLVM_VERSION_MAJOR > 3
   // getReplacements() now returns a map from filename to Replacements - so create an entry
   // for this source file and return a reference to it.
-  return Tool.getReplacements()[file];
+  return Tool.getReplacements()[std::string(file)];
 #else
   return Tool.getReplacements();
 #endif

--- a/hipify-clang/src/main.cpp
+++ b/hipify-clang/src/main.cpp
@@ -124,7 +124,7 @@ void appendArgumentsAdjusters(ct::RefactoringTool &Tool, const std::string &sSou
   // Includes for clang's CUDA wrappers for using by packaged hipify-clang
   static int Dummy;
   std::string hipify = llvm::sys::fs::getMainExecutable(hipify_exe, (void *)&Dummy);
-  std::string clang_inc_path = llvm::sys::path::parent_path(hipify);
+  std::string clang_inc_path = std::string(llvm::sys::path::parent_path(hipify));
   clang_inc_path.append("/include");
   Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster(clang_inc_path.c_str(), ct::ArgumentInsertPosition::BEGIN));
   Tool.appendArgumentsAdjuster(ct::getInsertArgumentAdjuster("-isystem", ct::ArgumentInsertPosition::BEGIN));


### PR DESCRIPTION
+ Add an explicit cast when assigning StringRef to std::string