### PR TITLE
[HIPIFY][HIP][doc] Sync with HIPIFY's #150 and #152

### DIFF
--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -573,7 +573,9 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcublasDzasum_v2\b/hipblasDzasum/g;
     $ft{'library'} += s/\bcublasDznrm2\b/hipblasDznrm2/g;
     $ft{'library'} += s/\bcublasDznrm2_v2\b/hipblasDznrm2/g;
+    $ft{'library'} += s/\bcublasGemmBatchedEx\b/hipblasGemmBatchedEx/g;
     $ft{'library'} += s/\bcublasGemmEx\b/hipblasGemmEx/g;
+    $ft{'library'} += s/\bcublasGemmStridedBatchedEx\b/hipblasGemmStridedBatchedEx/g;
     $ft{'library'} += s/\bcublasGetMatrix\b/hipblasGetMatrix/g;
     $ft{'library'} += s/\bcublasGetMatrixAsync\b/hipblasGetMatrixAsync/g;
     $ft{'library'} += s/\bcublasGetPointerMode\b/hipblasGetPointerMode/g;
@@ -4131,8 +4133,6 @@ sub warnUnsupportedFunctions {
         "cublasDtpttr",
         "cublasDtrttp",
         "cublasFree",
-        "cublasGemmBatchedEx",
-        "cublasGemmStridedBatchedEx",
         "cublasGetAtomicsMode",
         "cublasGetCudartVersion",
         "cublasGetError",

--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -575,11 +575,13 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcublasDznrm2_v2\b/hipblasDznrm2/g;
     $ft{'library'} += s/\bcublasGemmEx\b/hipblasGemmEx/g;
     $ft{'library'} += s/\bcublasGetMatrix\b/hipblasGetMatrix/g;
+    $ft{'library'} += s/\bcublasGetMatrixAsync\b/hipblasGetMatrixAsync/g;
     $ft{'library'} += s/\bcublasGetPointerMode\b/hipblasGetPointerMode/g;
     $ft{'library'} += s/\bcublasGetPointerMode_v2\b/hipblasGetPointerMode/g;
     $ft{'library'} += s/\bcublasGetStream\b/hipblasGetStream/g;
     $ft{'library'} += s/\bcublasGetStream_v2\b/hipblasGetStream/g;
     $ft{'library'} += s/\bcublasGetVector\b/hipblasGetVector/g;
+    $ft{'library'} += s/\bcublasGetVectorAsync\b/hipblasGetVectorAsync/g;
     $ft{'library'} += s/\bcublasHgemm\b/hipblasHgemm/g;
     $ft{'library'} += s/\bcublasHgemmBatched\b/hipblasHgemmBatched/g;
     $ft{'library'} += s/\bcublasHgemmStridedBatched\b/hipblasHgemmStridedBatched/g;
@@ -612,11 +614,13 @@ sub simpleSubstitutions {
     $ft{'library'} += s/\bcublasSdot\b/hipblasSdot/g;
     $ft{'library'} += s/\bcublasSdot_v2\b/hipblasSdot/g;
     $ft{'library'} += s/\bcublasSetMatrix\b/hipblasSetMatrix/g;
+    $ft{'library'} += s/\bcublasSetMatrixAsync\b/hipblasSetMatrixAsync/g;
     $ft{'library'} += s/\bcublasSetPointerMode\b/hipblasSetPointerMode/g;
     $ft{'library'} += s/\bcublasSetPointerMode_v2\b/hipblasSetPointerMode/g;
     $ft{'library'} += s/\bcublasSetStream\b/hipblasSetStream/g;
     $ft{'library'} += s/\bcublasSetStream_v2\b/hipblasSetStream/g;
     $ft{'library'} += s/\bcublasSetVector\b/hipblasSetVector/g;
+    $ft{'library'} += s/\bcublasSetVectorAsync\b/hipblasSetVectorAsync/g;
     $ft{'library'} += s/\bcublasSgbmv\b/hipblasSgbmv/g;
     $ft{'library'} += s/\bcublasSgbmv_v2\b/hipblasSgbmv/g;
     $ft{'library'} += s/\bcublasSgeam\b/hipblasSgeam/g;
@@ -4134,9 +4138,7 @@ sub warnUnsupportedFunctions {
         "cublasGetError",
         "cublasGetLoggerCallback",
         "cublasGetMathMode",
-        "cublasGetMatrixAsync",
         "cublasGetProperty",
-        "cublasGetVectorAsync",
         "cublasGetVersion",
         "cublasGetVersion_v2",
         "cublasIamaxEx",
@@ -4157,8 +4159,6 @@ sub warnUnsupportedFunctions {
         "cublasSetKernelStream",
         "cublasSetLoggerCallback",
         "cublasSetMathMode",
-        "cublasSetMatrixAsync",
-        "cublasSetVectorAsync",
         "cublasSgelsBatched",
         "cublasSgemmEx",
         "cublasSgetriBatched",

--- a/docs/markdown/CUBLAS_API_supported_by_HIP.md
+++ b/docs/markdown/CUBLAS_API_supported_by_HIP.md
@@ -143,10 +143,10 @@
 |`cublasGetVector`                                          |`hipblasGetVector`                               |
 |`cublasSetMatrix`                                          |`hipblasSetMatrix`                               |
 |`cublasGetMatrix`                                          |`hipblasGetMatrix`                               |
-|`cublasSetVectorAsync`                                     |                                                 |
-|`cublasGetVectorAsync`                                     |                                                 |
-|`cublasSetMatrixAsync`                                     |                                                 |
-|`cublasGetMatrixAsync`                                     |                                                 |
+|`cublasSetVectorAsync`                                     |`hipblasSetVectorAsync`                          |
+|`cublasGetVectorAsync`                                     |`hipblasGetVectorAsync`                          |
+|`cublasSetMatrixAsync`                                     |`hipblasSetMatrixAsync`                          |
+|`cublasGetMatrixAsync`                                     |`hipblasGetMatrixAsync`                          |
 |`cublasXerbla`                                             |                                                 |
 |`cublasNrm2Ex`                                             |                                                 | 8.0              |
 |`cublasSnrm2`                                              |`hipblasSnrm2`                                   |

--- a/docs/markdown/CUBLAS_API_supported_by_HIP.md
+++ b/docs/markdown/CUBLAS_API_supported_by_HIP.md
@@ -498,8 +498,8 @@
 |`cublasCgemmBatched`                                       |`hipblasCgemmBatched`                            |
 |`cublasCgemm3mBatched`                                     |                                                 | 8.0              |
 |`cublasZgemmBatched`                                       |`hipblasZgemmBatched`                            |
-|`cublasGemmBatchedEx`                                      |                                                 | 9.1              |
-|`cublasGemmStridedBatchedEx`                               |                                                 | 9.1              |
+|`cublasGemmBatchedEx`                                      |`hipblasGemmBatchedEx`                           | 9.1              |
+|`cublasGemmStridedBatchedEx`                               |`hipblasGemmStridedBatchedEx`                    | 9.1              |
 |`cublasSgemmStridedBatched`                                |`hipblasSgemmStridedBatched`                     | 8.0              |
 |`cublasDgemmStridedBatched`                                |`hipblasDgemmStridedBatched`                     | 8.0              |
 |`cublasCgemmStridedBatched`                                |`hipblasCgemmStridedBatched`                     | 8.0              |


### PR DESCRIPTION
Add support for vector and matrix async functions
Adding gemm_ex batched functions
Update hipify-perl and CUBLAS_API_supported_by_HIP.md accordingly