### PR TITLE
[HIP-Clang] Updating the RUNPATH for clang case

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -214,6 +214,7 @@ if ($HIP_PLATFORM eq "clang") {
     if (not $isWindows) {
       $HIPLDFLAGS .= " -Wl,--rpath-link=$HIP_LIB_PATH";
       $HIPLDFLAGS .= " -lhip_hcc";
+      $HIPLDFLAGS .= " -Wl,--enable-new-dtags -Wl,--rpath=$ROCM_PATH/lib:$ROCM_PATH/lib64:$ROCM_PATH/hip/lib ";
     } else {
       $HIPLDFLAGS .= " -lamdhip64";
     }


### PR DESCRIPTION
- Adding the RUNPATH for all the lib/ELF generated using hipcc for
  hip-clang case.

Change-Id: I0270281d10452750c3589d9e7f4666554937d27d