### PR TITLE
[HIP] add support for NoPreSync/NoPostSync flags for Cooperative Mult…

### DIFF
--- a/src/hip_hcc.cpp
+++ b/src/hip_hcc.cpp
@@ -263,7 +263,13 @@ ihipStream_t::ihipStream_t(ihipCtx_t* ctx, hc::accelerator_view av, unsigned int
 
 
 //---
-ihipStream_t::~ihipStream_t() {}
+ihipStream_t::~ihipStream_t() {
+    GET_TLS();
+    for (auto mem : coopMemsTracker) {
+        hip_internal::ihipHostFree(tls, mem->mgs);
+        hip_internal::ihipHostFree(tls, mem);
+    }
+}
 
 
 hc::hcWaitMode ihipStream_t::waitMode() const {

--- a/src/hip_hcc_internal.h
+++ b/src/hip_hcc_internal.h
@@ -551,6 +551,20 @@ public:
 typedef ihipStreamCriticalBase_t<StreamMutex> ihipStreamCritical_t;
 typedef LockedAccessor<ihipStreamCritical_t> LockedAccessor_StreamCrit_t;
 
+// do not change these two structs without changing the device library
+struct mg_sync {
+    uint w0;
+    uint w1;
+};
+
+struct mg_info {
+    struct mg_sync *mgs;
+    uint grid_id;
+    uint num_grids;
+    ulong prev_sum;
+    ulong all_sum;
+};
+
 //---
 // Internal stream structure.
 class ihipStream_t {
@@ -618,6 +632,8 @@ class ihipStream_t {
 
     // Before calling this function, stream must be resolved from "0" to the actual stream:
     bool isDefaultStream() const { return _id == 0; };
+
+    std::vector<mg_info*>  coopMemsTracker;
 
    public:
     //---
@@ -1017,27 +1033,13 @@ namespace hip_internal {
 hipError_t memcpyAsync(void* dst, const void* src, size_t sizeBytes, hipMemcpyKind kind,
                        hipStream_t stream);
 
-hipError_t ihipHostMalloc(TlsData *tls, void** ptr, size_t sizeBytes, unsigned int flags);
+hipError_t ihipHostMalloc(TlsData *tls, void** ptr, size_t sizeBytes, unsigned int flags, bool noSync = 0);
 
 hipError_t ihipHostFree(TlsData *tls, void* ptr);
 
 };
 
 #define MAX_COOPERATIVE_GPUs 255
-
-// do not change these two structs without changing the device library
-struct mg_sync {
-    uint w0;
-    uint w1;
-};
-
-struct mg_info {
-    struct mg_sync *mgs;
-    uint grid_id;
-    uint num_grids;
-    ulong prev_sum;
-    ulong all_sum;
-};
 
 //---
 // TODO - review the context creation strategy here.  Really should be:

--- a/src/hip_memory.cpp
+++ b/src/hip_memory.cpp
@@ -496,14 +496,14 @@ void* allocAndSharePtr(const char* msg, size_t sizeBytes, ihipCtx_t* ctx, bool s
     return ptr;
 }
 
-hipError_t ihipHostMalloc(TlsData *tls, void** ptr, size_t sizeBytes, unsigned int flags) {
+hipError_t ihipHostMalloc(TlsData *tls, void** ptr, size_t sizeBytes, unsigned int flags, bool noSync) {
     hipError_t hip_status = hipSuccess;
 
     if (sizeBytes == 0) {
         return hipSuccess;
     }
 
-    if (HIP_SYNC_HOST_ALLOC) {
+    if (HIP_SYNC_HOST_ALLOC && !noSync) {
         hipDeviceSynchronize();
     }
 
@@ -558,7 +558,7 @@ hipError_t ihipHostMalloc(TlsData *tls, void** ptr, size_t sizeBytes, unsigned i
         }
     }
 
-    if (HIP_SYNC_HOST_ALLOC) {
+    if (HIP_SYNC_HOST_ALLOC && !noSync) {
         hipDeviceSynchronize();
     }
     return hip_status;


### PR DESCRIPTION
…iDevice launch API

This PR adds support for hipCooperativeLaunchMultiDeviceNoPreSync/ hipCooperativeLaunchMultiDeviceNoPostSync flags for hipLaunchCooperativeKernelMultiDevice API

[background] By default (i.e., flag = 0), the kernel won't begin execution on any GPU until all prior work in all the specified streams has completed.
- by setting hipCooperativeLaunchMultiDeviceNoPreSync, each kernel will only wait for prior work in the stream corresponding to that GPU to complete before it begins execution.

- by setting hipCooperativeLaunchMultiDeviceNoPostSync, any subsequent work pushed in any of the specified streams will only wait for the kernel launched on the GPU corresponding to that stream to complete before it begins execution.
