### PR TITLE
Don't call install by default in Makefile for hipBusBandwidth

### DIFF
--- a/samples/1_Utils/hipBusBandwidth/Makefile
+++ b/samples/1_Utils/hipBusBandwidth/Makefile
@@ -7,7 +7,7 @@ HIPCC=$(HIP_PATH)/bin/hipcc
 EXE=hipBusBandwidth
 CXXFLAGS = -O3
 
-all: install
+all: ${EXE}
 
 $(EXE): hipBusBandwidth.cpp ResultDatabase.cpp
 	$(HIPCC) $(CXXFLAGS) $^ -o $@


### PR DESCRIPTION
Makes it easier and less confusing for non-root users