### PR TITLE
Wrap fPIC under xCompiler for nvcc

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -606,6 +606,9 @@ foreach $arg (@ARGV)
             } elsif ($arg eq "--hipcc-no-func-supp") {
               $funcSupp = 0;
             }
+        } elsif ( ($HIP_PLATFORM eq "nvcc") and ($arg eq "-fPIC") ) {
+            $arg = "-Xcompiler=-fPIC";
+            push (@options, "-Xcompiler=-fPIC");
         } else {
             push (@options, $arg);
         }


### PR DESCRIPTION
passing -fPIC to hipcc is broken on nvcc HIP_PLATFORM. nvcc does not understand -fPIC and throws error. nvcc accepts -fPIC using -Xcompiler=-fPIC flag. PR here fixes this.