### PR TITLE
Output file name should not change flags picked for compiler

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -375,6 +375,7 @@ my $toolArgs = "";  # arguments to pass to the hcc or nvcc tool
 my $optArg = ""; # -O args
 my $targetOpt = '--amdgpu-target=';
 my $targetsStr = "";
+my $skipOutputFile = 0; # file followed by -o should not contibute in picking compiler flags
 
 foreach $arg (@ARGV)
 {
@@ -386,8 +387,16 @@ foreach $arg (@ARGV)
         $needCXXFLAGS = 1;
         $needLDFLAGS  = 0;
     }
+
+    if ($skipOutputFile) {
+        $toolArgs .= " $arg";
+        $skipOutputFile = 0;
+        next;
+    }
+
     if ($arg eq '-o') {
         $needLDFLAGS = 1;
+        $skipOutputFile = 1;
     }
 
     if(($trimarg eq '-stdlib=libc++') and ($setStdLib eq 0))


### PR DESCRIPTION
Fixes SWDEV-207362,

The output file name should not contribute to picking up the right flags for the compiler. This fix solves issues when the output has conflicting extensions which confuses hipcc to treat them as the source files and add the required flags for them. 

PS: Output file refers to the file followed by -o 

Example: hipcc test.o -o test.hip will add the flags for .hip compilation ignoring the fact that it is an output file