### PR TITLE
Fix ambiguity of fma for _Float16 for libc++

### DIFF
--- a/include/hip/hcc_detail/math_functions.h
+++ b/include/hip/hcc_detail/math_functions.h
@@ -47,6 +47,19 @@ THE SOFTWARE.
 #include "kalmar_math.h"
 #endif
 
+#if _LIBCPP_VERSION && __HIP__
+namespace std {
+template <>
+struct __numeric_type<_Float16>
+{
+   static _Float16 __test(_Float16);
+
+   typedef _Float16 type;
+   static const bool value = true;
+};
+}
+#endif // _LIBCPP_VERSION
+
 #pragma push_macro("__DEVICE__")
 #pragma push_macro("__RETURN_TYPE")
 


### PR DESCRIPTION
libc++ defines fma as template function for auto promotion of mixed-type
arguments. libc++ does not handle _Float16 as _Float16 is not a supported
type by C++ standard. As such, it is unlikely we can commit our fix for
_Float16 to libc++ trunk.

Therefore we handle _Float16 with a template specialization of
__numeric_type in HIP headers.

Change-Id: If01960a657ebf1a7a67463cdcf66fab7458dff3c