### PR TITLE
remove incorrect dependency on rocm-dkms pkg

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -73,11 +73,14 @@ $HIPCC_LINK_FLAGS_APPEND=$ENV{'HIPCC_LINK_FLAGS_APPEND'};
 # derive HIP_PATH, as dirname $0 could be /opt/rocm/bin or /opt/rocm/hip/bin
 # depending on how it gets invoked.
 # ROCM_PATH which points to <rocm_install_dir> is determined based on whether
-# we find .info/version in the parent of HIP_PATH or not. If it is found,
-# ROCM_PATH is defined relative to HIP_PATH else it is hardcoded to /opt/rocm.
+# we find .info/version-dev in the parent of HIP_PATH or not. The version-dev
+# file is installed when rocm-dev or rocm-devX.Y.Z package is installed.
+# If it is found, ROCM_PATH is defined relative to HIP_PATH else it is
+# hardcoded to /opt/rocm which is assumed to be a symbolic link to the directory
+# of the installed ROCm version, ex /opt/rocm-X.Y.Z, directory on the system.
 #
 $HIP_PATH=$ENV{'HIP_PATH'} // dirname(Cwd::abs_path("$0/../")); # use parent directory of hipcc
-if (-e "$HIP_PATH/../.info/version") {
+if (-e "$HIP_PATH/../.info/version-dev") {
     $ROCM_PATH=$ENV{'ROCM_PATH'} // dirname("$HIP_PATH"); # use parent directory of HIP_PATH
 } else {
     $ROCM_PATH=$ENV{'ROCM_PATH'} // "/opt/rocm";

--- a/bin/hipconfig
+++ b/bin/hipconfig
@@ -80,7 +80,7 @@ sub can_run {
 # Define HIP_PATH based on location of the script. Same as hipcc.
 # Derive ROCM_PATH same as hipcc does. Others are relative to ROCM_PATH. 
 $HIP_PATH=$ENV{'HIP_PATH'} // dirname(Cwd::abs_path("$0/../")); # use parent directory of hipcc
-if (-e "$HIP_PATH/../.info/version") {
+if (-e "$HIP_PATH/../.info/version-dev") {
     $ROCM_PATH=$ENV{'ROCM_PATH'} // dirname("$HIP_PATH"); # use parent directory of HIP_PATH
 } else {
     $ROCM_PATH=$ENV{'ROCM_PATH'} // "/opt/rocm";


### PR DESCRIPTION
The `.info/version` file belongs to rocm-dkms (or rocm-dkmsX.Y.Z) package which is not required to install ROCm development tools package `rocm-dev` (or its equivalent `rocm-devX.Y.Z`) package.
The hipcc checks on `.info/version` fails when `rocm-dkms` or its equivalent `rocm-dkmsX.Y.Z` package is not installed on the system when only development packages are installed using `rocm-dev`.
FIx looks for `.info/version-dev` file which is installed as part of `rocm-dev` or its equivalent `rocm-devX.Y.Z` package.
(X.Y.Z refers to ROCm release number, 3.5.0 for 3.5, 3.7.0 for 3.7 etc.)