### PR TITLE
move hiprtc lines inside hcc block

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,11 +311,11 @@ if(HIP_PLATFORM STREQUAL "hcc")
         target_include_directories(
             hiprtc SYSTEM
                 PRIVATE ${PROJECT_SOURCE_DIR}/include ${HSA_PATH}/include)
+        set_target_properties(hiprtc PROPERTIES CXX_VISIBILITY_PRESET hidden)
+        set_target_properties(hiprtc PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
     endif()
     set_target_properties(hip_hcc PROPERTIES CXX_VISIBILITY_PRESET hidden)
     set_target_properties(hip_hcc PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
-    set_target_properties(hiprtc PROPERTIES CXX_VISIBILITY_PRESET hidden)
-    set_target_properties(hiprtc PROPERTIES VISIBILITY_INLINES_HIDDEN 1)
 
 
     if(HIP_PLATFORM STREQUAL "hcc")


### PR DESCRIPTION
Move the libhiprtc lines inside the `HIP_COMPILER STREQUAL "hcc"` block to fix cmake error when building with `-DHIP_COMPILER=hcc"`