### PR TITLE
Disable hip_memory.h

### DIFF
--- a/include/hip/hcc_detail/hip_runtime.h
+++ b/include/hip/hcc_detail/hip_runtime.h
@@ -515,6 +515,7 @@ hc_get_workitem_absolute_id(int dim)
 
 #endif // defined(__clang__) && defined(__HIP__)
 
-#include <hip/hcc_detail/hip_memory.h>
+// ToDo: Re-enable this after device side malloc is working.
+//#include <hip/hcc_detail/hip_memory.h>
 
 #endif  // HIP_HCC_DETAIL_RUNTIME_H


### PR DESCRIPTION
Currently device side malloc is not working and takes excessive
device memory.

Disable it for now until a working malloc is implemented.

Change-Id: I1ad908c1c53a83752383b4be96688a848642c699