### PR TITLE
Use deque instead of vector for code readers so that the iterators and references will be stable

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,7 +177,7 @@ def docker_build_inside_image( def build_image, String inside_args, String platf
             cd ${build_dir_rel}
             make install -j\$(nproc)
             make build_tests -i -j\$(nproc)
-            ctest -E "(hipMultiThreadDevice-pyramid|hipMemoryAllocateCoherentDriver)"
+            ctest --output-on-failure -E "(hipMultiThreadDevice-pyramid|hipMemoryAllocateCoherentDriver)"
           """
         // If unit tests output a junit or xunit file in the future, jenkins can parse that file
         // to display test results on the dashboard

--- a/src/program_state.inl
+++ b/src/program_state.inl
@@ -419,8 +419,7 @@ public:
         decltype(code_readers.second)::iterator it;
         {
           std::lock_guard<std::mutex> lck{code_readers.first};
-          it = code_readers.second.emplace_back(code_readers.second.end(),
-                                           move(file), move(tmp));
+          it = code_readers.second.emplace_back(move(file), move(tmp));
         }
 
         auto check_hsa_error = [](hsa_status_t s) {

--- a/src/program_state.inl
+++ b/src/program_state.inl
@@ -419,7 +419,8 @@ public:
         decltype(code_readers.second)::iterator it;
         {
           std::lock_guard<std::mutex> lck{code_readers.first};
-          it = code_readers.second.emplace_back(move(file), move(tmp));
+          code_readers.second.emplace_back(move(file), move(tmp));
+          it = std::prev(code_readers.second.end());
         }
 
         auto check_hsa_error = [](hsa_status_t s) {

--- a/src/program_state.inl
+++ b/src/program_state.inl
@@ -26,6 +26,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstdio>
+#include <deque>
 #include <memory>
 #include <mutex>
 #include <stdexcept>
@@ -202,7 +203,7 @@ public:
                         std::function<void(hsa_code_object_reader_t*)>>;
     std::pair<
         std::mutex,
-        std::vector<std::pair<std::string, RAII_code_reader>>> code_readers;
+        std::deque<std::pair<std::string, RAII_code_reader>>> code_readers;
 
     program_state_impl() {
         // Create placeholder for each agent for the per-agent members.
@@ -418,7 +419,7 @@ public:
         decltype(code_readers.second)::iterator it;
         {
           std::lock_guard<std::mutex> lck{code_readers.first};
-          it = code_readers.second.emplace(code_readers.second.end(),
+          it = code_readers.second.emplace_back(code_readers.second.end(),
                                            move(file), move(tmp));
         }
 

--- a/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
+++ b/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
@@ -18,7 +18,7 @@ THE SOFTWARE.
 */
 
 /* HIT_START
- * BUILD: %t %s ../../test_common.cpp EXCLUDE_HIP_PLATFORM nvcc
+ * BUILD: %t %s ../../test_common.cpp NVCC_OPTIONS -std=c++11
  * TEST: %t
  * HIT_END
  */
@@ -127,10 +127,16 @@ struct joinable_thread : std::thread
 void run_multi_threads(uint32_t n) {
     std::vector<ModuleFunction> mf(n);
     {
+        hipDevice_t device;
+        HIPCHECK(hipDeviceGet(&device, 0));
+
         auto buffer = load_file();
         std::vector<joinable_thread> threads;
         for (uint32_t i = 0; i < n; i++) {
             threads.emplace_back(std::thread{[&, i, buffer] {
+                hipCtx_t ctx;
+                HIPCHECK(hipDevicePrimaryCtxRetain(&ctx, device));
+                
                 mf[i] = load(buffer);
             }});
         }

--- a/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
+++ b/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
@@ -35,7 +35,7 @@ THE SOFTWARE.
 
 #define LEN 64
 #define SIZE LEN << 2
-#define THREADS 64
+#define THREADS 4
 
 #define FILENAME "vcpy_kernel.code"
 #define kernel_name "hello_world"
@@ -138,7 +138,7 @@ void run_multi_threads(uint32_t n) {
 int main() {
 
     HIPCHECK(hipInit(0));
-    run_multi_threads(THREADS);
+    run_multi_threads(THREADS * std::thread::hardware_concurrency());
 
     passed();
 }

--- a/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
+++ b/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
@@ -136,7 +136,7 @@ void run_multi_threads(uint32_t n) {
             threads.emplace_back(std::thread{[&, i, buffer] {
                 hipCtx_t ctx;
                 HIPCHECK(hipDevicePrimaryCtxRetain(&ctx, device));
-                
+                HIPCHECK(hipCtxPushCurrent(ctx));
                 mf[i] = load(buffer);
             }});
         }

--- a/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
+++ b/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
@@ -134,27 +134,27 @@ hipCtx_t create_context() {
 }
 
 void run_multi_threads(uint32_t n) {
+    auto ctx = create_context();
     std::vector<ModuleFunction> mf(n);
     {
         auto buffer = load_file();
         std::vector<joinable_thread> threads;
         for (uint32_t i = 0; i < n; i++) {
             threads.emplace_back(std::thread{[&, i, buffer] {
+                HIPCHECK(hipCtxSetCurrent(ctx));
                 mf[i] = load(buffer);
             }});
         }
     }
     for(auto&& x:mf)
         run(x);
-
+    hipCtxDestroy(ctx);
 }
 
 int main() {
 
     HIPCHECK(hipInit(0));
-    auto ctx = create_context();
     run_multi_threads(THREADS * std::thread::hardware_concurrency());
-    hipCtxDestroy(ctx);
 
     passed();
 }

--- a/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
+++ b/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
@@ -127,6 +127,7 @@ void run_multi_threads(uint32_t n) {
         std::vector<joinable_thread> threads;
         for (uint32_t i = 0; i < n; i++) {
             threads.emplace_back(std::thread{[=, &mf] {
+                hipSetDevice(0);
                 mf[i] = load();
             }});
         }

--- a/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
+++ b/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
@@ -136,7 +136,7 @@ void run_multi_threads(uint32_t n) {
             threads.emplace_back(std::thread{[&, i, buffer] {
                 hipCtx_t ctx;
                 HIPCHECK(hipDevicePrimaryCtxRetain(&ctx, device));
-                HIPCHECK(hipCtxPushCurrent(ctx));
+                
                 mf[i] = load(buffer);
             }});
         }

--- a/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
+++ b/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
@@ -18,7 +18,7 @@ THE SOFTWARE.
 */
 
 /* HIT_START
- * BUILD: %t %s ../../test_common.cpp
+ * BUILD: %t %s ../../test_common.cpp NVCC_OPTIONS -std=c++11
  * TEST: %t
  * HIT_END
  */

--- a/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
+++ b/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
@@ -35,7 +35,11 @@ THE SOFTWARE.
 
 #define LEN 64
 #define SIZE LEN << 2
+#ifdef __CUDACC__
+#define THREADS 1
+#else
 #define THREADS 8
+#endif
 
 #define FILENAME "vcpy_kernel.code"
 #define kernel_name "hello_world"

--- a/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
+++ b/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
@@ -1,0 +1,144 @@
+/*
+Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANNTY OF ANY KIND, EXPRESS OR
+IMPLIED, INNCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANNY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER INN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR INN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/* HIT_START
+ * BUILD: %t %s ../../test_common.cpp NVCC_OPTIONS -std=c++11
+ * TEST: %t
+ * HIT_END
+ */
+
+#include "hip/hip_runtime.h"
+#include "hip/hip_runtime_api.h"
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <thread>
+#include <chrono>
+
+#include "test_common.h"
+
+#define LEN 64
+#define SIZE LEN << 2
+#define THREADS 64
+
+#define FILENAME "vcpy_kernel.code"
+#define kernel_name "hello_world"
+
+using ModuleFunction = std::pair<hipModule_t, hipFunction_t>;
+
+ModuleFunction load() {
+    hipModule_t Module;
+    hipFunction_t Function;
+    std::ifstream file(FILENAME, std::ios::binary | std::ios::ate);
+    std::streamsize fsize = file.tellg();
+    file.seekg(0, std::ios::beg);
+
+    std::vector<char> buffer(fsize);
+    if (file.read(buffer.data(), fsize)) {
+        HIPCHECK(hipModuleLoadData(&Module, &buffer[0]));
+        HIPCHECK(hipModuleGetFunction(&Function, Module, kernel_name));
+    }
+    else {
+        failed("could not open code object '%s'\n", FILENAME);
+    }
+    return {Module, Function};
+}
+
+void run(ModuleFunction mf) {
+    hipModule_t Module = mf.first;
+    hipFunction_t Function = mf.second;
+        float *A, *B, *Ad, *Bd;
+    A = new float[LEN];
+    B = new float[LEN];
+
+    for (uint32_t i = 0; i < LEN; i++) {
+        A[i] = i * 1.0f;
+        B[i] = 0.0f;
+    }
+
+    HIPCHECK(hipMalloc((void**)&Ad, SIZE));
+    HIPCHECK(hipMalloc((void**)&Bd, SIZE));
+
+    HIPCHECK(hipMemcpy(Ad, A, SIZE, hipMemcpyHostToDevice));
+    HIPCHECK(hipMemcpy(Bd, B, SIZE, hipMemcpyHostToDevice));
+
+    hipStream_t stream;
+    HIPCHECK(hipStreamCreate(&stream));
+
+    struct {
+        void* _Ad;
+        void* _Bd;
+    } args;
+    args._Ad = (void*) Ad;
+    args._Bd = (void*) Bd;
+    size_t size = sizeof(args);
+
+    void* config[] = {HIP_LAUNCH_PARAM_BUFFER_POINTER, &args, HIP_LAUNCH_PARAM_BUFFER_SIZE, &size,
+                      HIP_LAUNCH_PARAM_END};
+    HIPCHECK(hipModuleLaunchKernel(Function, 1, 1, 1, LEN, 1, 1, 0, stream, NULL, (void**)&config));
+
+    HIPCHECK(hipStreamDestroy(stream));
+
+    HIPCHECK(hipModuleUnload(Module));
+
+    HIPCHECK(hipMemcpy(B, Bd, SIZE, hipMemcpyDeviceToHost));
+
+    for (uint32_t i = 0; i < LEN; i++) {
+        assert(A[i] == B[i]);
+    }
+}
+
+struct joinable_thread : std::thread
+{
+    template <class... Xs>
+    joinable_thread(Xs&&... xs) : std::thread(std::forward<Xs>(xs)...) // NOLINT
+    {
+    }
+
+    joinable_thread& operator=(joinable_thread&& other) = default;
+    joinable_thread(joinable_thread&& other)            = default;
+
+    ~joinable_thread()
+    {
+        if(this->joinable())
+            this->join();
+    }
+};
+
+void run_multi_threads(uint32_t n) {
+    std::vector<ModuleFunction> mf(n);
+    {
+        std::vector<joinable_thread> threads;
+        for (uint32_t i = 0; i < n; i++) {
+            threads.emplace_back(std::thread{[=, &mf] {
+                mf[i] = load();
+            }});
+        }
+    }
+    for(auto&& x:mf)
+        run(x);
+}
+
+int main() {
+
+    HIPCHECK(hipInit(0));
+    run_multi_threads(THREADS);
+
+    passed();
+}

--- a/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
+++ b/tests/src/runtimeApi/module/hipModuleLoadDataMultThreaded.cpp
@@ -18,7 +18,7 @@ THE SOFTWARE.
 */
 
 /* HIT_START
- * BUILD: %t %s ../../test_common.cpp NVCC_OPTIONS -std=c++11
+ * BUILD: %t %s ../../test_common.cpp EXCLUDE_HIP_PLATFORM nvcc
  * TEST: %t
  * HIT_END
  */
@@ -127,16 +127,10 @@ struct joinable_thread : std::thread
 void run_multi_threads(uint32_t n) {
     std::vector<ModuleFunction> mf(n);
     {
-        hipDevice_t device;
-        HIPCHECK(hipDeviceGet(&device, 0));
-
         auto buffer = load_file();
         std::vector<joinable_thread> threads;
         for (uint32_t i = 0; i < n; i++) {
             threads.emplace_back(std::thread{[&, i, buffer] {
-                hipCtx_t ctx;
-                HIPCHECK(hipDevicePrimaryCtxRetain(&ctx, device));
-                
                 mf[i] = load(buffer);
             }});
         }


### PR DESCRIPTION
Even though there is a lock for pushing back to the vector, the references and iterators to the element are used without a lock. This is a problem as other threads will push back to the vector which can invalidate the references and iterators from other threads.

Instead of locking the entire function, I switched to `std::deque` which has stable iterators and references when using `emplace_back`. 