### PR TITLE
Enable template max and min for HIP-Clang

### DIFF
--- a/include/hip/hcc_detail/math_functions.h
+++ b/include/hip/hcc_detail/math_functions.h
@@ -1410,11 +1410,17 @@ float func(float x, int y) \
 }
 __DEF_FLOAT_FUN2I(scalbn)
 
-#if __HCC__
 template<class T>
 __DEVICE__ inline static T min(T arg1, T arg2) {
   return (arg1 < arg2) ? arg1 : arg2;
 }
+
+template<class T>
+__DEVICE__ inline static T max(T arg1, T arg2) {
+  return (arg1 > arg2) ? arg1 : arg2;
+}
+
+#if __HCC__
 
 __DEVICE__ inline static uint32_t min(uint32_t arg1, int32_t arg2) {
   return min(arg1, (uint32_t) arg2);
@@ -1436,11 +1442,6 @@ __DEVICE__ inline static unsigned long long min(unsigned long long arg1, long lo
 __DEVICE__ inline static unsigned long long min(long long arg1, unsigned long long arg2) {
   return min((unsigned long long) arg1, arg2);
 }*/
-
-template<class T>
-__DEVICE__ inline static T max(T arg1, T arg2) {
-  return (arg1 > arg2) ? arg1 : arg2;
-}
 
 __DEVICE__ inline static uint32_t max(uint32_t arg1, int32_t arg2) {
   return max(arg1, (uint32_t) arg2);


### PR DESCRIPTION
It was for HCC only. HIP-Clang also needs it for __fp16 since AMDMIGraphX uses it.

Change-Id: Id49322b7b89ef799accdf6b47627a6fce51d1ab5