### PR TITLE
match FFS intrinsics

### DIFF
--- a/include/hip/hcc_detail/device_functions.h
+++ b/include/hip/hcc_detail/device_functions.h
@@ -69,19 +69,19 @@ __device__ static inline int __clzll(long long int input) {
 }
 
 __device__ static inline unsigned int __ffs(unsigned int input) {
-    return ( input == 0 ? -1 : __builtin_ctz(input) ) + 1;
+    return ( input == 0 ? 0 : __builtin_ctz(input) ) + 1;
 }
 
 __device__ static inline unsigned int __ffsll(unsigned long long int input) {
-    return ( input == 0 ? -1 : __builtin_ctzll(input) ) + 1;
+    return ( input == 0 ? 0 : __builtin_ctzll(input) ) + 1;
 }
 
 __device__ static inline unsigned int __ffs(int input) {
-    return ( input == 0 ? -1 : __builtin_ctz(input) ) + 1;
+    return ( input == 0 ? 0 : __builtin_ctz(input) ) + 1;
 }
 
 __device__ static inline unsigned int __ffsll(long long int input) {
-    return ( input == 0 ? -1 : __builtin_ctzll(input) ) + 1;
+    return ( input == 0 ? 0 : __builtin_ctzll(input) ) + 1;
 }
 
 __device__ static inline unsigned int __brev(unsigned int input) {


### PR DESCRIPTION
From the [CUDA docs](https://docs.nvidia.com/cuda/cuda-math-api/group__CUDA__MATH__INTRINSIC__INT.html#group__CUDA__MATH__INTRINSIC__INT_1gaf1eb22243e29e0b7222adee8ae7d4e4), `ffs(0) == 0`, not -1 as is currently implemented.