### PR TITLE
Fix compiler warning on NVCC path

### DIFF
--- a/include/hip/nvcc_detail/hip_runtime_api.h
+++ b/include/hip/nvcc_detail/hip_runtime_api.h
@@ -860,7 +860,7 @@ inline static hipError_t hipMemcpy(void* dst, const void* src, size_t sizeBytes,
 }
 
 
-inline hipError_t hipMemcpyWithStream(void* dst, const void* src,
+inline static hipError_t hipMemcpyWithStream(void* dst, const void* src,
 				      size_t sizeBytes, hipMemcpyKind copyKind,
 				      hipStream_t stream) {
 	cudaError_t error = cudaMemcpyAsync(dst, src, sizeBytes, 


### PR DESCRIPTION
GCC emits a warning about using static functions like
hipCUDAErrorTohipError inside this function, because it has an
inline directive, but it's not static. Adding static to this function
to silence warnings (and prevent potential problems in the future).