### PR TITLE
[HIP-Clang] Fix typos in hipBindTextureToMipmappedArray

### DIFF
--- a/include/hip/hcc_detail/hip_runtime_api.h
+++ b/include/hip/hcc_detail/hip_runtime_api.h
@@ -3939,7 +3939,7 @@ static inline hipError_t hipBindTextureToArray(
 {
     struct hipChannelFormatDesc desc;
     hipError_t err = hipGetChannelDesc(&desc, array);
-    return (err == hipSuccess) ? hipBindTextureToArray(&tex, array, desc) : err;
+    return (err == hipSuccess) ? hipBindTextureToArray(&tex, array, &desc) : err;
 }
 
 template<class T, int dim, enum hipTextureReadMode readMode>
@@ -3963,7 +3963,7 @@ static inline hipError_t hipBindTextureToMipmappedArray(
         return err;
     }
     err = hipGetChannelDesc(&desc, levelArray);
-    return (err == hipSuccess) ? hipBindTextureToMipmappedArray(&tex, mipmappedArray, desc) : err;
+    return (err == hipSuccess) ? hipBindTextureToMipmappedArray(&tex, mipmappedArray, &desc) : err;
 }
 
 template<class T, int dim, enum hipTextureReadMode readMode>


### PR DESCRIPTION
Change-Id: I75ed28a5862daffc0778910d7ba3b97f51a87949