### PR TITLE
[HIP-Clang] Update hipcc to use HIP_COMPILER variable

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -20,13 +20,15 @@ use Cwd 'abs_path';
 # If HIP_PLATFORM is not set hipcc will attempt auto-detect based on if nvcc is found.
 #
 # Other environment variable controls:
-# HIP_PATH  : Path to HIP directory, default is one dir level above location of this script
-# CUDA_PATH : Path to CUDA SDK (default /usr/local/cuda). Used on NVIDIA platforms only.
-# HCC_HOME  : Path to HCC SDK (defaults to ../../hcc relative to this
-#             script's abs_path). Used on AMD platforms only.
-# HSA_PATH  : Path to HSA dir (defaults to ../../hsa relative to abs_path
-#             of this script). Used on AMD platforms only.
-# HIP_VDI_HOME : Path to HIP/VDI directory. Used on AMD platforms only.
+# HIP_PATH       : Path to HIP directory, default is one dir level above location of this script.
+# CUDA_PATH      : Path to CUDA SDK (default /usr/local/cuda). Used on NVIDIA platforms only.
+# HCC_HOME       : Path to HCC SDK (defaults to ../../hcc relative to this
+#                  script's abs_path). Used on AMD platforms only.
+# HSA_PATH       : Path to HSA dir (defaults to ../../hsa relative to abs_path
+#                  of this script). Used on AMD platforms only.
+# HIP_VDI_HOME   : Path to HIP/VDI directory. Used on AMD platforms only.
+# HIP_CLANG_PATH : Path to HIP-Clang (default to ../../llvm/bin relative to this
+#                  script's abs_path). Used on AMD platforms only.
 
 if(scalar @ARGV == 0){
     print "No Arguments passed, exiting ...\n";
@@ -120,11 +122,13 @@ sub delete_temp_dirs {
 }
 
 #---
-#HIP_PLATFORM controls whether to use NVCC or HCC for compilation:
+#HIP_PLATFORM controls whether to use hcc (AMD) or nvcc as the platform:
 $HIP_PLATFORM= `$HIP_PATH/bin/hipconfig --platform` // "hcc";
 $HIP_VERSION= `$HIP_PATH/bin/hipconfig --version`;
-$HIP_COMPILER= $hipConfig{'HIP_COMPILER'};
-$HIP_RUNTIME= $hipConfig{'HIP_RUNTIME'};
+#HIP_COMPILER controls whether to use hcc, clang or nvcc for compilation:
+$HIP_COMPILER= `$HIP_PATH/bin/hipconfig --compiler`;
+#HIP_RUNTIME controls whether to use HCC, VDI, or NVCC as the runtime:
+$HIP_RUNTIME= `$HIP_PATH/bin/hipconfig --runtime`;
 
 # If using VDI runtime, need to find HIP_VDI_HOME
 if (defined $HIP_RUNTIME and $HIP_RUNTIME eq "VDI" and !defined $HIP_VDI_HOME) {
@@ -151,8 +155,7 @@ if (defined $HIP_VDI_HOME) {
     }
 }
 
-if (defined $HIP_COMPILER and $HIP_COMPILER eq "clang") {
-  $HIP_PLATFORM = "clang";
+if (defined $HIP_COMPILER and $HIP_PLATFORM eq "hcc" and $HIP_COMPILER eq "clang") {
   if (!defined $HIP_CLANG_PATH) {
     $HIP_CLANG_PATH = "$ROCM_PATH/llvm/bin";
   }
@@ -164,6 +167,8 @@ if (defined $HIP_COMPILER and $HIP_COMPILER eq "clang") {
 if ($verbose & 0x2) {
     print ("HIP_PATH=$HIP_PATH\n");
     print ("HIP_PLATFORM=$HIP_PLATFORM\n");
+    print ("HIP_COMPILER=$HIP_COMPILER\n");
+    print ("HIP_RUNTIME=$HIP_RUNTIME\n");
 }
 
 # set if user explicitly requests -stdlib=libc++. (else we default to libstdc++ for better interop with g++):
@@ -171,7 +176,7 @@ $setStdLib = 0;  # TODO - set to 0
 
 $default_amdgpu_target = 1;
 
-if ($HIP_PLATFORM eq "clang") {
+if ($HIP_PLATFORM eq "hcc" and $HIP_COMPILER eq "clang") {
     $HIPCC="$HIP_CLANG_PATH/clang++";
 
     # If $HIPCC clang++ is not compiled, use clang instead
@@ -231,7 +236,7 @@ if ($HIP_PLATFORM eq "clang") {
       $HIPCFLAGS .= " -D__HIP_VDI__";
     }
 
-} elsif ($HIP_PLATFORM eq "hcc") {
+} elsif ($HIP_PLATFORM eq "hcc" and $HIP_COMPILER eq "hcc") {
     $HIP_INCLUDE_PATH = "$HIP_PATH/include";
     if (! defined $HIP_LIB_PATH) {
         $HIP_LIB_PATH = "$HIP_PATH/lib";
@@ -334,6 +339,7 @@ if ($HIP_PLATFORM eq "clang") {
     $HIPLDFLAGS = " -Wno-deprecated-gpu-targets -lcuda -lcudart -L$CUDA_PATH/lib64";
 } else {
     printf ("error: unknown HIP_PLATFORM = '$HIP_PLATFORM'");
+    printf ("       or HIP_COMPILER = '$HIP_COMPILER'");
     exit (-1);
 }
 
@@ -349,7 +355,7 @@ my $hasC = 0;          # options contain a c-style file
 my $hasCXX = 0;        # options contain a cpp-style file (NVCC must force recognition as GPU file)
 my $hasCU = 0;         # options contain a cu-style file (HCC must force recognition as GPU file)
 my $hasHIP = 0;        # options contain a hip-style file (HIP-Clang must pass offloading options)
-my $needHipHcc = ($HIP_PLATFORM eq 'hcc');      # set if we need to link hip_hcc.o from src tree. (some builds, ie cmake, provide their own)
+my $needHipHcc = ($HIP_PLATFORM eq 'hcc' and $HIP_COMPILER eq 'hcc');      # set if we need to link hip_hcc.o from src tree. (some builds, ie cmake, provide their own)
 my $printHipVersion = 0;    # print HIP version
 my $printCXXFlags = 0;      # print HIPCXXFLAGS
 my $printLDFlags = 0;       # print HIPLDFLAGS
@@ -373,7 +379,7 @@ if ($verbose & 0x4) {
 
 # Handle code object generation
 my $ISACMD="";
-if($HIP_PLATFORM eq "hcc"){
+if($HIP_PLATFORM eq "hcc" and $HIP_COMPILER eq "hcc"){
     $ISACMD .= "$HIP_PATH/bin/lpl ";
     if($ARGV[0] eq "--genco"){
         foreach $isaarg (@ARGV[1..$#ARGV]){
@@ -388,7 +394,7 @@ if($HIP_PLATFORM eq "hcc"){
     }
 }
 
-if(($HIP_PLATFORM eq "hcc")){
+if(($HIP_PLATFORM eq "hcc" and $HIP_COMPILER eq "hcc")){
     $ENV{HCC_EXTRA_LIBRARIES}="\n";
 }
 
@@ -449,7 +455,7 @@ foreach $arg (@ARGV)
          $targetsStr .=  substr($arg, length($targetOpt));
          $default_amdgpu_target = 0;
          # hip-clang does not accept --amdgpu-target= options.
-         if ($HIP_PLATFORM eq 'clang') {
+         if ($HIP_PLATFORM eq "hcc" and $HIP_COMPILER eq "clang") {
              $swallowArg = 1;
          }
     }
@@ -462,7 +468,7 @@ foreach $arg (@ARGV)
         $coFormatv3 = 0;
     }
 
-    if (($arg =~ /--genco/) and $HIP_PLATFORM eq 'clang' ) {
+    if (($arg =~ /--genco/) and $HIP_PLATFORM eq 'hcc' and $HIP_COMPILER eq 'clang' ) {
         $arg = "--cuda-device-only";
     }
 
@@ -514,7 +520,7 @@ foreach $arg (@ARGV)
     ## hip-clang in command line.
     ## ToDo: Remove this after hip-clang switch to lto and lld is able to
     ## handle clang-offload-bundler bundles.
-    if ($arg =~ m/^-Wl,@/ and $HIP_PLATFORM eq 'clang') {
+    if ($arg =~ m/^-Wl,@/ and $HIP_PLATFORM eq 'hcc' and $HIP_COMPILER eq 'clang') {
         my $file = substr $arg, 5;
         open my $in, "<:encoding(utf8)", $file or die "$file: $!";
         my $new_arg = "";
@@ -570,13 +576,12 @@ foreach $arg (@ARGV)
         close $out;
         $arg = "$new_arg -Wl,\@$new_file";
     } elsif (($arg =~ m/\.a$/ || $arg =~ m/\.lo$/) &&
-             $HIP_PLATFORM eq 'clang') {
+             $HIP_PLATFORM eq 'hcc' and $HIP_COMPILER eq 'clang') {
         ## process static library for hip-clang
         ## extract object files from static library and pass them directly to
         ## hip-clang.
         ## ToDo: Remove this after hip-clang switch to lto and lld is able to
         ## handle clang-offload-bundler bundles.
-        
         my $new_arg = "";
         my $tmpdir = get_temp_dir ();
         my $libFile = $arg;
@@ -663,7 +668,7 @@ foreach $arg (@ARGV)
         }
         elsif ((($arg =~ /\.cu$/ or $arg =~ /\.cuh$/) and $HIP_COMPILE_CXX_AS_HIP ne '0') or ($arg =~ /\.hip$/)) {
             $needCXXFLAGS = 1;
-            if ($HIP_COMPILER eq "clang") {
+            if ($HIP_PLATFORM eq "hcc" and $HIP_COMPILER eq "clang") {
                 $hasHIP = 1;
                 $toolArgs .= " -x hip";
             } else {
@@ -677,7 +682,7 @@ foreach $arg (@ARGV)
     $prevArg = $arg;
 }
 
-if($HIP_PLATFORM eq "hcc" or $HIP_PLATFORM eq "clang"){
+if($HIP_PLATFORM eq "hcc"){
     # No AMDGPU target specified at commandline. So look for HCC_AMDGPU_TARGET
     if($default_amdgpu_target eq 1) {
         if (defined $ENV{HCC_AMDGPU_TARGET}) {
@@ -694,7 +699,7 @@ if($HIP_PLATFORM eq "hcc" or $HIP_PLATFORM eq "clang"){
     # Parse the targets collected in targetStr and set corresponding compiler options.
     my @targets = split(',', $targetsStr);
 
-    if($HIP_PLATFORM eq "hcc") {
+    if($HIP_COMPILER eq "hcc") {
         $GPU_ARCH_OPT = " --amdgpu-target=";
     } else {
         $GPU_ARCH_OPT = " --cuda-gpu-arch=";
@@ -710,7 +715,7 @@ if($HIP_PLATFORM eq "hcc" or $HIP_PLATFORM eq "clang"){
             $GPU_ARCH_ARG = $GPU_ARCH_OPT . $val;
             $HIPLDARCHFLAGS .= $GPU_ARCH_ARG;
             $HIPCXXFLAGS .= $archMacro;
-            if ($HIP_PLATFORM eq 'clang' and $hasHIP) {
+            if ($HIP_COMPILER eq 'clang' and $hasHIP) {
                 $HIPCXXFLAGS .= $GPU_ARCH_ARG;
             }
 
@@ -731,7 +736,7 @@ if($HIP_PLATFORM eq "hcc" or $HIP_PLATFORM eq "clang"){
 
 # hcc defaults to v2, so we need to convert to the appropriate flag
 # hip-clang defaults to v3, so we don't need to do anything
-if ($coFormatv3 and $HIP_PLATFORM eq 'hcc') {
+if ($coFormatv3 and $HIP_PLATFORM eq 'hcc' and $HIP_COMPILER eq 'hcc') {
     $HIPLDFLAGS .= " -mcode-object-v3";
     $HIPCXXFLAGS .= " -mcode-object-v3";
 }
@@ -739,7 +744,7 @@ if ($coFormatv3 and $HIP_PLATFORM eq 'hcc') {
 if ($hasCXX and $HIP_PLATFORM eq 'nvcc') {
     $HIPCXXFLAGS .= " -x cu";
 }
-if ($hasCU and $HIP_PLATFORM eq 'hcc') {
+if ($hasCU and $HIP_PLATFORM eq 'hcc' and $HIP_COMPILER eq 'hcc') {
     $HIPCXXFLAGS .= " -x c++";
 }
 
@@ -748,17 +753,17 @@ if ($buildDeps and $HIP_PLATFORM eq 'nvcc') {
     $HIPCFLAGS .= " -M -D__CUDACC__";
 }
 
-if ($buildDeps and $HIP_PLATFORM eq 'clang') {
+if ($buildDeps and $HIP_PLATFORM eq 'hcc' and $HIP_COMPILER eq 'clang') {
     $HIPCXXFLAGS .= " --cuda-host-only";
 }
 
 # Add --hip-link only if it is compile only and -fgpu-rdc is on.
-if ($rdc and !$compileOnly and $HIP_PLATFORM eq 'clang') {
+if ($rdc and !$compileOnly and $HIP_PLATFORM eq 'hcc' and $HIP_COMPILER eq 'clang') {
     $HIPLDFLAGS .= " --hip-link";
     $HIPLDFLAGS .= $HIPLDARCHFLAGS;
 }
 
-if ($setStdLib eq 0 and $HIP_PLATFORM eq 'hcc')
+if ($setStdLib eq 0 and $HIP_PLATFORM eq 'hcc' and $HIP_COMPILER eq 'hcc')
 {
     $HIPCXXFLAGS .= $HCC_WA_FLAGS;
 }
@@ -776,7 +781,7 @@ if ($needHipHcc) {
 # Reason is that NVCC uses the file extension to determine whether to compile in CUDA mode or
 # pass-through CPP mode.
 
-if ($HIP_PLATFORM eq "clang") {
+if ($HIP_PLATFORM eq "hcc" and $HIP_COMPILER eq "clang") {
     # Set default optimization level to -O3 for hip-clang.
     if ($optArg eq "") {
         $HIPCXXFLAGS .= " -O3";
@@ -843,7 +848,7 @@ if ($printLDFlags) {
     print $HIPLDFLAGS;
 }
 if ($runCmd) {
-    if ($HIP_PLATFORM eq "hcc" and exists($hipConfig{'HCC_VERSION'}) and $HCC_VERSION ne $hipConfig{'HCC_VERSION'}) {
+    if ($HIP_PLATFORM eq "hcc" and $HIP_COMPILER eq "hcc" and exists($hipConfig{'HCC_VERSION'}) and $HCC_VERSION ne $hipConfig{'HCC_VERSION'}) {
         print ("HIP ($HIP_PATH) was built using hcc $hipConfig{'HCC_VERSION'}, but you are using $HCC_HOME/hcc with version $HCC_VERSION from hipcc. Please rebuild HIP including cmake or update HCC_HOME variable.\n") ;
         die unless $ENV{'HIP_IGNORE_HCC_VERSION'};
     }


### PR DESCRIPTION
I've made a review change in amd-master-next first. This will update the hipcc script so that it will use HIP_PLATFORM, HIP_COMPILER, and HIP_RUNTIME variables correctly based on updated hipconfig file. 

Removing HIP_PLATFORM=clang, only use hcc and nvcc for now. HIP_PLATFORM should eventually switch to amd or nvcc.