### PR TITLE
Remove debug message from FindHIP.cmake

### DIFF
--- a/cmake/FindHIP.cmake
+++ b/cmake/FindHIP.cmake
@@ -75,7 +75,6 @@ if(UNIX AND NOT APPLE AND NOT CYGWIN)
         endif()
         # And push it back to the cache
         set(HIP_ROOT_DIR ${HIP_ROOT_DIR} CACHE PATH "HIP installed location" FORCE)
-        message("Found HIP at ${HIP_ROOT_DIR}")
     endif()
 
     # Find HIPCC executable


### PR DESCRIPTION
`FindHIP.cmake` seems to have a debug message in it which is quite ugly when configuring and it ships with upstream deploys. It seems to have been inserted for debugging purposes because the exact same information is pretty printed at the end of the script if not silenced through canonical means.
![kép](https://user-images.githubusercontent.com/9763499/76862143-ea472600-685d-11ea-87de-31e4c794b060.png)