### PR TITLE
Update hipLaunchCoopMultiKernel.cpp at the line 159

### DIFF
--- a/tests/src/runtimeApi/module/hipLaunchCoopMultiKernel.cpp
+++ b/tests/src/runtimeApi/module/hipLaunchCoopMultiKernel.cpp
@@ -156,7 +156,7 @@ int main() {
     for (int i = 0; i < nGpu; i++) {
       HIPCHECK(hipSetDevice(i));
       dimBlock.x = workgroups[set];
-      HIPCHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocks,
+      HIPCHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(reinterpret_cast<uint32_t*>(&numBlocks),
       (hipFunction_t)test_gws, dimBlock.x * dimBlock.y * dimBlock.z, dimBlock.x * sizeof(long)));
       
       std::cout << "GPU(" << i << ") Block size: " << dimBlock.x << " Num blocks per CU: " << numBlocks << "\n";


### PR DESCRIPTION
used reinterpret_cast<uint32_t*> for numBlocks, as expected by hipOccupancyMaxActiveBlocksPerMultiprocessor() api.