### PR TITLE
Fix errors in occupancy calculation function

### DIFF
--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -1418,9 +1418,17 @@ hipError_t ihipOccupancyMaxActiveBlocksPerMultiprocessor(
     if (ctx == nullptr) {
         return hipErrorInvalidDevice;
     }
+    if (numBlocks == nullptr) {
+        return hipErrorInvalidValue;
+    }
 
     hipDeviceProp_t prop{};
     ihipGetDeviceProperties(&prop, ihipGetTlsDefaultCtx()->getDevice()->_deviceId);
+
+    if (blockSize > prop.maxThreadsPerBlock) {
+        *numBlocks = 0;
+        return hipSuccess;
+    }
 
     prop.regsPerBlock = prop.regsPerBlock ? prop.regsPerBlock : 64 * 1024;
 


### PR DESCRIPTION
Fix two errors in hipOccupancyMaxActiveBlocksPerMultiprocessor.

1) Fix a possible segfault if the user passed in a null pointer for the numBlocks value. Return hipErrorInvalidValue when this situation occurs instead of just blowing up the runtime.

2) Handle the situation when the user is asking for a block size that is larger than what the target device can hold within a single block. Return numBlocks as zero, indicating that no blocks of this size can fit on the device, akin to how we will return 0 if you ask for more LDS space than the device has.