### PR TITLE
[hip] fix a build error when building hip with latest hcc

### DIFF
--- a/src/hip_module.cpp
+++ b/src/hip_module.cpp
@@ -510,7 +510,7 @@ hipError_t ihipLaunchCooperativeKernel(const void* f, dim3 gridDim,
     stream = ihipSyncAndResolveStream(stream);
 
     if (!stream->getDevice()->_props.cooperativeLaunch ||
-        blockDimX.x * blockDimX.y * blockDimX.z > stream->getDevice()->_props.maxThreadsPerBlock) {
+        blockDim.x * blockDim.y * blockDim.z > stream->getDevice()->_props.maxThreadsPerBlock) {
         return hipErrorInvalidConfiguration;
     }
 
@@ -553,7 +553,7 @@ hipError_t ihipLaunchCooperativeKernel(const void* f, dim3 gridDim,
     GET_TLS();
     uint32_t numBlocksPerSm = 0;
     result = ihipOccupancyMaxActiveBlocksPerMultiprocessor(tls, &numBlocksPerSm, kd,
-                    blockDimX.x * blockDimX.y * blockDimX.z, sharedMemBytes);
+                    blockDim.x * blockDim.y * blockDim.z, sharedMemBytes);
     if (result != hipSuccess) {
         return hipErrorLaunchFailure;
     }


### PR DESCRIPTION
there is a build error when building HIP with latest HCC from GitHub after [PR#1935](https://github.com/ROCm-Developer-Tools/HIP/pull/1935) merged into HIP master branch. this PR changed  blockDimX to blockDim and two lines missed this change where added in the current PR.