### PR TITLE
fix a bug when initializing a vector of hipFunction_t

### DIFF
--- a/src/hip_clang.cpp
+++ b/src/hip_clang.cpp
@@ -133,7 +133,7 @@ extern "C" void __hipRegisterFunction(
   int*         wSize)
 {
   HIP_INIT_API(NONE, modules, hostFunction, deviceFunction, deviceName);
-  std::vector<hipFunction_t> functions{g_deviceCnt};
+  std::vector<hipFunction_t> functions(g_deviceCnt);
 
   assert(modules && modules->size() >= g_deviceCnt);
   for (int deviceId = 0; deviceId < g_deviceCnt; ++deviceId) {

--- a/src/hip_clang.cpp
+++ b/src/hip_clang.cpp
@@ -50,7 +50,7 @@ __hipRegisterFatBinary(const void* data)
     return nullptr;
   }
 
-  auto modules = new std::vector<hipModule_t>{g_deviceCnt};
+  auto modules = new std::vector<hipModule_t>(g_deviceCnt);
   if (!modules) {
     return nullptr;
   }


### PR DESCRIPTION
In __hipRegisterFunction, we should use size argument method instead of initialization list method to initialize std::vector<hipFunction_t> functions.