### PR TITLE
Define missing flags for hipSetDeviceFlags on nvcc

### DIFF
--- a/include/hip/nvcc_detail/hip_runtime_api.h
+++ b/include/hip/nvcc_detail/hip_runtime_api.h
@@ -50,6 +50,14 @@ typedef enum hipMemcpyKind {
     hipMemcpyDefault
 } hipMemcpyKind;
 
+// Flags for hipSetDeviceFlags
+#define hipDeviceScheduleAuto cudaDeviceScheduleAuto
+#define hipDeviceScheduleSpin cudaDeviceScheduleSpin
+#define hipDeviceScheduleYield cudaDeviceScheduleYield
+#define hipDeviceScheduleBlockingSync cudaDeviceScheduleBlockingSync
+#define hipDeviceMapHost cudaDeviceMapHost
+#define hipDeviceLmemResizeToMax cudaDeviceLmemResizeToMax
+
 // hipDataType
 #define hipDataType cudaDataType
 #define HIP_R_16F CUDA_R_16F


### PR DESCRIPTION
Several values for the `flags` argument to `hipSetDeviceFlags` were defined in `include/hip/hcc_detail`, but not in `include/hip/nvcc_detail`.  This change adds the possible arguments to the function in `nvcc_detail/hip_runtime_api.h`.