### PR TITLE
[#2162] Change memoryType -> type in cPA attribute reference

### DIFF
--- a/include/hip/nvcc_detail/hip_runtime_api.h
+++ b/include/hip/nvcc_detail/hip_runtime_api.h
@@ -1353,7 +1353,7 @@ inline static hipError_t hipPointerGetAttributes(hipPointerAttribute_t* attribut
     struct cudaPointerAttributes cPA;
     hipError_t err = hipCUDAErrorTohipError(cudaPointerGetAttributes(&cPA, ptr));
     if (err == hipSuccess) {
-        switch (cPA.memoryType) {
+        switch (cPA.type) {
             case cudaMemoryTypeDevice:
                 attributes->memoryType = hipMemoryTypeDevice;
                 break;


### PR DESCRIPTION
[#2162] Change memoryType -> type in cPA attribute reference
* The cudaPointerAttributes type does not have an attribute called
"memoryType" in CUDA 11. Changing this reference to "type" resolves
compilation issues on NVCC platforms
