### PR TITLE
[hipcc] - removing dependency on rocm-dkms package

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -70,15 +70,20 @@ $HIPCC_LINK_FLAGS_APPEND=$ENV{'HIPCC_LINK_FLAGS_APPEND'};
 # linked by symlink, the absolute path of this script should be used to
 # derive HIP_PATH, as dirname $0 could be /opt/rocm/bin or /opt/rocm/hip/bin
 # depending on how it gets invoked.
-# ROCM_PATH which points to <rocm_install_dir> is determined based on whether
-# we find .info/version in the parent of HIP_PATH or not. If it is found,
-# ROCM_PATH is defined relative to HIP_PATH else it is hardcoded to /opt/rocm.
+#
+# ROCM_PATH which points to <rocm_install_dir> is defaulted to /opt/rocm and
+# if it is defined in the ENV and it exists, then set it to ENV var.
+# -> Here we are eliminating the dependency on .info/version which is installed
+# by rocm-dkms package which cant be installed in a docker.
+# -> Dont want to rely on parent of HIP_PATH since HIP can be installed into
+# any path.
+# ROCM_PATH is the variable used ahead for refering to all other ROCm stack
+# components.
 #
 $HIP_PATH=$ENV{'HIP_PATH'} // dirname(Cwd::abs_path("$0/../")); # use parent directory of hipcc
-if (-e "$HIP_PATH/../.info/version") {
-    $ROCM_PATH=$ENV{'ROCM_PATH'} // dirname("$HIP_PATH"); # use parent directory of HIP_PATH
-} else {
-    $ROCM_PATH=$ENV{'ROCM_PATH'} // "/opt/rocm";
+$ROCM_PATH="/opt/rocm";
+if (-e "$ENV{'ROCM_PATH'}") {
+    $ROCM_PATH=$ENV{'ROCM_PATH'};
 }
 $HIP_VDI_HOME=$ENV{'HIP_VDI_HOME'};
 $HIP_LIB_PATH=$ENV{'HIP_LIB_PATH'};


### PR DESCRIPTION
-> ROCM_PATH which points to <rocm_install_dir> is defaulted to /opt/rocm and
if it is defined in the ENV and it exists, then set it to ENV var.
-> Here we are eliminating the dependency on .info/version which is installed
by rocm-dkms package which cant be installed in a docker.
-> Dont want to rely on parent of HIP_PATH since HIP can be installed into
any path.