### PR TITLE
extractkernel obj dump args to use double dashes

### DIFF
--- a/bin/extractkernel
+++ b/bin/extractkernel
@@ -233,7 +233,7 @@ while(1) {
     my $isa_file_name = "${filename_prefix}-${asic_target}.isa";
 
     # use llvm-objdump to dump out GCN ISA
-    system("$llvm_objdump -disassemble -mcpu=$asic_target $hsaco_file_name > $isa_file_name") == 0 or die("Fail to disassemble AMDGPU ISA for target" . $asic_target);
+    system("$llvm_objdump --disassemble --mcpu=$asic_target $hsaco_file_name > $isa_file_name") == 0 or die("Fail to disassemble AMDGPU ISA for target" . $asic_target);
       
     if ($debug) {
       print("Generated GCN ISA for " . $asic_target . " at: " . $isa_file_name . "\n");


### PR DESCRIPTION
More recent llvm-objdump has changed disassemble and mcpu arguments to require double dashes.