### PR TITLE
Fix hipOccupancyMaxActiveBlocksPerMultiprocessor API on NVCC

### DIFF
--- a/include/hip/nvcc_detail/hip_runtime_api.h
+++ b/include/hip/nvcc_detail/hip_runtime_api.h
@@ -1280,8 +1280,9 @@ inline static hipError_t hipDeviceGetAttribute(int* pi, hipDeviceAttribute_t att
     return hipCUDAErrorTohipError(cerror);
 }
 
+template<class T>
 inline static hipError_t hipOccupancyMaxActiveBlocksPerMultiprocessor(int* numBlocks,
-                                                                      const void* func,
+                                                                      T func,
                                                                       int blockSize,
                                                                       size_t dynamicSMemSize) {
     cudaError_t cerror;


### PR DESCRIPTION
NVCC warned if you tried to use hipOccupancyMaxActiveBlocksPerMultiprocessor
because when passing in a device function pointer, "const void* func" was
insufficient to describe it accurately. Changing to a templated class type
definition to fix this.