### PR TITLE
Don't force compiler to treat libhip_hcc.so as a text file

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -733,11 +733,11 @@ if ($HIPCC_LINK_FLAGS_APPEND) {
 }
 
 my $CMD="$HIPCC";
-if ($needCXXFLAGS) {
-    $CMD .= " $HIPCXXFLAGS";
-}
 if ($needLDFLAGS and not $compileOnly) {
     $CMD .= " $HIPLDFLAGS";
+}
+if ($needCXXFLAGS) {
+    $CMD .= " $HIPCXXFLAGS";
 }
 $CMD .= " $toolArgs";
 


### PR DESCRIPTION
Fixes SWDEV-226025,

Right now -x c++ can come before libhip_hcc.so which forces the compiler to treat libhip_hcc.so as a text file and generates a lot of gibberish unicode. This PR changes the order of flags ensuring that -x c++ and similar flags come after libhip_hcc.so
Hopefully, this will not have any negative side effect. 

