### PR TITLE
Revert "fix a bug when initializing a vector of hipFunction_t"

### DIFF
--- a/src/hip_clang.cpp
+++ b/src/hip_clang.cpp
@@ -51,7 +51,7 @@ __hipRegisterFatBinary(const void* data)
     return nullptr;
   }
 
-  auto modules = new std::vector<hipModule_t>(g_deviceCnt);
+  auto modules = new std::vector<hipModule_t>{g_deviceCnt};
   if (!modules) {
     return nullptr;
   }
@@ -136,7 +136,7 @@ extern "C" void __hipRegisterFunction(
   int*         wSize)
 {
   HIP_INIT_API(NONE, modules, hostFunction, deviceFunction, deviceName);
-  std::vector<hipFunction_t> functions(g_deviceCnt);
+  std::vector<hipFunction_t> functions{g_deviceCnt};
 
   assert(modules && modules->size() >= g_deviceCnt);
   for (int deviceId = 0; deviceId < g_deviceCnt; ++deviceId) {


### PR DESCRIPTION
Reverts ROCm-Developer-Tools/HIP#1949
This is not a bug.
vector with hipModule_t instantiation definition will not be initialized by g_deviceCnt.
Variable definition will call vector( size_type count, const Allocator& alloc = Allocator()) directly