### PR TITLE
[HIP][SPARSE] sync with HIPIFY's #95 and #96

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -738,8 +738,12 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcurandSetQuasiRandomGeneratorDimensions\b/hiprandSetQuasiRandomGeneratorDimensions/g;
     $ft{'library'} += s/\bcurandSetStream\b/hiprandSetStream/g;
     $ft{'library'} += s/\bcusparseCaxpyi\b/hipsparseCaxpyi/g;
+    $ft{'library'} += s/\bcusparseCbsrmv\b/hipsparseCbsrmv/g;
     $ft{'library'} += s/\bcusparseCcsr2csc\b/hipsparseCcsr2csc/g;
     $ft{'library'} += s/\bcusparseCcsr2hyb\b/hipsparseCcsr2hyb/g;
+    $ft{'library'} += s/\bcusparseCcsrgeam\b/hipsparseCcsrgeam/g;
+    $ft{'library'} += s/\bcusparseCcsrgeam2\b/hipsparseCcsrgeam2/g;
+    $ft{'library'} += s/\bcusparseCcsrgeam2_bufferSizeExt\b/hipsparseCcsrgeam2_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseCcsrgemm\b/hipsparseCcsrgemm/g;
     $ft{'library'} += s/\bcusparseCcsrgemm2\b/hipsparseCcsrgemm2/g;
     $ft{'library'} += s/\bcusparseCcsrgemm2_bufferSizeExt\b/hipsparseCcsrgemm2_bufferSizeExt/g;
@@ -763,6 +767,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseCgthrz\b/hipsparseCgthrz/g;
     $ft{'library'} += s/\bcusparseChybmv\b/hipsparseChybmv/g;
     $ft{'library'} += s/\bcusparseCnnz\b/hipsparseCnnz/g;
+    $ft{'library'} += s/\bcusparseCnnz_compress\b/hipsparseCnnz_compress/g;
     $ft{'library'} += s/\bcusparseCreate\b/hipsparseCreate/g;
     $ft{'library'} += s/\bcusparseCreateCsrgemm2Info\b/hipsparseCreateCsrgemm2Info/g;
     $ft{'library'} += s/\bcusparseCreateCsrilu02Info\b/hipsparseCreateCsrilu02Info/g;
@@ -773,8 +778,12 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseCreateMatDescr\b/hipsparseCreateMatDescr/g;
     $ft{'library'} += s/\bcusparseCsctr\b/hipsparseCsctr/g;
     $ft{'library'} += s/\bcusparseDaxpyi\b/hipsparseDaxpyi/g;
+    $ft{'library'} += s/\bcusparseDbsrmv\b/hipsparseDbsrmv/g;
     $ft{'library'} += s/\bcusparseDcsr2csc\b/hipsparseDcsr2csc/g;
     $ft{'library'} += s/\bcusparseDcsr2hyb\b/hipsparseDcsr2hyb/g;
+    $ft{'library'} += s/\bcusparseDcsrgeam\b/hipsparseDcsrgeam/g;
+    $ft{'library'} += s/\bcusparseDcsrgeam2\b/hipsparseDcsrgeam2/g;
+    $ft{'library'} += s/\bcusparseDcsrgeam2_bufferSizeExt\b/hipsparseDcsrgeam2_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseDcsrgemm\b/hipsparseDcsrgemm/g;
     $ft{'library'} += s/\bcusparseDcsrgemm2\b/hipsparseDcsrgemm2/g;
     $ft{'library'} += s/\bcusparseDcsrgemm2_bufferSizeExt\b/hipsparseDcsrgemm2_bufferSizeExt/g;
@@ -804,6 +813,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseDgthrz\b/hipsparseDgthrz/g;
     $ft{'library'} += s/\bcusparseDhybmv\b/hipsparseDhybmv/g;
     $ft{'library'} += s/\bcusparseDnnz\b/hipsparseDnnz/g;
+    $ft{'library'} += s/\bcusparseDnnz_compress\b/hipsparseDnnz_compress/g;
     $ft{'library'} += s/\bcusparseDroti\b/hipsparseDroti/g;
     $ft{'library'} += s/\bcusparseDsctr\b/hipsparseDsctr/g;
     $ft{'library'} += s/\bcusparseGetMatDiagType\b/hipsparseGetMatDiagType/g;
@@ -814,8 +824,12 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseGetStream\b/hipsparseGetStream/g;
     $ft{'library'} += s/\bcusparseGetVersion\b/hipsparseGetVersion/g;
     $ft{'library'} += s/\bcusparseSaxpyi\b/hipsparseSaxpyi/g;
+    $ft{'library'} += s/\bcusparseSbsrmv\b/hipsparseSbsrmv/g;
     $ft{'library'} += s/\bcusparseScsr2csc\b/hipsparseScsr2csc/g;
     $ft{'library'} += s/\bcusparseScsr2hyb\b/hipsparseScsr2hyb/g;
+    $ft{'library'} += s/\bcusparseScsrgeam\b/hipsparseScsrgeam/g;
+    $ft{'library'} += s/\bcusparseScsrgeam2\b/hipsparseScsrgeam2/g;
+    $ft{'library'} += s/\bcusparseScsrgeam2_bufferSizeExt\b/hipsparseScsrgeam2_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseScsrgemm\b/hipsparseScsrgemm/g;
     $ft{'library'} += s/\bcusparseScsrgemm2\b/hipsparseScsrgemm2/g;
     $ft{'library'} += s/\bcusparseScsrgemm2_bufferSizeExt\b/hipsparseScsrgemm2_bufferSizeExt/g;
@@ -844,6 +858,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseSgthrz\b/hipsparseSgthrz/g;
     $ft{'library'} += s/\bcusparseShybmv\b/hipsparseShybmv/g;
     $ft{'library'} += s/\bcusparseSnnz\b/hipsparseSnnz/g;
+    $ft{'library'} += s/\bcusparseSnnz_compress\b/hipsparseSnnz_compress/g;
     $ft{'library'} += s/\bcusparseSroti\b/hipsparseSroti/g;
     $ft{'library'} += s/\bcusparseSsctr\b/hipsparseSsctr/g;
     $ft{'library'} += s/\bcusparseXbsrilu02_zeroPivot\b/hipsparseXbsrilu02_zeroPivot/g;
@@ -854,6 +869,8 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseXcscsort\b/hipsparseXcscsort/g;
     $ft{'library'} += s/\bcusparseXcscsort_bufferSizeExt\b/hipsparseXcscsort_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseXcsr2coo\b/hipsparseXcsr2coo/g;
+    $ft{'library'} += s/\bcusparseXcsrgeam2Nnz\b/hipsparseXcsrgeam2Nnz/g;
+    $ft{'library'} += s/\bcusparseXcsrgeamNnz\b/hipsparseXcsrgeamNnz/g;
     $ft{'library'} += s/\bcusparseXcsrgemm2Nnz\b/hipsparseXcsrgemm2Nnz/g;
     $ft{'library'} += s/\bcusparseXcsrgemmNnz\b/hipsparseXcsrgemmNnz/g;
     $ft{'library'} += s/\bcusparseXcsrilu02_zeroPivot\b/hipsparseXcsrilu02_zeroPivot/g;
@@ -862,8 +879,12 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseXcsrsort_bufferSizeExt\b/hipsparseXcsrsort_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseXcsrsv2_zeroPivot\b/hipsparseXcsrsv2_zeroPivot/g;
     $ft{'library'} += s/\bcusparseZaxpyi\b/hipsparseZaxpyi/g;
+    $ft{'library'} += s/\bcusparseZbsrmv\b/hipsparseZbsrmv/g;
     $ft{'library'} += s/\bcusparseZcsr2csc\b/hipsparseZcsr2csc/g;
     $ft{'library'} += s/\bcusparseZcsr2hyb\b/hipsparseZcsr2hyb/g;
+    $ft{'library'} += s/\bcusparseZcsrgeam\b/hipsparseZcsrgeam/g;
+    $ft{'library'} += s/\bcusparseZcsrgeam2\b/hipsparseZcsrgeam2/g;
+    $ft{'library'} += s/\bcusparseZcsrgeam2_bufferSizeExt\b/hipsparseZcsrgeam2_bufferSizeExt/g;
     $ft{'library'} += s/\bcusparseZcsrgemm\b/hipsparseZcsrgemm/g;
     $ft{'library'} += s/\bcusparseZcsrgemm2\b/hipsparseZcsrgemm2/g;
     $ft{'library'} += s/\bcusparseZcsrgemm2_bufferSizeExt\b/hipsparseZcsrgemm2_bufferSizeExt/g;
@@ -887,6 +908,7 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcusparseZgthrz\b/hipsparseZgthrz/g;
     $ft{'library'} += s/\bcusparseZhybmv\b/hipsparseZhybmv/g;
     $ft{'library'} += s/\bcusparseZnnz\b/hipsparseZnnz/g;
+    $ft{'library'} += s/\bcusparseZnnz_compress\b/hipsparseZnnz_compress/g;
     $ft{'library'} += s/\bcusparseZsctr\b/hipsparseZsctr/g;
     $ft{'device_library'} += s/\bcurand\b/hiprand/g;
     $ft{'device_library'} += s/\bcurand_discrete\b/hiprand_discrete/g;

--- a/docs/markdown/CUSPARSE_API_supported_by_HIP.md
+++ b/docs/markdown/CUSPARSE_API_supported_by_HIP.md
@@ -203,10 +203,10 @@
 
 |   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
 |-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseSbsrmv`                                           |                                                 |
-|`cusparseDbsrmv`                                           |                                                 |
-|`cusparseCbsrmv`                                           |                                                 |
-|`cusparseZbsrmv`                                           |                                                 |
+|`cusparseSbsrmv`                                           |`hipsparseSbsrmv`                                |
+|`cusparseDbsrmv`                                           |`hipsparseDbsrmv`                                |
+|`cusparseCbsrmv`                                           |`hipsparseCbsrmv`                                |
+|`cusparseZbsrmv`                                           |`hipsparseZbsrmv`                                |
 |`cusparseSbsrxmv`                                          |                                                 |
 |`cusparseDbsrxmv`                                          |                                                 |
 |`cusparseCbsrxmv`                                          |                                                 |
@@ -349,20 +349,20 @@
 
 |   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
 |-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseXcsrgeamNnz`                                      |                                                 |
-|`cusparseScsrgeam`                                         |                                                 |
-|`cusparseDcsrgeam`                                         |                                                 |
-|`cusparseCcsrgeam`                                         |                                                 |
-|`cusparseZcsrgeam`                                         |                                                 |
-|`cusparseXcsrgeam2Nnz`                                     |                                                 | 9.2              |
-|`cusparseScsrgeam2`                                        |                                                 | 9.2              |
-|`cusparseDcsrgeam2`                                        |                                                 | 9.2              |
-|`cusparseCcsrgeam2`                                        |                                                 | 9.2              |
-|`cusparseZcsrgeam2`                                        |                                                 | 9.2              |
-|`cusparseScsrgeam2_bufferSizeExt`                          |                                                 | 9.2              |
-|`cusparseDcsrgeam2_bufferSizeExt`                          |                                                 | 9.2              |
-|`cusparseCcsrgeam2_bufferSizeExt`                          |                                                 | 9.2              |
-|`cusparseZcsrgeam2_bufferSizeExt`                          |                                                 | 9.2              |
+|`cusparseXcsrgeamNnz`                                      |`hipsparseXcsrgeamNnz`                           |
+|`cusparseScsrgeam`                                         |`hipsparseScsrgeam`                              |
+|`cusparseDcsrgeam`                                         |`hipsparseDcsrgeam`                              |
+|`cusparseCcsrgeam`                                         |`hipsparseCcsrgeam`                              |
+|`cusparseZcsrgeam`                                         |`hipsparseZcsrgeam`                              |
+|`cusparseXcsrgeam2Nnz`                                     |`hipsparseXcsrgeam2Nnz`                          | 9.2              |
+|`cusparseScsrgeam2`                                        |`hipsparseScsrgeam2`                             | 9.2              |
+|`cusparseDcsrgeam2`                                        |`hipsparseDcsrgeam2`                             | 9.2              |
+|`cusparseCcsrgeam2`                                        |`hipsparseCcsrgeam2`                             | 9.2              |
+|`cusparseZcsrgeam2`                                        |`hipsparseZcsrgeam2`                             | 9.2              |
+|`cusparseScsrgeam2_bufferSizeExt`                          |`hipsparseScsrgeam2_bufferSizeExt`               | 9.2              |
+|`cusparseDcsrgeam2_bufferSizeExt`                          |`hipsparseDcsrgeam2_bufferSizeExt`               | 9.2              |
+|`cusparseCcsrgeam2_bufferSizeExt`                          |`hipsparseCcsrgeam2_bufferSizeExt`               | 9.2              |
+|`cusparseZcsrgeam2_bufferSizeExt`                          |`hipsparseZcsrgeam2_bufferSizeExt`               | 9.2              |
 |`cusparseXcsrgemmNnz`                                      |`hipsparseXcsrgemmNnz`                           |
 |`cusparseScsrgemm`                                         |`hipsparseScsrgemm`                              |
 |`cusparseDcsrgemm`                                         |`hipsparseDcsrgemm`                              |
@@ -377,7 +377,6 @@
 |`cusparseDcsrgemm2_bufferSizeExt`                          |`hipsparseDcsrgemm2_bufferSizeExt`               |
 |`cusparseCcsrgemm2_bufferSizeExt`                          |`hipsparseCcsrgemm2_bufferSizeExt`               |
 |`cusparseZcsrgemm2_bufferSizeExt`                          |`hipsparseZcsrgemm2_bufferSizeExt`               |
-
 
 ## **7. cuSPARSE Preconditioners Reference**
 
@@ -724,10 +723,10 @@
 |`cusparseHpruneCsr2csrNnzByPercentage`                     |                                                 | 9.0              |
 |`cusparseSpruneCsr2csrNnzByPercentage`                     |                                                 | 9.0              |
 |`cusparseDpruneCsr2csrNnzByPercentage`                     |                                                 | 9.0              |
-|`cusparseSnnz_compress`                                    |                                                 | 8.0              |
-|`cusparseDnnz_compress`                                    |                                                 | 8.0              |
-|`cusparseCnnz_compress`                                    |                                                 | 8.0              |
-|`cusparseZnnz_compress`                                    |                                                 | 8.0              |
+|`cusparseSnnz_compress`                                    |`hipsparseSnnz_compress`                         | 8.0              |
+|`cusparseDnnz_compress`                                    |`hipsparseDnnz_compress`                         | 8.0              |
+|`cusparseCnnz_compress`                                    |`hipsparseCnnz_compress`                         | 8.0              |
+|`cusparseZnnz_compress`                                    |`hipsparseZnnz_compress`                         | 8.0              |
 
 ## **10. cuSPARSE Generic API Reference**
 


### PR DESCRIPTION
Based on:
  https://github.com/ROCm-Developer-Tools/HIPIFY/pull/95
  https://github.com/ROCm-Developer-Tools/HIPIFY/pull/96
SPARSE: added csrgeam, csrgeam2, bsrmv, and csr2csr_compress
Update `hipify-perl` and `CUSPARSE_API_supported_by_HIP.md` accordingly