### PR TITLE
missing break statement in hipDeviceGetAttribute

### DIFF
--- a/src/hip_device.cpp
+++ b/src/hip_device.cpp
@@ -291,6 +291,7 @@ hipError_t ihipDeviceGetAttribute(int* pi, hipDeviceAttribute_t attr, int device
                 break;
             case hipDeviceAttributeMaxTexture3DDepth:
                 *pi = prop->maxTexture3D[2];
+                break;
             case hipDeviceAttributeHdpMemFlushCntl:
                 {
                     uint32_t** hdp = reinterpret_cast<uint32_t**>(pi);


### PR DESCRIPTION
The break is missing for hipDeviceAttributeMaxTexture3DDepth.