### PR TITLE
Adding regex for comprehensive match for compiler names

### DIFF
--- a/packaging/hip-targets-release.cmake
+++ b/packaging/hip-targets-release.cmake
@@ -12,7 +12,7 @@ get_filename_component(_IMPORT_PREFIX "${_DIR}/../../../" REALPATH)
 
 # Import target "hip::hip_hcc_static" for configuration "Release"
 set_property(TARGET hip::hip_hcc_static APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-if(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
+if(CMAKE_CXX_COMPILER MATCHES "(.*)hcc" OR CMAKE_CXX_COMPILER MATCHES "(.*)clang(.*)")
 set_target_properties(hip::hip_hcc_static PROPERTIES
   IMPORTED_LINK_INTERFACE_LANGUAGES_RELEASE "CXX"
   IMPORTED_LINK_INTERFACE_LIBRARIES_RELEASE "hc_am"
@@ -30,7 +30,7 @@ list(APPEND _IMPORT_CHECK_FILES_FOR_hip::hip_hcc_static "${_IMPORT_PREFIX}/lib/l
 
 # Import target "hip::hip_hcc" for configuration "Release"
 set_property(TARGET hip::hip_hcc APPEND PROPERTY IMPORTED_CONFIGURATIONS RELEASE)
-if(HIP_COMPILER STREQUAL "hcc" OR HIP_COMPILER STREQUAL "clang")
+if(CMAKE_CXX_COMPILER MATCHES "(.*)hcc" OR CMAKE_CXX_COMPILER MATCHES "(.*)clang(.*)")
 set_target_properties(hip::hip_hcc PROPERTIES
   IMPORTED_LINK_INTERFACE_LIBRARIES_RELEASE "hcc::hccrt;hcc::hc_am"
   IMPORTED_LOCATION_RELEASE "${_IMPORT_PREFIX}/lib/libhip_hcc.so"
@@ -38,7 +38,6 @@ set_target_properties(hip::hip_hcc PROPERTIES
   )
 else()
 set_target_properties(hip::hip_hcc PROPERTIES
-  IMPORTED_LINK_INTERFACE_LIBRARIES_RELEASE "hcc::hccrt"
   IMPORTED_LOCATION_RELEASE "${_IMPORT_PREFIX}/lib/libhip_hcc.so"
   IMPORTED_SONAME_RELEASE "libhip_hcc.so"
   )

--- a/packaging/hip-targets.cmake
+++ b/packaging/hip-targets.cmake
@@ -86,7 +86,7 @@ set_target_properties(hip::host PROPERTIES
 # Create imported target hip::device
 add_library(hip::device INTERFACE IMPORTED)
 
-if(HIP_COMPILER STREQUAL "hcc")
+if(CMAKE_CXX_COMPILER MATCHES "(.*)hcc")
 set_target_properties(hip::device PROPERTIES
   INTERFACE_LINK_LIBRARIES "hip::host;hcc::hccrt;hcc::hc_am"
   INTERFACE_INCLUDE_DIRECTORIES "${_IMPORT_PREFIX}/../include"


### PR DESCRIPTION
Adding regex for comprehensive match.
It should match with hcc and /opt/rocm/bin/hcc