### PR TITLE
[hip] Revise compiler wrapper for HIP-Clang.

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -138,10 +138,6 @@ if (defined $HIP_RUNTIME and $HIP_RUNTIME eq "VDI" and !defined $HIP_VDI_HOME) {
 if (defined $HIP_VDI_HOME) {
     if (!defined $HIP_CLANG_PATH and (-e "$HIP_VDI_HOME/bin/clang" or -e "$HIP_VDI_HOME/bin/clang.exe")) {
         $HIP_CLANG_PATH = "$HIP_VDI_HOME/bin";
-        # With HIP_VDI_HOME defined, assume the installation of clang components, including headers.
-        if (!defined $HIP_CLANG_INCLUDE_PATH) {
-            $HIP_CLANG_INCLUDE_PATH = "$HIP_VDI_HOME/include/clang";
-        }
     }
     if (!defined $DEVICE_LIB_PATH and -e "$HIP_VDI_HOME/lib/bitcode") {
         $DEVICE_LIB_PATH = "$HIP_VDI_HOME/lib/bitcode";


### PR DESCRIPTION
- As the builtin headers from clang are installed in the standard
  destination, there's no need to add them as system header paths.
  There's no need to add HIP headers as system headers as well.