### PR TITLE
Add __HIP_PLATFORM_HCC__ to hip::host target

### DIFF
--- a/hip-config.cmake.in
+++ b/hip-config.cmake.in
@@ -101,6 +101,11 @@ if (HSA_HEADER-NOTFOUND)
   message (FATAL_ERROR "HSA header not found! ROCM_PATH environment not set")
 endif()
 
+# Right now this is only supported for amd platforms
+set_target_properties(hip::host PROPERTIES
+  INTERFACE_COMPILE_DEFINITIONS "__HIP_PLATFORM_HCC__=1"
+)
+
 if(HIP_RUNTIME MATCHES "VDI")
   set_target_properties(hip::amdhip64 PROPERTIES
     INTERFACE_COMPILE_DEFINITIONS "__HIP_VDI__=1"


### PR DESCRIPTION
This is needed to avoid errors about requiring NVCC or HCC defines when including hip_runtime_api.h.

Since hip_runtime_api.h can be included from a host compiler(ie gcc or vanilla clang), `__HIP__` may not be defined so `__HIP_PLATFORM_HCC__` will not be defined resulting in a compile error.