### PR TITLE
[HIPCLANG] template based hipLaunchKernelGGL

### DIFF
--- a/include/hip/hcc_detail/hip_runtime.h
+++ b/include/hip/hcc_detail/hip_runtime.h
@@ -389,10 +389,25 @@ extern void ihipPostLaunchKernel(const char* kernelName, hipStream_t stream, gri
 
 typedef int hipLaunchParm;
 
+#ifdef HIP_MACRO_BASED_GGL
+
 #define hipLaunchKernelGGL(kernelName, numblocks, numthreads, memperblock, streamId, ...)          \
     do {                                                                                           \
         kernelName<<<(numblocks), (numthreads), (memperblock), (streamId)>>>(__VA_ARGS__);         \
     } while (0)
+
+#else
+
+template <typename... Args, typename F = void (*)(Args...)>
+inline
+void hipLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& dimBlocks,
+                        std::uint32_t sharedMemBytes, hipStream_t stream,
+                        Args... args) {
+  kernel<<<numBlocks, dimBlocks, sharedMemBytes, stream>>>(args...);
+}
+
+#endif // HIP_MACRO_BASED_GGL
+
 
 #include <hip/hip_runtime_api.h>
 

--- a/include/hip/nvcc_detail/hip_runtime.h
+++ b/include/hip/nvcc_detail/hip_runtime.h
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #ifndef HIP_INCLUDE_HIP_NVCC_DETAIL_HIP_RUNTIME_H
 #define HIP_INCLUDE_HIP_NVCC_DETAIL_HIP_RUNTIME_H
 
+#include <cstdint>
 #include <cuda_runtime.h>
 
 #include <hip/hip_runtime_api.h>
@@ -31,10 +32,24 @@ THE SOFTWARE.
 
 typedef int hipLaunchParm;
 
+#ifdef HIP_MACRO_BASED_GGL
+
 #define hipLaunchKernelGGL(kernelName, numblocks, numthreads, memperblock, streamId, ...)          \
     do {                                                                                           \
         kernelName<<<numblocks, numthreads, memperblock, streamId>>>(__VA_ARGS__);                 \
     } while (0)
+
+#else
+
+template <typename... Args, typename F = void (*)(Args...)>
+inline
+void hipLaunchKernelGGL(F kernel, const dim3& numBlocks, const dim3& dimBlocks,
+                        std::uint32_t sharedMemBytes, hipStream_t stream,
+                        Args... args) {
+  kernel<<<numBlocks, dimBlocks, sharedMemBytes, stream>>>(args...);
+}
+
+#endif // HIP_MACRO_BASED_GGL
 
 #define hipReadModeElementType cudaReadModeElementType
 


### PR DESCRIPTION
This replaces the C macro based hipLaunchKernelGGL used by hip-clang and cuda.  It's safer and more template friendly without having to wrap the kernel name around the `HIP_KERNEL_NAME` macro.