### PR TITLE
Fix a minor bug in vdi

### DIFF
--- a/vdi/hip_memory.cpp
+++ b/vdi/hip_memory.cpp
@@ -77,7 +77,8 @@ hipError_t ihipMalloc(void** ptr, size_t sizeBytes, unsigned int flags)
     return hipErrorOutOfMemory;
   }
 
-  if (amdContext->devices()[0]->info().maxMemAllocSize_ < sizeBytes) {
+  if (!(flags & CL_MEM_SVM_FINE_GRAIN_BUFFER) &&
+      (amdContext->devices()[0]->info().maxMemAllocSize_ < sizeBytes)) {
     return hipErrorOutOfMemory;
   }
 


### PR DESCRIPTION
device::Info::maxMemAllocSize_ should only retrict device memory allocations, for host memory, ROCR will do that in hsa_amd_memory_pool_allocate().