### PR TITLE
[hipcc] Skip warning on `gfx000`.

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -664,11 +664,11 @@ if($HIP_PLATFORM eq "hcc" or $HIP_PLATFORM eq "clang"){
             if ($HIP_PLATFORM eq 'clang') {
                 $HIPCXXFLAGS .= $GPU_ARCH_ARG;
             }
-        }
 
-        # If the specified target is not in the list of known target names, emit a warning.
-        if (grep(/$val/, @knownTargets) eq 0) {
-            print "Warning: The specified HIP target: $val is unknown. Correct compilation is not guaranteed.\n";
+            # If the specified target is not in the list of known target names, emit a warning.
+            if (grep(/$val/, @knownTargets) eq 0) {
+                print "Warning: The specified HIP target: $val is unknown. Correct compilation is not guaranteed.\n";
+            }
         }
     }
 


### PR DESCRIPTION
- The known target checking should skip `gfx000` as well as it won't be
  used in real compilation command formation. The avoid generating
  annoying warning on `gfx000`.