### PR TITLE
Minor compilation fixes for hipDispatchLatency

### DIFF
--- a/samples/1_Utils/hipDispatchLatency/hipDispatchEnqueueRateMT.cpp
+++ b/samples/1_Utils/hipDispatchLatency/hipDispatchEnqueueRateMT.cpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include <thread>
 #include <future>
 #include <functional>
+#include <vector>
 
 #define NUM_GROUPS 1
 #define GROUP_SIZE 1
@@ -126,7 +127,7 @@ struct thread_pool {
             thread.get();
         }
         threads.clear();
-        shared = {0};
+        shared.store(0, std::memory_order_seq_cst);
     }
     ~thread_pool() {
         finish();
@@ -134,7 +135,7 @@ struct thread_pool {
 private:
     std::atomic_int shared {0};
     std::vector<std::future<void>> threads;
-    int max_threads = 1;
+    const int max_threads = 1;
 };
 
 


### PR DESCRIPTION
```
hipDispatchEnqueueRateMT.cpp:136:10: error: no template named 'vector' in namespace 'std'
    std::vector<std::future<void>> threads;
    ~~~~~^
hipDispatchEnqueueRateMT.cpp:129:18: warning: braces around scalar initializer [-Wbraced-scalar-init]
        shared = {0};
                 ^~~

```