### PR TITLE
Introduce the ROCMINFO_PATH variable to override hard-coded rocm_agent_enumerator location

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -684,7 +684,8 @@ if($HIP_PLATFORM eq "hcc" or $HIP_PLATFORM eq "clang"){
             $targetsStr = $ENV{HCC_AMDGPU_TARGET};
         } else {
             # Else try using rocm_agent_enumerator
-            $ROCM_AGENT_ENUM = "${ROCM_PATH}/bin/rocm_agent_enumerator";
+            $ROCMINFO_PATH = $ENV{'ROCMINFO_PATH'} // $ROCM_PATH;
+            $ROCM_AGENT_ENUM = "${ROCMINFO_PATH}/bin/rocm_agent_enumerator";
             $targetsStr = `${ROCM_AGENT_ENUM} -t GPU`;
             $targetsStr =~ s/\n/,/g;
         }


### PR DESCRIPTION
In the spack package manager we do not provide a `bin/` or `lib/` folder in the prefix. The problem is that `hipcc` expects the `bin/` folder to exist. This PR introduces a variable `ROCMINFO_PATH` which can be set to the rocminfo package root folder, such that `rocm_agent_enumerator` can still be located.