### PR TITLE
[HIP][win][fix] Fix typo in device __shfl_xor function

### DIFF
--- a/include/hip/hcc_detail/device_functions.h
+++ b/include/hip/hcc_detail/device_functions.h
@@ -548,7 +548,7 @@ long __shfl_xor(long var, int lane_mask, int width = warpSize)
     return tmp1;
     #else
     static_assert(sizeof(long) == sizeof(int), "");
-    return static_cast<long>(__shfl_down(static_cast<int>(var), lane_delta, width));
+    return static_cast<long>(__shfl_down(static_cast<int>(var), lane_mask, width));
     #endif
 }
 __device__


### PR DESCRIPTION
On Windows the typo leads to the following error:

```cmd
d:\hip/include\hip/hcc_detail/device_functions.h(551,65): error G30564CF7: use of undeclared identifier 'lane_delta'
    return static_cast<long>(__shfl_down(static_cast<int>(var), lane_delta, width));
```