### PR TITLE
Do not define assert when NDEBUG is defined

### DIFF
--- a/include/hip/hcc_detail/hip_runtime.h
+++ b/include/hip/hcc_detail/hip_runtime.h
@@ -121,7 +121,7 @@ extern int HIP_TRACE_API;
 #endif
 
 // TODO-HCC add a dummy implementation of assert, need to replace with a proper kernel exit call.
-#if __HIP_DEVICE_COMPILE__ == 1
+#if __HIP_DEVICE_COMPILE__ == 1 && !defined(NDEBUG)
 #undef assert
 #define assert(COND)                                                                               \
     {                                                                                              \


### PR DESCRIPTION
Fixes #2071 