### PR TITLE
[vdi] Skip null texture object in `hipDestroyTextureObject`.

### DIFF
--- a/vdi/hip_texture.cpp
+++ b/vdi/hip_texture.cpp
@@ -309,7 +309,7 @@ hipError_t hipCreateTextureObject(hipTextureObject_t* pTexObject,
 
 hipError_t ihipDestroyTextureObject(hipTextureObject_t texObject) {
   if (texObject == nullptr) {
-    return hipErrorInvalidValue;
+    return hipSuccess;
   }
 
   const hipResourceType type = texObject->resDesc.resType;


### PR DESCRIPTION
- To match both CUDA and HCC runtime behavior.

Change-Id: I072b006dd554e17f8341f391d33bf6224a125a7e