### PR TITLE
[HIPIFY][HIP][doc] Update all CUDA2HIP docs: replace with auto-generated

### DIFF
--- a/docs/markdown/CUBLAS_API_supported_by_HIP.md
+++ b/docs/markdown/CUBLAS_API_supported_by_HIP.md
@@ -1,554 +1,602 @@
 # CUBLAS API supported by HIP
 
-## **1. CUBLAS Data types**
+## **2. CUBLAS Data types**
 
-| **type**     |   **CUDA**                                                    |**CUDA version\***|   **HIP**                                                  |**HIP value** (if differs) |
-|-------------:|---------------------------------------------------------------|:----------------:|------------------------------------------------------------|---------------------------|
-| define       |`CUBLAS_VER_MAJOR`                                             | 10.1 Update 2    |                                                            |
-| define       |`CUBLAS_VER_MINOR`                                             | 10.1 Update 2    |                                                            |
-| define       |`CUBLAS_VER_PATCH`                                             | 10.1 Update 2    |                                                            |
-| define       |`CUBLAS_VER_BUILD`                                             | 10.1 Update 2    |                                                            |
-| define       |`CUBLAS_VERSION`                                               | 10.1 Update 2    |                                                            |
-| enum         |***`cublasStatus`***                                           |                  |***`hipblasStatus_t`***                                     |
-| enum         |***`cublasStatus_t`***                                         |                  |***`hipblasStatus_t`***                                     |
-|            0 |*`CUBLAS_STATUS_SUCCESS`*                                      |                  |*`HIPBLAS_STATUS_SUCCESS`*                                  |
-|            1 |*`CUBLAS_STATUS_NOT_INITIALIZED`*                              |                  |*`HIPBLAS_STATUS_NOT_INITIALIZED`*                          |
-|            3 |*`CUBLAS_STATUS_ALLOC_FAILED`*                                 |                  |*`HIPBLAS_STATUS_ALLOC_FAILED`*                             | 2                         |
-|            7 |*`CUBLAS_STATUS_INVALID_VALUE`*                                |                  |*`HIPBLAS_STATUS_INVALID_VALUE`*                            | 3                         |
-|            8 |*`CUBLAS_STATUS_ARCH_MISMATCH`*                                |                  |*`HIPBLAS_STATUS_ARCH_MISMATCH`*                            |                           |
-|           11 |*`CUBLAS_STATUS_MAPPING_ERROR`*                                |                  |*`HIPBLAS_STATUS_MAPPING_ERROR`*                            | 4                         |
-|           13 |*`CUBLAS_STATUS_EXECUTION_FAILED`*                             |                  |*`HIPBLAS_STATUS_EXECUTION_FAILED`*                         | 5                         |
-|           14 |*`CUBLAS_STATUS_INTERNAL_ERROR`*                               |                  |*`HIPBLAS_STATUS_INTERNAL_ERROR`*                           | 6                         |
-|           15 |*`CUBLAS_STATUS_NOT_SUPPORTED`*                                |                  |*`HIPBLAS_STATUS_NOT_SUPPORTED`*                            | 7                         |
-|           16 |*`CUBLAS_STATUS_LICENSE_ERROR`*                                |                  |                                                            |
-| enum         |***`cublasOperation_t`***                                      |                  |***`hipblasOperation_t`***                                  |
-|            0 |*`CUBLAS_OP_N`*                                                |                  |*`HIPBLAS_OP_N`*                                            | 111                       |
-|            1 |*`CUBLAS_OP_T`*                                                |                  |*`HIPBLAS_OP_T`*                                            | 112                       |
-|            2 |*`CUBLAS_OP_C`*                                                |                  |*`HIPBLAS_OP_C`*                                            | 113                       |
-|            2 |*`CUBLAS_OP_HERMITAN`*                                         | 10.1             |*`HIPBLAS_OP_C`*                                            | 113                       |
-|            3 |*`CUBLAS_OP_CONJG`*                                            | 10.1             |                                                            |
-| enum         |***`cublasFillMode_t`***                                       |                  |***`hipblasFillMode_t`***                                   |
-|            0 |*`CUBLAS_FILL_MODE_LOWER`*                                     |                  |*`HIPBLAS_FILL_MODE_LOWER`*                                 | 121                       |
-|            1 |*`CUBLAS_FILL_MODE_UPPER`*                                     |                  |*`HIPBLAS_FILL_MODE_UPPER`*                                 | 122                       |
-|            2 |*`CUBLAS_FILL_MODE_FULL`*                                      | 10.1             |*`HIPBLAS_FILL_MODE_FULL`*                                  | 123                       |
-| enum         |***`cublasDiagType_t`***                                       |                  |***`hipblasDiagType_t`***                                   |
-|            0 |*`CUBLAS_DIAG_NON_UNIT`*                                       |                  |*`HIPBLAS_DIAG_NON_UNIT`*                                   | 131                       |
-|            1 |*`CUBLAS_DIAG_UNIT`*                                           |                  |*`HIPBLAS_DIAG_UNIT`*                                       | 132                       |
-| enum         |***`cublasSideMode_t`***                                       |                  |***`hipblasSideMode_t`***                                   |
-|            0 |*`CUBLAS_SIDE_LEFT`*                                           |                  |*`HIPBLAS_SIDE_LEFT`*                                       | 141                       |
-|            1 |*`CUBLAS_SIDE_RIGHT`*                                          |                  |*`HIPBLAS_SIDE_RIGHT`*                                      | 142                       |
-| enum         |***`cublasPointerMode_t`***                                    |                  |***`hipblasPointerMode_t`***                                |
-|            0 |*`CUBLAS_POINTER_MODE_HOST`*                                   |                  |*`HIPBLAS_POINTER_MODE_HOST`*                               |
-|            1 |*`CUBLAS_POINTER_MODE_DEVICE`*                                 |                  |*`HIPBLAS_POINTER_MODE_DEVICE`*                             |
-| enum         |***`cublasAtomicsMode_t`***                                    |                  |                                                            |
-|            0 |*`CUBLAS_ATOMICS_NOT_ALLOWED`*                                 |                  |                                                            |
-|            1 |*`CUBLAS_ATOMICS_ALLOWED`*                                     |                  |                                                            |
-| enum         |***`cublasGemmAlgo_t`***                                       | 8.0              |***`hipblasGemmAlgo_t`***                                   |
-|           -1 |*`CUBLAS_GEMM_DFALT`*                                          | 8.0              |*`HIPBLAS_GEMM_DEFAULT`*                                    | 160                       |
-|           -1 |*`CUBLAS_GEMM_DEFAULT`*                                        | 8.0              |*`HIPBLAS_GEMM_DEFAULT`*                                    | 160                       |
-|            0 |*`CUBLAS_GEMM_ALGO0`*                                          | 8.0              |                                                            |
-|            1 |*`CUBLAS_GEMM_ALGO1`*                                          | 8.0              |                                                            |
-|            2 |*`CUBLAS_GEMM_ALGO2`*                                          | 8.0              |                                                            |
-|            3 |*`CUBLAS_GEMM_ALGO3`*                                          | 8.0              |                                                            |
-|            4 |*`CUBLAS_GEMM_ALGO4`*                                          | 8.0              |                                                            |
-|            5 |*`CUBLAS_GEMM_ALGO5`*                                          | 8.0              |                                                            |
-|            6 |*`CUBLAS_GEMM_ALGO6`*                                          | 8.0              |                                                            |
-|            7 |*`CUBLAS_GEMM_ALGO7`*                                          | 8.0              |                                                            |
-|            8 |*`CUBLAS_GEMM_ALGO8`*                                          | 9.0              |                                                            |
-|            9 |*`CUBLAS_GEMM_ALGO9`*                                          | 9.0              |                                                            |
-|           10 |*`CUBLAS_GEMM_ALGO10`*                                         | 9.0              |                                                            |
-|           11 |*`CUBLAS_GEMM_ALGO11`*                                         | 9.0              |                                                            |
-|           12 |*`CUBLAS_GEMM_ALGO12`*                                         | 9.0              |                                                            |
-|           13 |*`CUBLAS_GEMM_ALGO13`*                                         | 9.0              |                                                            |
-|           14 |*`CUBLAS_GEMM_ALGO14`*                                         | 9.0              |                                                            |
-|           15 |*`CUBLAS_GEMM_ALGO15`*                                         | 9.0              |                                                            |
-|           16 |*`CUBLAS_GEMM_ALGO16`*                                         | 9.0              |                                                            |
-|           17 |*`CUBLAS_GEMM_ALGO17`*                                         | 9.0              |                                                            |
-|           18 |*`CUBLAS_GEMM_ALGO18`*                                         | 9.2              |                                                            |
-|           19 |*`CUBLAS_GEMM_ALGO19`*                                         | 9.2              |                                                            |
-|           20 |*`CUBLAS_GEMM_ALGO20`*                                         | 9.2              |                                                            |
-|           21 |*`CUBLAS_GEMM_ALGO21`*                                         | 9.2              |                                                            |
-|           22 |*`CUBLAS_GEMM_ALGO22`*                                         | 9.2              |                                                            |
-|           23 |*`CUBLAS_GEMM_ALGO23`*                                         | 9.2              |                                                            |
-|           99 |*`CUBLAS_GEMM_DEFAULT_TENSOR_OP`*                              | 9.0              |                                                            |
-|           99 |*`CUBLAS_GEMM_DFALT_TENSOR_OP`*                                | 9.0              |                                                            |
-|          100 |*`CUBLAS_GEMM_ALGO0_TENSOR_OP`*                                | 9.0              |                                                            |
-|          101 |*`CUBLAS_GEMM_ALGO1_TENSOR_OP`*                                | 9.0              |                                                            |
-|          102 |*`CUBLAS_GEMM_ALGO2_TENSOR_OP`*                                | 9.0              |                                                            |
-|          103 |*`CUBLAS_GEMM_ALGO3_TENSOR_OP`*                                | 9.0              |                                                            |
-|          104 |*`CUBLAS_GEMM_ALGO4_TENSOR_OP`*                                | 9.0              |                                                            |
-|          105 |*`CUBLAS_GEMM_ALGO5_TENSOR_OP`*                                | 9.2              |                                                            |
-|          106 |*`CUBLAS_GEMM_ALGO6_TENSOR_OP`*                                | 9.2              |                                                            |
-|          107 |*`CUBLAS_GEMM_ALGO7_TENSOR_OP`*                                | 9.2              |                                                            |
-|          108 |*`CUBLAS_GEMM_ALGO8_TENSOR_OP`*                                | 9.2              |                                                            |
-|          109 |*`CUBLAS_GEMM_ALGO9_TENSOR_OP`*                                | 9.2              |                                                            |
-|          110 |*`CUBLAS_GEMM_ALGO10_TENSOR_OP`*                               | 9.2              |                                                            |
-|          111 |*`CUBLAS_GEMM_ALGO11_TENSOR_OP`*                               | 9.2              |                                                            |
-|          112 |*`CUBLAS_GEMM_ALGO12_TENSOR_OP`*                               | 9.2              |                                                            |
-|          113 |*`CUBLAS_GEMM_ALGO13_TENSOR_OP`*                               | 9.2              |                                                            |
-|          114 |*`CUBLAS_GEMM_ALGO14_TENSOR_OP`*                               | 9.2              |                                                            |
-|          115 |*`CUBLAS_GEMM_ALGO15_TENSOR_OP`*                               | 9.2              |                                                            |
-| enum         |***`cublasMath_t`***                                           | 9.0              |                                                            |
-|            0 |*`CUBLAS_DEFAULT_MATH`*                                        | 9.0              |                                                            |
-|            1 |*`CUBLAS_TENSOR_OP_MATH`*                                      | 9.0              |                                                            |
-|            2 |*`CUBLAS_PEDANTIC_MATH`*                                       | 11.0             |                                                            |
-|            3 |*`CUBLAS_TF32_TENSOR_OP_MATH`*                                 | 11.0             |                                                            |
-|           16 |*`CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION`*           | 11.0             |                                                            |
-| enum*        |`cublasDataType_t`                                             | 7.5              |                                                            |
-| struct       |`cublasContext`                                                |                  |                                                            |
-| struct*      |`cublasHandle_t`                                               |                  |`hipblasHandle_t`                                           |
-| enum         |***`cublasComputeType_t`***                                    | 11.0             |                                                            |
-|           64 |*`CUBLAS_COMPUTE_16F`*                                         | 11.0             |                                                            |
-|           65 |*`CUBLAS_COMPUTE_16F_PEDANTIC`*                                | 11.0             |                                                            |
-|           68 |*`CUBLAS_COMPUTE_32F`*                                         | 11.0             |                                                            |
-|           69 |*`CUBLAS_COMPUTE_32F_PEDANTIC`*                                | 11.0             |                                                            |
-|           74 |*`CUBLAS_COMPUTE_32F_FAST_16F`*                                | 11.0             |                                                            |
-|           75 |*`CUBLAS_COMPUTE_32F_FAST_16BF`*                               | 11.0             |                                                            |
-|           77 |*`CUBLAS_COMPUTE_32F_FAST_TF32`*                               | 11.0             |                                                            |
-|           70 |*`CUBLAS_COMPUTE_64F`*                                         | 11.0             |                                                            |
-|           71 |*`CUBLAS_COMPUTE_64F_PEDANTIC`*                                | 11.0             |                                                            |
-|           72 |*`CUBLAS_COMPUTE_32I`*                                         | 11.0             |                                                            |
-|           73 |*`CUBLAS_COMPUTE_32I_PEDANTIC`*                                | 11.0             |                                                            |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`CUBLAS_ATOMICS_ALLOWED`|  |  |  ||
+|`CUBLAS_ATOMICS_NOT_ALLOWED`|  |  |  ||
+|`CUBLAS_COMPUTE_16F`| 11.0 |  |  |`HIPBLAS_COMPUTE_16F`|
+|`CUBLAS_COMPUTE_16F_PEDANTIC`| 11.0 |  |  |`HIPBLAS_COMPUTE_16F_PEDANTIC`|
+|`CUBLAS_COMPUTE_32F`| 11.0 |  |  |`HIPBLAS_COMPUTE_32F`|
+|`CUBLAS_COMPUTE_32F_FAST_16BF`| 11.0 |  |  |`HIPBLAS_COMPUTE_32F_FAST_16BF`|
+|`CUBLAS_COMPUTE_32F_FAST_16F`| 11.0 |  |  |`HIPBLAS_COMPUTE_32F_FAST_16F`|
+|`CUBLAS_COMPUTE_32F_FAST_TF32`| 11.0 |  |  |`HIPBLAS_COMPUTE_32F_FAST_TF32`|
+|`CUBLAS_COMPUTE_32F_PEDANTIC`| 11.0 |  |  |`HIPBLAS_COMPUTE_32F_PEDANTIC`|
+|`CUBLAS_COMPUTE_32I`| 11.0 |  |  |`HIPBLAS_COMPUTE_32I`|
+|`CUBLAS_COMPUTE_32I_PEDANTIC`| 11.0 |  |  |`HIPBLAS_COMPUTE_32I_PEDANTIC`|
+|`CUBLAS_COMPUTE_64F`| 11.0 |  |  |`HIPBLAS_COMPUTE_64F`|
+|`CUBLAS_COMPUTE_64F_PEDANTIC`| 11.0 |  |  |`HIPBLAS_COMPUTE_64F_PEDANTIC`|
+|`CUBLAS_DEFAULT_MATH`| 9.0 |  |  |`HIPBLAS_DEFAULT_MATH`|
+|`CUBLAS_DIAG_NON_UNIT`|  |  |  |`HIPBLAS_DIAG_NON_UNIT`|
+|`CUBLAS_DIAG_UNIT`|  |  |  |`HIPBLAS_DIAG_UNIT`|
+|`CUBLAS_FILL_MODE_FULL`| 10.1 |  |  |`HIPBLAS_FILL_MODE_FULL`|
+|`CUBLAS_FILL_MODE_LOWER`|  |  |  |`HIPBLAS_FILL_MODE_LOWER`|
+|`CUBLAS_FILL_MODE_UPPER`|  |  |  |`HIPBLAS_FILL_MODE_UPPER`|
+|`CUBLAS_GEMM_ALGO0`| 8.0 |  |  |`HIPBLAS_GEMM_ALGO0`|
+|`CUBLAS_GEMM_ALGO0_TENSOR_OP`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO0_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO1`| 8.0 |  |  |`HIPBLAS_GEMM_ALGO1`|
+|`CUBLAS_GEMM_ALGO10`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO10`|
+|`CUBLAS_GEMM_ALGO10_TENSOR_OP`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO10_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO11`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO11`|
+|`CUBLAS_GEMM_ALGO11_TENSOR_OP`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO11_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO12`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO12`|
+|`CUBLAS_GEMM_ALGO12_TENSOR_OP`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO12_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO13`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO13`|
+|`CUBLAS_GEMM_ALGO13_TENSOR_OP`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO13_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO14`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO14`|
+|`CUBLAS_GEMM_ALGO14_TENSOR_OP`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO14_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO15`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO15`|
+|`CUBLAS_GEMM_ALGO15_TENSOR_OP`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO15_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO16`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO16`|
+|`CUBLAS_GEMM_ALGO17`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO17`|
+|`CUBLAS_GEMM_ALGO18`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO18`|
+|`CUBLAS_GEMM_ALGO19`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO19`|
+|`CUBLAS_GEMM_ALGO1_TENSOR_OP`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO1_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO2`| 8.0 |  |  |`HIPBLAS_GEMM_ALGO2`|
+|`CUBLAS_GEMM_ALGO20`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO20`|
+|`CUBLAS_GEMM_ALGO21`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO21`|
+|`CUBLAS_GEMM_ALGO22`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO22`|
+|`CUBLAS_GEMM_ALGO23`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO23`|
+|`CUBLAS_GEMM_ALGO2_TENSOR_OP`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO2_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO3`| 8.0 |  |  |`HIPBLAS_GEMM_ALGO3`|
+|`CUBLAS_GEMM_ALGO3_TENSOR_OP`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO3_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO4`| 8.0 |  |  |`HIPBLAS_GEMM_ALGO4`|
+|`CUBLAS_GEMM_ALGO4_TENSOR_OP`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO4_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO5`| 8.0 |  |  |`HIPBLAS_GEMM_ALGO5`|
+|`CUBLAS_GEMM_ALGO5_TENSOR_OP`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO5_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO6`| 8.0 |  |  |`HIPBLAS_GEMM_ALGO6`|
+|`CUBLAS_GEMM_ALGO6_TENSOR_OP`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO6_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO7`| 8.0 |  |  |`HIPBLAS_GEMM_ALGO7`|
+|`CUBLAS_GEMM_ALGO7_TENSOR_OP`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO7_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO8`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO8`|
+|`CUBLAS_GEMM_ALGO8_TENSOR_OP`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO8_TENSOR_OP`|
+|`CUBLAS_GEMM_ALGO9`| 9.0 |  |  |`HIPBLAS_GEMM_ALGO9`|
+|`CUBLAS_GEMM_ALGO9_TENSOR_OP`| 9.2 |  |  |`HIPBLAS_GEMM_ALGO9_TENSOR_OP`|
+|`CUBLAS_GEMM_DEFAULT`| 8.0 |  |  |`HIPBLAS_GEMM_DEFAULT`|
+|`CUBLAS_GEMM_DEFAULT_TENSOR_OP`| 9.0 |  |  |`HIPBLAS_GEMM_DEFAULT_TENSOR_OP`|
+|`CUBLAS_GEMM_DFALT`| 8.0 |  |  |`HIPBLAS_GEMM_DEFAULT`|
+|`CUBLAS_GEMM_DFALT_TENSOR_OP`| 9.0 |  |  |`HIPBLAS_GEMM_DFALT_TENSOR_OP`|
+|`CUBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION`| 11.0 |  |  |`HIPBLAS_MATH_DISALLOW_REDUCED_PRECISION_REDUCTION`|
+|`CUBLAS_OP_C`|  |  |  |`HIPBLAS_OP_C`|
+|`CUBLAS_OP_CONJG`| 10.1 |  |  |`HIPBLAS_OP_CONJG`|
+|`CUBLAS_OP_HERMITAN`| 10.1 |  |  |`HIPBLAS_OP_C`|
+|`CUBLAS_OP_N`|  |  |  |`HIPBLAS_OP_N`|
+|`CUBLAS_OP_T`|  |  |  |`HIPBLAS_OP_T`|
+|`CUBLAS_PEDANTIC_MATH`| 11.0 |  |  |`HIPBLAS_PEDANTIC_MATH`|
+|`CUBLAS_POINTER_MODE_DEVICE`|  |  |  |`HIPBLAS_POINTER_MODE_DEVICE`|
+|`CUBLAS_POINTER_MODE_HOST`|  |  |  |`HIPBLAS_POINTER_MODE_HOST`|
+|`CUBLAS_SIDE_LEFT`|  |  |  |`HIPBLAS_SIDE_LEFT`|
+|`CUBLAS_SIDE_RIGHT`|  |  |  |`HIPBLAS_SIDE_RIGHT`|
+|`CUBLAS_STATUS_ALLOC_FAILED`|  |  |  |`HIPBLAS_STATUS_ALLOC_FAILED`|
+|`CUBLAS_STATUS_ARCH_MISMATCH`|  |  |  |`HIPBLAS_STATUS_ARCH_MISMATCH`|
+|`CUBLAS_STATUS_EXECUTION_FAILED`|  |  |  |`HIPBLAS_STATUS_EXECUTION_FAILED`|
+|`CUBLAS_STATUS_INTERNAL_ERROR`|  |  |  |`HIPBLAS_STATUS_INTERNAL_ERROR`|
+|`CUBLAS_STATUS_INVALID_VALUE`|  |  |  |`HIPBLAS_STATUS_INVALID_VALUE`|
+|`CUBLAS_STATUS_LICENSE_ERROR`|  |  |  |`HIPBLAS_STATUS_LICENSE_ERROR`|
+|`CUBLAS_STATUS_MAPPING_ERROR`|  |  |  |`HIPBLAS_STATUS_MAPPING_ERROR`|
+|`CUBLAS_STATUS_NOT_INITIALIZED`|  |  |  |`HIPBLAS_STATUS_NOT_INITIALIZED`|
+|`CUBLAS_STATUS_NOT_SUPPORTED`|  |  |  |`HIPBLAS_STATUS_NOT_SUPPORTED`|
+|`CUBLAS_STATUS_SUCCESS`|  |  |  |`HIPBLAS_STATUS_SUCCESS`|
+|`CUBLAS_TENSOR_OP_MATH`| 9.0 |  |  |`HIPBLAS_TENSOR_OP_MATH`|
+|`CUBLAS_TF32_TENSOR_OP_MATH`| 11.0 |  |  |`HIPBLAS_TF32_TENSOR_OP_MATH`|
+|`CUBLAS_VERSION`| 10.1 |  |  ||
+|`CUBLAS_VER_BUILD`| 10.2 |  |  ||
+|`CUBLAS_VER_MAJOR`| 10.1 |  |  ||
+|`CUBLAS_VER_MINOR`| 10.1 |  |  ||
+|`CUBLAS_VER_PATCH`| 10.1 |  |  ||
+|`cublasAtomicsMode_t`|  |  |  ||
+|`cublasComputeType_t`| 11.0 |  |  |`hipblasComputeType_t`|
+|`cublasContext`|  |  |  ||
+|`cublasDataType_t`| 7.5 |  |  |`hipblasDatatype_t`|
+|`cublasDiagType_t`|  |  |  |`hipblasDiagType_t`|
+|`cublasFillMode_t`|  |  |  |`hipblasFillMode_t`|
+|`cublasGemmAlgo_t`| 8.0 |  |  |`hipblasGemmAlgo_t`|
+|`cublasHandle_t`|  |  |  |`hipblasHandle_t`|
+|`cublasMath_t`| 9.0 |  |  |`hipblasMath_t`|
+|`cublasOperation_t`|  |  |  |`hipblasOperation_t`|
+|`cublasPointerMode_t`|  |  |  |`hipblasPointerMode_t`|
+|`cublasSideMode_t`|  |  |  |`hipblasSideMode_t`|
+|`cublasStatus`|  |  |  |`hipblasStatus_t`|
+|`cublasStatus_t`|  |  |  |`hipblasStatus_t`|
 
-## **2. CUBLAS API functions**
+## **3. CUDA Datatypes Reference**
 
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cublasCreate`                                             |`hipblasCreate`                                  |
-|`cublasCreate_v2`                                          |`hipblasCreate`                                  |
-|`cublasDestroy`                                            |`hipblasDestroy`                                 |
-|`cublasDestroy_v2`                                         |`hipblasDestroy`                                 |
-|`cublasGetVersion`                                         |                                                 |
-|`cublasGetVersion_v2`                                      |                                                 |
-|`cublasGetProperty`                                        |                                                 | 8.0              |
-|`cublasGetCudartVersion`                                   |                                                 | 10.1             |
-|`cublasGetStream`                                          |`hipblasGetStream`                               |
-|`cublasGetStream_v2`                                       |`hipblasGetStream`                               |
-|`cublasSetStream`                                          |`hipblasSetStream`                               |
-|`cublasSetStream_v2`                                       |`hipblasSetStream`                               |
-|`cublasGetPointerMode`                                     |`hipblasGetPointerMode`                          |
-|`cublasGetPointerMode_v2`                                  |`hipblasGetPointerMode`                          |
-|`cublasSetPointerMode`                                     |`hipblasSetPointerMode`                          |
-|`cublasSetPointerMode_v2`                                  |`hipblasSetPointerMode`                          |
-|`cublasGetAtomicsMode`                                     |                                                 |
-|`cublasSetAtomicsMode`                                     |                                                 |
-|`cublasGetMathMode`                                        |                                                 | 9.0              |
-|`cublasSetMathMode`                                        |                                                 | 9.0              |
-|`cublasLogCallback`                                        |                                                 | 9.2              |
-|`cublasLoggerConfigure`                                    |                                                 | 9.2              |
-|`cublasSetLoggerCallback`                                  |                                                 | 9.2              |
-|`cublasGetLoggerCallback`                                  |                                                 | 9.2              |
-|`cublasMigrateComputeType`                                 |                                                 | 11.0             |
-|`cublasSetVector`                                          |`hipblasSetVector`                               |
-|`cublasGetVector`                                          |`hipblasGetVector`                               |
-|`cublasSetMatrix`                                          |`hipblasSetMatrix`                               |
-|`cublasGetMatrix`                                          |`hipblasGetMatrix`                               |
-|`cublasSetVectorAsync`                                     |`hipblasSetVectorAsync`                          |
-|`cublasGetVectorAsync`                                     |`hipblasGetVectorAsync`                          |
-|`cublasSetMatrixAsync`                                     |`hipblasSetMatrixAsync`                          |
-|`cublasGetMatrixAsync`                                     |`hipblasGetMatrixAsync`                          |
-|`cublasXerbla`                                             |                                                 |
-|`cublasNrm2Ex`                                             |                                                 | 8.0              |
-|`cublasSnrm2`                                              |`hipblasSnrm2`                                   |
-|`cublasSnrm2_v2`                                           |`hipblasSnrm2`                                   |
-|`cublasDnrm2`                                              |`hipblasDnrm2`                                   |
-|`cublasDnrm2_v2`                                           |`hipblasDnrm2`                                   |
-|`cublasScnrm2`                                             |`hipblasScnrm2`                                  |
-|`cublasScnrm2_v2`                                          |`hipblasScnrm2`                                  |
-|`cublasDznrm2`                                             |`hipblasDznrm2`                                  |
-|`cublasDznrm2_v2`                                          |`hipblasDznrm2`                                  |
-|`cublasDotEx`                                              |                                                 | 8.0              |
-|`cublasDotcEx`                                             |                                                 | 8.0              |
-|`cublasSdot`                                               |`hipblasSdot`                                    |
-|`cublasSdot_v2`                                            |`hipblasSdot`                                    |
-|`cublasDdot`                                               |`hipblasDdot`                                    |
-|`cublasDdot_v2`                                            |`hipblasDdot`                                    |
-|`cublasCdotu`                                              |`hipblasCdotu`                                   |
-|`cublasCdotu_v2`                                           |`hipblasCdotu`                                   |
-|`cublasCdotc`                                              |`hipblasCdotc`                                   |
-|`cublasCdotc_v2`                                           |`hipblasCdotc`                                   |
-|`cublasZdotu`                                              |`hipblasZdotu`                                   |
-|`cublasZdotu_v2`                                           |`hipblasZdotu`                                   |
-|`cublasZdotc`                                              |`hipblasZdotc`                                   |
-|`cublasZdotc_v2`                                           |`hipblasZdotc`                                   |
-|`cublasScalEx`                                             |                                                 | 8.0              |
-|`cublasSscal`                                              |`hipblasSscal`                                   |
-|`cublasSscal_v2`                                           |`hipblasSscal`                                   |
-|`cublasDscal`                                              |`hipblasDscal`                                   |
-|`cublasDscal_v2`                                           |`hipblasDscal`                                   |
-|`cublasCscal`                                              |`hipblasCscal`                                   |
-|`cublasCscal_v2`                                           |`hipblasCscal`                                   |
-|`cublasCsscal`                                             |`hipblasCsscal`                                  |
-|`cublasCsscal_v2`                                          |`hipblasCsscal`                                  |
-|`cublasZscal`                                              |`hipblasZscal`                                   |
-|`cublasZscal_v2`                                           |`hipblasZscal`                                   |
-|`cublasZdscal`                                             |`hipblasZdscal`                                  |
-|`cublasZdscal_v2`                                          |`hipblasZdscal`                                  |
-|`cublasAxpyEx`                                             |                                                 | 8.0              |
-|`cublasSaxpy`                                              |`hipblasSaxpy`                                   |
-|`cublasSaxpy_v2`                                           |`hipblasSaxpy`                                   |
-|`cublasDaxpy`                                              |`hipblasDaxpy`                                   |
-|`cublasDaxpy_v2`                                           |`hipblasDaxpy`                                   |
-|`cublasCaxpy`                                              |`hipblasCaxpy`                                   |
-|`cublasCaxpy_v2`                                           |`hipblasCaxpy`                                   |
-|`cublasZaxpy`                                              |`hipblasZaxpy`                                   |
-|`cublasZaxpy_v2`                                           |`hipblasZaxpy`                                   |
-|`cublasScopy`                                              |`hipblasScopy`                                   |
-|`cublasScopy_v2`                                           |`hipblasScopy`                                   |
-|`cublasDcopy`                                              |`hipblasDcopy`                                   |
-|`cublasDcopy_v2`                                           |`hipblasDcopy`                                   |
-|`cublasCcopy`                                              |`hipblasCcopy`                                   |
-|`cublasCopyEx`                                             |                                                 | 10.1             |
-|`cublasCcopy_v2`                                           |`hipblasCcopy`                                   |
-|`cublasZcopy`                                              |`hipblasZcopy`                                   |
-|`cublasZcopy_v2`                                           |`hipblasZcopy`                                   |
-|`cublasSswap`                                              |`hipblasSswap`                                   |
-|`cublasSswap_v2`                                           |`hipblasSswap`                                   |
-|`cublasDswap`                                              |`hipblasDswap`                                   |
-|`cublasDswap_v2`                                           |`hipblasDswap`                                   |
-|`cublasCswap`                                              |`hipblasCswap`                                   |
-|`cublasCswap_v2`                                           |`hipblasCswap`                                   |
-|`cublasZswap`                                              |`hipblasZswap`                                   |
-|`cublasZswap_v2`                                           |`hipblasZswap`                                   |
-|`cublasIamaxEx`                                            |                                                 | 10.1             |
-|`cublasIsamax`                                             |`hipblasIsamax`                                  |
-|`cublasIsamax_v2`                                          |`hipblasIsamax`                                  |
-|`cublasIdamax`                                             |`hipblasIdamax`                                  |
-|`cublasIdamax_v2`                                          |`hipblasIdamax`                                  |
-|`cublasIcamax`                                             |`hipblasIcamax`                                  |
-|`cublasIcamax_v2`                                          |`hipblasIcamax`                                  |
-|`cublasIzamax`                                             |`hipblasIzamax`                                  |
-|`cublasIzamax_v2`                                          |`hipblasIzamax`                                  |
-|`cublasIaminEx`                                            |                                                 | 10.1             |
-|`cublasIsamin`                                             |`hipblasIsamin`                                  |
-|`cublasIsamin_v2`                                          |`hipblasIsamin`                                  |
-|`cublasIdamin`                                             |`hipblasIdamin`                                  |
-|`cublasIdamin_v2`                                          |`hipblasIdamin`                                  |
-|`cublasIcamin`                                             |`hipblasIcamin`                                  |
-|`cublasIcamin_v2`                                          |`hipblasIcamin`                                  |
-|`cublasIzamin`                                             |`hipblasIzamin`                                  |
-|`cublasIzamin_v2`                                          |`hipblasIzamin`                                  |
-|`cublasAsumEx`                                             |                                                 | 10.1             |
-|`cublasSasum`                                              |`hipblasSasum`                                   |
-|`cublasSasum_v2`                                           |`hipblasSasum`                                   |
-|`cublasDasum`                                              |`hipblasDasum`                                   |
-|`cublasDasum_v2`                                           |`hipblasDasum`                                   |
-|`cublasScasum`                                             |`hipblasScasum`                                  |
-|`cublasScasum_v2`                                          |`hipblasScasum`                                  |
-|`cublasDzasum`                                             |`hipblasDzasum`                                  |
-|`cublasDzasum_v2`                                          |`hipblasDzasum`                                  |
-|`cublasRotEx`                                              |                                                 | 10.1             |
-|`cublasSrot`                                               |`hipblasSrot`                                    |
-|`cublasSrot_v2`                                            |`hipblasSrot`                                    |
-|`cublasDrot`                                               |`hipblasDrot`                                    |
-|`cublasDrot_v2`                                            |`hipblasDrot`                                    |
-|`cublasCrot`                                               |`hipblasCrot`                                    |
-|`cublasCrot_v2`                                            |`hipblasCrot`                                    |
-|`cublasCsrot`                                              |`hipblasCsrot`                                   |
-|`cublasCsrot_v2`                                           |`hipblasCsrot`                                   |
-|`cublasZrot`                                               |`hipblasZrot`                                    |
-|`cublasZrot_v2`                                            |`hipblasZrot`                                    |
-|`cublasRotgEx`                                             |                                                 | 10.1             |
-|`cublasZdrot`                                              |`hipblasZdrot`                                   |
-|`cublasZdrot_v2`                                           |`hipblasZdrot`                                   |
-|`cublasSrotg`                                              |`hipblasSrotg`                                   |
-|`cublasSrotg_v2`                                           |`hipblasSrotg`                                   |
-|`cublasDrotg`                                              |`hipblasDrotg`                                   |
-|`cublasDrotg_v2`                                           |`hipblasDrotg`                                   |
-|`cublasCrotg`                                              |`hipblasCrotg`                                   |
-|`cublasCrotg_v2`                                           |`hipblasCrotg`                                   |
-|`cublasZrotg`                                              |`hipblasZrotg`                                   |
-|`cublasZrotg_v2`                                           |`hipblasZrotg`                                   |
-|`cublasRotmEx`                                             |                                                 | 10.1             |
-|`cublasSrotm`                                              |`hipblasSrotm`                                   |
-|`cublasSrotm_v2`                                           |`hipblasSrotm`                                   |
-|`cublasDrotm`                                              |`hipblasDrotm`                                   |
-|`cublasDrotm_v2`                                           |`hipblasDrotm`                                   |
-|`cublasRotmgEx`                                            |                                                 | 10.1             |
-|`cublasSrotmg`                                             |`hipblasSrotmg`                                  |
-|`cublasSrotmg_v2`                                          |`hipblasSrotmg`                                  |
-|`cublasDrotmg`                                             |`hipblasDrotmg`                                  |
-|`cublasDrotmg_v2`                                          |`hipblasDrotmg`                                  |
-|`cublasSgemv`                                              |`hipblasSgemv`                                   |
-|`cublasSgemv_v2`                                           |`hipblasSgemv`                                   |
-|`cublasSgemvBatched`                                       |`hipblasSgemvBatched`                            |
-|`cublasDgemv`                                              |`hipblasDgemv`                                   |
-|`cublasDgemv_v2`                                           |`hipblasDgemv`                                   |
-|`cublasCgemv`                                              |`hipblasCgemv`                                   |
-|`cublasCgemv_v2`                                           |`hipblasCgemv`                                   |
-|`cublasZgemv`                                              |`hipblasZgemv`                                   |
-|`cublasZgemv_v2`                                           |`hipblasZgemv`                                   |
-|`cublasSgbmv`                                              |`hipblasSgbmv`                                   |
-|`cublasSgbmv_v2`                                           |`hipblasSgbmv`                                   |
-|`cublasDgbmv`                                              |`hipblasDgbmv`                                   |
-|`cublasDgbmv_v2`                                           |`hipblasDgbmv`                                   |
-|`cublasCgbmv`                                              |`hipblasCgbmv`                                   |
-|`cublasCgbmv_v2`                                           |`hipblasCgbmv`                                   |
-|`cublasZgbmv`                                              |`hipblasZgbmv`                                   |
-|`cublasZgbmv_v2`                                           |`hipblasZgbmv`                                   |
-|`cublasStrmv`                                              |`hipblasStrmv`                                   |
-|`cublasStrmv_v2`                                           |`hipblasStrmv`                                   |
-|`cublasDtrmv`                                              |`hipblasDtrmv`                                   |
-|`cublasDtrmv_v2`                                           |`hipblasDtrmv`                                   |
-|`cublasCtrmv`                                              |`hipblasCtrmv`                                   |
-|`cublasCtrmv_v2`                                           |`hipblasCtrmv`                                   |
-|`cublasZtrmv`                                              |`hipblasZtrmv`                                   |
-|`cublasZtrmv_v2`                                           |`hipblasZtrmv`                                   |
-|`cublasStbmv`                                              |`hipblasStbmv`                                   |
-|`cublasStbmv_v2`                                           |`hipblasStbmv`                                   |
-|`cublasDtbmv`                                              |`hipblasDtbmv`                                   |
-|`cublasDtbmv_v2`                                           |`hipblasDtbmv`                                   |
-|`cublasCtbmv`                                              |`hipblasCtbmv`                                   |
-|`cublasCtbmv_v2`                                           |`hipblasCtbmv`                                   |
-|`cublasZtbmv`                                              |`hipblasZtbmv`                                   |
-|`cublasZtbmv_v2`                                           |`hipblasZtbmv`                                   |
-|`cublasStpmv`                                              |`hipblasStpmv`                                   |
-|`cublasStpmv_v2`                                           |`hipblasStpmv`                                   |
-|`cublasDtpmv`                                              |`hipblasDtpmv`                                   |
-|`cublasDtpmv_v2`                                           |`hipblasDtpmv`                                   |
-|`cublasCtpmv`                                              |`hipblasCtpmv`                                   |
-|`cublasCtpmv_v2`                                           |`hipblasCtpmv`                                   |
-|`cublasZtpmv`                                              |`hipblasZtpmv`                                   |
-|`cublasZtpmv_v2`                                           |`hipblasZtpmv`                                   |
-|`cublasStrsv`                                              |`hipblasStrsv`                                   |
-|`cublasStrsv_v2`                                           |`hipblasStrsv`                                   |
-|`cublasDtrsv`                                              |`hipblasDtrsv`                                   |
-|`cublasDtrsv_v2`                                           |`hipblasDtrsv`                                   |
-|`cublasCtrsv`                                              |`hipblasCtrsv`                                   |
-|`cublasCtrsv_v2`                                           |`hipblasCtrsv`                                   |
-|`cublasZtrsv`                                              |`hipblasZtrsv`                                   |
-|`cublasZtrsv_v2`                                           |`hipblasZtrsv`                                   |
-|`cublasStpsv`                                              |`hipblasStpsv`                                   |
-|`cublasStpsv_v2`                                           |`hipblasStpsv`                                   |
-|`cublasDtpsv`                                              |`hipblasDtpsv`                                   |
-|`cublasDtpsv_v2`                                           |`hipblasDtpsv`                                   |
-|`cublasCtpsv`                                              |`hipblasCtpsv`                                   |
-|`cublasCtpsv_v2`                                           |`hipblasCtpsv`                                   |
-|`cublasZtpsv`                                              |`hipblasZtpsv`                                   |
-|`cublasZtpsv_v2`                                           |`hipblasZtpsv`                                   |
-|`cublasStbsv`                                              |`hipblasStbsv`                                   |
-|`cublasStbsv_v2`                                           |`hipblasStbsv`                                   |
-|`cublasDtbsv`                                              |`hipblasDtbsv`                                   |
-|`cublasDtbsv_v2`                                           |`hipblasDtbsv`                                   |
-|`cublasCtbsv`                                              |`hipblasCtbsv`                                   |
-|`cublasCtbsv_v2`                                           |`hipblasCtbsv`                                   |
-|`cublasZtbsv`                                              |`hipblasZtbsv`                                   |
-|`cublasZtbsv_v2`                                           |`hipblasZtbsv`                                   |
-|`cublasSsymv`                                              |`hipblasSsymv`                                   |
-|`cublasSsymv_v2`                                           |`hipblasSsymv`                                   |
-|`cublasDsymv`                                              |`hipblasDsymv`                                   |
-|`cublasDsymv_v2`                                           |`hipblasDsymv`                                   |
-|`cublasCsymv`                                              |`hipblasCsymv`                                   |
-|`cublasCsymv_v2`                                           |`hipblasCsymv`                                   |
-|`cublasZsymv`                                              |`hipblasZsymv`                                   |
-|`cublasZsymv_v2`                                           |`hipblasZsymv`                                   |
-|`cublasChemv`                                              |`hipblasChemv`                                   |
-|`cublasChemv_v2`                                           |`hipblasChemv`                                   |
-|`cublasZhemv`                                              |`hipblasZhemv`                                   |
-|`cublasZhemv_v2`                                           |`hipblasZhemv`                                   |
-|`cublasSsbmv`                                              |`hipblasSsbmv`                                   |
-|`cublasSsbmv_v2`                                           |`hipblasSsbmv`                                   |
-|`cublasDsbmv`                                              |`hipblasDsbmv`                                   |
-|`cublasDsbmv_v2`                                           |`hipblasDsbmv`                                   |
-|`cublasChbmv`                                              |`hipblasChbmv`                                   |
-|`cublasChbmv_v2`                                           |`hipblasChbmv`                                   |
-|`cublasZhbmv`                                              |`hipblasZhbmv`                                   |
-|`cublasZhbmv_v2`                                           |`hipblasZhbmv`                                   |
-|`cublasSspmv`                                              |`hipblasSspmv`                                   |
-|`cublasSspmv_v2`                                           |`hipblasSspmv`                                   |
-|`cublasDspmv`                                              |`hipblasDspmv`                                   |
-|`cublasDspmv_v2`                                           |`hipblasDspmv`                                   |
-|`cublasChpmv`                                              |`hipblasChpmv`                                   |
-|`cublasChpmv_v2`                                           |`hipblasChpmv`                                   |
-|`cublasZhpmv`                                              |`hipblasZhpmv`                                   |
-|`cublasZhpmv_v2`                                           |`hipblasZhpmv`                                   |
-|`cublasSger`                                               |`hipblasSger`                                    |
-|`cublasSger_v2`                                            |`hipblasSger`                                    |
-|`cublasDger`                                               |`hipblasDger`                                    |
-|`cublasDger_v2`                                            |`hipblasDger`                                    |
-|`cublasCgeru`                                              |`hipblasCgeru`                                   |
-|`cublasCgeru_v2`                                           |`hipblasCgeru`                                   |
-|`cublasCgerc`                                              |`hipblasCgerc`                                   |
-|`cublasCgerc_v2`                                           |`hipblasCgerc`                                   |
-|`cublasZgeru`                                              |`hipblasZgeru`                                   |
-|`cublasZgeru_v2`                                           |`hipblasZgeru`                                   |
-|`cublasZgerc`                                              |`hipblasZgerc`                                   |
-|`cublasZgerc_v2`                                           |`hipblasZgerc`                                   |
-|`cublasSsyr`                                               |`hipblasSsyr`                                    |
-|`cublasSsyr_v2`                                            |`hipblasSsyr`                                    |
-|`cublasDsyr`                                               |`hipblasDsyr`                                    |
-|`cublasDsyr_v2`                                            |`hipblasDsyr`                                    |
-|`cublasCsyr`                                               |`hipblasCsyr`                                    |
-|`cublasCsyr_v2`                                            |`hipblasCsyr`                                    |
-|`cublasZsyr`                                               |`hipblasZsyr`                                    |
-|`cublasZsyr_v2`                                            |`hipblasZsyr`                                    |
-|`cublasCher`                                               |`hipblasCher`                                    |
-|`cublasCher_v2`                                            |`hipblasCher`                                    |
-|`cublasZher`                                               |`hipblasZher`                                    |
-|`cublasZher_v2`                                            |`hipblasZher`                                    |
-|`cublasSspr`                                               |`hipblasSspr`                                    |
-|`cublasSspr_v2`                                            |`hipblasSspr`                                    |
-|`cublasDspr`                                               |`hipblasDspr`                                    |
-|`cublasDspr_v2`                                            |`hipblasDspr`                                    |
-|`cublasChpr`                                               |`hipblasChpr`                                    |
-|`cublasChpr_v2`                                            |`hipblasChpr`                                    |
-|`cublasZhpr`                                               |`hipblasZhpr`                                    |
-|`cublasZhpr_v2`                                            |`hipblasZhpr`                                    |
-|`cublasSsyr2`                                              |`hipblasSsyr2`                                   |
-|`cublasSsyr2_v2`                                           |`hipblasSsyr2`                                   |
-|`cublasDsyr2`                                              |`hipblasDsyr2`                                   |
-|`cublasDsyr2_v2`                                           |`hipblasDsyr2`                                   |
-|`cublasCsyr2`                                              |`hipblasCsyr2`                                   |
-|`cublasCsyr2_v2`                                           |`hipblasCsyr2`                                   |
-|`cublasZsyr2`                                              |`hipblasZsyr2`                                   |
-|`cublasZsyr2_v2`                                           |`hipblasZsyr2`                                   |
-|`cublasCher2`                                              |`hipblasCher2`                                   |
-|`cublasCher2_v2`                                           |`hipblasCher2`                                   |
-|`cublasZher2`                                              |`hipblasZher2`                                   |
-|`cublasZher2_v2`                                           |`hipblasZher2`                                   |
-|`cublasSspr2`                                              |`hipblasSspr2`                                   |
-|`cublasSspr2_v2`                                           |`hipblasSspr2`                                   |
-|`cublasDspr2`                                              |`hipblasDspr2`                                   |
-|`cublasDspr2_v2`                                           |`hipblasDspr2`                                   |
-|`cublasChpr2`                                              |`hipblasChpr2`                                   |
-|`cublasChpr2_v2`                                           |`hipblasChpr2`                                   |
-|`cublasZhpr2`                                              |`hipblasZhpr2`                                   |
-|`cublasZhpr2_v2`                                           |`hipblasZhpr2`                                   |
-|`cublasSgemm`                                              |`hipblasSgemm`                                   |
-|`cublasSgemm_v2`                                           |`hipblasSgemm`                                   |
-|`cublasDgemm`                                              |`hipblasDgemm`                                   |
-|`cublasDgemm_v2`                                           |`hipblasDgemm`                                   |
-|`cublasCgemm`                                              |`hipblasCgemm`                                   |
-|`cublasCgemm_v2`                                           |`hipblasCgemm`                                   |
-|`cublasCgemm3m`                                            |                                                 | 8.0              |
-|`cublasCgemm3mEx`                                          |                                                 | 8.0              |
-|`cublasZgemm`                                              |`hipblasZgemm`                                   |
-|`cublasZgemm_v2`                                           |`hipblasZgemm`                                   |
-|`cublasZgemm3m`                                            |                                                 | 8.0              |
-|`cublasHgemm`                                              |`hipblasHgemm`                                   | 7.5              |
-|`cublasSgemmEx`                                            |                                                 | 7.5              |
-|`cublasGemmEx`                                             |`hipblasGemmEx`                                  | 8.0              |
-|`cublasCgemmEx`                                            |                                                 | 8.0              |
-|`cublasUint8gemmBias`                                      |                                                 | 8.0              |
-|`cublasSsyrk`                                              |`hipblasSsyrk`                                   |
-|`cublasSsyrk_v2`                                           |`hipblasSsyrk`                                   |
-|`cublasDsyrk`                                              |`hipblasDsyrk`                                   |
-|`cublasDsyrk_v2`                                           |`hipblasDsyrk`                                   |
-|`cublasCsyrk`                                              |`hipblasCsyrk`                                   |
-|`cublasCsyrk_v2`                                           |`hipblasCsyrk`                                   |
-|`cublasZsyrk`                                              |`hipblasZsyrk`                                   |
-|`cublasZsyrk_v2`                                           |`hipblasZsyrk`                                   |
-|`cublasCsyrkEx`                                            |                                                 | 8.0              |
-|`cublasCsyrk3mEx`                                          |                                                 | 8.0              |
-|`cublasCherk`                                              |`hipblasCherk`                                   |
-|`cublasCherk_v2`                                           |`hipblasCherk`                                   |
-|`cublasZherk`                                              |`hipblasZherk`                                   |
-|`cublasZherk_v2`                                           |`hipblasZherk`                                   |
-|`cublasCherkEx`                                            |                                                 | 8.0              |
-|`cublasCherk3mEx`                                          |                                                 | 8.0              |
-|`cublasSsyr2k`                                             |`hipblasSsyr2k`                                  |
-|`cublasSsyr2k_v2`                                          |`hipblasSsyr2k`                                  |
-|`cublasDsyr2k`                                             |`hipblasDsyr2k`                                  |
-|`cublasDsyr2k_v2`                                          |`hipblasDsyr2k`                                  |
-|`cublasCsyr2k`                                             |`hipblasCsyr2k`                                  |
-|`cublasCsyr2k_v2`                                          |`hipblasCsyr2k`                                  |
-|`cublasZsyr2k`                                             |`hipblasZsyr2k`                                  |
-|`cublasZsyr2k_v2`                                          |`hipblasZsyr2k`                                  |
-|`cublasCher2k`                                             |`hipblasCher2k`                                  |
-|`cublasCher2k_v2`                                          |`hipblasCher2k`                                  |
-|`cublasZher2k`                                             |`hipblasZher2k`                                  |
-|`cublasZher2k_v2`                                          |`hipblasZher2k`                                  |
-|`cublasSsyrkx`                                             |`hipblasSsyrkx`                                  |
-|`cublasDsyrkx`                                             |`hipblasDsyrkx`                                  |
-|`cublasCsyrkx`                                             |`hipblasCsyrkx`                                  |
-|`cublasZsyrkx`                                             |`hipblasZsyrkx`                                  |
-|`cublasCherkx`                                             |`hipblasCherkx`                                  |
-|`cublasZherkx`                                             |`hipblasZherkx`                                  |
-|`cublasSsymm`                                              |`hipblasSsymm`                                   |
-|`cublasSsymm_v2`                                           |`hipblasSsymm`                                   |
-|`cublasDsymm`                                              |`hipblasDsymm`                                   |
-|`cublasDsymm_v2`                                           |`hipblasDsymm`                                   |
-|`cublasCsymm`                                              |`hipblasCsymm`                                   |
-|`cublasCsymm_v2`                                           |`hipblasCsymm`                                   |
-|`cublasZsymm`                                              |`hipblasZsymm`                                   |
-|`cublasZsymm_v2`                                           |`hipblasZsymm`                                   |
-|`cublasChemm`                                              |`hipblasChemm`                                   |
-|`cublasChemm_v2`                                           |`hipblasChemm`                                   |
-|`cublasZhemm`                                              |`hipblasZhemm`                                   |
-|`cublasZhemm_v2`                                           |`hipblasZhemm`                                   |
-|`cublasStrsm`                                              |`hipblasStrsm`                                   |
-|`cublasStrsm_v2`                                           |`hipblasStrsm`                                   |
-|`cublasDtrsm`                                              |`hipblasDtrsm`                                   |
-|`cublasDtrsm_v2`                                           |`hipblasDtrsm`                                   |
-|`cublasCtrsm`                                              |`hipblasCtrsm`                                   |
-|`cublasCtrsm_v2`                                           |`hipblasCtrsm`                                   |
-|`cublasZtrsm`                                              |`hipblasZtrsm`                                   |
-|`cublasZtrsm_v2`                                           |`hipblasZtrsm`                                   |
-|`cublasStrmm`                                              |`hipblasStrmm`                                   |
-|`cublasStrmm_v2`                                           |`hipblasStrmm`                                   |
-|`cublasDtrmm`                                              |`hipblasDtrmm`                                   |
-|`cublasDtrmm_v2`                                           |`hipblasDtrmm`                                   |
-|`cublasCtrmm`                                              |`hipblasCtrmm`                                   |
-|`cublasCtrmm_v2`                                           |`hipblasCtrmm`                                   |
-|`cublasZtrmm`                                              |`hipblasZtrmm`                                   |
-|`cublasZtrmm_v2`                                           |`hipblasZtrmm`                                   |
-|`cublasHgemmBatched`                                       |`hipblasHgemmBatched`                            | 9.0              |
-|`cublasSgemmBatched`                                       |`hipblasSgemmBatched`                            |
-|`cublasDgemmBatched`                                       |`hipblasDgemmBatched`                            |
-|`cublasCgemmBatched`                                       |`hipblasCgemmBatched`                            |
-|`cublasCgemm3mBatched`                                     |                                                 | 8.0              |
-|`cublasZgemmBatched`                                       |`hipblasZgemmBatched`                            |
-|`cublasGemmBatchedEx`                                      |`hipblasGemmBatchedEx`                           | 9.1              |
-|`cublasGemmStridedBatchedEx`                               |`hipblasGemmStridedBatchedEx`                    | 9.1              |
-|`cublasSgemmStridedBatched`                                |`hipblasSgemmStridedBatched`                     | 8.0              |
-|`cublasDgemmStridedBatched`                                |`hipblasDgemmStridedBatched`                     | 8.0              |
-|`cublasCgemmStridedBatched`                                |`hipblasCgemmStridedBatched`                     | 8.0              |
-|`cublasCgemm3mStridedBatched`                              |                                                 | 8.0              |
-|`cublasZgemmStridedBatched`                                |`hipblasZgemmStridedBatched`                     | 8.0              |
-|`cublasHgemmStridedBatched`                                |`hipblasHgemmStridedBatched`                     | 8.0              |
-|`cublasSgeam`                                              |`hipblasSgeam`                                   |
-|`cublasDgeam`                                              |`hipblasDgeam`                                   |
-|`cublasCgeam`                                              |`hipblasCgeam`                                   |
-|`cublasZgeam`                                              |`hipblasZgeam`                                   |
-|`cublasSgetrfBatched`                                      |`hipblasSgetrfBatched`                           |
-|`cublasDgetrfBatched`                                      |`hipblasDgetrfBatched`                           |
-|`cublasCgetrfBatched`                                      |`hipblasCgetrfBatched`                           |
-|`cublasZgetrfBatched`                                      |`hipblasZgetrfBatched`                           |
-|`cublasSgetriBatched`                                      |`hipblasSgetriBatched`                           |
-|`cublasDgetriBatched`                                      |`hipblasDgetriBatched`                           |
-|`cublasCgetriBatched`                                      |`hipblasCgetriBatched`                           |
-|`cublasZgetriBatched`                                      |`hipblasZgetriBatched`                           |
-|`cublasSgetrsBatched`                                      |`hipblasSgetrsBatched`                           |
-|`cublasDgetrsBatched`                                      |`hipblasDgetrsBatched`                           |
-|`cublasCgetrsBatched`                                      |`hipblasCgetrsBatched`                           |
-|`cublasZgetrsBatched`                                      |`hipblasZgetrsBatched`                           |
-|`cublasStrsmBatched`                                       |`hipblasStrsmBatched`                            |
-|`cublasDtrsmBatched`                                       |`hipblasDtrsmBatched`                            |
-|`cublasCtrsmBatched`                                       |`hipblasCtrsmBatched`                            |
-|`cublasZtrsmBatched`                                       |`hipblasZtrsmBatched`                            |
-|`cublasSmatinvBatched`                                     |                                                 |
-|`cublasDmatinvBatched`                                     |                                                 |
-|`cublasCmatinvBatched`                                     |                                                 |
-|`cublasZmatinvBatched`                                     |                                                 |
-|`cublasSgeqrfBatched`                                      |`hipblasSgeqrfBatched`                           |
-|`cublasDgeqrfBatched`                                      |`hipblasDgeqrfBatched`                           |
-|`cublasCgeqrfBatched`                                      |`hipblasCgeqrfBatched`                           |
-|`cublasZgeqrfBatched`                                      |`hipblasZgeqrfBatched`                           |
-|`cublasSgelsBatched`                                       |                                                 |
-|`cublasDgelsBatched`                                       |                                                 |
-|`cublasCgelsBatched`                                       |                                                 |
-|`cublasZgelsBatched`                                       |                                                 |
-|`cublasSdgmm`                                              |`hipblasSdgmm`                                   |
-|`cublasDdgmm`                                              |`hipblasDdgmm`                                   |
-|`cublasCdgmm`                                              |`hipblasCdgmm`                                   |
-|`cublasZdgmm`                                              |`hipblasZdgmm`                                   |
-|`cublasStpttr`                                             |                                                 |
-|`cublasDtpttr`                                             |                                                 |
-|`cublasCtpttr`                                             |                                                 |
-|`cublasZtpttr`                                             |                                                 |
-|`cublasStrttp`                                             |                                                 |
-|`cublasDtrttp`                                             |                                                 |
-|`cublasCtrttp`                                             |                                                 |
-|`cublasZtrttp`                                             |                                                 |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`CUDA_C_16F`| 8.0 |  |  |`HIPBLAS_C_16F`|
+|`CUDA_C_32F`| 8.0 |  |  |`HIPBLAS_C_32F`|
+|`CUDA_C_32I`| 8.0 |  |  |`HIPBLAS_C_32I`|
+|`CUDA_C_32U`| 8.0 |  |  |`HIPBLAS_C_32U`|
+|`CUDA_C_64F`| 8.0 |  |  |`HIPBLAS_C_64F`|
+|`CUDA_C_8I`| 8.0 |  |  |`HIPBLAS_C_8I`|
+|`CUDA_C_8U`| 8.0 |  |  |`HIPBLAS_C_8U`|
+|`CUDA_R_16F`| 8.0 |  |  |`HIPBLAS_R_16F`|
+|`CUDA_R_32F`| 8.0 |  |  |`HIPBLAS_R_32F`|
+|`CUDA_R_32I`| 8.0 |  |  |`HIPBLAS_R_32I`|
+|`CUDA_R_32U`| 8.0 |  |  |`HIPBLAS_R_32U`|
+|`CUDA_R_64F`| 8.0 |  |  |`HIPBLAS_R_64F`|
+|`CUDA_R_8I`| 8.0 |  |  |`HIPBLAS_R_8I`|
+|`CUDA_R_8U`| 8.0 |  |  |`HIPBLAS_R_8U`|
+|`cudaDataType`| 8.0 |  |  |`hipblasDatatype_t`|
+|`cudaDataType_t`| 8.0 |  |  |`hipblasDatatype_t`|
 
-\* CUDA version, in which API has appeared and (optional) last version before abandoning it; no value in case of earlier versions < 7.5.
+## **4. CUBLAS Helper Function Reference**
+
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cublasAlloc`|  |  |  |`hipblasAlloc`|
+|`cublasCreate`|  |  |  |`hipblasCreate`|
+|`cublasCreate_v2`|  |  |  |`hipblasCreate`|
+|`cublasDestroy`|  |  |  |`hipblasDestroy`|
+|`cublasDestroy_v2`|  |  |  |`hipblasDestroy`|
+|`cublasFree`|  |  |  |`hipblasFree`|
+|`cublasGetAtomicsMode`|  |  |  |`hipblasGetAtomicsMode`|
+|`cublasGetCudartVersion`| 10.1 |  |  |`hipblasGetCudartVersion`|
+|`cublasGetError`|  |  |  |`hipblasGetError`|
+|`cublasGetLoggerCallback`| 9.2 |  |  |`hipblasGetLoggerCallback`|
+|`cublasGetMathMode`| 9.0 |  |  |`hipblasGetMathMode`|
+|`cublasGetMatrix`|  |  |  |`hipblasGetMatrix`|
+|`cublasGetMatrixAsync`|  |  |  |`hipblasGetMatrixAsync`|
+|`cublasGetPointerMode`|  |  |  |`hipblasGetPointerMode`|
+|`cublasGetPointerMode_v2`|  |  |  |`hipblasGetPointerMode`|
+|`cublasGetProperty`|  |  |  |`hipblasGetProperty`|
+|`cublasGetStream`|  |  |  |`hipblasGetStream`|
+|`cublasGetStream_v2`|  |  |  |`hipblasGetStream`|
+|`cublasGetVector`|  |  |  |`hipblasGetVector`|
+|`cublasGetVectorAsync`|  |  |  |`hipblasGetVectorAsync`|
+|`cublasGetVersion`|  |  |  |`hipblasGetVersion`|
+|`cublasGetVersion_v2`|  |  |  |`hipblasGetVersion`|
+|`cublasInit`|  |  |  |`hipblasInit`|
+|`cublasLogCallback`| 9.2 |  |  |`hipblasLogCallback`|
+|`cublasLoggerConfigure`| 9.2 |  |  |`hipblasLoggerConfigure`|
+|`cublasMigrateComputeType`| 11.0 |  |  |`hipblasMigrateComputeType`|
+|`cublasSetAtomicsMode`|  |  |  |`hipblasSetAtomicsMode`|
+|`cublasSetKernelStream`|  |  |  |`hipblasSetKernelStream`|
+|`cublasSetLoggerCallback`| 9.2 |  |  |`hipblasSetLoggerCallback`|
+|`cublasSetMathMode`|  |  |  |`hipblasSetMathMode`|
+|`cublasSetMatrix`|  |  |  |`hipblasSetMatrix`|
+|`cublasSetMatrixAsync`|  |  |  |`hipblasSetMatrixAsync`|
+|`cublasSetPointerMode`|  |  |  |`hipblasSetPointerMode`|
+|`cublasSetPointerMode_v2`|  |  |  |`hipblasSetPointerMode`|
+|`cublasSetStream`|  |  |  |`hipblasSetStream`|
+|`cublasSetStream_v2`|  |  |  |`hipblasSetStream`|
+|`cublasSetVector`|  |  |  |`hipblasSetVector`|
+|`cublasSetVectorAsync`|  |  |  |`hipblasSetVectorAsync`|
+|`cublasShutdown`|  |  |  |`hipblasShutdown`|
+|`cublasXerbla`|  |  |  |`hipblasXerbla`|
+
+## **5. CUBLAS Level-1 Function Reference**
+
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cublasCaxpy`|  |  |  |`hipblasCaxpy`|
+|`cublasCaxpy_v2`|  |  |  |`hipblasCaxpy`|
+|`cublasCcopy`|  |  |  |`hipblasCcopy`|
+|`cublasCcopy_v2`|  |  |  |`hipblasCcopy`|
+|`cublasCdotc`|  |  |  |`hipblasCdotc`|
+|`cublasCdotc_v2`|  |  |  |`hipblasCdotc`|
+|`cublasCdotu`|  |  |  |`hipblasCdotu`|
+|`cublasCdotu_v2`|  |  |  |`hipblasCdotu`|
+|`cublasCrot`|  |  |  |`hipblasCrot`|
+|`cublasCrot_v2`|  |  |  |`hipblasCrot`|
+|`cublasCrotg`|  |  |  |`hipblasCrotg`|
+|`cublasCrotg_v2`|  |  |  |`hipblasCrotg`|
+|`cublasCscal`|  |  |  |`hipblasCscal`|
+|`cublasCscal_v2`|  |  |  |`hipblasCscal`|
+|`cublasCsrot`|  |  |  |`hipblasCsrot`|
+|`cublasCsrot_v2`|  |  |  |`hipblasCsrot`|
+|`cublasCsscal`|  |  |  |`hipblasCsscal`|
+|`cublasCsscal_v2`|  |  |  |`hipblasCsscal`|
+|`cublasCswap`|  |  |  |`hipblasCswap`|
+|`cublasCswap_v2`|  |  |  |`hipblasCswap`|
+|`cublasDasum`|  |  |  |`hipblasDasum`|
+|`cublasDasum_v2`|  |  |  |`hipblasDasum`|
+|`cublasDaxpy`|  |  |  |`hipblasDaxpy`|
+|`cublasDaxpy_v2`|  |  |  |`hipblasDaxpy`|
+|`cublasDcopy`|  |  |  |`hipblasDcopy`|
+|`cublasDcopy_v2`|  |  |  |`hipblasDcopy`|
+|`cublasDdot`|  |  |  |`hipblasDdot`|
+|`cublasDdot_v2`|  |  |  |`hipblasDdot`|
+|`cublasDnrm2`|  |  |  |`hipblasDnrm2`|
+|`cublasDnrm2_v2`|  |  |  |`hipblasDnrm2`|
+|`cublasDrot`|  |  |  |`hipblasDrot`|
+|`cublasDrot_v2`|  |  |  |`hipblasDrot`|
+|`cublasDrotg`|  |  |  |`hipblasDrotg`|
+|`cublasDrotg_v2`|  |  |  |`hipblasDrotg`|
+|`cublasDrotm`|  |  |  |`hipblasDrotm`|
+|`cublasDrotm_v2`|  |  |  |`hipblasDrotm`|
+|`cublasDrotmg`|  |  |  |`hipblasDrotmg`|
+|`cublasDrotmg_v2`|  |  |  |`hipblasDrotmg`|
+|`cublasDscal`|  |  |  |`hipblasDscal`|
+|`cublasDscal_v2`|  |  |  |`hipblasDscal`|
+|`cublasDswap`|  |  |  |`hipblasDswap`|
+|`cublasDswap_v2`|  |  |  |`hipblasDswap`|
+|`cublasDzasum`|  |  |  |`hipblasDzasum`|
+|`cublasDzasum_v2`|  |  |  |`hipblasDzasum`|
+|`cublasDznrm2`|  |  |  |`hipblasDznrm2`|
+|`cublasDznrm2_v2`|  |  |  |`hipblasDznrm2`|
+|`cublasIcamax`|  |  |  |`hipblasIcamax`|
+|`cublasIcamax_v2`|  |  |  |`hipblasIcamax`|
+|`cublasIcamin`|  |  |  |`hipblasIcamin`|
+|`cublasIcamin_v2`|  |  |  |`hipblasIcamin`|
+|`cublasIdamax`|  |  |  |`hipblasIdamax`|
+|`cublasIdamax_v2`|  |  |  |`hipblasIdamax`|
+|`cublasIdamin`|  |  |  |`hipblasIdamin`|
+|`cublasIdamin_v2`|  |  |  |`hipblasIdamin`|
+|`cublasIsamax`|  |  |  |`hipblasIsamax`|
+|`cublasIsamax_v2`|  |  |  |`hipblasIsamax`|
+|`cublasIsamin`|  |  |  |`hipblasIsamin`|
+|`cublasIsamin_v2`|  |  |  |`hipblasIsamin`|
+|`cublasIzamax`|  |  |  |`hipblasIzamax`|
+|`cublasIzamax_v2`|  |  |  |`hipblasIzamax`|
+|`cublasIzamin`|  |  |  |`hipblasIzamin`|
+|`cublasIzamin_v2`|  |  |  |`hipblasIzamin`|
+|`cublasNrm2Ex`| 8.0 |  |  |`hipblasNrm2Ex`|
+|`cublasSasum`|  |  |  |`hipblasSasum`|
+|`cublasSasum_v2`|  |  |  |`hipblasSasum`|
+|`cublasSaxpy`|  |  |  |`hipblasSaxpy`|
+|`cublasSaxpy_v2`|  |  |  |`hipblasSaxpy`|
+|`cublasScasum`|  |  |  |`hipblasScasum`|
+|`cublasScasum_v2`|  |  |  |`hipblasScasum`|
+|`cublasScnrm2`|  |  |  |`hipblasScnrm2`|
+|`cublasScnrm2_v2`|  |  |  |`hipblasScnrm2`|
+|`cublasScopy`|  |  |  |`hipblasScopy`|
+|`cublasScopy_v2`|  |  |  |`hipblasScopy`|
+|`cublasSdot`|  |  |  |`hipblasSdot`|
+|`cublasSdot_v2`|  |  |  |`hipblasSdot`|
+|`cublasSnrm2`|  |  |  |`hipblasSnrm2`|
+|`cublasSnrm2_v2`|  |  |  |`hipblasSnrm2`|
+|`cublasSrot`|  |  |  |`hipblasSrot`|
+|`cublasSrot_v2`|  |  |  |`hipblasSrot`|
+|`cublasSrotg`|  |  |  |`hipblasSrotg`|
+|`cublasSrotg_v2`|  |  |  |`hipblasSrotg`|
+|`cublasSrotm`|  |  |  |`hipblasSrotm`|
+|`cublasSrotm_v2`|  |  |  |`hipblasSrotm`|
+|`cublasSrotmg`|  |  |  |`hipblasSrotmg`|
+|`cublasSrotmg_v2`|  |  |  |`hipblasSrotmg`|
+|`cublasSscal`|  |  |  |`hipblasSscal`|
+|`cublasSscal_v2`|  |  |  |`hipblasSscal`|
+|`cublasSswap`|  |  |  |`hipblasSswap`|
+|`cublasSswap_v2`|  |  |  |`hipblasSswap`|
+|`cublasZaxpy`|  |  |  |`hipblasZaxpy`|
+|`cublasZaxpy_v2`|  |  |  |`hipblasZaxpy`|
+|`cublasZcopy`|  |  |  |`hipblasZcopy`|
+|`cublasZcopy_v2`|  |  |  |`hipblasZcopy`|
+|`cublasZdotc`|  |  |  |`hipblasZdotc`|
+|`cublasZdotc_v2`|  |  |  |`hipblasZdotc`|
+|`cublasZdotu`|  |  |  |`hipblasZdotu`|
+|`cublasZdotu_v2`|  |  |  |`hipblasZdotu`|
+|`cublasZdrot`|  |  |  |`hipblasZdrot`|
+|`cublasZdrot_v2`|  |  |  |`hipblasZdrot`|
+|`cublasZdscal`|  |  |  |`hipblasZdscal`|
+|`cublasZdscal_v2`|  |  |  |`hipblasZdscal`|
+|`cublasZrot`|  |  |  |`hipblasZrot`|
+|`cublasZrot_v2`|  |  |  |`hipblasZrot`|
+|`cublasZrotg`|  |  |  |`hipblasZrotg`|
+|`cublasZrotg_v2`|  |  |  |`hipblasZrotg`|
+|`cublasZscal`|  |  |  |`hipblasZscal`|
+|`cublasZscal_v2`|  |  |  |`hipblasZscal`|
+|`cublasZswap`|  |  |  |`hipblasZswap`|
+|`cublasZswap_v2`|  |  |  |`hipblasZswap`|
+
+## **6. CUBLAS Level-2 Function Reference**
+
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cublasCgbmv`|  |  |  |`hipblasCgbmv`|
+|`cublasCgbmv_v2`|  |  |  |`hipblasCgbmv`|
+|`cublasCgemv`|  |  |  |`hipblasCgemv`|
+|`cublasCgemv_v2`|  |  |  |`hipblasCgemv`|
+|`cublasCgerc`|  |  |  |`hipblasCgerc`|
+|`cublasCgerc_v2`|  |  |  |`hipblasCgerc`|
+|`cublasCgeru`|  |  |  |`hipblasCgeru`|
+|`cublasCgeru_v2`|  |  |  |`hipblasCgeru`|
+|`cublasChbmv`|  |  |  |`hipblasChbmv`|
+|`cublasChbmv_v2`|  |  |  |`hipblasChbmv`|
+|`cublasChemv`|  |  |  |`hipblasChemv`|
+|`cublasChemv_v2`|  |  |  |`hipblasChemv`|
+|`cublasCher`|  |  |  |`hipblasCher`|
+|`cublasCher2`|  |  |  |`hipblasCher2`|
+|`cublasCher2_v2`|  |  |  |`hipblasCher2`|
+|`cublasCher_v2`|  |  |  |`hipblasCher`|
+|`cublasChpmv`|  |  |  |`hipblasChpmv`|
+|`cublasChpmv_v2`|  |  |  |`hipblasChpmv`|
+|`cublasChpr`|  |  |  |`hipblasChpr`|
+|`cublasChpr2`|  |  |  |`hipblasChpr2`|
+|`cublasChpr2_v2`|  |  |  |`hipblasChpr2`|
+|`cublasChpr_v2`|  |  |  |`hipblasChpr`|
+|`cublasCsymv`|  |  |  |`hipblasCsymv`|
+|`cublasCsymv_v2`|  |  |  |`hipblasCsymv`|
+|`cublasCsyr`|  |  |  |`hipblasCsyr`|
+|`cublasCsyr2`|  |  |  |`hipblasCsyr2`|
+|`cublasCsyr2_v2`|  |  |  |`hipblasCsyr2`|
+|`cublasCsyr_v2`|  |  |  |`hipblasCsyr`|
+|`cublasCtbmv`|  |  |  |`hipblasCtbmv`|
+|`cublasCtbmv_v2`|  |  |  |`hipblasCtbmv`|
+|`cublasCtbsv`|  |  |  |`hipblasCtbsv`|
+|`cublasCtbsv_v2`|  |  |  |`hipblasCtbsv`|
+|`cublasCtpmv`|  |  |  |`hipblasCtpmv`|
+|`cublasCtpmv_v2`|  |  |  |`hipblasCtpmv`|
+|`cublasCtpsv`|  |  |  |`hipblasCtpsv`|
+|`cublasCtpsv_v2`|  |  |  |`hipblasCtpsv`|
+|`cublasCtrmv`|  |  |  |`hipblasCtrmv`|
+|`cublasCtrmv_v2`|  |  |  |`hipblasCtrmv`|
+|`cublasCtrsv`|  |  |  |`hipblasCtrsv`|
+|`cublasCtrsv_v2`|  |  |  |`hipblasCtrsv`|
+|`cublasDgbmv`|  |  |  |`hipblasDgbmv`|
+|`cublasDgbmv_v2`|  |  |  |`hipblasDgbmv`|
+|`cublasDgemv`|  |  |  |`hipblasDgemv`|
+|`cublasDgemv_v2`|  |  |  |`hipblasDgemv`|
+|`cublasDger`|  |  |  |`hipblasDger`|
+|`cublasDger_v2`|  |  |  |`hipblasDger`|
+|`cublasDsbmv`|  |  |  |`hipblasDsbmv`|
+|`cublasDsbmv_v2`|  |  |  |`hipblasDsbmv`|
+|`cublasDspmv`|  |  |  |`hipblasDspmv`|
+|`cublasDspmv_v2`|  |  |  |`hipblasDspmv`|
+|`cublasDspr`|  |  |  |`hipblasDspr`|
+|`cublasDspr2`|  |  |  |`hipblasDspr2`|
+|`cublasDspr2_v2`|  |  |  |`hipblasDspr2`|
+|`cublasDspr_v2`|  |  |  |`hipblasDspr`|
+|`cublasDsymv`|  |  |  |`hipblasDsymv`|
+|`cublasDsymv_v2`|  |  |  |`hipblasDsymv`|
+|`cublasDsyr`|  |  |  |`hipblasDsyr`|
+|`cublasDsyr2`|  |  |  |`hipblasDsyr2`|
+|`cublasDsyr2_v2`|  |  |  |`hipblasDsyr2`|
+|`cublasDsyr_v2`|  |  |  |`hipblasDsyr`|
+|`cublasDtbmv`|  |  |  |`hipblasDtbmv`|
+|`cublasDtbmv_v2`|  |  |  |`hipblasDtbmv`|
+|`cublasDtbsv`|  |  |  |`hipblasDtbsv`|
+|`cublasDtbsv_v2`|  |  |  |`hipblasDtbsv`|
+|`cublasDtpmv`|  |  |  |`hipblasDtpmv`|
+|`cublasDtpmv_v2`|  |  |  |`hipblasDtpmv`|
+|`cublasDtpsv`|  |  |  |`hipblasDtpsv`|
+|`cublasDtpsv_v2`|  |  |  |`hipblasDtpsv`|
+|`cublasDtrmv`|  |  |  |`hipblasDtrmv`|
+|`cublasDtrmv_v2`|  |  |  |`hipblasDtrmv`|
+|`cublasDtrsv`|  |  |  |`hipblasDtrsv`|
+|`cublasDtrsv_v2`|  |  |  |`hipblasDtrsv`|
+|`cublasSgbmv`|  |  |  |`hipblasSgbmv`|
+|`cublasSgbmv_v2`|  |  |  |`hipblasSgbmv`|
+|`cublasSgemv`|  |  |  |`hipblasSgemv`|
+|`cublasSgemv_v2`|  |  |  |`hipblasSgemv`|
+|`cublasSger`|  |  |  |`hipblasSger`|
+|`cublasSger_v2`|  |  |  |`hipblasSger`|
+|`cublasSsbmv`|  |  |  |`hipblasSsbmv`|
+|`cublasSsbmv_v2`|  |  |  |`hipblasSsbmv`|
+|`cublasSspmv`|  |  |  |`hipblasSspmv`|
+|`cublasSspmv_v2`|  |  |  |`hipblasSspmv`|
+|`cublasSspr`|  |  |  |`hipblasSspr`|
+|`cublasSspr2`|  |  |  |`hipblasSspr2`|
+|`cublasSspr2_v2`|  |  |  |`hipblasSspr2`|
+|`cublasSspr_v2`|  |  |  |`hipblasSspr`|
+|`cublasSsymv`|  |  |  |`hipblasSsymv`|
+|`cublasSsymv_v2`|  |  |  |`hipblasSsymv`|
+|`cublasSsyr`|  |  |  |`hipblasSsyr`|
+|`cublasSsyr2`|  |  |  |`hipblasSsyr2`|
+|`cublasSsyr2_v2`|  |  |  |`hipblasSsyr2`|
+|`cublasSsyr_v2`|  |  |  |`hipblasSsyr`|
+|`cublasStbmv`|  |  |  |`hipblasStbmv`|
+|`cublasStbmv_v2`|  |  |  |`hipblasStbmv`|
+|`cublasStbsv`|  |  |  |`hipblasStbsv`|
+|`cublasStbsv_v2`|  |  |  |`hipblasStbsv`|
+|`cublasStpmv`|  |  |  |`hipblasStpmv`|
+|`cublasStpmv_v2`|  |  |  |`hipblasStpmv`|
+|`cublasStpsv`|  |  |  |`hipblasStpsv`|
+|`cublasStpsv_v2`|  |  |  |`hipblasStpsv`|
+|`cublasStrmv`|  |  |  |`hipblasStrmv`|
+|`cublasStrmv_v2`|  |  |  |`hipblasStrmv`|
+|`cublasStrsv`|  |  |  |`hipblasStrsv`|
+|`cublasStrsv_v2`|  |  |  |`hipblasStrsv`|
+|`cublasZgbmv`|  |  |  |`hipblasZgbmv`|
+|`cublasZgbmv_v2`|  |  |  |`hipblasZgbmv`|
+|`cublasZgemv`|  |  |  |`hipblasZgemv`|
+|`cublasZgemv_v2`|  |  |  |`hipblasZgemv`|
+|`cublasZgerc`|  |  |  |`hipblasZgerc`|
+|`cublasZgerc_v2`|  |  |  |`hipblasZgerc`|
+|`cublasZgeru`|  |  |  |`hipblasZgeru`|
+|`cublasZgeru_v2`|  |  |  |`hipblasZgeru`|
+|`cublasZhbmv`|  |  |  |`hipblasZhbmv`|
+|`cublasZhbmv_v2`|  |  |  |`hipblasZhbmv`|
+|`cublasZhemv`|  |  |  |`hipblasZhemv`|
+|`cublasZhemv_v2`|  |  |  |`hipblasZhemv`|
+|`cublasZher`|  |  |  |`hipblasZher`|
+|`cublasZher2`|  |  |  |`hipblasZher2`|
+|`cublasZher2_v2`|  |  |  |`hipblasZher2`|
+|`cublasZher_v2`|  |  |  |`hipblasZher`|
+|`cublasZhpmv`|  |  |  |`hipblasZhpmv`|
+|`cublasZhpmv_v2`|  |  |  |`hipblasZhpmv`|
+|`cublasZhpr`|  |  |  |`hipblasZhpr`|
+|`cublasZhpr2`|  |  |  |`hipblasZhpr2`|
+|`cublasZhpr2_v2`|  |  |  |`hipblasZhpr2`|
+|`cublasZhpr_v2`|  |  |  |`hipblasZhpr`|
+|`cublasZsymv`|  |  |  |`hipblasZsymv`|
+|`cublasZsymv_v2`|  |  |  |`hipblasZsymv`|
+|`cublasZsyr`|  |  |  |`hipblasZsyr`|
+|`cublasZsyr2`|  |  |  |`hipblasZsyr2`|
+|`cublasZsyr2_v2`|  |  |  |`hipblasZsyr2`|
+|`cublasZsyr_v2`|  |  |  |`hipblasZsyr`|
+|`cublasZtbmv`|  |  |  |`hipblasZtbmv`|
+|`cublasZtbmv_v2`|  |  |  |`hipblasZtbmv`|
+|`cublasZtbsv`|  |  |  |`hipblasZtbsv`|
+|`cublasZtbsv_v2`|  |  |  |`hipblasZtbsv`|
+|`cublasZtpmv`|  |  |  |`hipblasZtpmv`|
+|`cublasZtpmv_v2`|  |  |  |`hipblasZtpmv`|
+|`cublasZtpsv`|  |  |  |`hipblasZtpsv`|
+|`cublasZtpsv_v2`|  |  |  |`hipblasZtpsv`|
+|`cublasZtrmv`|  |  |  |`hipblasZtrmv`|
+|`cublasZtrmv_v2`|  |  |  |`hipblasZtrmv`|
+|`cublasZtrsv`|  |  |  |`hipblasZtrsv`|
+|`cublasZtrsv_v2`|  |  |  |`hipblasZtrsv`|
+
+## **7. CUBLAS Level-3 Function Reference**
+
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cublasCgemm`|  |  |  |`hipblasCgemm`|
+|`cublasCgemm3m`| 8.0 |  |  |`hipblasCgemm3m`|
+|`cublasCgemm3mBatched`| 8.0 |  |  |`hipblasCgemm3mBatched`|
+|`cublasCgemm3mEx`| 8.0 |  |  |`hipblasCgemm3mEx`|
+|`cublasCgemm3mStridedBatched`| 8.0 |  |  |`hipblasCgemm3mStridedBatched`|
+|`cublasCgemmBatched`|  |  |  |`hipblasCgemmBatched`|
+|`cublasCgemmStridedBatched`| 8.0 |  |  |`hipblasCgemmStridedBatched`|
+|`cublasCgemm_v2`|  |  |  |`hipblasCgemm`|
+|`cublasChemm`|  |  |  |`hipblasChemm`|
+|`cublasChemm_v2`|  |  |  |`hipblasChemm`|
+|`cublasCher2k`|  |  |  |`hipblasCher2k`|
+|`cublasCher2k_v2`|  |  |  |`hipblasCher2k`|
+|`cublasCherk`|  |  |  |`hipblasCherk`|
+|`cublasCherk_v2`|  |  |  |`hipblasCherk`|
+|`cublasCherkx`|  |  |  |`hipblasCherkx`|
+|`cublasCsymm`|  |  |  |`hipblasCsymm`|
+|`cublasCsymm_v2`|  |  |  |`hipblasCsymm`|
+|`cublasCsyr2k`|  |  |  |`hipblasCsyr2k`|
+|`cublasCsyr2k_v2`|  |  |  |`hipblasCsyr2k`|
+|`cublasCsyrk`|  |  |  |`hipblasCsyrk`|
+|`cublasCsyrk_v2`|  |  |  |`hipblasCsyrk`|
+|`cublasCsyrkx`|  |  |  |`hipblasCsyrkx`|
+|`cublasCtrmm`|  |  |  |`hipblasCtrmm`|
+|`cublasCtrmm_v2`|  |  |  |`hipblasCtrmm`|
+|`cublasCtrsm`|  |  |  |`hipblasCtrsm`|
+|`cublasCtrsm_v2`|  |  |  |`hipblasCtrsm`|
+|`cublasDgemm`|  |  |  |`hipblasDgemm`|
+|`cublasDgemmBatched`|  |  |  |`hipblasDgemmBatched`|
+|`cublasDgemmStridedBatched`| 8.0 |  |  |`hipblasDgemmStridedBatched`|
+|`cublasDgemm_v2`|  |  |  |`hipblasDgemm`|
+|`cublasDsymm`|  |  |  |`hipblasDsymm`|
+|`cublasDsymm_v2`|  |  |  |`hipblasDsymm`|
+|`cublasDsyr2k`|  |  |  |`hipblasDsyr2k`|
+|`cublasDsyr2k_v2`|  |  |  |`hipblasDsyr2k`|
+|`cublasDsyrk`|  |  |  |`hipblasDsyrk`|
+|`cublasDsyrk_v2`|  |  |  |`hipblasDsyrk`|
+|`cublasDsyrkx`|  |  |  |`hipblasDsyrkx`|
+|`cublasDtrmm`|  |  |  |`hipblasDtrmm`|
+|`cublasDtrmm_v2`|  |  |  |`hipblasDtrmm`|
+|`cublasDtrsm`|  |  |  |`hipblasDtrsm`|
+|`cublasDtrsm_v2`|  |  |  |`hipblasDtrsm`|
+|`cublasHgemm`| 7.5 |  |  |`hipblasHgemm`|
+|`cublasHgemmBatched`| 9.0 |  |  |`hipblasHgemmBatched`|
+|`cublasHgemmStridedBatched`| 8.0 |  |  |`hipblasHgemmStridedBatched`|
+|`cublasSgemm`|  |  |  |`hipblasSgemm`|
+|`cublasSgemmBatched`|  |  |  |`hipblasSgemmBatched`|
+|`cublasSgemmStridedBatched`| 8.0 |  |  |`hipblasSgemmStridedBatched`|
+|`cublasSgemm_v2`|  |  |  |`hipblasSgemm`|
+|`cublasSsymm`|  |  |  |`hipblasSsymm`|
+|`cublasSsymm_v2`|  |  |  |`hipblasSsymm`|
+|`cublasSsyr2k`|  |  |  |`hipblasSsyr2k`|
+|`cublasSsyr2k_v2`|  |  |  |`hipblasSsyr2k`|
+|`cublasSsyrk`|  |  |  |`hipblasSsyrk`|
+|`cublasSsyrk_v2`|  |  |  |`hipblasSsyrk`|
+|`cublasSsyrkx`|  |  |  |`hipblasSsyrkx`|
+|`cublasStrmm`|  |  |  |`hipblasStrmm`|
+|`cublasStrmm_v2`|  |  |  |`hipblasStrmm`|
+|`cublasStrsm`|  |  |  |`hipblasStrsm`|
+|`cublasStrsm_v2`|  |  |  |`hipblasStrsm`|
+|`cublasZgemm`|  |  |  |`hipblasZgemm`|
+|`cublasZgemm3m`| 8.0 |  |  |`hipblasZgemm3m`|
+|`cublasZgemmBatched`|  |  |  |`hipblasZgemmBatched`|
+|`cublasZgemmStridedBatched`| 8.0 |  |  |`hipblasZgemmStridedBatched`|
+|`cublasZgemm_v2`|  |  |  |`hipblasZgemm`|
+|`cublasZhemm`|  |  |  |`hipblasZhemm`|
+|`cublasZhemm_v2`|  |  |  |`hipblasZhemm`|
+|`cublasZher2k`|  |  |  |`hipblasZher2k`|
+|`cublasZher2k_v2`|  |  |  |`hipblasZher2k`|
+|`cublasZherk`|  |  |  |`hipblasZherk`|
+|`cublasZherk_v2`|  |  |  |`hipblasZherk`|
+|`cublasZherkx`|  |  |  |`hipblasZherkx`|
+|`cublasZsymm`|  |  |  |`hipblasZsymm`|
+|`cublasZsymm_v2`|  |  |  |`hipblasZsymm`|
+|`cublasZsyr2k`|  |  |  |`hipblasZsyr2k`|
+|`cublasZsyr2k_v2`|  |  |  |`hipblasZsyr2k`|
+|`cublasZsyrk`|  |  |  |`hipblasZsyrk`|
+|`cublasZsyrk_v2`|  |  |  |`hipblasZsyrk`|
+|`cublasZsyrkx`|  |  |  |`hipblasZsyrkx`|
+|`cublasZtrmm`|  |  |  |`hipblasZtrmm`|
+|`cublasZtrmm_v2`|  |  |  |`hipblasZtrmm`|
+|`cublasZtrsm`|  |  |  |`hipblasZtrsm`|
+|`cublasZtrsm_v2`|  |  |  |`hipblasZtrsm`|
+
+## **8. BLAS-like Extension**
+
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cublasAsumEx`| 10.1 |  |  |`hipblasAsumEx`|
+|`cublasAxpyEx`| 8.0 |  |  |`hipblasAxpyEx`|
+|`cublasCdgmm`|  |  |  |`hipblasCdgmm`|
+|`cublasCgeam`|  |  |  |`hipblasCgeam`|
+|`cublasCgelsBatched`|  |  |  |`hipblasCgelsBatched`|
+|`cublasCgemmEx`| 8.0 |  |  |`hipblasCgemmEx`|
+|`cublasCgeqrfBatched`|  |  |  |`hipblasCgeqrfBatched`|
+|`cublasCgetrfBatched`|  |  |  |`hipblasCgetrfBatched`|
+|`cublasCgetriBatched`|  |  |  |`hipblasCgetriBatched`|
+|`cublasCgetrsBatched`|  |  |  |`hipblasCgetrsBatched`|
+|`cublasCherk3mEx`| 8.0 |  |  |`hipblasCherk3mEx`|
+|`cublasCherkEx`| 8.0 |  |  |`hipblasCherkEx`|
+|`cublasCmatinvBatched`|  |  |  |`hipblasCmatinvBatched`|
+|`cublasCopyEx`| 10.1 |  |  |`hipblasCopyEx`|
+|`cublasCsyrk3mEx`| 8.0 |  |  |`hipblasCsyrk3mEx`|
+|`cublasCsyrkEx`| 8.0 |  |  |`hipblasCsyrkEx`|
+|`cublasCtpttr`|  |  |  |`hipblasCtpttr`|
+|`cublasCtrsmBatched`|  |  |  |`hipblasCtrsmBatched`|
+|`cublasCtrttp`|  |  |  |`hipblasCtrttp`|
+|`cublasDdgmm`|  |  |  |`hipblasDdgmm`|
+|`cublasDgeam`|  |  |  |`hipblasDgeam`|
+|`cublasDgelsBatched`|  |  |  |`hipblasDgelsBatched`|
+|`cublasDgeqrfBatched`|  |  |  |`hipblasDgeqrfBatched`|
+|`cublasDgetrfBatched`|  |  |  |`hipblasDgetrfBatched`|
+|`cublasDgetriBatched`|  |  |  |`hipblasDgetriBatched`|
+|`cublasDgetrsBatched`|  |  |  |`hipblasDgetrsBatched`|
+|`cublasDmatinvBatched`|  |  |  |`hipblasDmatinvBatched`|
+|`cublasDotEx`| 8.0 |  |  |`hipblasDotEx`|
+|`cublasDotcEx`| 8.0 |  |  |`hipblasDotcEx`|
+|`cublasDtpttr`|  |  |  |`hipblasDtpttr`|
+|`cublasDtrsmBatched`|  |  |  |`hipblasDtrsmBatched`|
+|`cublasDtrttp`|  |  |  |`hipblasDtrttp`|
+|`cublasGemmBatchedEx`| 9.1 |  |  |`hipblasGemmBatchedEx`|
+|`cublasGemmEx`| 8.0 |  |  |`hipblasGemmEx`|
+|`cublasGemmStridedBatchedEx`| 9.1 |  |  |`hipblasGemmStridedBatchedEx`|
+|`cublasIamaxEx`| 10.1 |  |  |`hipblasIamaxEx`|
+|`cublasIaminEx`| 10.1 |  |  |`hipblasIaminEx`|
+|`cublasRotEx`| 10.1 |  |  |`hipblasRotEx`|
+|`cublasRotgEx`| 10.1 |  |  |`hipblasRotgEx`|
+|`cublasRotmEx`| 10.1 |  |  |`hipblasRotmEx`|
+|`cublasRotmgEx`| 10.1 |  |  |`hipblasRotmgEx`|
+|`cublasScalEx`| 8.0 |  |  |`hipblasScalEx`|
+|`cublasSdgmm`|  |  |  |`hipblasSdgmm`|
+|`cublasSgeam`|  |  |  |`hipblasSgeam`|
+|`cublasSgelsBatched`|  |  |  |`hipblasSgelsBatched`|
+|`cublasSgemmEx`| 7.5 |  |  |`hipblasSgemmEx`|
+|`cublasSgeqrfBatched`|  |  |  |`hipblasSgeqrfBatched`|
+|`cublasSgetrfBatched`|  |  |  |`hipblasSgetrfBatched`|
+|`cublasSgetriBatched`|  |  |  |`hipblasSgetriBatched`|
+|`cublasSgetrsBatched`|  |  |  |`hipblasSgetrsBatched`|
+|`cublasSmatinvBatched`|  |  |  |`hipblasSmatinvBatched`|
+|`cublasStpttr`|  |  |  |`hipblasStpttr`|
+|`cublasStrsmBatched`|  |  |  |`hipblasStrsmBatched`|
+|`cublasStrttp`|  |  |  |`hipblasStrttp`|
+|`cublasSwapEx`| 10.1 |  |  |`hipblasSwapEx`|
+|`cublasUint8gemmBias`| 8.0 |  |  |`hipblasUint8gemmBias`|
+|`cublasZdgmm`|  |  |  |`hipblasZdgmm`|
+|`cublasZgeam`|  |  |  |`hipblasZgeam`|
+|`cublasZgelsBatched`|  |  |  |`hipblasZgelsBatched`|
+|`cublasZgeqrfBatched`|  |  |  |`hipblasZgeqrfBatched`|
+|`cublasZgetrfBatched`|  |  |  |`hipblasZgetrfBatched`|
+|`cublasZgetriBatched`|  |  |  |`hipblasZgetriBatched`|
+|`cublasZgetrsBatched`|  |  |  |`hipblasZgetrsBatched`|
+|`cublasZmatinvBatched`|  |  |  |`hipblasZmatinvBatched`|
+|`cublasZtpttr`|  |  |  |`hipblasZtpttr`|
+|`cublasZtrsmBatched`|  |  |  |`hipblasZtrsmBatched`|
+|`cublasZtrttp`|  |  |  |`hipblasZtrttp`|
+
+
+\* A - Added, D - Deprecated, R - Removed

--- a/docs/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
+++ b/docs/markdown/CUDA_Driver_API_functions_supported_by_HIP.md
@@ -1,1391 +1,1435 @@
-# CUDA Driver API functions supported by HIP
+# CUDA Driver API supported by HIP
 
-## **1. Data types used by CUDA driver**
+## **1. CUDA Driver Data Types**
 
-| **type**     |   **CUDA**                                                         |   **HIP**                                                  |**CUDA version\***|
-|-------------:|:-------------------------------------------------------------------|:-----------------------------------------------------------|:----------------:|
-| struct       |`CUDA_ARRAY3D_DESCRIPTOR`                                           |`HIP_ARRAY3D_DESCRIPTOR`                                    |
-| struct       |`CUDA_ARRAY3D_DESCRIPTOR_v1`                                        |`HIP_ARRAY3D_DESCRIPTOR`                                    | 11.0             |
-| typedef      |`CUDA_ARRAY3D_DESCRIPTOR_st`                                        |`HIP_ARRAY3D_DESCRIPTOR`                                    |
-| typedef      |`CUDA_ARRAY3D_DESCRIPTOR_v1_st`                                     |`HIP_ARRAY3D_DESCRIPTOR`                                    | 11.0             |
-| struct       |`CUDA_ARRAY_DESCRIPTOR`                                             |`HIP_ARRAY_DESCRIPTOR`                                      |
-| struct       |`CUDA_ARRAY_DESCRIPTOR_v1`                                          |`HIP_ARRAY_DESCRIPTOR`                                      | 11.0             |
-| typedef      |`CUDA_ARRAY_DESCRIPTOR_st`                                          |`HIP_ARRAY_DESCRIPTOR`                                      |
-| typedef      |`CUDA_ARRAY_DESCRIPTOR_v1_st`                                       |`HIP_ARRAY_DESCRIPTOR`                                      | 11.0             |
-| struct       |`CUDA_MEMCPY2D`                                                     |`hip_Memcpy2D`                                              |
-| struct       |`CUDA_MEMCPY2D_v1`                                                  |`hip_Memcpy2D`                                              | 11.0             |
-| typedef      |`CUDA_MEMCPY2D_st`                                                  |`hip_Memcpy2D`                                              |
-| typedef      |`CUDA_MEMCPY2D_v1_st`                                               |`hip_Memcpy2D`                                              | 11.0             |
-| struct       |`CUDA_MEMCPY3D`                                                     |`HIP_MEMCPY3D`                                              |
-| struct       |`CUDA_MEMCPY3D_v1`                                                  |`HIP_MEMCPY3D`                                              | 11.0             |
-| typedef      |`CUDA_MEMCPY3D_st`                                                  |`HIP_MEMCPY3D`                                              |
-| typedef      |`CUDA_MEMCPY3D_v1_st`                                               |`HIP_MEMCPY3D`                                              | 11.0             |
-| struct       |`CUDA_MEMCPY3D_PEER`                                                |                                                            |
-| typedef      |`CUDA_MEMCPY3D_PEER_st`                                             |                                                            |
-| struct       |`CUDA_POINTER_ATTRIBUTE_P2P_TOKENS`                                 |                                                            |
-| typedef      |`CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_st`                              |                                                            |
-| struct       |`CUDA_RESOURCE_DESC`                                                |                                                            |
-| typedef      |`CUDA_RESOURCE_DESC_st`                                             |                                                            |
-| struct       |`CUDA_RESOURCE_VIEW_DESC`                                           |                                                            |
-| typedef      |`CUDA_RESOURCE_VIEW_DESC_st`                                        |                                                            |
-| struct       |`CUDA_TEXTURE_DESC`                                                 |                                                            |
-| typedef      |`CUDA_TEXTURE_DESC_st`                                              |                                                            |
-| struct       |`CUdevprop`                                                         |                                                            |
-| typedef      |`CUdevprop_st`                                                      |                                                            |
-| struct       |`CUipcEventHandle`                                                  |`ihipIpcEventHandle_t`                                      |
-| typedef      |`CUipcEventHandle_st`                                               |`ihipIpcEventHandle_t`                                      |
-| struct       |`CUipcMemHandle`                                                    |`hipIpcMemHandle_t`                                         |
-| typedef      |`CUipcMemHandle_st`                                                 |`hipIpcMemHandle_st`                                        |
-| union        |`CUstreamBatchMemOpParams`                                          |                                                            | 8.0              |
-| typedef      |`CUstreamBatchMemOpParams_union`                                    |                                                            | 8.0              |
-| enum         |***`CUaddress_mode`***                                              |***`hipTextureAddressMode`***                               |
-| typedef      |***`CUaddress_mode_enum`***                                         |***`hipTextureAddressMode`***                               |
-|            0 |*`CU_TR_ADDRESS_MODE_WRAP`*                                         |*`hipAddressModeWrap`*                                      |
-|            1 |*`CU_TR_ADDRESS_MODE_CLAMP`*                                        |*`hipAddressModeClamp`*                                     |
-|            2 |*`CU_TR_ADDRESS_MODE_MIRROR`*                                       |*`hipAddressModeMirror`*                                    |
-|            3 |*`CU_TR_ADDRESS_MODE_BORDER`*                                       |*`hipAddressModeBorder`*                                    |
-| enum         |***`CUarray_cubemap_face`***                                        |                                                            |
-| typedef      |***`CUarray_cubemap_face_enum`***                                   |                                                            |
-|         0x00 |*`CU_CUBEMAP_FACE_POSITIVE_X`*                                      |                                                            |
-|         0x01 |*`CU_CUBEMAP_FACE_NEGATIVE_X`*                                      |                                                            |
-|         0x02 |*`CU_CUBEMAP_FACE_POSITIVE_Y`*                                      |                                                            |
-|         0x03 |*`CU_CUBEMAP_FACE_NEGATIVE_Y`*                                      |                                                            |
-|         0x04 |*`CU_CUBEMAP_FACE_POSITIVE_Z`*                                      |                                                            |
-|         0x05 |*`CU_CUBEMAP_FACE_NEGATIVE_Z`*                                      |                                                            |
-| enum         |***`CUarray_format`***                                              |***`hipArray_format`***                                     |
-| typedef      |***`CUarray_format_enum`***                                         |***`hipArray_format`***                                     |
-|         0x01 |*`CU_AD_FORMAT_UNSIGNED_INT8`*                                      |*`HIP_AD_FORMAT_UNSIGNED_INT8`*                             |
-|         0x02 |*`CU_AD_FORMAT_UNSIGNED_INT16`*                                     |*`HIP_AD_FORMAT_UNSIGNED_INT16`*                            |
-|         0x03 |*`CU_AD_FORMAT_UNSIGNED_INT32`*                                     |*`HIP_AD_FORMAT_UNSIGNED_INT32`*                            |
-|         0x08 |*`CU_AD_FORMAT_SIGNED_INT8`*                                        |*`HIP_AD_FORMAT_SIGNED_INT8`*                               |
-|         0x09 |*`CU_AD_FORMAT_SIGNED_INT16`*                                       |*`HIP_AD_FORMAT_SIGNED_INT16`*                              |
-|         0x0a |*`CU_AD_FORMAT_SIGNED_INT32`*                                       |*`HIP_AD_FORMAT_SIGNED_INT32`*                              |
-|         0x10 |*`CU_AD_FORMAT_HALF`*                                               |*`HIP_AD_FORMAT_HALF`*                                      |
-|         0x20 |*`CU_AD_FORMAT_FLOAT`*                                              |*`HIP_AD_FORMAT_FLOAT`*                                     |
-| enum         |***`CUctx_flags`***                                                 |                                                            |
-| typedef      |***`CUctx_flags_enum`***                                            |                                                            |
-|         0x00 |*`CU_CTX_SCHED_AUTO`*                                               |`hipDeviceScheduleAuto`                                     |
-|         0x01 |*`CU_CTX_SCHED_SPIN`*                                               |`hipDeviceScheduleSpin`                                     |
-|         0x02 |*`CU_CTX_SCHED_YIELD`*                                              |`hipDeviceScheduleYield`                                    |
-|         0x04 |*`CU_CTX_SCHED_BLOCKING_SYNC`*                                      |`hipDeviceScheduleBlockingSync`                             |
-|         0x04 |*`CU_CTX_BLOCKING_SYNC`*                                            |`hipDeviceScheduleBlockingSync`                             |
-|         0x07 |*`CU_CTX_SCHED_MASK`*                                               |`hipDeviceScheduleMask`                                     |
-|         0x08 |*`CU_CTX_MAP_HOST`*                                                 |`hipDeviceMapHost`                                          |
-|         0x10 |*`CU_CTX_LMEM_RESIZE_TO_MAX`*                                       |`hipDeviceLmemResizeToMax`                                  |
-|         0x1f |*`CU_CTX_FLAGS_MASK`*                                               |                                                            |
-| enum         |***`CUdevice_attribute`***                                          |***`hipDeviceAttribute_t`***                                |
-| typedef      |***`CUdevice_attribute_enum`***                                     |***`hipDeviceAttribute_t`***                                |
-|            1 |*`CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK`*                       |*`hipDeviceAttributeMaxThreadsPerBlock`*                    |
-|            2 |*`CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X`*                             |*`hipDeviceAttributeMaxBlockDimX`*                          |
-|            3 |*`CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y`*                             |*`hipDeviceAttributeMaxBlockDimY`*                          |
-|            4 |*`CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z`*                             |*`hipDeviceAttributeMaxBlockDimZ`*                          |
-|            5 |*`CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X`*                              |*`hipDeviceAttributeMaxGridDimX`*                           |
-|            6 |*`CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y`*                              |*`hipDeviceAttributeMaxGridDimY`*                           |
-|            7 |*`CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z`*                              |*`hipDeviceAttributeMaxGridDimZ`*                           |
-|            8 |*`CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK`*                 |*`hipDeviceAttributeMaxSharedMemoryPerBlock`*               |
-|            8 |*`CU_DEVICE_ATTRIBUTE_SHARED_MEMORY_PER_BLOCK`*                     |*`hipDeviceAttributeMaxSharedMemoryPerBlock`*               |
-|            9 |*`CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY`*                       |*`hipDeviceAttributeTotalConstantMemory`*                   |
-|           10 |*`CU_DEVICE_ATTRIBUTE_WARP_SIZE`*                                   |*`hipDeviceAttributeWarpSize`*                              |
-|           11 |*`CU_DEVICE_ATTRIBUTE_MAX_PITCH`*                                   |*`hipDeviceAttributeMaxPitch`*                              |
-|           12 |*`CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK`*                     |*`hipDeviceAttributeMaxRegistersPerBlock`*                  |
-|           12 |*`CU_DEVICE_ATTRIBUTE_REGISTERS_PER_BLOCK`*                         |*`hipDeviceAttributeMaxRegistersPerBlock`*                  |
-|           13 |*`CU_DEVICE_ATTRIBUTE_CLOCK_RATE`*                                  |*`hipDeviceAttributeClockRate`*                             |
-|           14 |*`CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT`*                           |*`hipDeviceAttributeTextureAlignment`*                      |
-|           15 |*`CU_DEVICE_ATTRIBUTE_GPU_OVERLAP`*                                 |                                                            |
-|           16 |*`CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT`*                        |*`hipDeviceAttributeMultiprocessorCount`*                   |
-|           17 |*`CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT`*                         |*`hipDeviceAttributeKernelExecTimeout`*                     |
-|           18 |*`CU_DEVICE_ATTRIBUTE_INTEGRATED`*                                  |*`hipDeviceAttributeIntegrated`*                            |
-|           19 |*`CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY`*                         |*`hipDeviceAttributeCanMapHostMemory`*                      |
-|           20 |*`CU_DEVICE_ATTRIBUTE_COMPUTE_MODE`*                                |*`hipDeviceAttributeComputeMode`*                           |
-|           21 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH`*                     |                                                            |
-|           22 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH`*                     |                                                            |
-|           23 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT`*                    |                                                            |
-|           24 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH`*                     |                                                            |
-|           25 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT`*                    |                                                            |
-|           26 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH`*                     |                                                            |
-|           27 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH`*             |                                                            |
-|           28 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT`*            |                                                            |
-|           29 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS`*            |                                                            |
-|           27 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_WIDTH`*               |                                                            |
-|           28 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_HEIGHT`*              |                                                            |
-|           29 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_NUMSLICES`*           |                                                            |
-|           30 |*`CU_DEVICE_ATTRIBUTE_SURFACE_ALIGNMENT`*                           |                                                            |
-|           31 |*`CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS`*                          |*`hipDeviceAttributeConcurrentKernels`*                     |
-|           32 |*`CU_DEVICE_ATTRIBUTE_ECC_ENABLED`*                                 |*`hipDeviceAttributeEccEnabled`*                            |
-|           33 |*`CU_DEVICE_ATTRIBUTE_PCI_BUS_ID`*                                  |*`hipDeviceAttributePciBusId`*                              |
-|           34 |*`CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID`*                               |*`hipDeviceAttributePciDeviceId`*                           |
-|           35 |*`CU_DEVICE_ATTRIBUTE_TCC_DRIVER`*                                  |                                                            |
-|           36 |*`CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE`*                           |*`hipDeviceAttributeMemoryClockRate`*                       |
-|           37 |*`CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH`*                     |*`hipDeviceAttributeMemoryBusWidth`*                        |
-|           38 |*`CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE`*                               |*`hipDeviceAttributeL2CacheSize`*                           |
-|           39 |*`CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR`*              |*`hipDeviceAttributeMaxThreadsPerMultiProcessor`*           |
-|           40 |*`CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT`*                          |                                                            |
-|           41 |*`CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING`*                          |                                                            |
-|           42 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_WIDTH`*             |                                                            |
-|           43 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_LAYERS`*            |                                                            |
-|           44 |*`CU_DEVICE_ATTRIBUTE_CAN_TEX2D_GATHER`*                            |                                                            |
-|           45 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_WIDTH`*              |                                                            |
-|           46 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_HEIGHT`*             |                                                            |
-|           47 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH_ALTERNATE`*           |                                                            |
-|           48 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT_ALTERNATE`*          |                                                            |
-|           49 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH_ALTERNATE`*           |                                                            |
-|           50 |*`CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID`*                               |                                                            |
-|           51 |*`CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT`*                     |                                                            |
-|           52 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_WIDTH`*                |                                                            |
-|           53 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_WIDTH`*        |                                                            |
-|           54 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_LAYERS`*       |                                                            |
-|           55 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH`*                     |                                                            |
-|           56 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH`*                     |                                                            |
-|           57 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT`*                    |                                                            |
-|           58 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH`*                     |                                                            |
-|           59 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT`*                    |                                                            |
-|           60 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH`*                     |                                                            |
-|           61 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_WIDTH`*             |                                                            |
-|           62 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_LAYERS`*            |                                                            |
-|           63 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_WIDTH`*             |                                                            |
-|           64 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_HEIGHT`*            |                                                            |
-|           65 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_LAYERS`*            |                                                            |
-|           66 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_WIDTH`*                |                                                            |
-|           67 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_WIDTH`*        |                                                            |
-|           68 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_LAYERS`*       |                                                            |
-|           69 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LINEAR_WIDTH`*              |                                                            |
-|           70 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH`*              |                                                            |
-|           71 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT`*             |                                                            |
-|           72 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH`*              |                                                            |
-|           73 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_WIDTH`*           |                                                            |
-|           74 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_HEIGHT`*          |                                                            |
-|           75 |*`CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR`*                    |*`hipDeviceAttributeComputeCapabilityMajor`*                |
-|           76 |*`CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR`*                    |*`hipDeviceAttributeComputeCapabilityMinor`*                |
-|           77 |*`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_MIPMAPPED_WIDTH`*           |                                                            |
-|           78 |*`CU_DEVICE_ATTRIBUTE_STREAM_PRIORITIES_SUPPORTED`*                 |                                                            |
-|           79 |*`CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED`*                   |                                                            |
-|           80 |*`CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED`*                    |                                                            |
-|           81 |*`CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR`*        |*`hipDeviceAttributeMaxSharedMemoryPerMultiprocessor`*      |
-|           82 |*`CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR`*            |                                                            |
-|           83 |*`CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY`*                              |                                                            |
-|           84 |*`CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD`*                             |*`hipDeviceAttributeIsMultiGpuBoard`*                       |
-|           85 |*`CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID`*                    |                                                            |
-|           86 |*`CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED`*                |                                                            | 8.0              |
-|           87 |*`CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO`*       |                                                            | 8.0              |
-|           88 |*`CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS`*                      |                                                            | 8.0              |
-|           89 |*`CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS`*                   |                                                            | 8.0              |
-|           90 |*`CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED`*                |                                                            | 8.0              |
-|           91 |*`CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM`*     |                                                            | 8.0              |
-|           92 |*`CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS`*                      |                                                            | 9.0              |
-|           93 |*`CU_DEVICE_ATTRIBUTE_CAN_USE_64_BIT_STREAM_MEM_OPS`*               |                                                            | 9.0              |
-|           94 |*`CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_WAIT_VALUE_NOR`*               |                                                            | 9.0              |
-|           95 |*`CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH`*                          |*`hipDeviceAttributeCooperativeLaunch`*                     | 9.0              |
-|           96 |*`CU_DEVICE_ATTRIBUTE_COOPERATIVE_MULTI_DEVICE_LAUNCH`*             |*`hipDeviceAttributeCooperativeMultiDeviceLaunch`*          | 9.0              |
-|           97 |*`CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN`*           |                                                            | 9.0              |
-|           98 |*`CU_DEVICE_ATTRIBUTE_CAN_FLUSH_REMOTE_WRITES`*                     |                                                            | 9.2              |
-|           99 |*`CU_DEVICE_ATTRIBUTE_HOST_REGISTER_SUPPORTED`*                     |                                                            | 9.2              |
-|          100 |*`CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES`*|                                                            | 9.2              |
-|          101 |*`CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST`*         |                                                            | 9.2              |
-|          102 |*`CU_DEVICE_ATTRIBUTE_VIRTUAL_ADDRESS_MANAGEMENT_SUPPORTED`*        |                                                            | 10.2             |
-|          103 |*`CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR_SUPPORTED`* |                                                            | 10.2             |
-|          104 |*`CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_WIN32_HANDLE_SUPPORTED`*          |                                                            | 10.2             |
-|          105 |*`CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_WIN32_KMT_HANDLE_SUPPORTED`*      |                                                            | 10.2             |
-|          106 |*`CU_DEVICE_ATTRIBUTE_MAX_BLOCKS_PER_MULTIPROCESSOR`*               |                                                            | 11.0             |
-|          107 |*`CU_DEVICE_ATTRIBUTE_GENERIC_COMPRESSION_SUPPORTED`*               |                                                            | 11.0             |
-|          108 |*`CU_DEVICE_ATTRIBUTE_MAX_PERSISTING_L2_CACHE_SIZE`*                |                                                            | 11.0             |
-|          109 |*`CU_DEVICE_ATTRIBUTE_MAX_ACCESS_POLICY_WINDOW_SIZE`*               |                                                            | 11.0             |
-|          110 |*`CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED`*     |                                                            | 11.0             |
-|          111 |*`CU_DEVICE_ATTRIBUTE_RESERVED_SHARED_MEMORY_PER_BLOCK`*            |                                                            | 11.0             |
-|          112 |*`CU_DEVICE_ATTRIBUTE_MAX`*                                         |                                                            |
-| enum         |***`CUevent_flags`***                                               |                                                            |
-| typedef      |***`CUevent_flags_enum`***                                          |                                                            |
-|         0x00 |*`CU_EVENT_DEFAULT`*                                                |*`hipEventDefault`*                                         |
-|         0x01 |*`CU_EVENT_BLOCKING_SYNC`*                                          |*`hipEventBlockingSync`*                                    |
-|         0x02 |*`CU_EVENT_DISABLE_TIMING`*                                         |*`hipEventDisableTiming`*                                   |
-|         0x04 |*`CU_EVENT_INTERPROCESS`*                                           |*`hipEventInterprocess`*                                    |
-| enum         |***`CUfilter_mode`***                                               |***`hipTextureFilterMode`***                                |
-| typedef      |***`CUfilter_mode_enum`***                                          |***`hipTextureFilterMode`***                                |
-|            0 |*`CU_TR_FILTER_MODE_POINT`*                                         |*`hipFilterModePoint`*                                      |
-|            1 |*`CU_TR_FILTER_MODE_LINEAR`*                                        |*`hipFilterModeLinear`*                                     |
-| enum         |***`CUfunc_cache`***                                                |***`hipFuncCache_t`***                                      |
-| typedef      |***`CUfunc_cache_enum`***                                           |***`hipFuncCache_t`***                                      |
-|         0x00 |*`CU_FUNC_CACHE_PREFER_NONE`*                                       |*`hipFuncCachePreferNone`*                                  |
-|         0x01 |*`CU_FUNC_CACHE_PREFER_SHARED`*                                     |*`hipFuncCachePreferShared`*                                |
-|         0x02 |*`CU_FUNC_CACHE_PREFER_L1`*                                         |*`hipFuncCachePreferL1`*                                    |
-|         0x03 |*`CU_FUNC_CACHE_PREFER_EQUAL`*                                      |*`hipFuncCachePreferEqual`*                                 |
-| enum         |***`CUfunction_attribute`***                                        |***`hipFunction_attribute`***                               |
-| typedef      |***`CUfunction_attribute_enum`***                                   |***`hipFunction_attribute`***                               |
-|            0 |*`CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK`*                         |*`HIP_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK`*                |
-|            1 |*`CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES`*                             |*`HIP_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES`*                    |
-|            2 |*`CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES`*                              |*`HIP_FUNC_ATTRIBUTE_CONST_SIZE_BYTES`*                     |
-|            3 |*`CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES`*                              |*`HIP_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES`*                     |
-|            4 |*`CU_FUNC_ATTRIBUTE_NUM_REGS`*                                      |*`HIP_FUNC_ATTRIBUTE_NUM_REGS`*                             |
-|            5 |*`CU_FUNC_ATTRIBUTE_PTX_VERSION`*                                   |*`HIP_FUNC_ATTRIBUTE_PTX_VERSION`*                          |
-|            6 |*`CU_FUNC_ATTRIBUTE_BINARY_VERSION`*                                |*`HIP_FUNC_ATTRIBUTE_BINARY_VERSION`*                       |
-|            7 |*`CU_FUNC_ATTRIBUTE_CACHE_MODE_CA`*                                 |*`HIP_FUNC_ATTRIBUTE_CACHE_MODE_CA`*                        |
-|            8 |*`CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES`*                 |*`HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES`*        | 9.0              |
-|            9 |*`CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT`*              |*`HIP_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT`*     | 9.0              |
-|           10 |*`CU_FUNC_ATTRIBUTE_MAX`*                                           |*`HIP_FUNC_ATTRIBUTE_MAX`*                                  |
-| enum         |***`CUgraphicsMapResourceFlags`***                                  |                                                            |
-| typedef      |***`CUgraphicsMapResourceFlags_enum`***                             |                                                            |
-|         0x00 |*`CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE`*                             |                                                            |
-|         0x01 |*`CU_GRAPHICS_MAP_RESOURCE_FLAGS_READ_ONLY`*                        |                                                            |
-|         0x02 |*`CU_GRAPHICS_MAP_RESOURCE_FLAGS_WRITE_DISCARD`*                    |                                                            |
-| enum         |***`CUgraphicsRegisterFlags`***                                     |                                                            |
-| typedef      |***`CUgraphicsRegisterFlags_enum`***                                |                                                            |
-|         0x00 |*`CU_GRAPHICS_REGISTER_FLAGS_NONE`*                                 |                                                            |
-|         0x01 |*`CU_GRAPHICS_REGISTER_FLAGS_READ_ONLY`*                            |                                                            |
-|         0x02 |*`CU_GRAPHICS_REGISTER_FLAGS_WRITE_DISCARD`*                        |                                                            |
-|         0x04 |*`CU_GRAPHICS_REGISTER_FLAGS_SURFACE_LDST`*                         |                                                            |
-|         0x08 |*`CU_GRAPHICS_REGISTER_FLAGS_TEXTURE_GATHER`*                       |                                                            |
-| enum         |***`CUipcMem_flags`***                                              |                                                            |
-| typedef      |***`CUipcMem_flags_enum`***                                         |                                                            |
-|          0x1 |*`CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS`*                              |*`hipIpcMemLazyEnablePeerAccess`*                           |
-| enum         |***`CUjit_cacheMode`***                                             |                                                            |
-| typedef      |***`CUjit_cacheMode_enum`***                                        |                                                            |
-|            0 |*`CU_JIT_CACHE_OPTION_NONE`*                                        |                                                            |
-|              |*`CU_JIT_CACHE_OPTION_CG`*                                          |                                                            |
-|              |*`CU_JIT_CACHE_OPTION_CA`*                                          |                                                            |
-| enum         |***`CUjit_fallback`***                                              |                                                            |
-| typedef      |***`CUjit_fallback_enum`***                                         |                                                            |
-|            0 |*`CU_PREFER_PTX`*                                                   |                                                            |
-|              |*`CU_PREFER_BINARY`*                                                |                                                            |
-| enum         |***`CUjit_option`***                                                |                                                            |
-| typedef      |***`CUjit_option_enum`***                                           |                                                            |
-|            0 |*`CU_JIT_MAX_REGISTERS`*                                            |                                                            |
-|              |*`CU_JIT_THREADS_PER_BLOCK`*                                        |                                                            |
-|              |*`CU_JIT_WALL_TIME`*                                                |                                                            |
-|              |*`CU_JIT_INFO_LOG_BUFFER`*                                          |                                                            |
-|              |*`CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES`*                               |                                                            |
-|              |*`CU_JIT_ERROR_LOG_BUFFER`*                                         |                                                            |
-|              |*`CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES`*                              |                                                            |
-|              |*`CU_JIT_OPTIMIZATION_LEVEL`*                                       |                                                            |
-|              |*`CU_JIT_TARGET_FROM_CUCONTEXT`*                                    |                                                            |
-|              |*`CU_JIT_TARGET`*                                                   |                                                            |
-|              |*`CU_JIT_FALLBACK_STRATEGY`*                                        |                                                            |
-|              |*`CU_JIT_GENERATE_DEBUG_INFO`*                                      |                                                            |
-|              |*`CU_JIT_LOG_VERBOSE`*                                              |                                                            |
-|              |*`CU_JIT_GENERATE_LINE_INFO`*                                       |                                                            |
-|              |*`CU_JIT_CACHE_MODE`*                                               |                                                            |
-|              |*`CU_JIT_NEW_SM3X_OPT`*                                             |                                                            | 8.0              |
-|              |*`CU_JIT_FAST_COMPILE`*                                             |                                                            | 8.0              |
-|              |*`CU_JIT_GLOBAL_SYMBOL_NAMES`*                                      |                                                            | 10.0             |
-|              |*`CU_JIT_GLOBAL_SYMBOL_ADDRESSES`*                                  |                                                            | 10.0             |
-|              |*`CU_JIT_GLOBAL_SYMBOL_COUNT`*                                      |                                                            | 10.0             |
-|              |*`CU_JIT_NUM_OPTIONS`*                                              |                                                            |
-| enum         |***`CUjit_target`***                                                |                                                            |
-| typedef      |***`CUjit_target_enum`***                                           |                                                            |
-|           10 |*`CU_TARGET_COMPUTE_10`*                                            |                                                            |
-|           11 |*`CU_TARGET_COMPUTE_11`*                                            |                                                            |
-|           12 |*`CU_TARGET_COMPUTE_12`*                                            |                                                            |
-|           13 |*`CU_TARGET_COMPUTE_13`*                                            |                                                            |
-|           20 |*`CU_TARGET_COMPUTE_20`*                                            |                                                            |
-|           21 |*`CU_TARGET_COMPUTE_21`*                                            |                                                            |
-|           30 |*`CU_TARGET_COMPUTE_30`*                                            |                                                            |
-|           32 |*`CU_TARGET_COMPUTE_32`*                                            |                                                            |
-|           35 |*`CU_TARGET_COMPUTE_35`*                                            |                                                            |
-|           37 |*`CU_TARGET_COMPUTE_37`*                                            |                                                            |
-|           50 |*`CU_TARGET_COMPUTE_50`*                                            |                                                            |
-|           52 |*`CU_TARGET_COMPUTE_52`*                                            |                                                            |
-|           53 |*`CU_TARGET_COMPUTE_53`*                                            |                                                            | 8.0              |
-|           60 |*`CU_TARGET_COMPUTE_60`*                                            |                                                            | 8.0              |
-|           61 |*`CU_TARGET_COMPUTE_61`*                                            |                                                            | 8.0              |
-|           62 |*`CU_TARGET_COMPUTE_62`*                                            |                                                            | 8.0              |
-|           70 |*`CU_TARGET_COMPUTE_70`*                                            |                                                            | 9.0              |
-|           72 |*`CU_TARGET_COMPUTE_72`*                                            |                                                            | 10.1             |
-|           73 |*`CU_TARGET_COMPUTE_73`*                                            |                                                            | 9.1 - 9.2        |
-|           75 |*`CU_TARGET_COMPUTE_75`*                                            |                                                            | 9.1              |
-|           80 |*`CU_TARGET_COMPUTE_80`*                                            |                                                            | 11.0             |
-| enum         |***`CUjitInputType`***                                              |                                                            |
-| typedef      |***`CUjitInputType_enum`***                                         |                                                            |
-|            0 |*`CU_JIT_INPUT_CUBIN`*                                              |                                                            |
-|              |*`CU_JIT_INPUT_PTX`*                                                |                                                            |
-|              |*`CU_JIT_INPUT_FATBINARY`*                                          |                                                            |
-|              |*`CU_JIT_INPUT_OBJECT`*                                             |                                                            |
-|              |*`CU_JIT_INPUT_LIBRARY`*                                            |                                                            |
-|              |*`CU_JIT_NUM_INPUT_TYPES`*                                          |                                                            |
-| enum         |***`CUlimit`***                                                     |***`hipLimit_t`***                                          |
-| typedef      |***`CUlimit_enum`***                                                |***`hipLimit_t`***                                          |
-|         0x00 |*`CU_LIMIT_STACK_SIZE`*                                             |                                                            |
-|         0x01 |*`CU_LIMIT_PRINTF_FIFO_SIZE`*                                       |                                                            |
-|         0x02 |*`CU_LIMIT_MALLOC_HEAP_SIZE`*                                       |*`hipLimitMallocHeapSize`*                                  |
-|         0x03 |*`CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH`*                                 |                                                            |
-|         0x04 |*`CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT`*                       |                                                            |
-|         0x05 |*`CU_LIMIT_MAX_L2_FETCH_GRANULARITY`*                               |                                                            | 10.0             |
-|         0x06 |*`CU_LIMIT_PERSISTING_L2_CACHE_SIZE`*                               |                                                            | 11.0             |
-|              |*`CU_LIMIT_MAX`*                                                    |                                                            |
-| enum         |***`CUmem_advise`***                                                |                                                            | 8.0              |
-| typedef      |***`CUmem_advise_enum`***                                           |                                                            | 8.0              |
-|            1 |*`CU_MEM_ADVISE_SET_READ_MOSTLY`*                                   |                                                            | 8.0              |
-|            2 |*`CU_MEM_ADVISE_UNSET_READ_MOSTLY`*                                 |                                                            | 8.0              |
-|            3 |*`CU_MEM_ADVISE_SET_PREFERRED_LOCATION`*                            |                                                            | 8.0              |
-|            4 |*`CU_MEM_ADVISE_UNSET_PREFERRED_LOCATION`*                          |                                                            | 8.0              |
-|            5 |*`CU_MEM_ADVISE_SET_ACCESSED_BY`*                                   |                                                            | 8.0              |
-|            6 |*`CU_MEM_ADVISE_UNSET_ACCESSED_BY`*                                 |                                                            | 8.0              |
-| enum         |***`CUmemAttach_flags`***                                           |                                                            |
-| typedef      |***`CUmemAttach_flags_enum`***                                      |                                                            |
-|          0x1 |*`CU_MEM_ATTACH_GLOBAL`*                                            |*`hipMemAttachGlobal`*                                      |
-|          0x2 |*`CU_MEM_ATTACH_HOST`*                                              |*`hipMemAttachHost`*                                        |
-|          0x4 |*`CU_MEM_ATTACH_SINGLE`*                                            |                                                            |
-| enum         |***`CUmemorytype`***                                                |*`hipMemoryType`*                                           |
-| typedef      |***`CUmemorytype_enum`***                                           |*`hipMemoryType`*                                           |
-|         0x01 |*`CU_MEMORYTYPE_HOST`*                                              |*`hipMemoryTypeHost`*                                       |
-|         0x02 |*`CU_MEMORYTYPE_DEVICE`*                                            |*`hipMemoryTypeDevice`*                                     |
-|         0x03 |*`CU_MEMORYTYPE_ARRAY`*                                             |*`hipMemoryTypeArray`*                                      |
-|         0x04 |*`CU_MEMORYTYPE_UNIFIED`*                                           |*`hipMemoryTypeUnified`*                                    |
-| enum         |***`CUmem_range_attribute`***                                       |                                                            | 8.0              |
-| typedef      |***`CUmem_range_attribute_enum`***                                  |                                                            | 8.0              |
-|            1 |*`CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY`*                              |                                                            | 8.0              |
-|            2 |*`CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION`*                       |                                                            | 8.0              |
-|            3 |*`CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY`*                              |                                                            | 8.0              |
-|            4 |*`CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION`*                   |                                                            | 8.0              |
-| enum         |***`CUcomputemode`***                                               |***`hipComputeMode`***                                      |
-| typedef      |***`CUcomputemode_enum`***                                          |***`hipComputeMode`***                                      |
-|            0 |*`CU_COMPUTEMODE_DEFAULT`*                                          |*`hipComputeModeDefault`*                                   |
-|            1 |*`CU_COMPUTEMODE_EXCLUSIVE`*                                        |*`hipComputeModeExclusive`*                                 |
-|            2 |*`CU_COMPUTEMODE_PROHIBITED`*                                       |*`hipComputeModeProhibited`*                                |
-|            3 |*`CU_COMPUTEMODE_EXCLUSIVE_PROCESS`*                                |*`hipComputeModeExclusiveProcess`*                          |
-| enum         |***`CUoccupancy_flags`***                                           |                                                            |
-| typedef      |***`CUoccupancy_flags_enum`***                                      |                                                            |
-|         0x00 |*`CU_OCCUPANCY_DEFAULT`*                                            |                                                            |
-|         0x01 |*`CU_OCCUPANCY_DISABLE_CACHING_OVERRIDE`*                           |                                                            |
-| enum         |***`CUpointer_attribute`***                                         |                                                            |
-| typedef      |***`CUpointer_attribute_enum`***                                    |                                                            |
-|            1 |*`CU_POINTER_ATTRIBUTE_CONTEXT`*                                    |                                                            |
-|            2 |*`CU_POINTER_ATTRIBUTE_MEMORY_TYPE`*                                |                                                            |
-|            3 |*`CU_POINTER_ATTRIBUTE_DEVICE_POINTER`*                             |                                                            |
-|            4 |*`CU_POINTER_ATTRIBUTE_HOST_POINTER`*                               |                                                            |
-|            5 |*`CU_POINTER_ATTRIBUTE_P2P_TOKENS`*                                 |                                                            |
-|            6 |*`CU_POINTER_ATTRIBUTE_SYNC_MEMOPS`*                                |                                                            |
-|            7 |*`CU_POINTER_ATTRIBUTE_BUFFER_ID`*                                  |                                                            |
-|            8 |*`CU_POINTER_ATTRIBUTE_IS_MANAGED`*                                 |                                                            |
-|            9 |*`CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL`*                             |                                                            | 9.2              |
-|           10 |*`CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE`*                 |                                                            | 10.2             |
-|           11 |*`CU_POINTER_ATTRIBUTE_RANGE_START_ADDR`*                           |                                                            | 10.2             |
-|           12 |*`CU_POINTER_ATTRIBUTE_RANGE_SIZE`*                                 |                                                            | 10.2             |
-|           13 |*`CU_POINTER_ATTRIBUTE_MAPPED`*                                     |                                                            | 10.2             |
-|           14 |*`CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES`*                       |                                                            | 10.2             |
-|           15 |*`CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE`*                 |                                                            | 11.0             |
-| enum         |***`CUresourcetype`***                                              |                                                            |
-| typedef      |***`CUresourcetype_enum`***                                         |                                                            |
-|         0x00 |*`CU_RESOURCE_TYPE_ARRAY`*                                          |                                                            |
-|         0x01 |*`CU_RESOURCE_TYPE_MIPMAPPED_ARRAY`*                                |                                                            |
-|         0x02 |*`CU_RESOURCE_TYPE_LINEAR`*                                         |                                                            |
-|         0x03 |*`CU_RESOURCE_TYPE_PITCH2D`*                                        |                                                            |
-| enum         |***`CUresourceViewFormat`***                                        |***`hipResourceViewFormat`***                               |
-| typedef      |***`CUresourceViewFormat_enum`***                                   |***`hipResourceViewFormat`***                               |
-|         0x00 |*`CU_RES_VIEW_FORMAT_NONE`*                                         |*`hipResViewFormatNone`*                                    |
-|         0x01 |*`CU_RES_VIEW_FORMAT_UINT_1X8`*                                     |*`hipResViewFormatUnsignedChar1`*                           |
-|         0x02 |*`CU_RES_VIEW_FORMAT_UINT_2X8`*                                     |*`hipResViewFormatUnsignedChar2`*                           |
-|         0x03 |*`CU_RES_VIEW_FORMAT_UINT_4X8`*                                     |*`hipResViewFormatUnsignedChar4`*                           |
-|         0x04 |*`CU_RES_VIEW_FORMAT_SINT_1X8`*                                     |*`hipResViewFormatSignedChar1`*                             |
-|         0x05 |*`CU_RES_VIEW_FORMAT_SINT_2X8`*                                     |*`hipResViewFormatSignedChar2`*                             |
-|         0x06 |*`CU_RES_VIEW_FORMAT_SINT_4X8`*                                     |*`hipResViewFormatSignedChar4`*                             |
-|         0x07 |*`CU_RES_VIEW_FORMAT_UINT_1X16`*                                    |*`hipResViewFormatUnsignedShort1`*                          |
-|         0x08 |*`CU_RES_VIEW_FORMAT_UINT_2X16`*                                    |*`hipResViewFormatUnsignedShort2`*                          |
-|         0x09 |*`CU_RES_VIEW_FORMAT_UINT_4X16`*                                    |*`hipResViewFormatUnsignedShort4`*                          |
-|         0x0a |*`CU_RES_VIEW_FORMAT_SINT_1X16`*                                    |*`hipResViewFormatSignedShort1`*                            |
-|         0x0b |*`CU_RES_VIEW_FORMAT_SINT_2X16`*                                    |*`hipResViewFormatSignedShort2`*                            |
-|         0x0c |*`CU_RES_VIEW_FORMAT_SINT_4X16`*                                    |*`hipResViewFormatSignedShort4`*                            |
-|         0x0d |*`CU_RES_VIEW_FORMAT_UINT_1X32`*                                    |*`hipResViewFormatUnsignedInt1`*                            |
-|         0x0e |*`CU_RES_VIEW_FORMAT_UINT_2X32`*                                    |*`hipResViewFormatUnsignedInt2`*                            |
-|         0x0f |*`CU_RES_VIEW_FORMAT_UINT_4X32`*                                    |*`hipResViewFormatUnsignedInt4`*                            |
-|         0x10 |*`CU_RES_VIEW_FORMAT_SINT_1X32`*                                    |*`hipResViewFormatSignedInt1`*                              |
-|         0x11 |*`CU_RES_VIEW_FORMAT_SINT_2X32`*                                    |*`hipResViewFormatSignedInt2`*                              |
-|         0x12 |*`CU_RES_VIEW_FORMAT_SINT_4X32`*                                    |*`hipResViewFormatSignedInt4`*                              |
-|         0x13 |*`CU_RES_VIEW_FORMAT_FLOAT_1X16`*                                   |*`hipResViewFormatHalf1`*                                   |
-|         0x14 |*`CU_RES_VIEW_FORMAT_FLOAT_2X16`*                                   |*`hipResViewFormatHalf2`*                                   |
-|         0x15 |*`CU_RES_VIEW_FORMAT_FLOAT_4X16`*                                   |*`hipResViewFormatHalf4`*                                   |
-|         0x16 |*`CU_RES_VIEW_FORMAT_FLOAT_1X32`*                                   |*`hipResViewFormatFloat1`*                                  |
-|         0x17 |*`CU_RES_VIEW_FORMAT_FLOAT_2X32`*                                   |*`hipResViewFormatFloat2`*                                  |
-|         0x18 |*`CU_RES_VIEW_FORMAT_FLOAT_4X32`*                                   |*`hipResViewFormatFloat4`*                                  |
-|         0x19 |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC1`*                                 |*`hipResViewFormatUnsignedBlockCompressed1`*                |
-|         0x1a |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC2`*                                 |*`hipResViewFormatUnsignedBlockCompressed2`*                |
-|         0x1b |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC3`*                                 |*`hipResViewFormatUnsignedBlockCompressed3`*                |
-|         0x1c |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC4`*                                 |*`hipResViewFormatUnsignedBlockCompressed4`*                |
-|         0x1d |*`CU_RES_VIEW_FORMAT_SIGNED_BC4`*                                   |*`hipResViewFormatSignedBlockCompressed4`*                  |
-|         0x1e |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC5`*                                 |*`hipResViewFormatUnsignedBlockCompressed5`*                |
-|         0x1f |*`CU_RES_VIEW_FORMAT_SIGNED_BC5`*                                   |*`hipResViewFormatSignedBlockCompressed5`*                  |
-|         0x20 |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC6H`*                                |*`hipResViewFormatUnsignedBlockCompressed6H`*               |
-|         0x21 |*`CU_RES_VIEW_FORMAT_SIGNED_BC6H`*                                  |*`hipResViewFormatSignedBlockCompressed6H`*                 |
-|         0x22 |*`CU_RES_VIEW_FORMAT_UNSIGNED_BC7`*                                 |*`hipResViewFormatUnsignedBlockCompressed7`*                |
-| enum         |***`CUresult`***                                                    |***`hipError_t`***                                          |
-| typedef      |`cudaError_enum`                                                    |***`hipError_t`***                                          |
-|            0 |*`CUDA_SUCCESS`*                                                    |*`hipSuccess`*                                              |
-|            1 |*`CUDA_ERROR_INVALID_VALUE`*                                        |*`hipErrorInvalidValue`*                                    |
-|            2 |*`CUDA_ERROR_OUT_OF_MEMORY`*                                        |*`hipErrorOutOfMemory`*                                     |
-|            3 |*`CUDA_ERROR_NOT_INITIALIZED`*                                      |*`hipErrorNotInitialized`*                                  |
-|            4 |*`CUDA_ERROR_DEINITIALIZED`*                                        |*`hipErrorDeinitialized`*                                   |
-|            5 |*`CUDA_ERROR_PROFILER_DISABLED`*                                    |*`hipErrorProfilerDisabled`*                                |
-|            6 |*`CUDA_ERROR_PROFILER_NOT_INITIALIZED`*                             |*`hipErrorProfilerNotInitialized`*                          |
-|            7 |*`CUDA_ERROR_PROFILER_ALREADY_STARTED`*                             |*`hipErrorProfilerAlreadyStarted`*                          |
-|            8 |*`CUDA_ERROR_PROFILER_ALREADY_STOPPED`*                             |*`hipErrorProfilerAlreadyStopped`*                          |
-|          100 |*`CUDA_ERROR_NO_DEVICE`*                                            |*`hipErrorNoDevice`*                                        |
-|          101 |*`CUDA_ERROR_INVALID_DEVICE`*                                       |*`hipErrorInvalidDevice`*                                   |
-|          200 |*`CUDA_ERROR_INVALID_IMAGE`*                                        |*`hipErrorInvalidImage`*                                    |
-|          201 |*`CUDA_ERROR_INVALID_CONTEXT`*                                      |*`hipErrorInvalidContext`*                                  |
-|          202 |*`CUDA_ERROR_CONTEXT_ALREADY_CURRENT`*                              |*`hipErrorContextAlreadyCurrent`*                           |
-|          205 |*`CUDA_ERROR_MAP_FAILED`*                                           |*`hipErrorMapFailed`*                                       |
-|          206 |*`CUDA_ERROR_UNMAP_FAILED`*                                         |*`hipErrorUnmapFailed`*                                     |
-|          207 |*`CUDA_ERROR_ARRAY_IS_MAPPED`*                                      |*`hipErrorArrayIsMapped`*                                   |
-|          208 |*`CUDA_ERROR_ALREADY_MAPPED`*                                       |*`hipErrorAlreadyMapped`*                                   |
-|          209 |*`CUDA_ERROR_NO_BINARY_FOR_GPU`*                                    |*`hipErrorNoBinaryForGpu`*                                  |
-|          210 |*`CUDA_ERROR_ALREADY_ACQUIRED`*                                     |*`hipErrorAlreadyAcquired`*                                 |
-|          211 |*`CUDA_ERROR_NOT_MAPPED`*                                           |*`hipErrorNotMapped`*                                       |
-|          212 |*`CUDA_ERROR_NOT_MAPPED_AS_ARRAY`*                                  |*`hipErrorNotMappedAsArray`*                                |
-|          213 |*`CUDA_ERROR_NOT_MAPPED_AS_POINTER`*                                |*`hipErrorNotMappedAsPointer`*                              |
-|          214 |*`CUDA_ERROR_ECC_UNCORRECTABLE`*                                    |*`hipErrorECCNotCorrectable`*                               |
-|          215 |*`CUDA_ERROR_UNSUPPORTED_LIMIT`*                                    |*`hipErrorUnsupportedLimit`*                                |
-|          216 |*`CUDA_ERROR_CONTEXT_ALREADY_IN_USE`*                               |*`hipErrorContextAlreadyInUse`*                             |
-|          217 |*`CUDA_ERROR_PEER_ACCESS_UNSUPPORTED`*                              |*`hipErrorPeerAccessUnsupported`*                           |
-|          218 |*`CUDA_ERROR_INVALID_PTX`*                                          |*`hipErrorInvalidKernelFile`*                               |
-|          219 |*`CUDA_ERROR_INVALID_GRAPHICS_CONTEXT`*                             |*`hipErrorInvalidGraphicsContext`*                          |
-|          220 |*`CUDA_ERROR_NVLINK_UNCORRECTABLE`*                                 |                                                            | 8.0              |
-|          221 |*`CUDA_ERROR_JIT_COMPILER_NOT_FOUND`*                               |                                                            | 9.0              |
-|          300 |*`CUDA_ERROR_INVALID_SOURCE`*                                       |*`hipErrorInvalidSource`*                                   |
-|          301 |*`CUDA_ERROR_FILE_NOT_FOUND`*                                       |*`hipErrorFileNotFound`*                                    |
-|          302 |*`CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND`*                       |*`hipErrorSharedObjectSymbolNotFound`*                      |
-|          303 |*`CUDA_ERROR_SHARED_OBJECT_INIT_FAILED`*                            |*`hipErrorSharedObjectInitFailed`*                          |
-|          304 |*`CUDA_ERROR_OPERATING_SYSTEM`*                                     |*`hipErrorOperatingSystem`*                                 |
-|          400 |*`CUDA_ERROR_INVALID_HANDLE`*                                       |*`hipErrorInvalidHandle`*                                   |
-|          401 |*`CUDA_ERROR_ILLEGAL_STATE`*                                        |                                                            | 10.0             |
-|          500 |*`CUDA_ERROR_NOT_FOUND`*                                            |*`hipErrorNotFound`*                                        |
-|          600 |*`CUDA_ERROR_NOT_READY`*                                            |*`hipErrorNotReady`*                                        |
-|          700 |*`CUDA_ERROR_ILLEGAL_ADDRESS`*                                      |*`hipErrorIllegalAddress`*                                  |
-|          701 |*`CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES`*                              |*`hipErrorLaunchOutOfResources`*                            |
-|          702 |*`CUDA_ERROR_LAUNCH_TIMEOUT`*                                       |*`hipErrorLaunchTimeOut`*                                   |
-|          703 |*`CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING`*                        |                                                            |
-|          704 |*`CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED`*                          |*`hipErrorPeerAccessAlreadyEnabled`*                        |
-|          705 |*`CUDA_ERROR_PEER_ACCESS_NOT_ENABLED`*                              |*`hipErrorPeerAccessNotEnabled`*                            |
-|          708 |*`CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE`*                               |*`hipErrorSetOnActiveProcess`*                              |
-|          709 |*`CUDA_ERROR_CONTEXT_IS_DESTROYED`*                                 |                                                            |
-|          710 |*`CUDA_ERROR_ASSERT`*                                               |*`hipErrorAssert`*                                          |
-|          711 |*`CUDA_ERROR_TOO_MANY_PEERS`*                                       |                                                            |
-|          712 |*`CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED`*                       |*`hipErrorHostMemoryAlreadyRegistered`*                     |
-|          713 |*`CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED`*                           |*`hipErrorHostMemoryNotRegistered`*                         |
-|          714 |*`CUDA_ERROR_HARDWARE_STACK_ERROR`*                                 |                                                            |
-|          715 |*`CUDA_ERROR_ILLEGAL_INSTRUCTION`*                                  |                                                            |
-|          716 |*`CUDA_ERROR_MISALIGNED_ADDRESS`*                                   |                                                            |
-|          717 |*`CUDA_ERROR_INVALID_ADDRESS_SPACE`*                                |                                                            |
-|          718 |*`CUDA_ERROR_INVALID_PC`*                                           |                                                            |
-|          719 |*`CUDA_ERROR_LAUNCH_FAILED`*                                        |*`hipErrorLaunchFailure`*                                   |
-|          720 |*`CUDA_ERROR_COOPERATIVE_LAUNCH_TOO_LARGE`*                         |*`hipErrorCooperativeLaunchTooLarge`*                       |
-|          800 |*`CUDA_ERROR_NOT_PERMITTED`*                                        |                                                            |
-|          801 |*`CUDA_ERROR_NOT_SUPPORTED`*                                        |*`hipErrorNotSupported`*                                    |
-|          802 |*`CUDA_ERROR_SYSTEM_NOT_READY`*                                     |                                                            | 10.0             |
-|          803 |*`CUDA_ERROR_SYSTEM_DRIVER_MISMATCH`*                               |                                                            | 10.1             |
-|          804 |*`CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE`*                       |                                                            | 10.1             |
-|          900 |*`CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED`*                           |                                                            | 10.0             |
-|          901 |*`CUDA_ERROR_STREAM_CAPTURE_INVALIDATED`*                           |                                                            | 10.0             |
-|          902 |*`CUDA_ERROR_STREAM_CAPTURE_MERGE`*                                 |                                                            | 10.0             |
-|          903 |*`CUDA_ERROR_STREAM_CAPTURE_UNMATCHED`*                             |                                                            | 10.0             |
-|          904 |*`CUDA_ERROR_STREAM_CAPTURE_UNJOINED`*                              |                                                            | 10.0             |
-|          905 |*`CUDA_ERROR_STREAM_CAPTURE_ISOLATION`*                             |                                                            | 10.0             |
-|          906 |*`CUDA_ERROR_STREAM_CAPTURE_IMPLICIT`*                              |                                                            | 10.0             |
-|          907 |*`CUDA_ERROR_CAPTURED_EVENT`*                                       |                                                            | 10.0             |
-|          908 |*`CUDA_ERROR_STREAM_CAPTURE_WRONG_THREAD`*                          |                                                            | 10.1             |
-|          909 |*`CUDA_ERROR_TIMEOUT`*                                              |                                                            | 10.2             |
-|          910 |*`CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE`*                            |                                                            | 10.2             |
-|          999 |*`CUDA_ERROR_UNKNOWN`*                                              |*`hipErrorUnknown`*                                         |
-| enum         |***`CUsharedconfig`***                                              |***`hipSharedMemConfig`***                                  |
-| typedef      |***`CUsharedconfig_enum`***                                         |***`hipSharedMemConfig`***                                  |
-|         0x00 |*`CU_SHARED_MEM_CONFIG_DEFAULT_BANK_SIZE`*                          |*`hipSharedMemBankSizeDefault`*                             |
-|         0x01 |*`CU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE`*                        |*`hipSharedMemBankSizeFourByte`*                            |
-|         0x02 |*`CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE`*                       |*`hipSharedMemBankSizeEightByte`*                           |
-| enum         |***`CUshared_carveout`***                                           |                                                            | 9.0              |
-| typedef      |***`CUshared_carveout_enum`***                                      |                                                            | 9.0              |
-|           -1 |*`CU_SHAREDMEM_CARVEOUT_DEFAULT`*                                   |                                                            | 9.0              |
-|          100 |*`CU_SHAREDMEM_CARVEOUT_MAX_SHARED`*                                |                                                            | 9.0              |
-|            0 |*`CU_SHAREDMEM_CARVEOUT_MAX_L1`*                                    |                                                            | 9.0              |
-| enum         |***`CUstream_flags`***                                              |                                                            |
-| typedef      |***`CUstream_flags_enum`***                                         |                                                            |
-|          0x0 |*`CU_STREAM_DEFAULT`*                                               |*`hipStreamDefault`*                                        |
-|          0x1 |*`CU_STREAM_NON_BLOCKING`*                                          |*`hipStreamNonBlocking`*                                    |
-| enum         |***`CUstreamBatchMemOpType`***                                      |                                                            | 8.0              |
-| typedef      |***`CUstreamBatchMemOpType_enum`***                                 |                                                            | 8.0              |
-|            1 |*`CU_STREAM_MEM_OP_WAIT_VALUE_32`*                                  |                                                            | 8.0              |
-|            2 |*`CU_STREAM_MEM_OP_WRITE_VALUE_32`*                                 |                                                            | 8.0              |
-|            3 |*`CU_STREAM_MEM_OP_FLUSH_REMOTE_WRITES`*                            |                                                            | 8.0              |
-|            4 |*`CU_STREAM_MEM_OP_WAIT_VALUE_64`*                                  |                                                            | 9.0              |
-|            5 |*`CU_STREAM_MEM_OP_WRITE_VALUE_64`*                                 |                                                            | 9.0              |
-| enum         |***`CUGLDeviceList`***                                              |                                                            |
-| typedef      |***`CUGLDeviceList_enum`***                                         |                                                            |
-|         0x01 |*`CU_GL_DEVICE_LIST_ALL`*                                           |                                                            |
-|         0x02 |*`CU_GL_DEVICE_LIST_CURRENT_FRAME`*                                 |                                                            |
-|         0x03 |*`CU_GL_DEVICE_LIST_NEXT_FRAME`*                                    |                                                            |
-| enum         |***`CUGLmap_flags`***                                               |                                                            |
-| typedef      |***`CUGLmap_flags_enum`***                                          |                                                            |
-|         0x00 |*`CU_GL_MAP_RESOURCE_FLAGS_NONE`*                                   |                                                            |
-|         0x01 |*`CU_GL_MAP_RESOURCE_FLAGS_READ_ONLY`*                              |                                                            |
-|         0x02 |*`CU_GL_MAP_RESOURCE_FLAGS_WRITE_DISCARD`*                          |                                                            |
-| enum         |***`CUd3d9DeviceList`***                                            |                                                            |
-| typedef      |***`CUd3d9DeviceList_enum`***                                       |                                                            |
-|         0x01 |*`CU_D3D9_DEVICE_LIST_ALL`*                                         |                                                            |
-|         0x02 |*`CU_D3D9_DEVICE_LIST_CURRENT_FRAME`*                               |                                                            |
-|         0x03 |*`CU_D3D9_DEVICE_LIST_NEXT_FRAME`*                                  |                                                            |
-| enum         |***`CUd3d9map_flags`***                                             |                                                            |
-| typedef      |***`CUd3d9map_flags_enum`***                                        |                                                            |
-|         0x00 |*`CU_D3D9_MAPRESOURCE_FLAGS_NONE`*                                  |                                                            |
-|         0x01 |*`CU_D3D9_MAPRESOURCE_FLAGS_READONLY`*                              |                                                            |
-|         0x02 |*`CU_D3D9_MAPRESOURCE_FLAGS_WRITEDISCARD`*                          |                                                            |
-| enum         |***`CUd3d9register_flags`***                                        |                                                            |
-| typedef      |***`CUd3d9register_flags_enum`***                                   |                                                            |
-|         0x00 |*`CU_D3D9_REGISTER_FLAGS_NONE`*                                     |                                                            |
-|         0x01 |*`CU_D3D9_REGISTER_FLAGS_ARRAY`*                                    |                                                            |
-| enum         |***`CUd3d10DeviceList`***                                           |                                                            |
-| typedef      |***`CUd3d10DeviceList_enum`***                                      |                                                            |
-|         0x01 |*`CU_D3D10_DEVICE_LIST_ALL`*                                        |                                                            |
-|         0x02 |*`CU_D3D10_DEVICE_LIST_CURRENT_FRAME`*                              |                                                            |
-|         0x03 |*`CU_D3D10_DEVICE_LIST_NEXT_FRAME`*                                 |                                                            |
-| enum         |***`CUd3d10map_flags`***                                            |                                                            |
-| typedef      |***`CUd3d10map_flags_enum`***                                       |                                                            |
-|         0x00 |*`CU_D3D10_MAPRESOURCE_FLAGS_NONE`*                                 |                                                            |
-|         0x01 |*`CU_D3D10_MAPRESOURCE_FLAGS_READONLY`*                             |                                                            |
-|         0x02 |*`CU_D3D10_MAPRESOURCE_FLAGS_WRITEDISCARD`*                         |                                                            |
-| enum         |***`CUd3d10register_flags`***                                       |                                                            |
-| typedef      |***`CUd3d10register_flags_enum`***                                  |                                                            |
-|         0x00 |*`CU_D3D10_REGISTER_FLAGS_NONE`*                                    |                                                            |
-|         0x01 |*`CU_D3D10_REGISTER_FLAGS_ARRAY`*                                   |                                                            |
-| enum         |***`CUd3d11DeviceList`***                                           |                                                            |
-| typedef      |***`CUd3d11DeviceList_enum`***                                      |                                                            |
-|         0x01 |*`CU_D3D11_DEVICE_LIST_ALL`*                                        |                                                            |
-|         0x02 |*`CU_D3D11_DEVICE_LIST_CURRENT_FRAME`*                              |                                                            |
-|         0x03 |*`CU_D3D11_DEVICE_LIST_NEXT_FRAME`*                                 |                                                            |
-| struct       |`CUarray_st`                                                        |`hipArray`                                                  |
-| typedef      |`CUarray`                                                           |`hipArray *`                                                |
-| struct       |`CUctx`                                                             |`ihipCtx_t`                                                 |
-| typedef      |`CUcontext_st`                                                      |`hipCtx_t`                                                  |
-| typedef      |`CUdevice`                                                          |`hipDevice_t`                                               |
-| typedef      |`CUdeviceptr`                                                       |`hipDeviceptr_t`                                            |
-| typedef      |`CUdeviceptr_v1`                                                    |`hipDeviceptr_t`                                            | 11.0             |
-| struct       |`CUeglStreamConnection_st`                                          |                                                            | 9.1              |
-| typedef      |`CUeglStreamConnection`                                             |                                                            | 9.1              |
-| typedef      |`CUevent`                                                           |`hipEvent_t`                                                |
-| struct       |`CUevent_st`                                                        |`ihipEvent_t`                                               |
-| typedef      |`CUfunction`                                                        |`hipFunction_t`                                             |
-| struct       |`CUfunc_st`                                                         |`ihipModuleSymbol_t`                                        |
-| typedef      |`CUgraphicsResource`                                                |                                                            |
-| struct       |`CUgraphicsResource_st`                                             |                                                            |
-| typedef      |`CUmipmappedArray`                                                  |`hipMipmappedArray_t`                                       |
-| struct       |`CUmipmappedArray_st`                                               |`hipMipmappedArray`                                         |
-| typedef      |`CUmodule`                                                          |`hipModule_t`                                               |
-| struct       |`CUmod_st`                                                          |`ihipModule_t`                                              |
-| typedef      |`CUstream`                                                          |`hipStream_t`                                               |
-| struct       |`CUstream_st`                                                       |`ihipStream_t`                                              |
-| typedef      |`CUstreamCallback`                                                  |`hipStreamCallback_t`                                       |
-| typedef      |`CUsurfObject`                                                      |`hipSurfaceObject_t`                                        |
-| typedef      |`CUsurfref`                                                         |                                                            |
-| struct       |`CUsurfref_st`                                                      |                                                            |
-| typedef      |`CUtexObject`                                                       |`hipTextureObject_t`                                        |
-| typedef      |`CUtexref`                                                          |                                                            |
-| struct       |`CUtexref_st`                                                       |`textureReference`                                          |
-| define       |`CU_IPC_HANDLE_SIZE`                                                |                                                            |
-| define       |`CU_LAUNCH_PARAM_BUFFER_POINTER`                                    |`HIP_LAUNCH_PARAM_BUFFER_POINTER`                           |
-| define       |`CU_LAUNCH_PARAM_BUFFER_SIZE`                                       |`HIP_LAUNCH_PARAM_BUFFER_SIZE`                              |
-| define       |`CU_LAUNCH_PARAM_END`                                               |`HIP_LAUNCH_PARAM_END`                                      |
-| define       |`CU_MEMHOSTALLOC_DEVICEMAP`                                         |`hipHostMallocMapped`                                       |
-| define       |`CU_MEMHOSTALLOC_PORTABLE`                                          |`hipHostMallocPortable`                                     |
-| define       |`CU_MEMHOSTALLOC_WRITECOMBINED`                                     |`hipHostMallocWriteCombined`                                |
-| define       |`CU_MEMHOSTREGISTER_DEVICEMAP`                                      |`hipHostRegisterMapped`                                     |
-| define       |`CU_MEMHOSTREGISTER_IOMEMORY`                                       |`hipHostRegisterIoMemory`                                   | 7.5              |
-| define       |`CU_MEMHOSTREGISTER_PORTABLE`                                       |`hipHostRegisterPortable`                                   |
-| define       |`CU_PARAM_TR_DEFAULT`                                               |                                                            |
-| define       |`CU_STREAM_LEGACY`                                                  |                                                            |
-| define       |`CU_STREAM_PER_THREAD`                                              |                                                            |
-| define       |`CU_TRSA_OVERRIDE_FORMAT`                                           |`HIP_TRSA_OVERRIDE_FORMAT`                                  |
-| define       |`CU_TRSF_NORMALIZED_COORDINATES`                                    |`HIP_TRSF_NORMALIZED_COORDINATES`                           |
-| define       |`CU_TRSF_READ_AS_INTEGER`                                           |`HIP_TRSF_READ_AS_INTEGER`                                  |
-| define       |`CU_TRSF_SRGB`                                                      |                                                            |
-| define       |`CUDA_ARRAY3D_2DARRAY`                                              |                                                            |
-| define       |`CUDA_ARRAY3D_CUBEMAP`                                              |`hipArrayCubemap`                                           |
-| define       |`CUDA_ARRAY3D_DEPTH_TEXTURE`                                        |                                                            |
-| define       |`CUDA_ARRAY3D_LAYERED`                                              |`hipArrayLayered`                                           |
-| define       |`CUDA_ARRAY3D_SURFACE_LDST`                                         |`hipArraySurfaceLoadStore`                                  |
-| define       |`CUDA_ARRAY3D_TEXTURE_GATHER`                                       |`hipArrayTextureGather`                                     |
-| define       |`CUDA_ARRAY3D_COLOR_ATTACHMENT`                                     |                                                            | 10.0             |
-| define       |`CUDA_VERSION`                                                      |                                                            |
-| typedef      |`CUexternalMemory`                                                  |                                                            | 10.0             |
-| struct       |`CUextMemory_st`                                                    |                                                            | 10.0             |
-| typedef      |`CUexternalSemaphore`                                               |                                                            | 10.0             |
-| struct       |`CUextSemaphore_st`                                                 |                                                            | 10.0             |
-| typedef      |`CUgraph`                                                           |                                                            | 10.0             |
-| struct       |`CUgraph_st`                                                        |                                                            | 10.0             |
-| typedef      |`CUgraphNode`                                                       |                                                            | 10.0             |
-| struct       |`CUgraphNode_st`                                                    |                                                            | 10.0             |
-| typedef      |`CUgraphExec`                                                       |                                                            | 10.0             |
-| struct       |`CUgraphExec_st`                                                    |                                                            | 10.0             |
-| typedef      |`CUhostFn`                                                          |                                                            | 10.0             |
-| typedef      |`CUoccupancyB2DSize`                                                |                                                            |
-| struct       |`CUDA_KERNEL_NODE_PARAMS`                                           |                                                            | 10.0             |
-| typedef      |`CUDA_KERNEL_NODE_PARAMS_st`                                        |                                                            | 10.0             |
-| struct       |`CUDA_LAUNCH_PARAMS`                                                |                                                            | 9.0              |
-| typedef      |`CUDA_LAUNCH_PARAMS_st`                                             |                                                            | 9.0              |
-| struct       |`CUDA_MEMSET_NODE_PARAMS`                                           |                                                            | 10.0             |
-| typedef      |`CUDA_MEMSET_NODE_PARAMS_st`                                        |                                                            | 10.0             |
-| struct       |`CUDA_HOST_NODE_PARAMS`                                             |                                                            | 10.0             |
-| typedef      |`CUDA_HOST_NODE_PARAMS_st`                                          |                                                            | 10.0             |
-| enum         |***`CUgraphNodeType`***                                             |                                                            | 10.0             |
-| typedef      |***`CUgraphNodeType_enum`***                                        |                                                            | 10.0             |
-|            0 |*`CU_GRAPH_NODE_TYPE_KERNEL`*                                       |                                                            | 10.0             |
-|            1 |*`CU_GRAPH_NODE_TYPE_MEMCPY`*                                       |                                                            | 10.0             |
-|            2 |*`CU_GRAPH_NODE_TYPE_MEMSET`*                                       |                                                            | 10.0             |
-|            3 |*`CU_GRAPH_NODE_TYPE_HOST`*                                         |                                                            | 10.0             |
-|            4 |*`CU_GRAPH_NODE_TYPE_GRAPH`*                                        |                                                            | 10.0             |
-|            5 |*`CU_GRAPH_NODE_TYPE_EMPTY`*                                        |                                                            | 10.0             |
-|            6 |*`CU_GRAPH_NODE_TYPE_COUNT`*                                        |                                                            | 10.0             |
-| enum         |***`CUstreamCaptureStatus`***                                       |                                                            | 10.0             |
-| typedef      |***`CUstreamCaptureStatus_enum`***                                  |                                                            | 10.0             |
-|            0 |*`CU_STREAM_CAPTURE_STATUS_NONE`*                                   |                                                            | 10.0             |
-|            1 |*`CU_STREAM_CAPTURE_STATUS_ACTIVE`*                                 |                                                            | 10.0             |
-|            2 |*`CU_STREAM_CAPTURE_STATUS_INVALIDATED`*                            |                                                            | 10.0             |
-| enum         |***`CUstreamCaptureMode`***                                         |                                                            | 10.1             |
-| typedef      |***`CUstreamCaptureMode_enum`***                                    |                                                            | 10.1             |
-|            0 |*`CU_STREAM_CAPTURE_MODE_GLOBAL`*                                   |                                                            | 10.1             |
-|            1 |*`CU_STREAM_CAPTURE_MODE_THREAD_LOCAL`*                             |                                                            | 10.1             |
-|            2 |*`CU_STREAM_CAPTURE_MODE_RELAXED`*                                  |                                                            | 10.1             |
-| enum         |***`CUstreamWaitValue_flags`***                                     |                                                            | 8.0              |
-| typedef      |***`CUstreamWaitValue_flags_enum`***                                |                                                            | 8.0              |
-|          0x0 |*`CU_STREAM_WAIT_VALUE_GEQ`*                                        |                                                            | 8.0              |
-|          0x1 |*`CU_STREAM_WAIT_VALUE_EQ`*                                         |                                                            | 8.0              |
-|          0x2 |*`CU_STREAM_WAIT_VALUE_AND`*                                        |                                                            | 8.0              |
-|        1<<30 |*`CU_STREAM_WAIT_VALUE_FLUSH`*                                      |                                                            | 8.0              |
-| enum         |***`CUstreamWriteValue_flags`***                                    |                                                            | 8.0              |
-| typedef      |***`CUstreamWriteValue_flags_enum`***                               |                                                            | 8.0              |
-|          0x0 |*`CU_STREAM_WRITE_VALUE_DEFAULT`*                                   |                                                            | 8.0              |
-|          0x1 |*`CU_STREAM_WRITE_VALUE_NO_MEMORY_BARRIER`*                         |                                                            | 8.0              |
-| enum         |***`CUdevice_P2PAttribute`***                                       |                                                            | 8.0              |
-| typedef      |***`CUdevice_P2PAttribute_enum`***                                  |                                                            | 8.0              |
-|         0x01 |*`CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK`*                        |                                                            | 8.0              |
-|         0x02 |*`CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED`*                        |                                                            | 8.0              |
-|         0x03 |*`CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED`*                 |                                                            | 8.0              |
-|         0x04 |*`CU_DEVICE_P2P_ATTRIBUTE_ACCESS_ACCESS_SUPPORTED`*                 |                                                            | 10.1             |
-|         0x04 |*`CU_DEVICE_P2P_ATTRIBUTE_ARRAY_ACCESS_ACCESS_SUPPORTED`*           |                                                            | 9.2 - 10.0       |
-|         0x04 |*`CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED`*             |                                                            | 9.2              |
-| enum         |***`CUeglColorFormat`***                                            |                                                            | 8.0              |
-| typedef      |***`CUeglColorFormate_enum`***                                      |                                                            | 8.0              |
-|         0x00 |*`CU_EGL_COLOR_FORMAT_YUV420_PLANAR`*                               |                                                            | 8.0              |
-|         0x01 |*`CU_EGL_COLOR_FORMAT_YUV420_SEMIPLANAR`*                           |                                                            | 8.0              |
-|         0x02 |*`CU_EGL_COLOR_FORMAT_YUV422_PLANAR`*                               |                                                            | 8.0              |
-|         0x03 |*`CU_EGL_COLOR_FORMAT_YUV422_SEMIPLANAR`*                           |                                                            | 8.0              |
-|         0x04 |*`CU_EGL_COLOR_FORMAT_RGB`*                                         |                                                            | 8.0              |
-|         0x05 |*`CU_EGL_COLOR_FORMAT_BGR`*                                         |                                                            | 8.0              |
-|         0x06 |*`CU_EGL_COLOR_FORMAT_ARGB`*                                        |                                                            | 8.0              |
-|         0x07 |*`CU_EGL_COLOR_FORMAT_RGBA`*                                        |                                                            | 8.0              |
-|         0x08 |*`CU_EGL_COLOR_FORMAT_L`*                                           |                                                            | 8.0              |
-|         0x09 |*`CU_EGL_COLOR_FORMAT_R`*                                           |                                                            | 8.0              |
-|         0x0A |*`CU_EGL_COLOR_FORMAT_YUV444_PLANAR`*                               |                                                            | 9.0              |
-|         0x0B |*`CU_EGL_COLOR_FORMAT_YUV444_SEMIPLANAR`*                           |                                                            | 9.0              |
-|         0x0C |*`CU_EGL_COLOR_FORMAT_YUYV_422`*                                    |                                                            | 9.0              |
-|         0x0D |*`CU_EGL_COLOR_FORMAT_UYVY_422`*                                    |                                                            | 9.0              |
-|         0x0E |*`CU_EGL_COLOR_FORMAT_ABGR`*                                        |                                                            | 9.1              |
-|         0x0F |*`CU_EGL_COLOR_FORMAT_BGRA`*                                        |                                                            | 9.1              |
-|         0x10 |*`CU_EGL_COLOR_FORMAT_A`*                                           |                                                            | 9.1              |
-|         0x11 |*`CU_EGL_COLOR_FORMAT_RG`*                                          |                                                            | 9.1              |
-|         0x12 |*`CU_EGL_COLOR_FORMAT_AYUV`*                                        |                                                            | 9.1              |
-|         0x13 |*`CU_EGL_COLOR_FORMAT_YVU444_SEMIPLANAR`*                           |                                                            | 9.1              |
-|         0x14 |*`CU_EGL_COLOR_FORMAT_YVU422_SEMIPLANAR`*                           |                                                            | 9.1              |
-|         0x15 |*`CU_EGL_COLOR_FORMAT_YVU420_SEMIPLANAR`*                           |                                                            | 9.1              |
-|         0x16 |*`CU_EGL_COLOR_FORMAT_Y10V10U10_444_SEMIPLANAR`*                    |                                                            | 9.1              |
-|         0x17 |*`CU_EGL_COLOR_FORMAT_Y10V10U10_420_SEMIPLANAR`*                    |                                                            | 9.1              |
-|         0x18 |*`CU_EGL_COLOR_FORMAT_Y12V12U12_444_SEMIPLANAR`*                    |                                                            | 9.1              |
-|         0x19 |*`CU_EGL_COLOR_FORMAT_Y12V12U12_420_SEMIPLANAR`*                    |                                                            | 9.1              |
-|         0x1A |*`CU_EGL_COLOR_FORMAT_VYUY_ER`*                                     |                                                            | 9.1              |
-|         0x1B |*`CU_EGL_COLOR_FORMAT_UYVY_ER`*                                     |                                                            | 9.1              |
-|         0x1C |*`CU_EGL_COLOR_FORMAT_YUYV_ER`*                                     |                                                            | 9.1              |
-|         0x1D |*`CU_EGL_COLOR_FORMAT_YVYU_ER`*                                     |                                                            | 9.1              |
-|         0x1E |*`CU_EGL_COLOR_FORMAT_YUV_ER`*                                      |                                                            | 9.1              |
-|         0x1F |*`CU_EGL_COLOR_FORMAT_YUVA_ER`*                                     |                                                            | 9.1              |
-|         0x20 |*`CU_EGL_COLOR_FORMAT_AYUV_ER`*                                     |                                                            | 9.1              |
-|         0x21 |*`CU_EGL_COLOR_FORMAT_YUV444_PLANAR_ER`*                            |                                                            | 9.1              |
-|         0x22 |*`CU_EGL_COLOR_FORMAT_YUV422_PLANAR_ER`*                            |                                                            | 9.1              |
-|         0x23 |*`CU_EGL_COLOR_FORMAT_YUV420_PLANAR_ER`*                            |                                                            | 9.1              |
-|         0x24 |*`CU_EGL_COLOR_FORMAT_YUV444_SEMIPLANAR_ER`*                        |                                                            | 9.1              |
-|         0x25 |*`CU_EGL_COLOR_FORMAT_YUV422_SEMIPLANAR_ER`*                        |                                                            | 9.1              |
-|         0x26 |*`CU_EGL_COLOR_FORMAT_YUV420_SEMIPLANAR_ER`*                        |                                                            | 9.1              |
-|         0x27 |*`CU_EGL_COLOR_FORMAT_YVU444_PLANAR_ER`*                            |                                                            | 9.1              |
-|         0x28 |*`CU_EGL_COLOR_FORMAT_YVU422_PLANAR_ER`*                            |                                                            | 9.1              |
-|         0x29 |*`CU_EGL_COLOR_FORMAT_YVU420_PLANAR_ER`*                            |                                                            | 9.1              |
-|         0x2A |*`CU_EGL_COLOR_FORMAT_YVU444_SEMIPLANAR_ER`*                        |                                                            | 9.1              |
-|         0x2B |*`CU_EGL_COLOR_FORMAT_YVU422_SEMIPLANAR_ER`*                        |                                                            | 9.1              |
-|         0x2C |*`CU_EGL_COLOR_FORMAT_YVU420_SEMIPLANAR_ER`*                        |                                                            | 9.1              |
-|         0x2D |*`CU_EGL_COLOR_FORMAT_BAYER_RGGB`*                                  |                                                            | 9.1              |
-|         0x2E |*`CU_EGL_COLOR_FORMAT_BAYER_BGGR`*                                  |                                                            | 9.1              |
-|         0x2F |*`CU_EGL_COLOR_FORMAT_BAYER_GRBG`*                                  |                                                            | 9.1              |
-|         0x30 |*`CU_EGL_COLOR_FORMAT_BAYER_GBRG`*                                  |                                                            | 9.1              |
-|         0x31 |*`CU_EGL_COLOR_FORMAT_BAYER10_RGGB`*                                |                                                            | 9.1              |
-|         0x32 |*`CU_EGL_COLOR_FORMAT_BAYER10_BGGR`*                                |                                                            | 9.1              |
-|         0x33 |*`CU_EGL_COLOR_FORMAT_BAYER10_GRBG`*                                |                                                            | 9.1              |
-|         0x34 |*`CU_EGL_COLOR_FORMAT_BAYER10_GBRG`*                                |                                                            | 9.1              |
-|         0x35 |*`CU_EGL_COLOR_FORMAT_BAYER12_RGGB`*                                |                                                            | 9.1              |
-|         0x36 |*`CU_EGL_COLOR_FORMAT_BAYER12_BGGR`*                                |                                                            | 9.1              |
-|         0x37 |*`CU_EGL_COLOR_FORMAT_BAYER12_GRBG`*                                |                                                            | 9.1              |
-|         0x38 |*`CU_EGL_COLOR_FORMAT_BAYER12_GBRG`*                                |                                                            | 9.1              |
-|         0x39 |*`CU_EGL_COLOR_FORMAT_BAYER14_RGGB`*                                |                                                            | 9.1              |
-|         0x3A |*`CU_EGL_COLOR_FORMAT_BAYER14_BGGR`*                                |                                                            | 9.1              |
-|         0x3B |*`CU_EGL_COLOR_FORMAT_BAYER14_GRBG`*                                |                                                            | 9.1              |
-|         0x3C |*`CU_EGL_COLOR_FORMAT_BAYER14_GBRG`*                                |                                                            | 9.1              |
-|         0x3D |*`CU_EGL_COLOR_FORMAT_BAYER20_RGGB`*                                |                                                            | 9.1              |
-|         0x3E |*`CU_EGL_COLOR_FORMAT_BAYER20_BGGR`*                                |                                                            | 9.1              |
-|         0x3F |*`CU_EGL_COLOR_FORMAT_BAYER20_GRBG`*                                |                                                            | 9.1              |
-|         0x40 |*`CU_EGL_COLOR_FORMAT_BAYER20_GBRG`*                                |                                                            | 9.1              |
-|         0x41 |*`CU_EGL_COLOR_FORMAT_YVU444_PLANAR`*                               |                                                            | 9.1              |
-|         0x42 |*`CU_EGL_COLOR_FORMAT_YVU422_PLANAR`*                               |                                                            | 9.1              |
-|         0x43 |*`CU_EGL_COLOR_FORMAT_YVU420_PLANAR`*                               |                                                            | 9.1              |
-|         0x44 |*`CU_EGL_COLOR_FORMAT_BAYER_ISP_RGGB`*                              |                                                            | 9.2              |
-|         0x45 |*`CU_EGL_COLOR_FORMAT_BAYER_ISP_BGGR`*                              |                                                            | 9.2              |
-|         0x46 |*`CU_EGL_COLOR_FORMAT_BAYER_ISP_GRBG`*                              |                                                            | 9.2              |
-|         0x47 |*`CU_EGL_COLOR_FORMAT_BAYER_ISP_GBRG`*                              |                                                            | 9.2              |
-|         0x48 |*`CU_EGL_COLOR_FORMAT_MAX`*                                         |                                                            | 9.0              |
-| enum         |***`CUeglFrameType`***                                              |                                                            | 8.0              |
-| typedef      |***`CUeglFrameType_enum`***                                         |                                                            | 8.0              |
-|            0 |*`CU_EGL_FRAME_TYPE_ARRAY`*                                         |                                                            | 8.0              |
-|            1 |*`CU_EGL_FRAME_TYPE_PITCH`*                                         |                                                            | 8.0              |
-| enum         |***`CUeglResourceLocationFlags`***                                  |                                                            | 8.0              |
-| typedef      |***`CUeglResourceLocationFlags_enum`***                             |                                                            | 8.0              |
-|         0x00 |*`CU_EGL_RESOURCE_LOCATION_SYSMEM`*                                 |                                                            | 8.0              |
-|         0x01 |*`CU_EGL_RESOURCE_LOCATION_VIDMEM`*                                 |                                                            | 8.0              |
-| enum         |***`CUexternalMemoryHandleType`***                                  |                                                            | 10.0             |
-| typedef      |***`CUexternalMemoryHandleType_enum`***                             |                                                            | 10.0             |
-|            1 |*`CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD`*                        |                                                            | 10.0             |
-|            2 |*`CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32`*                     |                                                            | 10.0             |
-|            3 |*`CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT`*                 |                                                            | 10.0             |
-|            4 |*`CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP`*                       |                                                            | 10.0             |
-|            5 |*`CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE`*                   |                                                            | 10.0             |
-|            6 |*`CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_RESOURCE`*                   |                                                            | 10.2             |
-|            7 |*`CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_RESOURCE_KMT`*               |                                                            | 10.2             |
-|            8 |*`CU_EXTERNAL_MEMORY_HANDLE_TYPE_NVSCIBUF`*                         |                                                            | 10.2             |
-| define       |`CUDA_EXTERNAL_MEMORY_DEDICATED`                                    |                                                            | 10.0             |
-| define       |`CUDA_EXTERNAL_SEMAPHORE_SIGNAL_SKIP_NVSCIBUF_MEMSYNC`              |                                                            | 10.2             |
-| define       |`CUDA_EXTERNAL_SEMAPHORE_WAIT_SKIP_NVSCIBUF_MEMSYNC`                |                                                            | 10.2             |
-| define       |`CUDA_NVSCISYNC_ATTR_SIGNAL`                                        |                                                            | 10.2             |
-| define       |`CUDA_NVSCISYNC_ATTR_WAIT`                                          |                                                            | 10.2             |
-| struct       |`CUDA_EXTERNAL_MEMORY_HANDLE_DESC`                                  |                                                            | 10.0             |
-| typedef      |`CUDA_EXTERNAL_MEMORY_HANDLE_DESC_st`                               |                                                            | 10.0             |
-| struct       |`CUDA_EXTERNAL_MEMORY_BUFFER_DESC`                                  |                                                            | 10.0             |
-| typedef      |`CUDA_EXTERNAL_MEMORY_BUFFER_DESC_st`                               |                                                            | 10.0             |
-| struct       |`CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC`                         |                                                            | 10.0             |
-| typedef      |`CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC_st`                      |                                                            | 10.0             |
-| enum         |***`CUexternalSemaphoreHandleType`***                               |                                                            | 10.0             |
-| typedef      |***`CUexternalSemaphoreHandleType_enum`***                          |                                                            | 10.0             |
-|            1 |*`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD`*                     |                                                            | 10.0             |
-|            2 |*`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32`*                  |                                                            | 10.0             |
-|            3 |*`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT`*              |                                                            | 10.0             |
-|            4 |*`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE`*                   |                                                            | 10.0             |
-|            5 |*`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D11_FENCE`*                   |                                                            | 10.2             |
-|            6 |*`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_NVSCISYNC`*                     |                                                            | 10.2             |
-|            7 |*`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D11_KEYED_MUTEX`*             |                                                            | 10.2             |
-|            8 |*`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D11_KEYED_MUTEX_KMT`*         |                                                            | 10.2             |
-| struct       |`CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC`                               |                                                            | 10.0             |
-| typedef      |`CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC_st`                            |                                                            | 10.0             |
-| struct       |`CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS`                             |                                                            | 10.0             |
-| typedef      |`CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_st`                          |                                                            | 10.0             |
-| struct       |`CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS`                               |                                                            | 10.0             |
-| typedef      |`CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_st`                            |                                                            | 10.0             |
-| define       |`CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_PRE_LAUNCH_SYNC`           |                                                            | 9.0              |
-| define       |`CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC`          |                                                            | 9.0              |
-| define       |`__CUDACC__`                                                        |`__HIPCC__`                                                 |
-| define       |`CUDA_CB`                                                           |                                                            |
-| define       |`CU_DEVICE_CPU`                                                     |                                                            | 8.0              |
-| define       |`CU_DEVICE_INVALID`                                                 |                                                            | 8.0              |
-| struct       |`CUuuid`                                                            |                                                            |
-| typedef      |`CUuuid_st`                                                         |                                                            |
-| enum         |***`CUmemAllocationHandleType`***                                   |                                                            | 10.2             |
-| typedef      |***`CUmemAllocationHandleType_enum`***                              |                                                            | 10.2             |
-|          0x1 |*`CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`*                        |                                                            | 10.2             |
-|          0x2 |*`CU_MEM_HANDLE_TYPE_WIN32`*                                        |                                                            | 10.2             |
-|          0x4 |*`CU_MEM_HANDLE_TYPE_WIN32_KMT`*                                    |                                                            | 10.2             |
-|   0xFFFFFFFF |*`CU_MEM_HANDLE_TYPE_MAX`*                                          |                                                            | 10.2             |
-| enum         |***`CUmemAccess_flags`***                                           |                                                            | 10.2             |
-| typedef      |***`CUmemAccess_flags_enum`***                                      |                                                            | 10.2             |
-|          0x1 |*`CU_MEM_ACCESS_FLAGS_PROT_NONE`*                                   |                                                            | 10.2             |
-|          0x2 |*`CU_MEM_ACCESS_FLAGS_PROT_READ`*                                   |                                                            | 10.2             |
-|          0x3 |*`CU_MEM_ACCESS_FLAGS_PROT_READWRITE`*                              |                                                            | 10.2             |
-|   0xFFFFFFFF |*`CU_MEM_ACCESS_FLAGS_PROT_MAX`*                                    |                                                            | 10.2             |
-| enum         |***`CUmemLocationType`***                                           |                                                            | 10.2             |
-| typedef      |***`CUmemLocationType_enum`***                                      |                                                            | 10.2             |
-|          0x0 |*`CU_MEM_LOCATION_TYPE_INVALID`*                                    |                                                            | 10.2             |
-|          0x1 |*`CU_MEM_LOCATION_TYPE_DEVICE`*                                     |                                                            | 10.2             |
-|   0xFFFFFFFF |*`CU_MEM_LOCATION_TYPE_MAX`*                                        |                                                            | 10.2             |
-| enum         |***`CUmemAllocationGranularity_flags`***                            |                                                            | 10.2             |
-| typedef      |***`CUmemAllocationGranularity_flags_enum`***                       |                                                            | 10.2             |
-|          0x0 |*`CU_MEM_ALLOC_GRANULARITY_MINIMUM`*                                |                                                            | 10.2             |
-|          0x1 |*`CU_MEM_ALLOC_GRANULARITY_RECOMMENDED`*                            |                                                            | 10.2             |
-| struct       |`CUmemLocation`                                                     |                                                            | 10.2             |
-| typedef      |`CUmemLocation_st`                                                  |                                                            | 10.2             |
-| struct       |`CUmemAllocationProp`                                               |                                                            | 10.2             |
-| typedef      |`CUmemAllocationProp_st`                                            |                                                            | 10.2             |
-| struct       |`CUmemAccessDesc`                                                   |                                                            | 10.2             |
-| typedef      |`CUmemAccessDesc_st`                                                |                                                            | 10.2             |
-| enum         |***`CUgraphExecUpdateResult`***                                     |                                                            | 10.2             |
-| typedef      |***`CUgraphExecUpdateResult_enum`***                                |                                                            | 10.2             |
-|          0x0 |*`CU_GRAPH_EXEC_UPDATE_SUCCESS`*                                    |                                                            | 10.2             |
-|          0x1 |*`CU_GRAPH_EXEC_UPDATE_ERROR`*                                      |                                                            | 10.2             |
-|          0x2 |*`CU_GRAPH_EXEC_UPDATE_ERROR_TOPOLOGY_CHANGED`*                     |                                                            | 10.2             |
-|          0x3 |*`CU_GRAPH_EXEC_UPDATE_ERROR_NODE_TYPE_CHANGED`*                    |                                                            | 10.2             |
-|          0x4 |*`CU_GRAPH_EXEC_UPDATE_ERROR_FUNCTION_CHANGED`*                     |                                                            | 10.2             |
-|          0x5 |*`CU_GRAPH_EXEC_UPDATE_ERROR_PARAMETERS_CHANGED`*                   |                                                            | 10.2             |
-|          0x6 |*`CU_GRAPH_EXEC_UPDATE_ERROR_NOT_SUPPORTED`*                        |                                                            | 10.2             |
-| typedef      |`CUmemGenericAllocationHandle`                                      |                                                            | 10.2             |
-| enum         |***`CUaccessProperty`***                                            |                                                            | 11.0             |
-| typedef      |***`CUaccessProperty_enum`***                                       |                                                            | 11.0             |
-|            0 |*`CU_ACCESS_PROPERTY_NORMAL`*                                       |                                                            | 11.0             |
-|            1 |*`CU_ACCESS_PROPERTY_STREAMING`*                                    |                                                            | 11.0             |
-|            2 |*`CU_ACCESS_PROPERTY_PERSISTING`*                                   |                                                            | 11.0             |
-| struct       |`CUaccessPolicyWindow`                                              |                                                            | 11.0             |
-| typedef      |`CUaccessPolicyWindow_st`                                           |                                                            | 11.0             |
-| enum         |***`CUsynchronizationPolicy`***                                     |                                                            | 11.0             |
-| typedef      |***`CUsynchronizationPolicy_enum`***                                |                                                            | 11.0             |
-|            1 |*`CU_SYNC_POLICY_AUTO`*                                             |                                                            | 11.0             |
-|            2 |*`CU_SYNC_POLICY_SPIN`*                                             |                                                            | 11.0             |
-|            3 |*`CU_SYNC_POLICY_YIELD`*                                            |                                                            | 11.0             |
-|            4 |*`CU_SYNC_POLICY_BLOCKING_SYNC`*                                    |                                                            | 11.0             |
-| enum         |***`CUkernelNodeAttrID`***                                          |                                                            | 11.0             |
-| typedef      |***`CUkernelNodeAttrID_enum`***                                     |                                                            | 11.0             |
-|            1 |*`CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW`*                   |                                                            | 11.0             |
-|            2 |*`CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE`*                            |                                                            | 11.0             |
-| union        |`CUkernelNodeAttrValue`                                             |                                                            | 11.0             |
-| typedef      |`CUkernelNodeAttrValue_union`                                       |                                                            | 11.0             |
-| enum         |***`CUstreamAttrID`***                                              |                                                            | 11.0             |
-| typedef      |***`CUstreamAttrID_enum`***                                         |                                                            | 11.0             |
-|            1 |*`CU_STREAM_ATTRIBUTE_ACCESS_POLICY_WINDOW`*                        |                                                            | 11.0             |
-|            3 |*`CU_STREAM_ATTRIBUTE_SYNCHRONIZATION_POLICY`*                      |                                                            | 11.0             |
-| union        |`CUstreamAttrValue`                                                 |                                                            | 11.0             |
-| typedef      |`CUstreamAttrValue_union`                                           |                                                            | 11.0             |
-| enum         |***`CUmemAllocationCompType`***                                     |                                                            | 11.0             |
-| typedef      |***`CUmemAllocationCompType_enum`***                                |                                                            | 11.0             |
-|          0x0 |*`CU_MEM_ALLOCATION_COMP_NONE`*                                     |                                                            | 11.0             |
-|          0x1 |*`CU_MEM_ALLOCATION_COMP_GENERIC`*                                  |                                                            | 11.0             |
-| define       |`CU_TRSF_DISABLE_TRILINEAR_OPTIMIZATION`                            |                                                            | 11.0             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`CUDA_ARRAY3D_2DARRAY`|  | 5.0 |  ||
+|`CUDA_ARRAY3D_COLOR_ATTACHMENT`| 10.0 |  |  ||
+|`CUDA_ARRAY3D_CUBEMAP`|  |  |  |`hipArrayCubemap`|
+|`CUDA_ARRAY3D_DEPTH_TEXTURE`|  |  |  ||
+|`CUDA_ARRAY3D_DESCRIPTOR`|  |  |  |`HIP_ARRAY3D_DESCRIPTOR`|
+|`CUDA_ARRAY3D_DESCRIPTOR_st`|  |  |  |`HIP_ARRAY3D_DESCRIPTOR`|
+|`CUDA_ARRAY3D_LAYERED`|  |  |  |`hipArrayLayered`|
+|`CUDA_ARRAY3D_SURFACE_LDST`|  |  |  |`hipArraySurfaceLoadStore`|
+|`CUDA_ARRAY3D_TEXTURE_GATHER`|  |  |  |`hipArrayTextureGather`|
+|`CUDA_ARRAY_DESCRIPTOR`|  |  |  |`HIP_ARRAY_DESCRIPTOR`|
+|`CUDA_ARRAY_DESCRIPTOR_st`|  |  |  |`HIP_ARRAY_DESCRIPTOR`|
+|`CUDA_ARRAY_DESCRIPTOR_v1`|  |  |  |`HIP_ARRAY_DESCRIPTOR`|
+|`CUDA_ARRAY_DESCRIPTOR_v1_st`|  |  |  |`HIP_ARRAY_DESCRIPTOR`|
+|`CUDA_CB`|  |  |  ||
+|`CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_POST_LAUNCH_SYNC`| 9.0 |  |  |`hipCooperativeLaunchMultiDeviceNoPostSync`|
+|`CUDA_COOPERATIVE_LAUNCH_MULTI_DEVICE_NO_PRE_LAUNCH_SYNC`| 9.0 |  |  |`hipCooperativeLaunchMultiDeviceNoPreSync`|
+|`CUDA_ERROR_ALREADY_ACQUIRED`|  |  |  |`hipErrorAlreadyAcquired`|
+|`CUDA_ERROR_ALREADY_MAPPED`|  |  |  |`hipErrorAlreadyMapped`|
+|`CUDA_ERROR_ARRAY_IS_MAPPED`|  |  |  |`hipErrorArrayIsMapped`|
+|`CUDA_ERROR_ASSERT`|  |  |  |`hipErrorAssert`|
+|`CUDA_ERROR_CAPTURED_EVENT`| 10.0 |  |  ||
+|`CUDA_ERROR_COMPAT_NOT_SUPPORTED_ON_DEVICE`| 10.1 |  |  ||
+|`CUDA_ERROR_CONTEXT_ALREADY_CURRENT`|  | 3.2 |  |`hipErrorContextAlreadyCurrent`|
+|`CUDA_ERROR_CONTEXT_ALREADY_IN_USE`|  |  |  |`hipErrorContextAlreadyInUse`|
+|`CUDA_ERROR_CONTEXT_IS_DESTROYED`|  |  |  ||
+|`CUDA_ERROR_COOPERATIVE_LAUNCH_TOO_LARGE`| 9.0 |  |  |`hipErrorCooperativeLaunchTooLarge`|
+|`CUDA_ERROR_DEINITIALIZED`|  |  |  |`hipErrorDeinitialized`|
+|`CUDA_ERROR_ECC_UNCORRECTABLE`|  |  |  |`hipErrorECCNotCorrectable`|
+|`CUDA_ERROR_FILE_NOT_FOUND`|  |  |  |`hipErrorFileNotFound`|
+|`CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE`| 10.2 |  |  ||
+|`CUDA_ERROR_HARDWARE_STACK_ERROR`|  |  |  ||
+|`CUDA_ERROR_HOST_MEMORY_ALREADY_REGISTERED`|  |  |  |`hipErrorHostMemoryAlreadyRegistered`|
+|`CUDA_ERROR_HOST_MEMORY_NOT_REGISTERED`|  |  |  |`hipErrorHostMemoryNotRegistered`|
+|`CUDA_ERROR_ILLEGAL_ADDRESS`|  |  |  |`hipErrorIllegalAddress`|
+|`CUDA_ERROR_ILLEGAL_INSTRUCTION`|  |  |  ||
+|`CUDA_ERROR_ILLEGAL_STATE`| 10.0 |  |  ||
+|`CUDA_ERROR_INVALID_ADDRESS_SPACE`|  |  |  ||
+|`CUDA_ERROR_INVALID_CONTEXT`|  |  |  |`hipErrorInvalidContext`|
+|`CUDA_ERROR_INVALID_DEVICE`|  |  |  |`hipErrorInvalidDevice`|
+|`CUDA_ERROR_INVALID_GRAPHICS_CONTEXT`|  |  |  |`hipErrorInvalidGraphicsContext`|
+|`CUDA_ERROR_INVALID_HANDLE`|  |  |  |`hipErrorInvalidHandle`|
+|`CUDA_ERROR_INVALID_IMAGE`|  |  |  |`hipErrorInvalidImage`|
+|`CUDA_ERROR_INVALID_PC`|  |  |  ||
+|`CUDA_ERROR_INVALID_PTX`|  |  |  |`hipErrorInvalidKernelFile`|
+|`CUDA_ERROR_INVALID_SOURCE`|  |  |  |`hipErrorInvalidSource`|
+|`CUDA_ERROR_INVALID_VALUE`|  |  |  |`hipErrorInvalidValue`|
+|`CUDA_ERROR_JIT_COMPILER_NOT_FOUND`| 9.0 |  |  ||
+|`CUDA_ERROR_LAUNCH_FAILED`|  |  |  |`hipErrorLaunchFailure`|
+|`CUDA_ERROR_LAUNCH_INCOMPATIBLE_TEXTURING`|  |  |  ||
+|`CUDA_ERROR_LAUNCH_OUT_OF_RESOURCES`|  |  |  |`hipErrorLaunchOutOfResources`|
+|`CUDA_ERROR_LAUNCH_TIMEOUT`|  |  |  |`hipErrorLaunchTimeOut`|
+|`CUDA_ERROR_MAP_FAILED`|  |  |  |`hipErrorMapFailed`|
+|`CUDA_ERROR_MISALIGNED_ADDRESS`|  |  |  ||
+|`CUDA_ERROR_NOT_FOUND`|  |  |  |`hipErrorNotFound`|
+|`CUDA_ERROR_NOT_INITIALIZED`|  |  |  |`hipErrorNotInitialized`|
+|`CUDA_ERROR_NOT_MAPPED`|  |  |  |`hipErrorNotMapped`|
+|`CUDA_ERROR_NOT_MAPPED_AS_ARRAY`|  |  |  |`hipErrorNotMappedAsArray`|
+|`CUDA_ERROR_NOT_MAPPED_AS_POINTER`|  |  |  |`hipErrorNotMappedAsPointer`|
+|`CUDA_ERROR_NOT_PERMITTED`|  |  |  ||
+|`CUDA_ERROR_NOT_READY`|  |  |  |`hipErrorNotReady`|
+|`CUDA_ERROR_NOT_SUPPORTED`|  |  |  |`hipErrorNotSupported`|
+|`CUDA_ERROR_NO_BINARY_FOR_GPU`|  |  |  |`hipErrorNoBinaryForGpu`|
+|`CUDA_ERROR_NO_DEVICE`|  |  |  |`hipErrorNoDevice`|
+|`CUDA_ERROR_NVLINK_UNCORRECTABLE`| 8.0 |  |  ||
+|`CUDA_ERROR_OPERATING_SYSTEM`|  |  |  |`hipErrorOperatingSystem`|
+|`CUDA_ERROR_OUT_OF_MEMORY`|  |  |  |`hipErrorOutOfMemory`|
+|`CUDA_ERROR_PEER_ACCESS_ALREADY_ENABLED`|  |  |  |`hipErrorPeerAccessAlreadyEnabled`|
+|`CUDA_ERROR_PEER_ACCESS_NOT_ENABLED`|  |  |  |`hipErrorPeerAccessNotEnabled`|
+|`CUDA_ERROR_PEER_ACCESS_UNSUPPORTED`|  |  |  |`hipErrorPeerAccessUnsupported`|
+|`CUDA_ERROR_PRIMARY_CONTEXT_ACTIVE`|  |  |  |`hipErrorSetOnActiveProcess`|
+|`CUDA_ERROR_PROFILER_ALREADY_STARTED`|  | 5.0 |  |`hipErrorProfilerAlreadyStarted`|
+|`CUDA_ERROR_PROFILER_ALREADY_STOPPED`|  | 5.0 |  |`hipErrorProfilerAlreadyStopped`|
+|`CUDA_ERROR_PROFILER_DISABLED`|  |  |  |`hipErrorProfilerDisabled`|
+|`CUDA_ERROR_PROFILER_NOT_INITIALIZED`|  | 5.0 |  |`hipErrorProfilerNotInitialized`|
+|`CUDA_ERROR_SHARED_OBJECT_INIT_FAILED`|  |  |  |`hipErrorSharedObjectInitFailed`|
+|`CUDA_ERROR_SHARED_OBJECT_SYMBOL_NOT_FOUND`|  |  |  |`hipErrorSharedObjectSymbolNotFound`|
+|`CUDA_ERROR_STREAM_CAPTURE_IMPLICIT`| 10.0 |  |  ||
+|`CUDA_ERROR_STREAM_CAPTURE_INVALIDATED`| 10.0 |  |  ||
+|`CUDA_ERROR_STREAM_CAPTURE_ISOLATION`| 10.0 |  |  ||
+|`CUDA_ERROR_STREAM_CAPTURE_MERGE`| 10.0 |  |  ||
+|`CUDA_ERROR_STREAM_CAPTURE_UNJOINED`| 10.0 |  |  ||
+|`CUDA_ERROR_STREAM_CAPTURE_UNMATCHED`| 10.0 |  |  ||
+|`CUDA_ERROR_STREAM_CAPTURE_UNSUPPORTED`| 10.0 |  |  ||
+|`CUDA_ERROR_STREAM_CAPTURE_WRONG_THREAD`| 10.1 |  |  ||
+|`CUDA_ERROR_SYSTEM_DRIVER_MISMATCH`| 10.1 |  |  ||
+|`CUDA_ERROR_SYSTEM_NOT_READY`| 10.0 |  |  ||
+|`CUDA_ERROR_TIMEOUT`| 10.2 |  |  ||
+|`CUDA_ERROR_TOO_MANY_PEERS`|  |  |  ||
+|`CUDA_ERROR_UNKNOWN`|  |  |  |`hipErrorUnknown`|
+|`CUDA_ERROR_UNMAP_FAILED`|  |  |  |`hipErrorUnmapFailed`|
+|`CUDA_ERROR_UNSUPPORTED_LIMIT`|  |  |  |`hipErrorUnsupportedLimit`|
+|`CUDA_EXTERNAL_MEMORY_BUFFER_DESC`| 10.0 |  |  ||
+|`CUDA_EXTERNAL_MEMORY_BUFFER_DESC_st`| 10.0 |  |  ||
+|`CUDA_EXTERNAL_MEMORY_DEDICATED`| 10.0 |  |  ||
+|`CUDA_EXTERNAL_MEMORY_HANDLE_DESC`| 10.0 |  |  ||
+|`CUDA_EXTERNAL_MEMORY_HANDLE_DESC_st`| 10.0 |  |  ||
+|`CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC`| 10.0 |  |  ||
+|`CUDA_EXTERNAL_MEMORY_MIPMAPPED_ARRAY_DESC_st`| 10.0 |  |  ||
+|`CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC`| 10.0 |  |  ||
+|`CUDA_EXTERNAL_SEMAPHORE_HANDLE_DESC_st`| 10.0 |  |  ||
+|`CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS`| 10.0 |  |  ||
+|`CUDA_EXTERNAL_SEMAPHORE_SIGNAL_PARAMS_st`| 10.0 |  |  ||
+|`CUDA_EXTERNAL_SEMAPHORE_SIGNAL_SKIP_NVSCIBUF_MEMSYNC`| 10.2 |  |  ||
+|`CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS`| 10.0 |  |  ||
+|`CUDA_EXTERNAL_SEMAPHORE_WAIT_PARAMS_st`| 10.0 |  |  ||
+|`CUDA_EXTERNAL_SEMAPHORE_WAIT_SKIP_NVSCIBUF_MEMSYNC`| 10.2 |  |  ||
+|`CUDA_HOST_NODE_PARAMS`| 10.0 |  |  ||
+|`CUDA_HOST_NODE_PARAMS_st`| 10.0 |  |  ||
+|`CUDA_KERNEL_NODE_PARAMS`| 10.0 |  |  ||
+|`CUDA_KERNEL_NODE_PARAMS_st`| 10.0 |  |  ||
+|`CUDA_LAUNCH_PARAMS`| 9.0 |  |  ||
+|`CUDA_LAUNCH_PARAMS_st`| 9.0 |  |  ||
+|`CUDA_MEMCPY2D`|  |  |  |`hip_Memcpy2D`|
+|`CUDA_MEMCPY2D_st`|  |  |  |`hip_Memcpy2D`|
+|`CUDA_MEMCPY2D_v1`|  |  |  |`hip_Memcpy2D`|
+|`CUDA_MEMCPY2D_v1_st`|  |  |  |`hip_Memcpy2D`|
+|`CUDA_MEMCPY3D`|  |  |  |`HIP_MEMCPY3D`|
+|`CUDA_MEMCPY3D_PEER`|  |  |  ||
+|`CUDA_MEMCPY3D_PEER_st`|  |  |  ||
+|`CUDA_MEMCPY3D_st`|  |  |  |`HIP_MEMCPY3D`|
+|`CUDA_MEMCPY3D_v1`|  |  |  |`HIP_MEMCPY3D`|
+|`CUDA_MEMCPY3D_v1_st`|  |  |  |`HIP_MEMCPY3D`|
+|`CUDA_MEMSET_NODE_PARAMS`| 10.0 |  |  ||
+|`CUDA_MEMSET_NODE_PARAMS_st`| 10.0 |  |  ||
+|`CUDA_NVSCISYNC_ATTR_SIGNAL`| 10.2 |  |  ||
+|`CUDA_NVSCISYNC_ATTR_WAIT`| 10.2 |  |  ||
+|`CUDA_POINTER_ATTRIBUTE_P2P_TOKENS`|  |  |  ||
+|`CUDA_POINTER_ATTRIBUTE_P2P_TOKENS_st`|  |  |  ||
+|`CUDA_RESOURCE_DESC`|  |  |  ||
+|`CUDA_RESOURCE_DESC_st`|  |  |  ||
+|`CUDA_RESOURCE_VIEW_DESC`|  |  |  ||
+|`CUDA_RESOURCE_VIEW_DESC_st`|  |  |  ||
+|`CUDA_SUCCESS`|  |  |  |`hipSuccess`|
+|`CUDA_TEXTURE_DESC`|  |  |  ||
+|`CUDA_TEXTURE_DESC_st`|  |  |  ||
+|`CUDA_VERSION`|  |  |  ||
+|`CUGLDeviceList`|  |  |  ||
+|`CUGLDeviceList_enum`|  |  |  ||
+|`CUGLmap_flags`|  |  |  ||
+|`CUGLmap_flags_enum`|  |  |  ||
+|`CU_ACCESS_PROPERTY_NORMAL`| 11.0 |  |  ||
+|`CU_ACCESS_PROPERTY_PERSISTING`| 11.0 |  |  ||
+|`CU_ACCESS_PROPERTY_STREAMING`| 11.0 |  |  ||
+|`CU_AD_FORMAT_FLOAT`|  |  |  |`HIP_AD_FORMAT_FLOAT`|
+|`CU_AD_FORMAT_HALF`|  |  |  |`HIP_AD_FORMAT_HALF`|
+|`CU_AD_FORMAT_SIGNED_INT16`|  |  |  |`HIP_AD_FORMAT_SIGNED_INT16`|
+|`CU_AD_FORMAT_SIGNED_INT32`|  |  |  |`HIP_AD_FORMAT_SIGNED_INT32`|
+|`CU_AD_FORMAT_SIGNED_INT8`|  |  |  |`HIP_AD_FORMAT_SIGNED_INT8`|
+|`CU_AD_FORMAT_UNSIGNED_INT16`|  |  |  |`HIP_AD_FORMAT_UNSIGNED_INT16`|
+|`CU_AD_FORMAT_UNSIGNED_INT32`|  |  |  |`HIP_AD_FORMAT_UNSIGNED_INT32`|
+|`CU_AD_FORMAT_UNSIGNED_INT8`|  |  |  |`HIP_AD_FORMAT_UNSIGNED_INT8`|
+|`CU_COMPUTEMODE_DEFAULT`|  |  |  |`hipComputeModeDefault`|
+|`CU_COMPUTEMODE_EXCLUSIVE`|  |  | 8.0 |`hipComputeModeExclusive`|
+|`CU_COMPUTEMODE_EXCLUSIVE_PROCESS`|  |  |  |`hipComputeModeExclusiveProcess`|
+|`CU_COMPUTEMODE_PROHIBITED`|  |  |  |`hipComputeModeProhibited`|
+|`CU_CTX_BLOCKING_SYNC`|  | 4.0 |  |`hipDeviceScheduleBlockingSync`|
+|`CU_CTX_FLAGS_MASK`|  |  |  ||
+|`CU_CTX_LMEM_RESIZE_TO_MAX`|  |  |  |`hipDeviceLmemResizeToMax`|
+|`CU_CTX_MAP_HOST`|  |  |  |`hipDeviceMapHost`|
+|`CU_CTX_SCHED_AUTO`|  |  |  |`hipDeviceScheduleAuto`|
+|`CU_CTX_SCHED_BLOCKING_SYNC`|  |  |  |`hipDeviceScheduleBlockingSync`|
+|`CU_CTX_SCHED_MASK`|  |  |  |`hipDeviceScheduleMask`|
+|`CU_CTX_SCHED_SPIN`|  |  |  |`hipDeviceScheduleSpin`|
+|`CU_CTX_SCHED_YIELD`|  |  |  |`hipDeviceScheduleYield`|
+|`CU_CUBEMAP_FACE_NEGATIVE_X`|  |  |  ||
+|`CU_CUBEMAP_FACE_NEGATIVE_Y`|  |  |  ||
+|`CU_CUBEMAP_FACE_NEGATIVE_Z`|  |  |  ||
+|`CU_CUBEMAP_FACE_POSITIVE_X`|  |  |  ||
+|`CU_CUBEMAP_FACE_POSITIVE_Y`|  |  |  ||
+|`CU_CUBEMAP_FACE_POSITIVE_Z`|  |  |  ||
+|`CU_D3D10_DEVICE_LIST_ALL`|  |  |  ||
+|`CU_D3D10_DEVICE_LIST_CURRENT_FRAME`|  |  |  ||
+|`CU_D3D10_DEVICE_LIST_NEXT_FRAME`|  |  |  ||
+|`CU_D3D10_MAPRESOURCE_FLAGS_NONE`|  |  |  ||
+|`CU_D3D10_MAPRESOURCE_FLAGS_READONLY`|  |  |  ||
+|`CU_D3D10_MAPRESOURCE_FLAGS_WRITEDISCARD`|  |  |  ||
+|`CU_D3D10_REGISTER_FLAGS_ARRAY`|  |  |  ||
+|`CU_D3D10_REGISTER_FLAGS_NONE`|  |  |  ||
+|`CU_D3D11_DEVICE_LIST_ALL`|  |  |  ||
+|`CU_D3D11_DEVICE_LIST_CURRENT_FRAME`|  |  |  ||
+|`CU_D3D11_DEVICE_LIST_NEXT_FRAME`|  |  |  ||
+|`CU_D3D9_DEVICE_LIST_ALL`|  |  |  ||
+|`CU_D3D9_DEVICE_LIST_CURRENT_FRAME`|  |  |  ||
+|`CU_D3D9_DEVICE_LIST_NEXT_FRAME`|  |  |  ||
+|`CU_D3D9_MAPRESOURCE_FLAGS_NONE`|  |  |  ||
+|`CU_D3D9_MAPRESOURCE_FLAGS_READONLY`|  |  |  ||
+|`CU_D3D9_MAPRESOURCE_FLAGS_WRITEDISCARD`|  |  |  ||
+|`CU_D3D9_REGISTER_FLAGS_ARRAY`|  |  |  ||
+|`CU_D3D9_REGISTER_FLAGS_NONE`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_ASYNC_ENGINE_COUNT`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_CAN_FLUSH_REMOTE_WRITES`| 9.2 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_CAN_MAP_HOST_MEMORY`|  |  |  |`hipDeviceAttributeCanMapHostMemory`|
+|`CU_DEVICE_ATTRIBUTE_CAN_TEX2D_GATHER`|  | 5.0 |  ||
+|`CU_DEVICE_ATTRIBUTE_CAN_USE_64_BIT_STREAM_MEM_OPS`| 9.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_CAN_USE_HOST_POINTER_FOR_REGISTERED_MEM`| 9.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_MEM_OPS`| 9.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_CAN_USE_STREAM_WAIT_VALUE_NOR`| 9.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_CLOCK_RATE`|  |  |  |`hipDeviceAttributeClockRate`|
+|`CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR`|  |  |  |`hipDeviceAttributeComputeCapabilityMajor`|
+|`CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR`|  |  |  |`hipDeviceAttributeComputeCapabilityMinor`|
+|`CU_DEVICE_ATTRIBUTE_COMPUTE_MODE`|  |  |  |`hipDeviceAttributeComputeMode`|
+|`CU_DEVICE_ATTRIBUTE_COMPUTE_PREEMPTION_SUPPORTED`| 8.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_CONCURRENT_KERNELS`|  |  |  |`hipDeviceAttributeConcurrentKernels`|
+|`CU_DEVICE_ATTRIBUTE_CONCURRENT_MANAGED_ACCESS`| 8.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_COOPERATIVE_LAUNCH`| 9.0 |  |  |`hipDeviceAttributeCooperativeLaunch`|
+|`CU_DEVICE_ATTRIBUTE_COOPERATIVE_MULTI_DEVICE_LAUNCH`| 9.0 |  |  |`hipDeviceAttributeCooperativeMultiDeviceLaunch`|
+|`CU_DEVICE_ATTRIBUTE_DIRECT_MANAGED_MEM_ACCESS_FROM_HOST`| 9.2 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_ECC_ENABLED`|  |  |  |`hipDeviceAttributeEccEnabled`|
+|`CU_DEVICE_ATTRIBUTE_GENERIC_COMPRESSION_SUPPORTED`| 11.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_GLOBAL_L1_CACHE_SUPPORTED`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_GLOBAL_MEMORY_BUS_WIDTH`|  |  |  |`hipDeviceAttributeMemoryBusWidth`|
+|`CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED`| 11.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_GPU_OVERLAP`|  | 5.0 |  ||
+|`CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR_SUPPORTED`| 10.2 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_WIN32_HANDLE_SUPPORTED`| 10.2 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_HANDLE_TYPE_WIN32_KMT_HANDLE_SUPPORTED`| 10.2 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_HOST_NATIVE_ATOMIC_SUPPORTED`| 8.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_HOST_REGISTER_SUPPORTED`| 9.2 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_INTEGRATED`|  |  |  |`hipDeviceAttributeIntegrated`|
+|`CU_DEVICE_ATTRIBUTE_KERNEL_EXEC_TIMEOUT`|  |  |  |`hipDeviceAttributeKernelExecTimeout`|
+|`CU_DEVICE_ATTRIBUTE_L2_CACHE_SIZE`|  |  |  |`hipDeviceAttributeL2CacheSize`|
+|`CU_DEVICE_ATTRIBUTE_LOCAL_L1_CACHE_SUPPORTED`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MANAGED_MEMORY`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAX`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_LAYERS`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_LAYERED_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE1D_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_HEIGHT`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_HEIGHT`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_LAYERS`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_LAYERED_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE2D_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_DEPTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_HEIGHT`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACE3D_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_LAYERS`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_LAYERED_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_SURFACECUBEMAP_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_LAYERS`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LAYERED_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_LINEAR_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_MIPMAPPED_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE1D_WIDTH`|  |  |  |`hipDeviceAttributeMaxTexture1DWidth`|
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_HEIGHT`|  | 5.0 |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_NUMSLICES`|  | 5.0 |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_ARRAY_WIDTH`|  | 5.0 |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_HEIGHT`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_GATHER_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_HEIGHT`|  |  |  |`hipDeviceAttributeMaxTexture2DHeight`|
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_HEIGHT`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_LAYERS`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LAYERED_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_HEIGHT`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_PITCH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_LINEAR_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_HEIGHT`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_MIPMAPPED_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE2D_WIDTH`|  |  |  |`hipDeviceAttributeMaxTexture2DWidth`|
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH`|  |  |  |`hipDeviceAttributeMaxTexture3DDepth`|
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_DEPTH_ALTERNATE`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT`|  |  |  |`hipDeviceAttributeMaxTexture3DHeight`|
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_HEIGHT_ALTERNATE`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH`|  |  |  |`hipDeviceAttributeMaxTexture3DWidth`|
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURE3D_WIDTH_ALTERNATE`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_LAYERS`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_LAYERED_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAXIMUM_TEXTURECUBEMAP_WIDTH`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAX_ACCESS_POLICY_WINDOW_SIZE`| 11.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAX_BLOCKS_PER_MULTIPROCESSOR`| 11.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_X`|  |  |  |`hipDeviceAttributeMaxBlockDimX`|
+|`CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Y`|  |  |  |`hipDeviceAttributeMaxBlockDimY`|
+|`CU_DEVICE_ATTRIBUTE_MAX_BLOCK_DIM_Z`|  |  |  |`hipDeviceAttributeMaxBlockDimZ`|
+|`CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X`|  |  |  |`hipDeviceAttributeMaxGridDimX`|
+|`CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Y`|  |  |  |`hipDeviceAttributeMaxGridDimY`|
+|`CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_Z`|  |  |  |`hipDeviceAttributeMaxGridDimZ`|
+|`CU_DEVICE_ATTRIBUTE_MAX_PERSISTING_L2_CACHE_SIZE`| 11.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAX_PITCH`|  |  |  |`hipDeviceAttributeMaxPitch`|
+|`CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_BLOCK`|  |  |  |`hipDeviceAttributeMaxRegistersPerBlock`|
+|`CU_DEVICE_ATTRIBUTE_MAX_REGISTERS_PER_MULTIPROCESSOR`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK`|  |  |  |`hipDeviceAttributeMaxSharedMemoryPerBlock`|
+|`CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN`| 9.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_MULTIPROCESSOR`|  |  |  |`hipDeviceAttributeMaxSharedMemoryPerMultiprocessor`|
+|`CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_BLOCK`|  |  |  |`hipDeviceAttributeMaxThreadsPerBlock`|
+|`CU_DEVICE_ATTRIBUTE_MAX_THREADS_PER_MULTIPROCESSOR`|  |  |  |`hipDeviceAttributeMaxThreadsPerMultiProcessor`|
+|`CU_DEVICE_ATTRIBUTE_MEMORY_CLOCK_RATE`|  |  |  |`hipDeviceAttributeMemoryClockRate`|
+|`CU_DEVICE_ATTRIBUTE_MULTIPROCESSOR_COUNT`|  |  |  |`hipDeviceAttributeMultiprocessorCount`|
+|`CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD`|  |  |  |`hipDeviceAttributeIsMultiGpuBoard`|
+|`CU_DEVICE_ATTRIBUTE_MULTI_GPU_BOARD_GROUP_ID`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS`| 8.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES`| 9.2 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_PCI_BUS_ID`|  |  |  |`hipDeviceAttributePciBusId`|
+|`CU_DEVICE_ATTRIBUTE_PCI_DEVICE_ID`|  |  |  |`hipDeviceAttributePciDeviceId`|
+|`CU_DEVICE_ATTRIBUTE_PCI_DOMAIN_ID`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_REGISTERS_PER_BLOCK`|  | 5.0 |  |`hipDeviceAttributeMaxRegistersPerBlock`|
+|`CU_DEVICE_ATTRIBUTE_RESERVED_SHARED_MEMORY_PER_BLOCK`| 11.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_SHARED_MEMORY_PER_BLOCK`|  | 5.0 |  |`hipDeviceAttributeMaxSharedMemoryPerBlock`|
+|`CU_DEVICE_ATTRIBUTE_SINGLE_TO_DOUBLE_PRECISION_PERF_RATIO`| 8.0 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_STREAM_PRIORITIES_SUPPORTED`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_SURFACE_ALIGNMENT`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_TCC_DRIVER`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_TEXTURE_ALIGNMENT`|  |  |  |`hipDeviceAttributeTextureAlignment`|
+|`CU_DEVICE_ATTRIBUTE_TEXTURE_PITCH_ALIGNMENT`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_TOTAL_CONSTANT_MEMORY`|  |  |  |`hipDeviceAttributeTotalConstantMemory`|
+|`CU_DEVICE_ATTRIBUTE_UNIFIED_ADDRESSING`|  |  |  ||
+|`CU_DEVICE_ATTRIBUTE_VIRTUAL_ADDRESS_MANAGEMENT_SUPPORTED`| 10.2 |  |  ||
+|`CU_DEVICE_ATTRIBUTE_WARP_SIZE`|  |  |  |`hipDeviceAttributeWarpSize`|
+|`CU_DEVICE_CPU`| 8.0 |  |  ||
+|`CU_DEVICE_INVALID`| 8.0 |  |  ||
+|`CU_DEVICE_P2P_ATTRIBUTE_ACCESS_ACCESS_SUPPORTED`| 10.1 | 10.1 |  ||
+|`CU_DEVICE_P2P_ATTRIBUTE_ACCESS_SUPPORTED`| 8.0 |  |  ||
+|`CU_DEVICE_P2P_ATTRIBUTE_ARRAY_ACCESS_ACCESS_SUPPORTED`| 9.2 | 10.0 | 10.1 ||
+|`CU_DEVICE_P2P_ATTRIBUTE_CUDA_ARRAY_ACCESS_SUPPORTED`| 10.0 |  |  ||
+|`CU_DEVICE_P2P_ATTRIBUTE_NATIVE_ATOMIC_SUPPORTED`| 8.0 |  |  ||
+|`CU_DEVICE_P2P_ATTRIBUTE_PERFORMANCE_RANK`| 8.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_A`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_ABGR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_ARGB`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_AYUV`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_AYUV_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER10_BGGR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER10_GBRG`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER10_GRBG`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER10_RGGB`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER12_BGGR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER12_GBRG`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER12_GRBG`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER12_RGGB`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER14_BGGR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER14_GBRG`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER14_GRBG`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER14_RGGB`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER20_BGGR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER20_GBRG`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER20_GRBG`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER20_RGGB`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER_BGGR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER_GBRG`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER_GRBG`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER_ISP_BGGR`| 9.2 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER_ISP_GBRG`| 9.2 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER_ISP_GRBG`| 9.2 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER_ISP_RGGB`| 9.2 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BAYER_RGGB`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BGR`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_BGRA`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_L`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_MAX`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_R`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_RG`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_RGB`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_RGBA`|  |  |  ||
+|`CU_EGL_COLOR_FORMAT_UYVY_422`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_UYVY_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_VYUY_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_Y10V10U10_420_SEMIPLANAR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_Y10V10U10_444_SEMIPLANAR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_Y12V12U12_420_SEMIPLANAR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_Y12V12U12_444_SEMIPLANAR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUV420_PLANAR`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUV420_PLANAR_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUV420_SEMIPLANAR`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUV420_SEMIPLANAR_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUV422_PLANAR`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUV422_PLANAR_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUV422_SEMIPLANAR`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUV422_SEMIPLANAR_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUV444_PLANAR`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUV444_PLANAR_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUV444_SEMIPLANAR`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUV444_SEMIPLANAR_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUVA_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUV_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUYV_422`| 9.0 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YUYV_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YVU420_PLANAR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YVU420_PLANAR_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YVU420_SEMIPLANAR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YVU420_SEMIPLANAR_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YVU422_PLANAR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YVU422_PLANAR_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YVU422_SEMIPLANAR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YVU422_SEMIPLANAR_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YVU444_PLANAR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YVU444_PLANAR_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YVU444_SEMIPLANAR`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YVU444_SEMIPLANAR_ER`| 9.1 |  |  ||
+|`CU_EGL_COLOR_FORMAT_YVYU_ER`| 9.1 |  |  ||
+|`CU_EGL_FRAME_TYPE_ARRAY`| 9.0 |  |  ||
+|`CU_EGL_FRAME_TYPE_PITCH`| 9.0 |  |  ||
+|`CU_EGL_RESOURCE_LOCATION_SYSMEM`| 9.0 |  |  ||
+|`CU_EGL_RESOURCE_LOCATION_VIDMEM`| 9.0 |  |  ||
+|`CU_EVENT_BLOCKING_SYNC`|  |  |  |`hipEventBlockingSync`|
+|`CU_EVENT_DEFAULT`|  |  |  |`hipEventDefault`|
+|`CU_EVENT_DISABLE_TIMING`|  |  |  |`hipEventDisableTiming`|
+|`CU_EVENT_INTERPROCESS`|  |  |  |`hipEventInterprocess`|
+|`CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_RESOURCE`| 10.2 |  |  ||
+|`CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D11_RESOURCE_KMT`| 10.2 |  |  ||
+|`CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_HEAP`| 10.0 |  |  ||
+|`CU_EXTERNAL_MEMORY_HANDLE_TYPE_D3D12_RESOURCE`| 10.0 |  |  ||
+|`CU_EXTERNAL_MEMORY_HANDLE_TYPE_NVSCIBUF`| 10.2 |  |  ||
+|`CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD`| 10.0 |  |  ||
+|`CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32`| 10.0 |  |  ||
+|`CU_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_KMT`| 10.0 |  |  ||
+|`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D11_FENCE`| 10.2 |  |  ||
+|`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D11_KEYED_MUTEX`| 10.2 |  |  ||
+|`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D11_KEYED_MUTEX_KMT`| 10.2 |  |  ||
+|`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_D3D12_FENCE`| 10.0 |  |  ||
+|`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_NVSCISYNC`| 10.2 |  |  ||
+|`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD`| 10.0 |  |  ||
+|`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32`| 10.0 |  |  ||
+|`CU_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT`| 10.0 |  |  ||
+|`CU_FUNC_ATTRIBUTE_BINARY_VERSION`|  |  |  |`HIP_FUNC_ATTRIBUTE_BINARY_VERSION`|
+|`CU_FUNC_ATTRIBUTE_CACHE_MODE_CA`|  |  |  |`HIP_FUNC_ATTRIBUTE_CACHE_MODE_CA`|
+|`CU_FUNC_ATTRIBUTE_CONST_SIZE_BYTES`|  |  |  |`HIP_FUNC_ATTRIBUTE_CONST_SIZE_BYTES`|
+|`CU_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES`|  |  |  |`HIP_FUNC_ATTRIBUTE_LOCAL_SIZE_BYTES`|
+|`CU_FUNC_ATTRIBUTE_MAX`|  |  |  |`HIP_FUNC_ATTRIBUTE_MAX`|
+|`CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES`| 9.0 |  |  |`HIP_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES`|
+|`CU_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK`|  |  |  |`HIP_FUNC_ATTRIBUTE_MAX_THREADS_PER_BLOCK`|
+|`CU_FUNC_ATTRIBUTE_NUM_REGS`|  |  |  |`HIP_FUNC_ATTRIBUTE_NUM_REGS`|
+|`CU_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT`| 9.0 |  |  |`HIP_FUNC_ATTRIBUTE_PREFERRED_SHARED_MEMORY_CARVEOUT`|
+|`CU_FUNC_ATTRIBUTE_PTX_VERSION`|  |  |  |`HIP_FUNC_ATTRIBUTE_PTX_VERSION`|
+|`CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES`|  |  |  |`HIP_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES`|
+|`CU_FUNC_CACHE_PREFER_EQUAL`|  |  |  |`hipFuncCachePreferEqual`|
+|`CU_FUNC_CACHE_PREFER_L1`|  |  |  |`hipFuncCachePreferL1`|
+|`CU_FUNC_CACHE_PREFER_NONE`|  |  |  |`hipFuncCachePreferNone`|
+|`CU_FUNC_CACHE_PREFER_SHARED`|  |  |  |`hipFuncCachePreferShared`|
+|`CU_GL_DEVICE_LIST_ALL`|  |  |  ||
+|`CU_GL_DEVICE_LIST_CURRENT_FRAME`|  |  |  ||
+|`CU_GL_DEVICE_LIST_NEXT_FRAME`|  |  |  ||
+|`CU_GL_MAP_RESOURCE_FLAGS_NONE`|  |  |  ||
+|`CU_GL_MAP_RESOURCE_FLAGS_READ_ONLY`|  |  |  ||
+|`CU_GL_MAP_RESOURCE_FLAGS_WRITE_DISCARD`|  |  |  ||
+|`CU_GRAPHICS_MAP_RESOURCE_FLAGS_NONE`|  |  |  ||
+|`CU_GRAPHICS_MAP_RESOURCE_FLAGS_READ_ONLY`|  |  |  ||
+|`CU_GRAPHICS_MAP_RESOURCE_FLAGS_WRITE_DISCARD`|  |  |  ||
+|`CU_GRAPHICS_REGISTER_FLAGS_NONE`|  |  |  ||
+|`CU_GRAPHICS_REGISTER_FLAGS_READ_ONLY`|  |  |  ||
+|`CU_GRAPHICS_REGISTER_FLAGS_SURFACE_LDST`|  |  |  ||
+|`CU_GRAPHICS_REGISTER_FLAGS_TEXTURE_GATHER`|  |  |  ||
+|`CU_GRAPHICS_REGISTER_FLAGS_WRITE_DISCARD`|  |  |  ||
+|`CU_GRAPH_EXEC_UPDATE_ERROR`| 10.2 |  |  ||
+|`CU_GRAPH_EXEC_UPDATE_ERROR_FUNCTION_CHANGED`| 10.2 |  |  ||
+|`CU_GRAPH_EXEC_UPDATE_ERROR_NODE_TYPE_CHANGED`| 10.2 |  |  ||
+|`CU_GRAPH_EXEC_UPDATE_ERROR_NOT_SUPPORTED`| 10.2 |  |  ||
+|`CU_GRAPH_EXEC_UPDATE_ERROR_PARAMETERS_CHANGED`| 10.2 |  |  ||
+|`CU_GRAPH_EXEC_UPDATE_ERROR_TOPOLOGY_CHANGED`| 10.2 |  |  ||
+|`CU_GRAPH_EXEC_UPDATE_SUCCESS`| 10.2 |  |  ||
+|`CU_GRAPH_NODE_TYPE_COUNT`| 10.0 |  | 11.0 ||
+|`CU_GRAPH_NODE_TYPE_EMPTY`| 10.0 |  |  ||
+|`CU_GRAPH_NODE_TYPE_GRAPH`| 10.0 |  |  ||
+|`CU_GRAPH_NODE_TYPE_HOST`| 10.0 |  |  ||
+|`CU_GRAPH_NODE_TYPE_KERNEL`| 10.0 |  |  ||
+|`CU_GRAPH_NODE_TYPE_MEMCPY`| 10.0 |  |  ||
+|`CU_GRAPH_NODE_TYPE_MEMSET`| 10.0 |  |  ||
+|`CU_IPC_HANDLE_SIZE`|  |  |  ||
+|`CU_IPC_MEM_LAZY_ENABLE_PEER_ACCESS`|  |  |  |`hipIpcMemLazyEnablePeerAccess`|
+|`CU_JIT_CACHE_MODE`|  |  |  |`hipJitOptionCacheMode`|
+|`CU_JIT_CACHE_OPTION_CA`|  |  |  ||
+|`CU_JIT_CACHE_OPTION_CG`|  |  |  ||
+|`CU_JIT_CACHE_OPTION_NONE`|  |  |  ||
+|`CU_JIT_ERROR_LOG_BUFFER`|  |  |  |`hipJitOptionErrorLogBuffer`|
+|`CU_JIT_ERROR_LOG_BUFFER_SIZE_BYTES`|  |  |  |`hipJitOptionErrorLogBufferSizeBytes`|
+|`CU_JIT_FALLBACK_STRATEGY`|  |  |  |`hipJitOptionFallbackStrategy`|
+|`CU_JIT_FAST_COMPILE`|  |  |  |`hipJitOptionFastCompile`|
+|`CU_JIT_GENERATE_DEBUG_INFO`|  |  |  |`hipJitOptionGenerateDebugInfo`|
+|`CU_JIT_GENERATE_LINE_INFO`|  |  |  |`hipJitOptionGenerateLineInfo`|
+|`CU_JIT_GLOBAL_SYMBOL_ADDRESSES`|  |  |  |`hipJitGlobalSymbolAddresses`|
+|`CU_JIT_GLOBAL_SYMBOL_COUNT`|  |  |  |`hipJitGlobalSymbolCount`|
+|`CU_JIT_GLOBAL_SYMBOL_NAMES`|  |  |  |`hipJitGlobalSymbolNames`|
+|`CU_JIT_INFO_LOG_BUFFER`|  |  |  |`hipJitOptionInfoLogBuffer`|
+|`CU_JIT_INFO_LOG_BUFFER_SIZE_BYTES`|  |  |  |`hipJitOptionInfoLogBufferSizeBytes`|
+|`CU_JIT_INPUT_CUBIN`|  |  |  ||
+|`CU_JIT_INPUT_FATBINARY`|  |  |  ||
+|`CU_JIT_INPUT_LIBRARY`|  |  |  ||
+|`CU_JIT_INPUT_OBJECT`|  |  |  ||
+|`CU_JIT_INPUT_PTX`|  |  |  ||
+|`CU_JIT_LOG_VERBOSE`|  |  |  |`hipJitOptionLogVerbose`|
+|`CU_JIT_MAX_REGISTERS`|  |  |  |`hipJitOptionMaxRegisters`|
+|`CU_JIT_NEW_SM3X_OPT`|  |  |  |`hipJitOptionSm3xOpt`|
+|`CU_JIT_NUM_INPUT_TYPES`|  |  |  ||
+|`CU_JIT_NUM_OPTIONS`|  |  |  |`hipJitOptionNumOptions`|
+|`CU_JIT_OPTIMIZATION_LEVEL`|  |  |  |`hipJitOptionOptimizationLevel`|
+|`CU_JIT_TARGET`|  |  |  |`hipJitOptionTarget`|
+|`CU_JIT_TARGET_FROM_CUCONTEXT`|  |  |  |`hipJitOptionTargetFromContext`|
+|`CU_JIT_THREADS_PER_BLOCK`|  |  |  |`hipJitOptionThreadsPerBlock`|
+|`CU_JIT_WALL_TIME`|  |  |  |`hipJitOptionWallTime`|
+|`CU_KERNEL_NODE_ATTRIBUTE_ACCESS_POLICY_WINDOW`| 11.0 |  |  ||
+|`CU_KERNEL_NODE_ATTRIBUTE_COOPERATIVE`| 11.0 |  |  ||
+|`CU_LAUNCH_PARAM_BUFFER_POINTER`|  |  |  |`HIP_LAUNCH_PARAM_BUFFER_POINTER`|
+|`CU_LAUNCH_PARAM_BUFFER_SIZE`|  |  |  |`HIP_LAUNCH_PARAM_BUFFER_SIZE`|
+|`CU_LAUNCH_PARAM_END`|  |  |  |`HIP_LAUNCH_PARAM_END`|
+|`CU_LIMIT_DEV_RUNTIME_PENDING_LAUNCH_COUNT`|  |  |  ||
+|`CU_LIMIT_DEV_RUNTIME_SYNC_DEPTH`|  |  |  ||
+|`CU_LIMIT_MALLOC_HEAP_SIZE`|  |  |  |`hipLimitMallocHeapSize`|
+|`CU_LIMIT_MAX`|  |  |  ||
+|`CU_LIMIT_MAX_L2_FETCH_GRANULARITY`| 10.0 |  |  ||
+|`CU_LIMIT_PERSISTING_L2_CACHE_SIZE`| 11.0 |  |  ||
+|`CU_LIMIT_PRINTF_FIFO_SIZE`|  |  |  ||
+|`CU_LIMIT_STACK_SIZE`|  |  |  ||
+|`CU_MEMHOSTALLOC_DEVICEMAP`|  |  |  |`hipHostMallocMapped`|
+|`CU_MEMHOSTALLOC_PORTABLE`|  |  |  |`hipHostMallocPortable`|
+|`CU_MEMHOSTALLOC_WRITECOMBINED`|  |  |  |`hipHostMallocWriteCombined`|
+|`CU_MEMHOSTREGISTER_DEVICEMAP`|  |  |  |`hipHostRegisterMapped`|
+|`CU_MEMHOSTREGISTER_IOMEMORY`| 7.5 |  |  |`hipHostRegisterIoMemory`|
+|`CU_MEMHOSTREGISTER_PORTABLE`|  |  |  |`hipHostRegisterPortable`|
+|`CU_MEMORYTYPE_ARRAY`|  |  |  |`hipMemoryTypeArray`|
+|`CU_MEMORYTYPE_DEVICE`|  |  |  |`hipMemoryTypeDevice`|
+|`CU_MEMORYTYPE_HOST`|  |  |  |`hipMemoryTypeHost`|
+|`CU_MEMORYTYPE_UNIFIED`|  |  |  |`hipMemoryTypeUnified`|
+|`CU_MEM_ACCESS_FLAGS_PROT_MAX`| 10.2 |  |  ||
+|`CU_MEM_ACCESS_FLAGS_PROT_NONE`| 10.2 |  |  ||
+|`CU_MEM_ACCESS_FLAGS_PROT_READ`| 10.2 |  |  ||
+|`CU_MEM_ACCESS_FLAGS_PROT_READWRITE`| 10.2 |  |  ||
+|`CU_MEM_ADVISE_SET_ACCESSED_BY`| 8.0 |  |  ||
+|`CU_MEM_ADVISE_SET_PREFERRED_LOCATION`| 8.0 |  |  ||
+|`CU_MEM_ADVISE_SET_READ_MOSTLY`| 8.0 |  |  ||
+|`CU_MEM_ADVISE_UNSET_ACCESSED_BY`| 8.0 |  |  ||
+|`CU_MEM_ADVISE_UNSET_PREFERRED_LOCATION`| 8.0 |  |  ||
+|`CU_MEM_ADVISE_UNSET_READ_MOSTLY`| 8.0 |  |  ||
+|`CU_MEM_ALLOC_GRANULARITY_MINIMUM`| 10.2 |  |  ||
+|`CU_MEM_ALLOC_GRANULARITY_RECOMMENDED`| 10.2 |  |  ||
+|`CU_MEM_ATTACH_GLOBAL`|  |  |  |`hipMemAttachGlobal`|
+|`CU_MEM_ATTACH_HOST`|  |  |  |`hipMemAttachHost`|
+|`CU_MEM_ATTACH_SINGLE`|  |  |  ||
+|`CU_MEM_HANDLE_TYPE_MAX`| 10.2 |  |  ||
+|`CU_MEM_HANDLE_TYPE_POSIX_FILE_DESCRIPTOR`| 10.2 |  |  ||
+|`CU_MEM_HANDLE_TYPE_WIN32`| 10.2 |  |  ||
+|`CU_MEM_HANDLE_TYPE_WIN32_KMT`| 10.2 |  |  ||
+|`CU_MEM_LOCATION_TYPE_DEVICE`| 10.2 |  |  ||
+|`CU_MEM_LOCATION_TYPE_INVALID`| 10.2 |  |  ||
+|`CU_MEM_LOCATION_TYPE_MAX`| 10.2 |  |  ||
+|`CU_MEM_RANGE_ATTRIBUTE_ACCESSED_BY`| 8.0 |  |  ||
+|`CU_MEM_RANGE_ATTRIBUTE_LAST_PREFETCH_LOCATION`| 8.0 |  |  ||
+|`CU_MEM_RANGE_ATTRIBUTE_PREFERRED_LOCATION`| 8.0 |  |  ||
+|`CU_MEM_RANGE_ATTRIBUTE_READ_MOSTLY`| 8.0 |  |  ||
+|`CU_OCCUPANCY_DEFAULT`|  |  |  |`hipOccupancyDefault`|
+|`CU_OCCUPANCY_DISABLE_CACHING_OVERRIDE`|  |  |  ||
+|`CU_PARAM_TR_DEFAULT`|  |  |  ||
+|`CU_POINTER_ATTRIBUTE_ALLOWED_HANDLE_TYPES`| 10.2 |  |  ||
+|`CU_POINTER_ATTRIBUTE_BUFFER_ID`|  |  |  ||
+|`CU_POINTER_ATTRIBUTE_CONTEXT`|  |  |  ||
+|`CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL`| 9.2 |  |  ||
+|`CU_POINTER_ATTRIBUTE_DEVICE_POINTER`|  |  |  ||
+|`CU_POINTER_ATTRIBUTE_HOST_POINTER`|  |  |  ||
+|`CU_POINTER_ATTRIBUTE_IS_GPU_DIRECT_RDMA_CAPABLE`| 11.0 |  |  ||
+|`CU_POINTER_ATTRIBUTE_IS_LEGACY_CUDA_IPC_CAPABLE`| 10.2 |  |  ||
+|`CU_POINTER_ATTRIBUTE_IS_MANAGED`|  |  |  ||
+|`CU_POINTER_ATTRIBUTE_MAPPED`| 10.2 |  |  ||
+|`CU_POINTER_ATTRIBUTE_MEMORY_TYPE`|  |  |  ||
+|`CU_POINTER_ATTRIBUTE_P2P_TOKENS`|  |  |  ||
+|`CU_POINTER_ATTRIBUTE_RANGE_SIZE`| 10.2 |  |  ||
+|`CU_POINTER_ATTRIBUTE_RANGE_START_ADDR`| 10.2 |  |  ||
+|`CU_POINTER_ATTRIBUTE_SYNC_MEMOPS`|  |  |  ||
+|`CU_PREFER_BINARY`|  |  |  ||
+|`CU_PREFER_PTX`|  |  |  ||
+|`CU_RESOURCE_TYPE_ARRAY`|  |  |  |`hipResourceTypeArray`|
+|`CU_RESOURCE_TYPE_LINEAR`|  |  |  |`hipResourceTypeLinear`|
+|`CU_RESOURCE_TYPE_MIPMAPPED_ARRAY`|  |  |  |`hipResourceTypeMipmappedArray`|
+|`CU_RESOURCE_TYPE_PITCH2D`|  |  |  |`hipResourceTypePitch2D`|
+|`CU_RES_VIEW_FORMAT_FLOAT_1X16`|  |  |  |`hipResViewFormatHalf1`|
+|`CU_RES_VIEW_FORMAT_FLOAT_1X32`|  |  |  |`hipResViewFormatFloat1`|
+|`CU_RES_VIEW_FORMAT_FLOAT_2X16`|  |  |  |`hipResViewFormatHalf2`|
+|`CU_RES_VIEW_FORMAT_FLOAT_2X32`|  |  |  |`hipResViewFormatFloat2`|
+|`CU_RES_VIEW_FORMAT_FLOAT_4X16`|  |  |  |`hipResViewFormatHalf4`|
+|`CU_RES_VIEW_FORMAT_FLOAT_4X32`|  |  |  |`hipResViewFormatFloat4`|
+|`CU_RES_VIEW_FORMAT_NONE`|  |  |  |`hipResViewFormatNone`|
+|`CU_RES_VIEW_FORMAT_SIGNED_BC4`|  |  |  |`hipResViewFormatSignedBlockCompressed4`|
+|`CU_RES_VIEW_FORMAT_SIGNED_BC5`|  |  |  |`hipResViewFormatSignedBlockCompressed5`|
+|`CU_RES_VIEW_FORMAT_SIGNED_BC6H`|  |  |  |`hipResViewFormatSignedBlockCompressed6H`|
+|`CU_RES_VIEW_FORMAT_SINT_1X16`|  |  |  |`hipResViewFormatSignedShort1`|
+|`CU_RES_VIEW_FORMAT_SINT_1X32`|  |  |  |`hipResViewFormatSignedInt1`|
+|`CU_RES_VIEW_FORMAT_SINT_1X8`|  |  |  |`hipResViewFormatSignedChar1`|
+|`CU_RES_VIEW_FORMAT_SINT_2X16`|  |  |  |`hipResViewFormatSignedShort2`|
+|`CU_RES_VIEW_FORMAT_SINT_2X32`|  |  |  |`hipResViewFormatSignedInt2`|
+|`CU_RES_VIEW_FORMAT_SINT_2X8`|  |  |  |`hipResViewFormatSignedChar2`|
+|`CU_RES_VIEW_FORMAT_SINT_4X16`|  |  |  |`hipResViewFormatSignedShort4`|
+|`CU_RES_VIEW_FORMAT_SINT_4X32`|  |  |  |`hipResViewFormatSignedInt4`|
+|`CU_RES_VIEW_FORMAT_SINT_4X8`|  |  |  |`hipResViewFormatSignedChar4`|
+|`CU_RES_VIEW_FORMAT_UINT_1X16`|  |  |  |`hipResViewFormatUnsignedShort1`|
+|`CU_RES_VIEW_FORMAT_UINT_1X32`|  |  |  |`hipResViewFormatUnsignedInt1`|
+|`CU_RES_VIEW_FORMAT_UINT_1X8`|  |  |  |`hipResViewFormatUnsignedChar1`|
+|`CU_RES_VIEW_FORMAT_UINT_2X16`|  |  |  |`hipResViewFormatUnsignedShort2`|
+|`CU_RES_VIEW_FORMAT_UINT_2X32`|  |  |  |`hipResViewFormatUnsignedInt2`|
+|`CU_RES_VIEW_FORMAT_UINT_2X8`|  |  |  |`hipResViewFormatUnsignedChar2`|
+|`CU_RES_VIEW_FORMAT_UINT_4X16`|  |  |  |`hipResViewFormatUnsignedShort4`|
+|`CU_RES_VIEW_FORMAT_UINT_4X32`|  |  |  |`hipResViewFormatUnsignedInt4`|
+|`CU_RES_VIEW_FORMAT_UINT_4X8`|  |  |  |`hipResViewFormatUnsignedChar4`|
+|`CU_RES_VIEW_FORMAT_UNSIGNED_BC1`|  |  |  |`hipResViewFormatUnsignedBlockCompressed1`|
+|`CU_RES_VIEW_FORMAT_UNSIGNED_BC2`|  |  |  |`hipResViewFormatUnsignedBlockCompressed2`|
+|`CU_RES_VIEW_FORMAT_UNSIGNED_BC3`|  |  |  |`hipResViewFormatUnsignedBlockCompressed3`|
+|`CU_RES_VIEW_FORMAT_UNSIGNED_BC4`|  |  |  |`hipResViewFormatUnsignedBlockCompressed4`|
+|`CU_RES_VIEW_FORMAT_UNSIGNED_BC5`|  |  |  |`hipResViewFormatUnsignedBlockCompressed5`|
+|`CU_RES_VIEW_FORMAT_UNSIGNED_BC6H`|  |  |  |`hipResViewFormatUnsignedBlockCompressed6H`|
+|`CU_RES_VIEW_FORMAT_UNSIGNED_BC7`|  |  |  |`hipResViewFormatUnsignedBlockCompressed7`|
+|`CU_SHAREDMEM_CARVEOUT_DEFAULT`| 9.0 |  |  ||
+|`CU_SHAREDMEM_CARVEOUT_MAX_L1`| 9.0 |  |  ||
+|`CU_SHAREDMEM_CARVEOUT_MAX_SHARED`| 9.0 |  |  ||
+|`CU_SHARED_MEM_CONFIG_DEFAULT_BANK_SIZE`|  |  |  |`hipSharedMemBankSizeDefault`|
+|`CU_SHARED_MEM_CONFIG_EIGHT_BYTE_BANK_SIZE`|  |  |  |`hipSharedMemBankSizeEightByte`|
+|`CU_SHARED_MEM_CONFIG_FOUR_BYTE_BANK_SIZE`|  |  |  |`hipSharedMemBankSizeFourByte`|
+|`CU_STREAM_ATTRIBUTE_ACCESS_POLICY_WINDOW`| 11.0 |  |  ||
+|`CU_STREAM_ATTRIBUTE_SYNCHRONIZATION_POLICY`| 11.0 |  |  ||
+|`CU_STREAM_CAPTURE_MODE_GLOBAL`| 10.1 |  |  ||
+|`CU_STREAM_CAPTURE_MODE_RELAXED`| 10.1 |  |  ||
+|`CU_STREAM_CAPTURE_MODE_THREAD_LOCAL`| 10.1 |  |  ||
+|`CU_STREAM_CAPTURE_STATUS_ACTIVE`| 10.0 |  |  ||
+|`CU_STREAM_CAPTURE_STATUS_INVALIDATED`| 10.0 |  |  ||
+|`CU_STREAM_CAPTURE_STATUS_NONE`| 10.0 |  |  ||
+|`CU_STREAM_DEFAULT`|  |  |  |`hipStreamDefault`|
+|`CU_STREAM_LEGACY`|  |  |  ||
+|`CU_STREAM_MEM_OP_FLUSH_REMOTE_WRITES`| 8.0 |  |  ||
+|`CU_STREAM_MEM_OP_WAIT_VALUE_32`| 8.0 |  |  ||
+|`CU_STREAM_MEM_OP_WAIT_VALUE_64`| 9.0 |  |  ||
+|`CU_STREAM_MEM_OP_WRITE_VALUE_32`| 8.0 |  |  ||
+|`CU_STREAM_MEM_OP_WRITE_VALUE_64`| 9.0 |  |  ||
+|`CU_STREAM_NON_BLOCKING`|  |  |  |`hipStreamNonBlocking`|
+|`CU_STREAM_PER_THREAD`|  |  |  ||
+|`CU_STREAM_WAIT_VALUE_AND`| 8.0 |  |  ||
+|`CU_STREAM_WAIT_VALUE_EQ`| 8.0 |  |  ||
+|`CU_STREAM_WAIT_VALUE_FLUSH`| 8.0 |  |  ||
+|`CU_STREAM_WAIT_VALUE_GEQ`| 8.0 |  |  ||
+|`CU_STREAM_WRITE_VALUE_DEFAULT`| 8.0 |  |  ||
+|`CU_STREAM_WRITE_VALUE_NO_MEMORY_BARRIER`| 8.0 |  |  ||
+|`CU_SYNC_POLICY_AUTO`| 11.0 |  |  ||
+|`CU_SYNC_POLICY_BLOCKING_SYNC`| 11.0 |  |  ||
+|`CU_SYNC_POLICY_SPIN`| 11.0 |  |  ||
+|`CU_SYNC_POLICY_YIELD`| 11.0 |  |  ||
+|`CU_TARGET_COMPUTE_10`|  |  | 9.0 ||
+|`CU_TARGET_COMPUTE_11`|  |  | 9.0 ||
+|`CU_TARGET_COMPUTE_12`|  |  | 9.0 ||
+|`CU_TARGET_COMPUTE_13`|  |  | 9.0 ||
+|`CU_TARGET_COMPUTE_20`|  |  |  ||
+|`CU_TARGET_COMPUTE_21`|  |  |  ||
+|`CU_TARGET_COMPUTE_30`|  |  |  ||
+|`CU_TARGET_COMPUTE_32`|  |  |  ||
+|`CU_TARGET_COMPUTE_35`|  |  |  ||
+|`CU_TARGET_COMPUTE_37`|  |  |  ||
+|`CU_TARGET_COMPUTE_50`|  |  |  ||
+|`CU_TARGET_COMPUTE_52`|  |  |  ||
+|`CU_TARGET_COMPUTE_53`| 8.0 |  |  ||
+|`CU_TARGET_COMPUTE_60`| 8.0 |  |  ||
+|`CU_TARGET_COMPUTE_61`| 8.0 |  |  ||
+|`CU_TARGET_COMPUTE_62`| 8.0 |  |  ||
+|`CU_TARGET_COMPUTE_70`| 9.0 |  |  ||
+|`CU_TARGET_COMPUTE_72`| 10.1 |  |  ||
+|`CU_TARGET_COMPUTE_73`| 9.1 |  | 10.0 ||
+|`CU_TARGET_COMPUTE_75`| 9.1 |  |  ||
+|`CU_TARGET_COMPUTE_80`| 11.0 |  |  ||
+|`CU_TRSA_OVERRIDE_FORMAT`|  |  |  |`HIP_TRSA_OVERRIDE_FORMAT`|
+|`CU_TRSF_DISABLE_TRILINEAR_OPTIMIZATION`| 11.0 |  |  ||
+|`CU_TRSF_NORMALIZED_COORDINATES`|  |  |  |`HIP_TRSF_NORMALIZED_COORDINATES`|
+|`CU_TRSF_READ_AS_INTEGER`|  |  |  |`HIP_TRSF_READ_AS_INTEGER`|
+|`CU_TRSF_SRGB`|  |  |  ||
+|`CU_TR_ADDRESS_MODE_BORDER`|  |  |  |`hipAddressModeBorder`|
+|`CU_TR_ADDRESS_MODE_CLAMP`|  |  |  |`hipAddressModeClamp`|
+|`CU_TR_ADDRESS_MODE_MIRROR`|  |  |  |`hipAddressModeMirror`|
+|`CU_TR_ADDRESS_MODE_WRAP`|  |  |  |`hipAddressModeWrap`|
+|`CU_TR_FILTER_MODE_LINEAR`|  |  |  |`hipFilterModeLinear`|
+|`CU_TR_FILTER_MODE_POINT`|  |  |  |`hipFilterModePoint`|
+|`CUaccessPolicyWindow`| 11.0 |  |  ||
+|`CUaccessPolicyWindow_st`| 11.0 |  |  ||
+|`CUaccessProperty`| 11.0 |  |  ||
+|`CUaccessProperty_enum`| 11.0 |  |  ||
+|`CUaddress_mode`|  |  |  |`hipTextureAddressMode`|
+|`CUaddress_mode_enum`|  |  |  |`hipTextureAddressMode`|
+|`CUarray`|  |  |  |`hipArray *`|
+|`CUarray_cubemap_face`|  |  |  ||
+|`CUarray_cubemap_face_enum`|  |  |  ||
+|`CUarray_format`|  |  |  |`hipArray_format`|
+|`CUarray_format_enum`|  |  |  |`hipArray_format`|
+|`CUarray_st`|  |  |  |`hipArray`|
+|`CUcomputemode`|  |  |  |`hipComputeMode`|
+|`CUcomputemode_enum`|  |  |  |`hipComputeMode`|
+|`CUcontext`|  |  |  |`hipCtx_t`|
+|`CUctx_flags`|  |  |  ||
+|`CUctx_flags_enum`|  |  |  ||
+|`CUctx_st`|  |  |  |`ihipCtx_t`|
+|`CUd3d10DeviceList`|  |  |  ||
+|`CUd3d10DeviceList_enum`|  |  |  ||
+|`CUd3d10map_flags`|  |  |  ||
+|`CUd3d10map_flags_enum`|  |  |  ||
+|`CUd3d10register_flags`|  |  |  ||
+|`CUd3d10register_flags_enum`|  |  |  ||
+|`CUd3d11DeviceList`|  |  |  ||
+|`CUd3d11DeviceList_enum`|  |  |  ||
+|`CUd3d9DeviceList`|  |  |  ||
+|`CUd3d9DeviceList_enum`|  |  |  ||
+|`CUd3d9map_flags`|  |  |  ||
+|`CUd3d9map_flags_enum`|  |  |  ||
+|`CUd3d9register_flags`|  |  |  ||
+|`CUd3d9register_flags_enum`|  |  |  ||
+|`CUdevice`|  |  |  |`hipDevice_t`|
+|`CUdevice_P2PAttribute`| 8.0 |  |  ||
+|`CUdevice_P2PAttribute_enum`| 8.0 |  |  ||
+|`CUdevice_attribute`|  |  |  |`hipDeviceAttribute_t`|
+|`CUdevice_attribute_enum`|  |  |  |`hipDeviceAttribute_t`|
+|`CUdeviceptr`|  |  |  |`hipDeviceptr_t`|
+|`CUdeviceptr_v1`|  |  |  |`hipDeviceptr_t`|
+|`CUdevprop`|  |  |  ||
+|`CUdevprop_st`|  |  |  ||
+|`CUeglColorFormat`| 9.0 |  |  ||
+|`CUeglColorFormate_enum`| 9.0 |  |  ||
+|`CUeglFrameType`| 9.0 |  |  ||
+|`CUeglFrameType_enum`| 9.0 |  |  ||
+|`CUeglResourceLocationFlags`| 9.0 |  |  ||
+|`CUeglResourceLocationFlags_enum`| 9.0 |  |  ||
+|`CUeglStreamConnection`| 9.0 |  |  ||
+|`CUeglStreamConnection_st`| 9.0 |  |  ||
+|`CUevent`|  |  |  |`hipEvent_t`|
+|`CUevent_flags`|  |  |  ||
+|`CUevent_flags_enum`|  |  |  ||
+|`CUevent_st`|  |  |  |`ihipEvent_t`|
+|`CUextMemory_st`| 10.0 |  |  ||
+|`CUextSemaphore_st`| 10.0 |  |  ||
+|`CUexternalMemory`| 10.0 |  |  ||
+|`CUexternalMemoryHandleType`| 10.0 |  |  ||
+|`CUexternalMemoryHandleType_enum`| 10.0 |  |  ||
+|`CUexternalSemaphore`| 10.0 |  |  ||
+|`CUexternalSemaphoreHandleType`| 10.0 |  |  ||
+|`CUexternalSemaphoreHandleType_enum`| 10.0 |  |  ||
+|`CUfilter_mode`|  |  |  |`hipTextureFilterMode`|
+|`CUfilter_mode_enum`|  |  |  |`hipTextureFilterMode`|
+|`CUfunc_cache`|  |  |  |`hipFuncCache_t`|
+|`CUfunc_cache_enum`|  |  |  |`hipFuncCache_t`|
+|`CUfunc_st`|  |  |  |`ihipModuleSymbol_t`|
+|`CUfunction`|  |  |  |`hipFunction_t`|
+|`CUfunction_attribute`|  |  |  |`hipFunction_attribute`|
+|`CUfunction_attribute_enum`|  |  |  |`hipFunction_attribute`|
+|`CUgraph`| 10.0 |  |  ||
+|`CUgraphExec`| 10.0 |  |  ||
+|`CUgraphExecUpdateResult`| 10.2 |  |  ||
+|`CUgraphExecUpdateResult_enum`| 10.2 |  |  ||
+|`CUgraphExec_st`| 10.0 |  |  ||
+|`CUgraphNode`| 10.0 |  |  ||
+|`CUgraphNodeType`| 10.0 |  |  ||
+|`CUgraphNodeType_enum`| 10.0 |  |  ||
+|`CUgraphNode_st`| 10.0 |  |  ||
+|`CUgraph_st`| 10.0 |  |  ||
+|`CUgraphicsMapResourceFlags`|  |  |  ||
+|`CUgraphicsMapResourceFlags_enum`|  |  |  ||
+|`CUgraphicsRegisterFlags`|  |  |  ||
+|`CUgraphicsRegisterFlags_enum`|  |  |  ||
+|`CUgraphicsResource`|  |  |  ||
+|`CUgraphicsResource_st`|  |  |  ||
+|`CUhostFn`| 10.0 |  |  ||
+|`CUipcEventHandle`|  |  |  |`ihipIpcEventHandle_t`|
+|`CUipcEventHandle_st`|  |  |  |`ihipIpcEventHandle_t`|
+|`CUipcMemHandle`|  |  |  |`hipIpcMemHandle_t`|
+|`CUipcMemHandle_st`|  |  |  |`hipIpcMemHandle_st`|
+|`CUipcMem_flags`|  |  |  ||
+|`CUipcMem_flags_enum`|  |  |  ||
+|`CUjitInputType`|  |  |  ||
+|`CUjitInputType_enum`|  |  |  ||
+|`CUjit_cacheMode`|  |  |  ||
+|`CUjit_cacheMode_enum`|  |  |  ||
+|`CUjit_fallback`|  |  |  ||
+|`CUjit_fallback_enum`|  |  |  ||
+|`CUjit_option`|  |  |  |`hipJitOption`|
+|`CUjit_option_enum`|  |  |  |`hipJitOption`|
+|`CUjit_target`|  |  |  ||
+|`CUjit_target_enum`|  |  |  ||
+|`CUkernelNodeAttrID`| 11.0 |  |  ||
+|`CUkernelNodeAttrID_enum`| 11.0 |  |  ||
+|`CUkernelNodeAttrValue`| 11.0 |  |  ||
+|`CUkernelNodeAttrValue_union`| 11.0 |  |  ||
+|`CUlimit`|  |  |  |`hipLimit_t`|
+|`CUlimit_enum`|  |  |  |`hipLimit_t`|
+|`CUmemAccessDesc`| 10.2 |  |  ||
+|`CUmemAccessDesc_st`| 10.2 |  |  ||
+|`CUmemAccess_flags`| 10.2 |  |  ||
+|`CUmemAccess_flags_enum`| 10.2 |  |  ||
+|`CUmemAllocationGranularity_flags`| 10.2 |  |  ||
+|`CUmemAllocationGranularity_flags_enum`| 10.2 |  |  ||
+|`CUmemAllocationHandleType`| 10.2 |  |  ||
+|`CUmemAllocationHandleType_enum`| 10.2 |  |  ||
+|`CUmemAllocationProp`| 10.2 |  |  ||
+|`CUmemAllocationProp_st`| 10.2 |  |  ||
+|`CUmemAttach_flags`|  |  |  ||
+|`CUmemAttach_flags_enum`|  |  |  ||
+|`CUmemGenericAllocationHandle`| 10.2 |  |  ||
+|`CUmemLocation`| 10.2 |  |  ||
+|`CUmemLocationType`| 10.2 |  |  ||
+|`CUmemLocationType_enum`| 10.2 |  |  ||
+|`CUmemLocation_st`| 10.2 |  |  ||
+|`CUmem_advise`| 8.0 |  |  ||
+|`CUmem_advise_enum`| 8.0 |  |  ||
+|`CUmem_range_attribute`| 8.0 |  |  ||
+|`CUmem_range_attribute_enum`| 8.0 |  |  ||
+|`CUmemorytype`|  |  |  |`hipMemoryType`|
+|`CUmemorytype_enum`|  |  |  |`hipMemoryType`|
+|`CUmipmappedArray`|  |  |  |`hipMipmappedArray_t`|
+|`CUmipmappedArray_st`|  |  |  |`hipMipmappedArray_st`|
+|`CUmod_st`|  |  |  |`ihipModule_t`|
+|`CUmodule`|  |  |  |`hipModule_t`|
+|`CUoccupancyB2DSize`|  |  |  ||
+|`CUoccupancy_flags`|  |  |  ||
+|`CUoccupancy_flags_enum`|  |  |  ||
+|`CUpointer_attribute`|  |  |  ||
+|`CUpointer_attribute_enum`|  |  |  ||
+|`CUresourceViewFormat`|  |  |  |`hipResourceViewFormat`|
+|`CUresourceViewFormat_enum`|  |  |  |`hipResourceViewFormat`|
+|`CUresourcetype`|  |  |  |`hipResourceType`|
+|`CUresourcetype_enum`|  |  |  |`hipResourceType`|
+|`CUresult`|  |  |  |`hipError_t`|
+|`CUshared_carveout`| 9.0 |  |  ||
+|`CUshared_carveout_enum`| 9.0 |  |  ||
+|`CUsharedconfig`|  |  |  |`hipSharedMemConfig`|
+|`CUsharedconfig_enum`|  |  |  |`hipSharedMemConfig`|
+|`CUstream`|  |  |  |`hipStream_t`|
+|`CUstreamAttrID`| 11.0 |  |  ||
+|`CUstreamAttrID_enum`| 11.0 |  |  ||
+|`CUstreamAttrValue`| 11.0 |  |  ||
+|`CUstreamAttrValue_union`| 11.0 |  |  ||
+|`CUstreamBatchMemOpParams`| 8.0 |  |  ||
+|`CUstreamBatchMemOpParams_union`| 8.0 |  |  ||
+|`CUstreamBatchMemOpType`| 8.0 |  |  ||
+|`CUstreamBatchMemOpType_enum`| 8.0 |  |  ||
+|`CUstreamCallback`|  |  |  |`hipStreamCallback_t`|
+|`CUstreamCaptureMode`| 10.1 |  |  ||
+|`CUstreamCaptureMode_enum`| 10.1 |  |  ||
+|`CUstreamCaptureStatus`| 10.0 |  |  ||
+|`CUstreamCaptureStatus_enum`| 10.0 |  |  ||
+|`CUstreamWaitValue_flags`| 8.0 |  |  ||
+|`CUstreamWaitValue_flags_enum`| 8.0 |  |  ||
+|`CUstreamWriteValue_flags`| 8.0 |  |  ||
+|`CUstreamWriteValue_flags_enum`| 8.0 |  |  ||
+|`CUstream_flags`|  |  |  ||
+|`CUstream_flags_enum`|  |  |  ||
+|`CUstream_st`|  |  |  |`ihipStream_t`|
+|`CUsurfObject`|  |  |  ||
+|`CUsurfref`|  |  |  ||
+|`CUsurfref_st`|  |  |  ||
+|`CUsynchronizationPolicy`| 11.0 |  |  ||
+|`CUsynchronizationPolicy_enum`| 11.0 |  |  ||
+|`CUtexObject`|  |  |  |`hipTextureObject_t`|
+|`CUtexref`|  |  |  ||
+|`CUtexref_st`|  |  |  |`textureReference`|
+|`CUuuid`|  |  |  ||
+|`CUuuid_st`|  |  |  ||
+|`__CUDACC__`|  |  |  |`__HIPCC__`|
+|`cudaError_enum`|  |  |  |`hipError_t`|
 
 ## **2. Error Handling**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuGetErrorName`                                          |                               |
-| `cuGetErrorString`                                        |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuGetErrorName`|  |  |  ||
+|`cuGetErrorString`|  |  |  ||
 
 ## **3. Initialization**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuInit`                                                  | `hipInit`                     |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuInit`|  |  |  |`hipInit`|
 
 ## **4. Version Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuDriverGetVersion`                                      | `hipDriverGetVersion`         |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuDriverGetVersion`|  |  |  |`hipDriverGetVersion`|
 
 ## **5. Device Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cuDriverGetVersion`                                      | `hipGetDevice`                |
-| `cuDeviceGetAttribute`                                    | `hipDeviceGetAttribute`       |
-| `cuDeviceGetCount`                                        | `hipGetDeviceCount`           |
-| `cuDeviceGetName`                                         | `hipDeviceGetName`            |
-| `cuDeviceGetNvSciSyncAttributes`                          |                               | 10.2             |
-| `cuDeviceTotalMem`                                        | `hipDeviceTotalMem`           |
-| `cuDeviceGetLuid`                                         |                               | 10.0             |
-| `cuDeviceGetUuid`                                         |                               | 9.2              |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuDeviceGet`|  |  |  |`hipGetDevice`|
+|`cuDeviceGetAttribute`|  |  |  |`hipDeviceGetAttribute`|
+|`cuDeviceGetCount`|  |  |  |`hipGetDeviceCount`|
+|`cuDeviceGetLuid`| 10.0 |  |  ||
+|`cuDeviceGetName`|  |  |  |`hipDeviceGetName`|
+|`cuDeviceGetNvSciSyncAttributes`| 10.2 |  |  ||
+|`cuDeviceGetUuid`| 9.2 |  |  ||
+|`cuDeviceTotalMem`|  |  |  |`hipDeviceTotalMem`|
+|`cuDeviceTotalMem_v2`|  |  |  |`hipDeviceTotalMem`|
 
 ## **6. Device Management [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuDeviceComputeCapability`                               | `hipDeviceComputeCapability`  |
-| `cuDeviceGetProperties`                                   |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuDeviceComputeCapability`|  | 9.2 |  |`hipDeviceComputeCapability`|
+|`cuDeviceGetProperties`|  | 9.2 |  ||
 
 ## **7. Primary Context Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuDevicePrimaryCtxGetState`                              | `hipDevicePrimaryCtxGetState` |
-| `cuDevicePrimaryCtxRelease`                               | `hipDevicePrimaryCtxRelease`  |
-| `cuDevicePrimaryCtxReset`                                 | `hipDevicePrimaryCtxReset`    |
-| `cuDevicePrimaryCtxRetain`                                | `hipDevicePrimaryCtxRetain`   |
-| `cuDevicePrimaryCtxSetFlags`                              | `hipDevicePrimaryCtxSetFlags` |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuDevicePrimaryCtxGetState`|  |  |  |`hipDevicePrimaryCtxGetState`|
+|`cuDevicePrimaryCtxRelease`|  |  |  |`hipDevicePrimaryCtxRelease`|
+|`cuDevicePrimaryCtxRelease_v2`| 11.0 |  |  |`hipDevicePrimaryCtxRelease`|
+|`cuDevicePrimaryCtxReset`|  |  |  |`hipDevicePrimaryCtxReset`|
+|`cuDevicePrimaryCtxReset_v2`| 11.0 |  |  |`hipDevicePrimaryCtxReset`|
+|`cuDevicePrimaryCtxRetain`|  |  |  |`hipDevicePrimaryCtxRetain`|
+|`cuDevicePrimaryCtxSetFlags`|  |  |  |`hipDevicePrimaryCtxSetFlags`|
+|`cuDevicePrimaryCtxSetFlags_v2`| 11.0 |  |  |`hipDevicePrimaryCtxSetFlags`|
 
 ## **8. Context Management**
 
-|   **CUDA**                                                |   **HIP**                        |**CUDA version\***|
-|-----------------------------------------------------------|----------------------------------|------------------|
-| `cuCtxCreate`                                             | `hipCtxCreate`                   |
-| `cuCtxDestroy`                                            | `hipCtxDestroy`                  |
-| `cuCtxGetApiVersion`                                      | `hipCtxGetApiVersion`            |
-| `cuCtxGetCacheConfig`                                     | `hipCtxGetCacheConfig`           |
-| `cuCtxGetCurrent`                                         | `hipCtxGetCurrent`               |
-| `cuCtxGetDevice`                                          | `hipCtxGetDevice`                |
-| `cuCtxGetFlags`                                           | `hipCtxGetFlags`                 |
-| `cuCtxGetLimit`                                           | `hipDeviceGetLimit`              |
-| `cuCtxGetSharedMemConfig`                                 | `hipCtxGetSharedMemConfig`       |
-| `cuCtxGetStreamPriorityRange`                             | `hipDeviceGetStreamPriorityRange`|
-| `cuCtxPopCurrent`                                         | `hipCtxPopCurrent`               |
-| `cuCtxPushCurrent`                                        | `hipCtxPushCurrent`              |
-| `cuCtxResetPersistingL2Cache`                             |                                  | 11.0             |
-| `cuCtxSetCacheConfig`                                     | `hipCtxSetCacheConfig`           |
-| `cuCtxSetCurrent`                                         | `hipCtxSetCurrent`               |
-| `cuCtxSetLimit`                                           | `hipDeviceSetLimit`              |
-| `cuCtxSetSharedMemConfig`                                 | `hipCtxSetSharedMemConfig`       |
-| `cuCtxSynchronize`                                        | `hipCtxSynchronize`              |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuCtxCreate`|  |  |  |`hipCtxCreate`|
+|`cuCtxCreate_v2`|  |  |  |`hipCtxCreate`|
+|`cuCtxDestroy`|  |  |  |`hipCtxDestroy`|
+|`cuCtxDestroy_v2`|  |  |  |`hipCtxDestroy`|
+|`cuCtxGetApiVersion`|  |  |  |`hipCtxGetApiVersion`|
+|`cuCtxGetCacheConfig`|  |  |  |`hipCtxGetCacheConfig`|
+|`cuCtxGetCurrent`|  |  |  |`hipCtxGetCurrent`|
+|`cuCtxGetDevice`|  |  |  |`hipCtxGetDevice`|
+|`cuCtxGetFlags`|  |  |  |`hipCtxGetFlags`|
+|`cuCtxGetLimit`|  |  |  |`hipDeviceGetLimit`|
+|`cuCtxGetSharedMemConfig`|  |  |  |`hipCtxGetSharedMemConfig`|
+|`cuCtxGetStreamPriorityRange`|  |  |  |`hipDeviceGetStreamPriorityRange`|
+|`cuCtxPopCurrent`|  |  |  |`hipCtxPopCurrent`|
+|`cuCtxPopCurrent_v2`|  |  |  |`hipCtxPopCurrent`|
+|`cuCtxPushCurrent`|  |  |  |`hipCtxPushCurrent`|
+|`cuCtxPushCurrent_v2`|  |  |  |`hipCtxPushCurrent`|
+|`cuCtxResetPersistingL2Cache`| 11.0 |  |  ||
+|`cuCtxSetCacheConfig`|  |  |  |`hipCtxSetCacheConfig`|
+|`cuCtxSetCurrent`|  |  |  |`hipCtxSetCurrent`|
+|`cuCtxSetLimit`|  |  |  |`hipDeviceSetLimit`|
+|`cuCtxSetSharedMemConfig`|  |  |  |`hipCtxSetSharedMemConfig`|
+|`cuCtxSynchronize`|  |  |  |`hipCtxSynchronize`|
 
 ## **9. Context Management [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuCtxAttach`                                             |                               |
-| `cuCtxDetach`                                             |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuCtxAttach`|  |  |  ||
+|`cuCtxDetach`|  |  |  ||
 
 ## **10. Module Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuLinkAddData`                                           |                               |
-| `cuLinkAddFile`                                           |                               |
-| `cuLinkComplete`                                          |                               |
-| `cuLinkCreate`                                            |                               |
-| `cuLinkDestroy`                                           |                               |
-| `cuModuleGetFunction`                                     | `hipModuleGetFunction`        |
-| `cuModuleGetGlobal`                                       | `hipModuleGetGlobal`          |
-| `cuModuleGetSurfRef`                                      |                               |
-| `cuModuleGetTexRef`                                       | `hipModuleGetTexRef`          |
-| `cuModuleLoad`                                            | `hipModuleLoad`               |
-| `cuModuleLoadData`                                        | `hipModuleLoadData`           |
-| `cuModuleLoadDataEx`                                      | `hipModuleLoadDataEx`         |
-| `cuModuleLoadFatBinary`                                   |                               |
-| `cuModuleUnload`                                          | `hipModuleUnload`             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuLinkAddData`|  |  |  ||
+|`cuLinkAddData_v2`|  |  |  ||
+|`cuLinkAddFile`|  |  |  ||
+|`cuLinkAddFile_v2`|  |  |  ||
+|`cuLinkComplete`|  |  |  ||
+|`cuLinkCreate`|  |  |  ||
+|`cuLinkCreate_v2`|  |  |  ||
+|`cuLinkDestroy`|  |  |  ||
+|`cuModuleGetFunction`|  |  |  |`hipModuleGetFunction`|
+|`cuModuleGetGlobal`|  |  |  |`hipModuleGetGlobal`|
+|`cuModuleGetGlobal_v2`|  |  |  |`hipModuleGetGlobal`|
+|`cuModuleGetSurfRef`|  |  |  ||
+|`cuModuleGetTexRef`|  |  |  |`hipModuleGetTexRef`|
+|`cuModuleLoad`|  |  |  |`hipModuleLoad`|
+|`cuModuleLoadData`|  |  |  |`hipModuleLoadData`|
+|`cuModuleLoadDataEx`|  |  |  |`hipModuleLoadDataEx`|
+|`cuModuleLoadFatBinary`|  |  |  ||
+|`cuModuleUnload`|  |  |  |`hipModuleUnload`|
 
 ## **11. Memory Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuArray3DCreate`                                         | `hipArray3DCreate`            |
-| `cuArray3DGetDescriptor`                                  |                               |
-| `cuArrayCreate`                                           | `hipArrayCreate`              |
-| `cuArrayDestroy`                                          |                               |
-| `cuArrayGetDescriptor`                                    |                               |
-| `cuDeviceGetByPCIBusId`                                   | `hipDeviceGetByPCIBusId`      |
-| `cuDeviceGetPCIBusId`                                     | `hipDeviceGetPCIBusId`        |
-| `cuIpcCloseMemHandle`                                     | `hipIpcCloseMemHandle`        |
-| `cuIpcGetEventHandle`                                     |                               |
-| `cuIpcGetMemHandle`                                       | `hipIpcGetMemHandle`          |
-| `cuIpcOpenEventHandle`                                    |                               |
-| `cuIpcOpenMemHandle`                                      | `hipIpcOpenMemHandle`         |
-| `cuMemAlloc`                                              | `hipMalloc`                   |
-| `cuMemAllocHost`                                          | `hipHostMalloc`               |
-| `cuMemAllocManaged`                                       | `hipMallocManaged`            |
-| `cuMemAllocPitch`                                         | `hipMemAllocPitch`            |
-| `cuMemcpy`                                                |                               |
-| `cuMemcpy2D`                                              | `hipMemcpyParam2D`            |
-| `cuMemcpy2DAsync`                                         | `hipMemcpyParam2DAsync`       |
-| `cuMemcpy2DUnaligned`                                     |                               |
-| `cuMemcpy3D`                                              | `hipDrvMemcpy3D`              |
-| `cuMemcpy3DAsync`                                         | `hipDrvMemcpy3DAsync`         |
-| `cuMemcpy3DPeer`                                          |                               |
-| `cuMemcpy3DPeerAsync`                                     |                               |
-| `cuMemcpyAsync`                                           |                               |
-| `cuMemcpyAtoA`                                            |                               |
-| `cuMemcpyAtoD`                                            |                               |
-| `cuMemcpyAtoH`                                            | `hipMemcpyAtoH`               |
-| `cuMemcpyAtoHAsync`                                       |                               |
-| `cuMemcpyDtoA`                                            |                               |
-| `cuMemcpyDtoD`                                            | `hipMemcpyDtoD`               |
-| `cuMemcpyDtoDAsync`                                       | `hipMemcpyDtoDAsync`          |
-| `cuMemcpyDtoH`                                            | `hipMemcpyDtoH`               |
-| `cuMemcpyDtoHAsync`                                       | `hipMemcpyDtoHAsync`          |
-| `cuMemcpyHtoA`                                            | `hipMemcpyHtoA`               |
-| `cuMemcpyHtoAAsync`                                       |                               |
-| `cuMemcpyHtoD`                                            | `hipMemcpyHtoD`               |
-| `cuMemcpyHtoDAsync`                                       | `hipMemcpyHtoDAsync`          |
-| `cuMemcpyPeer`                                            |                               |
-| `cuMemcpyPeerAsync`                                       |                               |
-| `cuMemFree`                                               | `hipFree`                     |
-| `cuMemFreeHost`                                           | `hipHostFree`                 |
-| `cuMemGetAddressRange`                                    | `hipMemGetAddressRange`       |
-| `cuMemGetInfo`                                            | `hipMemGetInfo`               |
-| `cuMemHostAlloc`                                          | `hipHostMalloc`               |
-| `cuMemHostGetDevicePointer`                               | `hipHostGetDevicePointer`     |
-| `cuMemHostGetFlags`                                       | `hipHostGetFlags`             |
-| `cuMemHostRegister`                                       | `hipHostRegister`             |
-| `cuMemHostUnregister`                                     | `hipHostUnregister`           |
-| `cuMemsetD16`                                             | `hipMemsetD16`                |
-| `cuMemsetD16Async`                                        | `hipMemsetD16Async`           |
-| `cuMemsetD2D16`                                           |                               |
-| `cuMemsetD2D16Async`                                      |                               |
-| `cuMemsetD2D32`                                           |                               |
-| `cuMemsetD2D32Async`                                      |                               |
-| `cuMemsetD2D8`                                            |                               |
-| `cuMemsetD2D8Async`                                       |                               |
-| `cuMemsetD32`                                             | `hipMemsetD32`                |
-| `cuMemsetD32Async`                                        | `hipMemsetD32Async`           |
-| `cuMemsetD8`                                              | `hipMemsetD8`                 |
-| `cuMemsetD8Async`                                         | `hipMemsetD8Async`            |
-| `cuMipmappedArrayCreate`                                  |                               |
-| `cuMipmappedArrayDestroy`                                 |                               |
-| `cuMipmappedArrayGetLevel`                                |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuArray3DCreate`|  |  |  |`hipArray3DCreate`|
+|`cuArray3DCreate_v2`|  |  |  |`hipArray3DCreate`|
+|`cuArray3DGetDescriptor`|  |  |  ||
+|`cuArray3DGetDescriptor_v2`|  |  |  ||
+|`cuArrayCreate`|  |  |  |`hipArrayCreate`|
+|`cuArrayCreate_v2`|  |  |  |`hipArrayCreate`|
+|`cuArrayDestroy`|  |  |  ||
+|`cuArrayGetDescriptor`|  |  |  ||
+|`cuArrayGetDescriptor_v2`|  |  |  ||
+|`cuDeviceGetByPCIBusId`|  |  |  |`hipDeviceGetByPCIBusId`|
+|`cuDeviceGetPCIBusId`|  |  |  |`hipDeviceGetPCIBusId`|
+|`cuIpcCloseMemHandle`|  |  |  |`hipIpcCloseMemHandle`|
+|`cuIpcGetEventHandle`|  |  |  ||
+|`cuIpcGetMemHandle`|  |  |  |`hipIpcGetMemHandle`|
+|`cuIpcOpenEventHandle`|  |  |  ||
+|`cuIpcOpenMemHandle`|  |  |  |`hipIpcOpenMemHandle`|
+|`cuMemAlloc`|  |  |  |`hipMalloc`|
+|`cuMemAllocHost`|  |  |  |`hipHostMalloc`|
+|`cuMemAllocHost_v2`|  |  |  |`hipHostMalloc`|
+|`cuMemAllocManaged`|  |  |  |`hipMallocManaged`|
+|`cuMemAllocPitch`|  |  |  |`hipMemAllocPitch`|
+|`cuMemAllocPitch_v2`|  |  |  |`hipMemAllocPitch`|
+|`cuMemAlloc_v2`|  |  |  |`hipMalloc`|
+|`cuMemFree`|  |  |  |`hipFree`|
+|`cuMemFreeHost`|  |  |  |`hipHostFree`|
+|`cuMemFree_v2`|  |  |  |`hipFree`|
+|`cuMemGetAddressRange`|  |  |  |`hipMemGetAddressRange`|
+|`cuMemGetAddressRange_v2`|  |  |  |`hipMemGetAddressRange`|
+|`cuMemGetInfo`|  |  |  |`hipMemGetInfo`|
+|`cuMemGetInfo_v2`|  |  |  |`hipMemGetInfo`|
+|`cuMemHostAlloc`|  |  |  |`hipHostMalloc`|
+|`cuMemHostGetDevicePointer`|  |  |  |`hipHostGetDevicePointer`|
+|`cuMemHostGetDevicePointer_v2`|  |  |  |`hipHostGetDevicePointer`|
+|`cuMemHostGetFlags`|  |  |  |`hipHostGetFlags`|
+|`cuMemHostRegister`|  |  |  |`hipHostRegister`|
+|`cuMemHostRegister_v2`|  |  |  |`hipHostRegister`|
+|`cuMemHostUnregister`|  |  |  |`hipHostUnregister`|
+|`cuMemcpy`|  |  |  ||
+|`cuMemcpy2D`|  |  |  |`hipMemcpyParam2D`|
+|`cuMemcpy2DAsync`|  |  |  |`hipMemcpyParam2DAsync`|
+|`cuMemcpy2DAsync_v2`|  |  |  |`hipMemcpyParam2DAsync`|
+|`cuMemcpy2DUnaligned`|  |  |  ||
+|`cuMemcpy2DUnaligned_v2`|  |  |  ||
+|`cuMemcpy2D_v2`|  |  |  |`hipMemcpyParam2D`|
+|`cuMemcpy3D`|  |  |  |`hipDrvMemcpy3D`|
+|`cuMemcpy3DAsync`|  |  |  |`hipDrvMemcpy3DAsync`|
+|`cuMemcpy3DAsync_v2`|  |  |  |`hipDrvMemcpy3DAsync`|
+|`cuMemcpy3DPeer`|  |  |  ||
+|`cuMemcpy3DPeerAsync`|  |  |  ||
+|`cuMemcpy3D_v2`|  |  |  |`hipDrvMemcpy3D`|
+|`cuMemcpyAsync`|  |  |  ||
+|`cuMemcpyAtoA`|  |  |  ||
+|`cuMemcpyAtoA_v2`|  |  |  ||
+|`cuMemcpyAtoD`|  |  |  ||
+|`cuMemcpyAtoD_v2`|  |  |  ||
+|`cuMemcpyAtoH`|  |  |  |`hipMemcpyAtoH`|
+|`cuMemcpyAtoHAsync`|  |  |  ||
+|`cuMemcpyAtoHAsync_v2`|  |  |  ||
+|`cuMemcpyAtoH_v2`|  |  |  |`hipMemcpyAtoH`|
+|`cuMemcpyDtoA`|  |  |  ||
+|`cuMemcpyDtoA_v2`|  |  |  ||
+|`cuMemcpyDtoD`|  |  |  |`hipMemcpyDtoD`|
+|`cuMemcpyDtoDAsync`|  |  |  |`hipMemcpyDtoDAsync`|
+|`cuMemcpyDtoDAsync_v2`|  |  |  |`hipMemcpyDtoDAsync`|
+|`cuMemcpyDtoD_v2`|  |  |  |`hipMemcpyDtoD`|
+|`cuMemcpyDtoH`|  |  |  |`hipMemcpyDtoH`|
+|`cuMemcpyDtoHAsync`|  |  |  |`hipMemcpyDtoHAsync`|
+|`cuMemcpyDtoHAsync_v2`|  |  |  |`hipMemcpyDtoHAsync`|
+|`cuMemcpyDtoH_v2`|  |  |  |`hipMemcpyDtoH`|
+|`cuMemcpyHtoA`|  |  |  |`hipMemcpyHtoA`|
+|`cuMemcpyHtoAAsync`|  |  |  ||
+|`cuMemcpyHtoAAsync_v2`|  |  |  ||
+|`cuMemcpyHtoA_v2`|  |  |  |`hipMemcpyHtoA`|
+|`cuMemcpyHtoD`|  |  |  |`hipMemcpyHtoD`|
+|`cuMemcpyHtoDAsync`|  |  |  |`hipMemcpyHtoDAsync`|
+|`cuMemcpyHtoDAsync_v2`|  |  |  |`hipMemcpyHtoDAsync`|
+|`cuMemcpyHtoD_v2`|  |  |  |`hipMemcpyHtoD`|
+|`cuMemcpyPeer`|  |  |  ||
+|`cuMemcpyPeerAsync`|  |  |  ||
+|`cuMemsetD16`|  |  |  |`hipMemsetD16`|
+|`cuMemsetD16Async`|  |  |  |`hipMemsetD16Async`|
+|`cuMemsetD16_v2`|  |  |  |`hipMemsetD16`|
+|`cuMemsetD2D16`|  |  |  ||
+|`cuMemsetD2D16Async`|  |  |  ||
+|`cuMemsetD2D16_v2`|  |  |  ||
+|`cuMemsetD2D32`|  |  |  ||
+|`cuMemsetD2D32Async`|  |  |  ||
+|`cuMemsetD2D32_v2`|  |  |  ||
+|`cuMemsetD2D8`|  |  |  ||
+|`cuMemsetD2D8Async`|  |  |  ||
+|`cuMemsetD2D8_v2`|  |  |  ||
+|`cuMemsetD32`|  |  |  |`hipMemsetD32`|
+|`cuMemsetD32Async`|  |  |  |`hipMemsetD32Async`|
+|`cuMemsetD32_v2`|  |  |  |`hipMemsetD32`|
+|`cuMemsetD8`|  |  |  |`hipMemsetD8`|
+|`cuMemsetD8Async`|  |  |  |`hipMemsetD8Async`|
+|`cuMemsetD8_v2`|  |  |  |`hipMemsetD8`|
+|`cuMipmappedArrayCreate`|  |  |  ||
+|`cuMipmappedArrayDestroy`|  |  |  ||
+|`cuMipmappedArrayGetLevel`|  |  |  ||
 
 ## **12. Virtual Memory Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cuMemAddressFree`                                        |                               | 10.2             |
-| `cuMemAddressReserve`                                     |                               | 10.2             |
-| `cuMemCreate`                                             |                               | 10.2             |
-| `cuMemExportToShareableHandle`                            |                               | 10.2             |
-| `cuMemGetAccess`                                          |                               | 10.2             |
-| `cuMemGetAllocationGranularity`                           |                               | 10.2             |
-| `cuMemGetAllocationPropertiesFromHandle`                  |                               | 10.2             |
-| `cuMemImportFromShareableHandle`                          |                               | 10.2             |
-| `cuMemMap`                                                |                               | 10.2             |
-| `cuMemRelease`                                            |                               | 10.2             |
-| `cuMemRetainAllocationHandle`                             |                               | 11.0             |
-| `cuMemSetAccess`                                          |                               | 10.2             |
-| `cuMemUnmap`                                              |                               | 10.2             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuMemAddressFree`| 10.2 |  |  ||
+|`cuMemAddressReserve`| 10.2 |  |  ||
+|`cuMemCreate`| 10.2 |  |  ||
+|`cuMemExportToShareableHandle`| 10.2 |  |  ||
+|`cuMemGetAccess`| 10.2 |  |  ||
+|`cuMemGetAllocationGranularity`| 10.2 |  |  ||
+|`cuMemGetAllocationPropertiesFromHandle`| 10.2 |  |  ||
+|`cuMemImportFromShareableHandle`| 10.2 |  |  ||
+|`cuMemMap`| 10.2 |  |  ||
+|`cuMemRelease`| 10.2 |  |  ||
+|`cuMemRetainAllocationHandle`| 11.0 |  |  ||
+|`cuMemSetAccess`| 10.2 |  |  ||
+|`cuMemUnmap`| 10.2 |  |  ||
 
 ## **13. Unified Addressing**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cuMemAdvise`                                             |                               | 8.0              |
-| `cuMemPrefetchAsync`                                      |                               | 8.0              |
-| `cuMemRangeGetAttribute`                                  |                               | 8.0              |
-| `cuMemRangeGetAttributes`                                 |                               | 8.0              |
-| `cuPointerGetAttribute`                                   |                               |
-| `cuPointerGetAttributes`                                  |                               |
-| `cuPointerSetAttribute`                                   |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuMemAdvise`| 8.0 |  |  ||
+|`cuMemPrefetchAsync`| 8.0 |  |  ||
+|`cuMemRangeGetAttribute`| 8.0 |  |  ||
+|`cuMemRangeGetAttributes`| 8.0 |  |  ||
+|`cuPointerGetAttribute`|  |  |  ||
+|`cuPointerGetAttributes`|  |  |  ||
+|`cuPointerSetAttribute`|  |  |  ||
 
 ## **14. Stream Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cuStreamAddCallback`                                     | `hipStreamAddCallback`        |
-| `cuStreamAttachMemAsync`                                  |                               |
-| `cuStreamCopyAttributes`                                  |                               | 11.0             |
-| `cuStreamCreate`                                          | `hipStreamCreateWithFlags`    |
-| `cuStreamCreateWithPriority`                              | `hipStreamCreateWithPriority` |
-| `cuStreamDestroy`                                         | `hipStreamDestroy`            |
-| `cuStreamGetFlags`                                        | `hipStreamGetFlags`           |
-| `cuStreamGetPriority`                                     | `hipStreamGetPriority`        |
-| `cuStreamQuery`                                           | `hipStreamQuery`              |
-| `cuStreamSetAttribute`                                    |                               | 11.0             |
-| `cuStreamSynchronize`                                     | `hipStreamSynchronize`        |
-| `cuStreamWaitEvent`                                       | `hipStreamWaitEvent`          |
-| `cuStreamBeginCapture`                                    |                               | 10.0             |
-| `cuStreamBeginCapture_ptsz`                               |                               | 10.1             |
-| `cuStreamEndCapture`                                      |                               | 10.0             |
-| `cuStreamGetAttribute`                                    |                               | 11.0             |
-| `cuStreamGetCaptureInfo`                                  |                               | 10.1             |
-| `cuStreamIsCapturing`                                     |                               | 10.0             |
-| `cuThreadExchangeStreamCaptureMode`                       |                               | 10.1             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuStreamAddCallback`|  |  |  |`hipStreamAddCallback`|
+|`cuStreamAttachMemAsync`|  |  |  ||
+|`cuStreamBeginCapture`| 10.0 |  |  ||
+|`cuStreamBeginCapture_ptsz`| 10.1 |  |  ||
+|`cuStreamBeginCapture_v2`| 10.1 |  |  ||
+|`cuStreamCopyAttributes`| 11.0 |  |  ||
+|`cuStreamCreate`|  |  |  |`hipStreamCreateWithFlags`|
+|`cuStreamCreateWithPriority`|  |  |  |`hipStreamCreateWithPriority`|
+|`cuStreamDestroy`|  |  |  |`hipStreamDestroy`|
+|`cuStreamDestroy_v2`|  |  |  |`hipStreamDestroy`|
+|`cuStreamEndCapture`| 10.0 |  |  ||
+|`cuStreamGetAttribute`| 11.0 |  |  ||
+|`cuStreamGetCaptureInfo`| 10.1 |  |  ||
+|`cuStreamGetCtx`| 9.2 |  |  ||
+|`cuStreamGetFlags`|  |  |  |`hipStreamGetFlags`|
+|`cuStreamGetPriority`|  |  |  |`hipStreamGetPriority`|
+|`cuStreamIsCapturing`| 10.0 |  |  ||
+|`cuStreamQuery`|  |  |  |`hipStreamQuery`|
+|`cuStreamSetAttribute`| 11.0 |  |  ||
+|`cuStreamSynchronize`|  |  |  |`hipStreamSynchronize`|
+|`cuStreamWaitEvent`|  |  |  |`hipStreamWaitEvent`|
+|`cuThreadExchangeStreamCaptureMode`| 10.1 |  |  ||
 
 ## **15. Event Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuEventCreate`                                           | `hipEventCreateWithFlags`     |
-| `cuEventDestroy`                                          | `hipEventDestroy`             |
-| `cuEventElapsedTime`                                      | `hipEventElapsedTime`         |
-| `cuEventQuery`                                            | `hipEventQuery`               |
-| `cuEventRecord`                                           | `hipEventRecord`              |
-| `cuEventSynchronize`                                      | `hipEventSynchronize`         |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuEventCreate`|  |  |  |`hipEventCreateWithFlags`|
+|`cuEventDestroy`|  |  |  |`hipEventDestroy`|
+|`cuEventDestroy_v2`|  |  |  |`hipEventDestroy`|
+|`cuEventElapsedTime`|  |  |  |`hipEventElapsedTime`|
+|`cuEventQuery`|  |  |  |`hipEventQuery`|
+|`cuEventRecord`|  |  |  |`hipEventRecord`|
+|`cuEventSynchronize`|  |  |  |`hipEventSynchronize`|
 
 ## **16. External Resource Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cuSignalExternalSemaphoresAsync`                         |                               | 10.0             |
-| `cuWaitExternalSemaphoresAsync`                           |                               | 10.0             |
-| `cuImportExternalMemory`                                  |                               | 10.0             |
-| `cuExternalMemoryGetMappedBuffer`                         |                               | 10.0             |
-| `cuExternalMemoryGetMappedMipmappedArray`                 |                               | 10.0             |
-| `cuDestroyExternalMemory`                                 |                               | 10.0             |
-| `cuImportExternalSemaphore`                               |                               | 10.0             |
-| `cuDestroyExternalSemaphore`                              |                               | 10.0             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuDestroyExternalMemory`| 10.0 |  |  ||
+|`cuDestroyExternalSemaphore`| 10.0 |  |  ||
+|`cuExternalMemoryGetMappedBuffer`| 10.0 |  |  ||
+|`cuExternalMemoryGetMappedMipmappedArray`| 10.0 |  |  ||
+|`cuImportExternalMemory`| 10.0 |  |  ||
+|`cuImportExternalSemaphore`| 10.0 |  |  ||
+|`cuSignalExternalSemaphoresAsync`| 10.0 |  |  ||
+|`cuWaitExternalSemaphoresAsync`| 10.0 |  |  ||
 
 ## **17. Stream Memory Operations**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cuStreamBatchMemOp`                                      |                               | 8.0              |
-| `cuStreamWaitValue32`                                     |                               | 8.0              |
-| `cuStreamWaitValue64`                                     |                               | 9.0              |
-| `cuStreamWriteValue32`                                    |                               | 8.0              |
-| `cuStreamWriteValue64`                                    |                               | 9.0              |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuStreamBatchMemOp`| 8.0 |  |  ||
+|`cuStreamWaitValue32`| 8.0 |  |  ||
+|`cuStreamWaitValue64`| 9.0 |  |  ||
+|`cuStreamWriteValue32`| 8.0 |  |  ||
+|`cuStreamWriteValue64`| 9.0 |  |  ||
 
 ## **18. Execution Control**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cuFuncGetAttribute`                                      | `hipFuncGetAttribute`         |
-| `cuFuncGetModule`                                         |                               | 11.0             |
-| `cuFuncSetAttribute`                                      |                               | 9.0              |
-| `cuFuncSetCacheConfig`                                    | `hipFuncSetCacheConfig`       |
-| `cuFuncSetSharedMemConfig`                                |                               |
-| `cuLaunchKernel`                                          | `hipModuleLaunchKernel`       |
-| `cuLaunchHostFunc`                                        |                               | 10.0             |
-| `cuLaunchCooperativeKernel`                               |                               | 9.0              |
-| `cuLaunchCooperativeKernelMultiDevice`                    |                               | 9.0              |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuFuncGetAttribute`|  |  |  |`hipFuncGetAttribute`|
+|`cuFuncGetModule`| 11.0 |  |  ||
+|`cuFuncSetAttribute`| 9.0 |  |  ||
+|`cuFuncSetCacheConfig`|  |  |  ||
+|`cuFuncSetSharedMemConfig`|  |  |  ||
+|`cuLaunchCooperativeKernel`| 9.0 |  |  ||
+|`cuLaunchCooperativeKernelMultiDevice`| 9.0 |  |  ||
+|`cuLaunchHostFunc`| 10.0 |  |  ||
+|`cuLaunchKernel`|  |  |  |`hipModuleLaunchKernel`|
 
 ## **19. Execution Control [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuFuncSetBlockShape`                                     |                               |
-| `cuFuncSetSharedSize`                                     |                               |
-| `cuLaunch`                                                |                               |
-| `cuLaunchGrid`                                            |                               |
-| `cuLaunchGridAsync`                                       |                               |
-| `cuParamSetf`                                             |                               |
-| `cuParamSeti`                                             |                               |
-| `cuParamSetTexRef`                                        |                               |
-| `cuParamSetv`                                             |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuFuncSetBlockShape`|  | 9.2 |  ||
+|`cuFuncSetSharedSize`|  | 9.2 |  ||
+|`cuLaunch`|  | 9.2 |  ||
+|`cuLaunchGrid`|  | 9.2 |  ||
+|`cuLaunchGridAsync`|  | 9.2 |  ||
+|`cuParamSetSize`|  | 9.2 |  ||
+|`cuParamSetTexRef`|  | 9.2 |  ||
+|`cuParamSetf`|  | 9.2 |  ||
+|`cuParamSeti`|  | 9.2 |  ||
+|`cuParamSetv`|  | 9.2 |  ||
 
 ## **20. Graph Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cuGraphCreate`                                           |                               | 10.0             |
-| `cuGraphLaunch`                                           |                               | 10.0             |
-| `cuGraphAddKernelNode`                                    |                               | 10.0             |
-| `cuGraphKernelNodeGetParams`                              |                               | 10.0             |
-| `cuGraphKernelNodeSetAttribute`                           |                               | 11.0             |
-| `cuGraphKernelNodeSetParams`                              |                               | 10.0             |
-| `cuGraphAddMemcpyNode`                                    |                               | 10.0             |
-| `cuGraphMemcpyNodeGetParams`                              |                               | 10.0             |
-| `cuGraphMemcpyNodeSetParams`                              |                               | 10.0             |
-| `cuGraphAddMemsetNode`                                    |                               | 10.0             |
-| `cuGraphMemsetNodeGetParams`                              |                               | 10.0             |
-| `cuGraphMemsetNodeSetParams`                              |                               | 10.0             |
-| `cuGraphAddHostNode`                                      |                               | 10.0             |
-| `cuGraphHostNodeGetParams`                                |                               | 10.0             |
-| `cuGraphHostNodeSetParams`                                |                               | 10.0             |
-| `cuGraphAddChildGraphNode`                                |                               | 10.0             |
-| `cuGraphChildGraphNodeGetGraph`                           |                               | 10.0             |
-| `cuGraphAddEmptyNode`                                     |                               | 10.0             |
-| `cuGraphClone`                                            |                               | 10.0             |
-| `cuGraphNodeFindInClone`                                  |                               | 10.0             |
-| `cuGraphNodeGetType`                                      |                               | 10.0             |
-| `cuGraphGetNodes`                                         |                               | 10.0             |
-| `cuGraphGetRootNodes`                                     |                               | 10.0             |
-| `cuGraphGetEdges`                                         |                               | 10.0             |
-| `cuGraphNodeGetDependencies`                              |                               | 10.0             |
-| `cuGraphNodeGetDependentNodes`                            |                               | 10.0             |
-| `cuGraphAddDependencies`                                  |                               | 10.0             |
-| `cuGraphRemoveDependencies`                               |                               | 10.0             |
-| `cuGraphDestroyNode`                                      |                               | 10.0             |
-| `cuGraphInstantiate`                                      |                               | 10.0             |
-| `cuGraphKernelNodeCopyAttributes`                         |                               | 11.0             |
-| `cuGraphKernelNodeGetAttribute`                           |                               | 11.0             |
-| `cuGraphExecDestroy`                                      |                               | 10.0             |
-| `cuGraphExecKernelNodeSetParams`                          |                               | 10.1             |
-| `cuGraphExecMemcpyNodeSetParams`                          |                               | 10.2             |
-| `cuGraphExecMemsetNodeSetParams`                          |                               | 10.2             |
-| `cuGraphExecHostNodeSetParams`                            |                               | 10.2             |
-| `cuGraphExecUpdate`                                       |                               | 10.2             |
-| `cuGraphDestroy`                                          |                               | 10.0             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuGraphAddChildGraphNode`| 10.0 |  |  ||
+|`cuGraphAddDependencies`| 10.0 |  |  ||
+|`cuGraphAddEmptyNode`| 10.0 |  |  ||
+|`cuGraphAddHostNode`| 10.0 |  |  ||
+|`cuGraphAddKernelNode`| 10.0 |  |  ||
+|`cuGraphAddMemcpyNode`| 10.0 |  |  ||
+|`cuGraphAddMemsetNode`| 10.0 |  |  ||
+|`cuGraphChildGraphNodeGetGraph`| 10.0 |  |  ||
+|`cuGraphClone`| 10.0 |  |  ||
+|`cuGraphCreate`| 10.0 |  |  ||
+|`cuGraphDestroy`| 10.0 |  |  ||
+|`cuGraphDestroyNode`| 10.0 |  |  ||
+|`cuGraphExecDestroy`| 10.0 |  |  ||
+|`cuGraphExecHostNodeSetParams`| 10.2 |  |  ||
+|`cuGraphExecKernelNodeSetParams`| 10.1 |  |  ||
+|`cuGraphExecMemcpyNodeSetParams`| 10.2 |  |  ||
+|`cuGraphExecMemsetNodeSetParams`| 10.2 |  |  ||
+|`cuGraphExecUpdate`| 10.2 |  |  ||
+|`cuGraphGetEdges`| 10.0 |  |  ||
+|`cuGraphGetNodes`| 10.0 |  |  ||
+|`cuGraphGetRootNodes`| 10.0 |  |  ||
+|`cuGraphHostNodeGetParams`| 10.0 |  |  ||
+|`cuGraphHostNodeSetParams`| 10.0 |  |  ||
+|`cuGraphInstantiate`| 10.0 |  |  ||
+|`cuGraphInstantiate_v2`| 11.0 |  |  ||
+|`cuGraphKernelNodeCopyAttributes`| 11.0 |  |  ||
+|`cuGraphKernelNodeGetAttribute`| 11.0 |  |  ||
+|`cuGraphKernelNodeGetParams`| 10.0 |  |  ||
+|`cuGraphKernelNodeSetAttribute`| 11.0 |  |  ||
+|`cuGraphKernelNodeSetParams`| 10.0 |  |  ||
+|`cuGraphLaunch`| 10.0 |  |  ||
+|`cuGraphMemcpyNodeGetParams`| 10.0 |  |  ||
+|`cuGraphMemcpyNodeSetParams`| 10.0 |  |  ||
+|`cuGraphMemsetNodeGetParams`| 10.0 |  |  ||
+|`cuGraphMemsetNodeSetParams`| 10.0 |  |  ||
+|`cuGraphNodeFindInClone`| 10.0 |  |  ||
+|`cuGraphNodeGetDependencies`| 10.0 |  |  ||
+|`cuGraphNodeGetDependentNodes`| 10.0 |  |  ||
+|`cuGraphNodeGetType`| 10.0 |  |  ||
+|`cuGraphRemoveDependencies`| 10.0 |  |  ||
 
 ## **21. Occupancy**
 
-|   **CUDA**                                                |   **HIP**                                                  |**CUDA version\***|
-|-----------------------------------------------------------|------------------------------------------------------------|------------------|
-| `cuOccupancyAvailableDynamicSMemPerBlock`                 |                                                            | 11.0             |
-| `cuOccupancyMaxActiveBlocksPerMultiprocessor`             |`hipDrvOccupancyMaxActiveBlocksPerMultiprocessor`           |
-| `cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`    |`hipDrvOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`  |
-| `cuOccupancyMaxPotentialBlockSize`                        |`hipOccupancyMaxPotentialBlockSize`                         |
-| `cuOccupancyMaxPotentialBlockSizeWithFlags`               |                                                            |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuOccupancyAvailableDynamicSMemPerBlock`| 11.0 |  |  ||
+|`cuOccupancyMaxActiveBlocksPerMultiprocessor`|  |  |  |`hipDrvOccupancyMaxActiveBlocksPerMultiprocessor`|
+|`cuOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`|  |  |  |`hipDrvOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`|
+|`cuOccupancyMaxPotentialBlockSize`|  |  |  |`hipOccupancyMaxPotentialBlockSize`|
+|`cuOccupancyMaxPotentialBlockSizeWithFlags`|  |  |  ||
 
 ## **22. Texture Reference Management [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cuTexRefGetAddress`                                      |`hipTexRefGetAddress`          |
-| `cuTexRefGetAddressMode`                                  |`hipTexRefGetAddressMode`      |
-| `cuTexRefGetArray`                                        |`hipTexRefGetArray`            |
-| `cuTexRefGetBorderColor`                                  |                               | 8.0              |
-| `cuTexRefGetFilterMode`                                   |                               |
-| `cuTexRefGetFlags`                                        |                               |
-| `cuTexRefGetFormat`                                       |                               |
-| `cuTexRefGetMaxAnisotropy`                                |                               |
-| `cuTexRefGetMipmapFilterMode`                             |                               |
-| `cuTexRefGetMipmapLevelBias`                              |                               |
-| `cuTexRefGetMipmapLevelClamp`                             |                               |
-| `cuTexRefGetMipmappedArray`                               |                               |
-| `cuTexRefSetAddress`                                      | `hipTexRefSetAddress`         |
-| `cuTexRefSetAddress2D`                                    | `hipTexRefSetAddress2D`       |
-| `cuTexRefSetAddressMode`                                  | `hipTexRefSetAddressMode`     |
-| `cuTexRefSetArray`                                        | `hipTexRefSetArray`           |
-| `cuTexRefSetBorderColor`                                  |                               | 8.0              |
-| `cuTexRefSetFilterMode`                                   | `hipTexRefSetFilterMode`      |
-| `cuTexRefSetFlags`                                        | `hipTexRefSetFlags`           |
-| `cuTexRefSetFormat`                                       | `hipTexRefSetFormat`          |
-| `cuTexRefSetMaxAnisotropy`                                |                               |
-| `cuTexRefSetMipmapFilterMode`                             |                               |
-| `cuTexRefSetMipmapLevelBias`                              |                               |
-| `cuTexRefSetMipmapLevelClamp`                             |                               |
-| `cuTexRefSetMipmappedArray`                               |                               |
-| `cuTexRefCreate`                                          |                               |
-| `cuTexRefDestroy`                                         |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuTexRefCreate`|  | 11.0 |  ||
+|`cuTexRefDestroy`|  | 11.0 |  ||
+|`cuTexRefGetAddress`|  | 11.0 |  |`hipTexRefGetAddress`|
+|`cuTexRefGetAddressMode`|  | 11.0 |  |`hipTexRefGetAddressMode`|
+|`cuTexRefGetAddress_v2`|  | 11.0 |  |`hipTexRefGetAddress`|
+|`cuTexRefGetArray`|  | 11.0 |  |`hipTexRefGetArray`|
+|`cuTexRefGetBorderColor`| 8.0 | 11.0 |  ||
+|`cuTexRefGetFilterMode`|  | 11.0 |  ||
+|`cuTexRefGetFlags`|  | 11.0 |  ||
+|`cuTexRefGetFormat`|  | 11.0 |  ||
+|`cuTexRefGetMaxAnisotropy`|  | 11.0 |  ||
+|`cuTexRefGetMipmapFilterMode`|  | 11.0 |  ||
+|`cuTexRefGetMipmapLevelBias`|  | 11.0 |  ||
+|`cuTexRefGetMipmapLevelClamp`|  | 11.0 |  ||
+|`cuTexRefGetMipmappedArray`|  | 11.0 |  ||
+|`cuTexRefSetAddress`|  | 11.0 |  |`hipTexRefSetAddress`|
+|`cuTexRefSetAddress2D`|  | 11.0 |  |`hipTexRefSetAddress2D`|
+|`cuTexRefSetAddress2D_v2`|  |  |  |`hipTexRefSetAddress2D`|
+|`cuTexRefSetAddress2D_v3`|  |  |  |`hipTexRefSetAddress2D`|
+|`cuTexRefSetAddressMode`|  | 11.0 |  |`hipTexRefSetAddressMode`|
+|`cuTexRefSetAddress_v2`|  | 11.0 |  |`hipTexRefSetAddress`|
+|`cuTexRefSetArray`|  | 11.0 |  |`hipTexRefSetArray`|
+|`cuTexRefSetBorderColor`| 8.0 | 11.0 |  ||
+|`cuTexRefSetFilterMode`|  | 11.0 |  |`hipTexRefSetFilterMode`|
+|`cuTexRefSetFlags`|  | 11.0 |  |`hipTexRefSetFlags`|
+|`cuTexRefSetFormat`|  | 11.0 |  |`hipTexRefSetFormat`|
+|`cuTexRefSetMaxAnisotropy`|  | 11.0 |  ||
+|`cuTexRefSetMipmapFilterMode`|  | 11.0 |  ||
+|`cuTexRefSetMipmapLevelBias`|  | 11.0 |  ||
+|`cuTexRefSetMipmapLevelClamp`|  | 11.0 |  ||
+|`cuTexRefSetMipmappedArray`|  | 11.0 |  ||
 
 ## **23. Surface Reference Management [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuSurfRefGetArray`                                       |                               |
-| `cuSurfRefSetArray`                                       |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuSurfRefGetArray`|  | 11.0 |  ||
+|`cuSurfRefSetArray`|  | 11.0 |  ||
 
 ## **24. Texture Object Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuTexObjectCreate`                                       |                               |
-| `cuTexObjectDestroy`                                      |                               |
-| `cuTexObjectGetResourceDesc`                              |                               |
-| `cuTexObjectGetResourceViewDesc`                          |                               |
-| `cuTexObjectGetTextureDesc`                               |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuTexObjectCreate`|  |  |  ||
+|`cuTexObjectDestroy`|  |  |  ||
+|`cuTexObjectGetResourceDesc`|  |  |  ||
+|`cuTexObjectGetResourceViewDesc`|  |  |  ||
+|`cuTexObjectGetTextureDesc`|  |  |  ||
 
 ## **25. Surface Object Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuSurfObjectCreate`                                      |                               |
-| `cuSurfObjectDestroy`                                     |                               |
-| `cuSurfObjectGetResourceDesc`                             |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuSurfObjectCreate`|  |  |  ||
+|`cuSurfObjectDestroy`|  |  |  ||
+|`cuSurfObjectGetResourceDesc`|  |  |  ||
 
 ## **26. Peer Context Memory Access**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cuCtxEnablePeerAccess`                                   | `hipCtxEnablePeerAccess`      |
-| `cuCtxDisablePeerAccess`                                  | `hipCtxDisablePeerAccess`     |
-| `cuDeviceCanAccessPeer`                                   | `hipDeviceCanAccessPeer`      |
-| `cuDeviceGetP2PAttribute`                                 |                               | 8.0              |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuCtxDisablePeerAccess`|  |  |  |`hipCtxDisablePeerAccess`|
+|`cuCtxEnablePeerAccess`|  |  |  |`hipCtxEnablePeerAccess`|
+|`cuDeviceCanAccessPeer`|  |  |  |`hipDeviceCanAccessPeer`|
+|`cuDeviceGetP2PAttribute`| 8.0 |  |  ||
 
 ## **27. Graphics Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuGraphicsMapResources`                                  |                               |
-| `cuGraphicsResourceGetMappedMipmappedArray`               |                               |
-| `cuGraphicsResourceGetMappedPointer`                      |                               |
-| `cuGraphicsResourceSetMapFlags`                           |                               |
-| `cuGraphicsSubResourceGetMappedArray`                     |                               |
-| `cuGraphicsUnmapResources`                                |                               |
-| `cuGraphicsUnregisterResource`                            |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuGraphicsMapResources`|  |  |  ||
+|`cuGraphicsResourceGetMappedMipmappedArray`|  |  |  ||
+|`cuGraphicsResourceGetMappedPointer`|  |  |  ||
+|`cuGraphicsResourceGetMappedPointer_v2`|  |  |  ||
+|`cuGraphicsResourceSetMapFlags`|  |  |  ||
+|`cuGraphicsResourceSetMapFlags_v2`|  |  |  ||
+|`cuGraphicsSubResourceGetMappedArray`|  |  |  ||
+|`cuGraphicsUnmapResources`|  |  |  ||
+|`cuGraphicsUnregisterResource`|  |  |  ||
 
-## **28. Profiler Control**
+## **28. Profiler Control [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuProfilerInitialize`                                    |                               |
-| `cuProfilerStart`                                         | `hipProfilerStart`            |
-| `cuProfilerStop`                                          | `hipProfilerStop`             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuProfilerInitialize`|  | 11.0 |  ||
 
-## **29. OpenGL Interoperability**
+## **29. Profiler Control**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuGLGetDevices`                                          |                               |
-| `cuGraphicsGLRegisterBuffer`                              |                               |
-| `cuGraphicsGLRegisterImage`                               |                               |
-| `cuWGLGetDevice`                                          |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuProfilerStart`|  |  |  |`hipProfilerStart`|
+|`cuProfilerStop`|  |  |  |`hipProfilerStop`|
 
-## **29.1. OpenGL Interoperability [DEPRECATED]**
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuGLCtxCreate`                                           |                               |
-| `cuGLInit`                                                |                               |
-| `cuGLMapBufferObject`                                     |                               |
-| `cuGLMapBufferObjectAsync`                                |                               |
-| `cuGLRegisterBufferObject`                                |                               |
-| `cuGLSetBufferObjectMapFlags`                             |                               |
-| `cuGLUnmapBufferObject`                                   |                               |
-| `cuGLUnmapBufferObjectAsync`                              |                               |
-| `cuGLUnregisterBufferObject`                              |                               |
+## **30. OpenGL Interoperability**
 
-## **30. Direct3D 9 Interoperability**
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuGLCtxCreate`|  | 9.2 |  ||
+|`cuGLGetDevices`|  |  |  ||
+|`cuGLInit`|  | 9.2 |  ||
+|`cuGLMapBufferObject`|  | 9.2 |  ||
+|`cuGLMapBufferObjectAsync`|  | 9.2 |  ||
+|`cuGLRegisterBufferObject`|  | 9.2 |  ||
+|`cuGLSetBufferObjectMapFlags`|  | 9.2 |  ||
+|`cuGLUnmapBufferObject`|  | 9.2 |  ||
+|`cuGLUnmapBufferObjectAsync`|  | 9.2 |  ||
+|`cuGLUnregisterBufferObject`|  | 9.2 |  ||
+|`cuGraphicsGLRegisterBuffer`|  |  |  ||
+|`cuGraphicsGLRegisterImage`|  |  |  ||
+|`cuWGLGetDevice`|  |  |  ||
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuD3D9CtxCreate`                                         |                               |
-| `cuD3D9CtxCreateOnDevice`                                 |                               |
-| `cuD3D9GetDevice`                                         |                               |
-| `cuD3D9GetDevices`                                        |                               |
-| `cuD3D9GetDirect3DDevice`                                 |                               |
-| `cuGraphicsD3D9RegisterResource`                          |                               |
+## **31. Direct3D 9 Interoperability**
 
-## **30.1. Direct3D 9 Interoperability [DEPRECATED]**
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuD3D9MapResources`                                      |                               |
-| `cuD3D9RegisterResource`                                  |                               |
-| `cuD3D9ResourceGetMappedArray`                            |                               |
-| `cuD3D9ResourceGetMappedPitch`                            |                               |
-| `cuD3D9ResourceGetMappedPointer`                          |                               |
-| `cuD3D9ResourceGetMappedSize`                             |                               |
-| `cuD3D9ResourceGetSurfaceDimensions`                      |                               |
-| `cuD3D9ResourceSetMapFlags`                               |                               |
-| `cuD3D9UnmapResources`                                    |                               |
-| `cuD3D9UnregisterResource`                                |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuD3D9CtxCreate`|  |  |  ||
+|`cuD3D9CtxCreateOnDevice`|  |  |  ||
+|`cuD3D9GetDevice`|  |  |  ||
+|`cuD3D9GetDevices`|  |  |  ||
+|`cuD3D9GetDirect3DDevice`|  |  |  ||
+|`cuD3D9MapResources`|  | 9.2 |  ||
+|`cuD3D9RegisterResource`|  | 9.2 |  ||
+|`cuD3D9ResourceGetMappedArray`|  | 9.2 |  ||
+|`cuD3D9ResourceGetMappedPitch`|  | 9.2 |  ||
+|`cuD3D9ResourceGetMappedPointer`|  | 9.2 |  ||
+|`cuD3D9ResourceGetMappedSize`|  | 9.2 |  ||
+|`cuD3D9ResourceGetSurfaceDimensions`|  | 9.2 |  ||
+|`cuD3D9ResourceSetMapFlags`|  | 9.2 |  ||
+|`cuD3D9UnmapResources`|  | 9.2 |  ||
+|`cuD3D9UnregisterResource`|  | 9.2 |  ||
+|`cuGraphicsD3D9RegisterResource`|  |  |  ||
 
-## **31. Direct3D 10 Interoperability**
+## **32. Direct3D 10 Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuD3D10GetDevice`                                        |                               |
-| `cuD3D10GetDevices`                                       |                               |
-| `cuGraphicsD3D10RegisterResource`                         |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuD3D10CtxCreate`|  | 9.2 |  ||
+|`cuD3D10CtxCreateOnDevice`|  | 9.2 |  ||
+|`cuD3D10GetDevice`|  |  |  ||
+|`cuD3D10GetDevices`|  |  |  ||
+|`cuD3D10GetDirect3DDevice`|  | 9.2 |  ||
+|`cuD3D10MapResources`|  | 9.2 |  ||
+|`cuD3D10RegisterResource`|  | 9.2 |  ||
+|`cuD3D10ResourceGetMappedArray`|  | 9.2 |  ||
+|`cuD3D10ResourceGetMappedPitch`|  | 9.2 |  ||
+|`cuD3D10ResourceGetMappedPointer`|  | 9.2 |  ||
+|`cuD3D10ResourceGetMappedSize`|  | 9.2 |  ||
+|`cuD3D10ResourceGetSurfaceDimensions`|  | 9.2 |  ||
+|`cuD3D10ResourceSetMapFlags`|  | 9.2 |  ||
+|`cuD3D10UnmapResources`|  | 9.2 |  ||
+|`cuD3D10UnregisterResource`|  | 9.2 |  ||
+|`cuGraphicsD3D10RegisterResource`|  |  |  ||
 
-## **31.1. Direct3D 10 Interoperability [DEPRECATED]**
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuD3D10CtxCreate`                                        |                               |
-| `cuD3D10CtxCreateOnDevice`                                |                               |
-| `cuD3D10GetDirect3DDevice`                                |                               |
-| `cuD3D10MapResources`                                     |                               |
-| `cuD3D10RegisterResource`                                 |                               |
-| `cuD3D10ResourceGetMappedArray`                           |                               |
-| `cuD3D10ResourceGetMappedPitch`                           |                               |
-| `cuD3D10ResourceGetMappedPointer`                         |                               |
-| `cuD3D10ResourceGetMappedSize`                            |                               |
-| `cuD3D10ResourceGetSurfaceDimensions`                     |                               |
-| `cuD3D10ResourceSetMapFlags`                              |                               |
-| `cuD3D10UnmapResources`                                   |                               |
-| `cuD3D10UnregisterResource`                               |                               |
+## **33. Direct3D 11 Interoperability**
 
-## **32. Direct3D 11 Interoperability**
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuD3D11CtxCreate`|  | 9.2 |  ||
+|`cuD3D11CtxCreateOnDevice`|  | 9.2 |  ||
+|`cuD3D11GetDevice`|  |  |  ||
+|`cuD3D11GetDevices`|  |  |  ||
+|`cuD3D11GetDirect3DDevice`|  | 9.2 |  ||
+|`cuGraphicsD3D11RegisterResource`|  |  |  ||
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuD3D11GetDevice`                                        |                               |
-| `cuD3D11GetDevices`                                       |                               |
-| `cuGraphicsD3D11RegisterResource`                         |                               |
+## **34. VDPAU Interoperability**
 
-## **32.1. Direct3D 11 Interoperability [DEPRECATED]**
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuD3D11CtxCreate`                                        |                               |
-| `cuD3D11CtxCreateOnDevice`                                |                               |
-| `cuD3D11GetDirect3DDevice`                                |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuGraphicsVDPAURegisterOutputSurface`|  |  |  ||
+|`cuGraphicsVDPAURegisterVideoSurface`|  |  |  ||
+|`cuVDPAUCtxCreate`|  |  |  ||
+|`cuVDPAUGetDevice`|  |  |  ||
 
-## **33. VDPAU Interoperability**
+## **35. EGL Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|------------------|
-| `cuGraphicsVDPAURegisterOutputSurface`                    |                               |
-| `cuGraphicsVDPAURegisterVideoSurface`                     |                               |
-| `cuVDPAUCtxCreate`                                        |                               |
-| `cuVDPAUGetDevice`                                        |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuEGLStreamConsumerAcquireFrame`| 9.1 |  |  ||
+|`cuEGLStreamConsumerConnect`| 9.1 |  |  ||
+|`cuEGLStreamConsumerConnectWithFlags`| 9.1 |  |  ||
+|`cuEGLStreamConsumerDisconnect`| 9.1 |  |  ||
+|`cuEGLStreamConsumerReleaseFrame`| 9.1 |  |  ||
+|`cuEGLStreamProducerConnect`| 9.1 |  |  ||
+|`cuEGLStreamProducerDisconnect`| 9.1 |  |  ||
+|`cuEGLStreamProducerPresentFrame`| 9.1 |  |  ||
+|`cuEGLStreamProducerReturnFrame`| 9.1 |  |  ||
+|`cuEventCreateFromEGLSync`| 9.1 |  |  ||
+|`cuGraphicsEGLRegisterImage`| 9.1 |  |  ||
+|`cuGraphicsResourceGetMappedEglFrame`| 9.1 |  |  ||
 
-## **34. EGL Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cuEGLStreamConsumerAcquireFrame`                         |                               | 8.0              |
-| `cuEGLStreamConsumerConnect`                              |                               | 8.0              |
-| `cuEGLStreamConsumerConnectWithFlags`                     |                               | 9.1              |
-| `cuEGLStreamConsumerDisconnect`                           |                               | 9.1              |
-| `cuEGLStreamConsumerReleaseFrame`                         |                               | 9.1              |
-| `cuEGLStreamProducerConnect`                              |                               | 9.1              |
-| `cuEGLStreamProducerDisconnect`                           |                               | 9.1              |
-| `cuEGLStreamProducerPresentFrame`                         |                               | 9.1              |
-| `cuEGLStreamProducerReturnFrame`                          |                               | 9.1              |
-| `cuGraphicsEGLRegisterImage`                              |                               | 9.1              |
-| `cuGraphicsResourceGetMappedEglFrame`                     |                               | 9.1              |
-| `cuEventCreateFromEGLSync`                                |                               | 9.0              |
-
-\* CUDA version, in which API has appeared and (optional) last version before abandoning it; no value in case of earlier versions < 7.5.
+\* A - Added, D - Deprecated, R - Removed

--- a/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
+++ b/docs/markdown/CUDA_Runtime_API_functions_supported_by_HIP.md
@@ -1,1151 +1,1128 @@
-# CUDA Runtime API functions supported by HIP
+# CUDA Runtime API supported by HIP
 
 ## **1. Device Management**
 
-|   **CUDA**                                                |   **HIP**                         |**CUDA version\***|
-|-----------------------------------------------------------|-----------------------------------|:----------------:|
-| `cudaChooseDevice`                                        | `hipChooseDevice`                 |
-| `cudaDeviceGetAttribute`                                  | `hipDeviceGetAttribute`           |
-| `cudaDeviceGetByPCIBusId`                                 | `hipDeviceGetByPCIBusId`          |
-| `cudaDeviceGetCacheConfig`                                | `hipDeviceGetCacheConfig`         |
-| `cudaDeviceGetLimit`                                      | `hipDeviceGetLimit`               |
-| `cudaDeviceGetNvSciSyncAttributes`                        |                                   | 10.2             |
-| `cudaDeviceGetPCIBusId`                                   | `hipDeviceGetPCIBusId`            |
-| `cudaDeviceGetSharedMemConfig`                            | `hipDeviceGetSharedMemConfig`     |
-| `cudaDeviceGetStreamPriorityRange`                        | `hipDeviceGetStreamPriorityRange` |
-| `cudaDeviceReset`                                         | `hipDeviceReset`                  |
-| `cudaDeviceSetCacheConfig`                                | `hipDeviceSetCacheConfig`         |
-| `cudaDeviceSetLimit`                                      | `hipDeviceSetLimit`               |
-| `cudaDeviceSetSharedMemConfig`                            | `hipDeviceSetSharedMemConfig`     |
-| `cudaDeviceSynchronize`                                   | `hipDeviceSynchronize`            |
-| `cudaGetDevice`                                           | `hipGetDevice`                    |
-| `cudaGetDeviceCount`                                      | `hipGetDeviceCount`               |
-| `cudaGetDeviceFlags`                                      | `hipCtxGetFlags`                  |
-| `cudaGetDeviceProperties`                                 | `hipGetDeviceProperties`          |
-| `cudaIpcCloseMemHandle`                                   | `hipIpcCloseMemHandle`            |
-| `cudaIpcGetEventHandle`                                   | `hipIpcGetEventHandle`            |
-| `cudaIpcGetMemHandle`                                     | `hipIpcGetMemHandle`              |
-| `cudaIpcOpenEventHandle`                                  | `hipIpcOpenEventHandle`           |
-| `cudaIpcOpenMemHandle`                                    | `hipIpcOpenMemHandle`             |
-| `cudaSetDevice`                                           | `hipSetDevice`                    |
-| `cudaSetDeviceFlags`                                      | `hipSetDeviceFlags`               |
-| `cudaSetValidDevices`                                     |                                   |
-| `cudaDeviceGetP2PAttribute`                               |                                   | 8.0              |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaChooseDevice`|  |  |  |`hipChooseDevice`|
+|`cudaDeviceGetAttribute`|  |  |  |`hipDeviceGetAttribute`|
+|`cudaDeviceGetByPCIBusId`|  |  |  |`hipDeviceGetByPCIBusId`|
+|`cudaDeviceGetCacheConfig`|  |  |  |`hipDeviceGetCacheConfig`|
+|`cudaDeviceGetLimit`|  |  |  |`hipDeviceGetLimit`|
+|`cudaDeviceGetNvSciSyncAttributes`| 10.2 |  |  ||
+|`cudaDeviceGetP2PAttribute`| 8.0 |  |  ||
+|`cudaDeviceGetPCIBusId`|  |  |  |`hipDeviceGetPCIBusId`|
+|`cudaDeviceGetSharedMemConfig`|  |  |  |`hipDeviceGetSharedMemConfig`|
+|`cudaDeviceGetStreamPriorityRange`|  |  |  |`hipDeviceGetStreamPriorityRange`|
+|`cudaDeviceReset`|  |  |  |`hipDeviceReset`|
+|`cudaDeviceSetCacheConfig`|  |  |  |`hipDeviceSetCacheConfig`|
+|`cudaDeviceSetLimit`|  |  |  |`hipDeviceSetLimit`|
+|`cudaDeviceSetSharedMemConfig`|  |  |  |`hipDeviceSetSharedMemConfig`|
+|`cudaDeviceSynchronize`|  |  |  |`hipDeviceSynchronize`|
+|`cudaGetDevice`|  |  |  |`hipGetDevice`|
+|`cudaGetDeviceCount`|  |  |  |`hipGetDeviceCount`|
+|`cudaGetDeviceFlags`|  |  |  |`hipCtxGetFlags`|
+|`cudaGetDeviceProperties`|  |  |  |`hipGetDeviceProperties`|
+|`cudaIpcCloseMemHandle`|  |  |  |`hipIpcCloseMemHandle`|
+|`cudaIpcGetEventHandle`|  |  |  |`hipIpcGetEventHandle`|
+|`cudaIpcGetMemHandle`|  |  |  |`hipIpcGetMemHandle`|
+|`cudaIpcOpenEventHandle`|  |  |  |`hipIpcOpenEventHandle`|
+|`cudaIpcOpenMemHandle`|  |  |  |`hipIpcOpenMemHandle`|
+|`cudaSetDevice`|  |  |  |`hipSetDevice`|
+|`cudaSetDeviceFlags`|  |  |  |`hipSetDeviceFlags`|
+|`cudaSetValidDevices`|  |  |  ||
 
 ## **2. Thread Management [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaThreadExit`                                          | `hipDeviceReset`              |
-| `cudaThreadGetCacheConfig`                                | `hipDeviceGetCacheConfig`     |
-| `cudaThreadGetLimit`                                      |                               |
-| `cudaThreadSetCacheConfig`                                | `hipDeviceSetCacheConfig`     |
-| `cudaThreadSetLimit`                                      |                               |
-| `cudaThreadSynchronize`                                   | `hipDeviceSynchronize`        |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaThreadExit`|  | 10.0 |  |`hipDeviceReset`|
+|`cudaThreadGetCacheConfig`|  | 10.0 |  |`hipDeviceGetCacheConfig`|
+|`cudaThreadGetLimit`|  | 10.0 |  ||
+|`cudaThreadSetCacheConfig`|  | 10.0 |  |`hipDeviceSetCacheConfig`|
+|`cudaThreadSetLimit`|  | 10.0 |  ||
+|`cudaThreadSynchronize`|  | 10.0 |  |`hipDeviceSynchronize`|
 
 ## **3. Error Handling**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaGetErrorName`                                        | `hipGetErrorName`             |
-| `cudaGetErrorString`                                      | `hipGetErrorString`           |
-| `cudaGetLastError`                                        | `hipGetLastError`             |
-| `cudaPeekAtLastError`                                     | `hipPeekAtLastError`          |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaGetErrorName`|  |  |  |`hipGetErrorName`|
+|`cudaGetErrorString`|  |  |  |`hipGetErrorString`|
+|`cudaGetLastError`|  |  |  |`hipGetLastError`|
+|`cudaPeekAtLastError`|  |  |  |`hipPeekAtLastError`|
 
 ## **4. Stream Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaStreamAddCallback`                                   | `hipStreamAddCallback`        |
-| `cudaCtxResetPersistingL2Cache`                           |                               | 11.0             |
-| `cudaStreamAttachMemAsync`                                |                               |
-| `cudaStreamBeginCapture`                                  |                               | 10.0             |
-| `cudaStreamEndCapture`                                    |                               | 10.0             |
-| `cudaStreamIsCapturing`                                   |                               | 10.0             |
-| `cudaStreamGetCaptureInfo`                                |                               | 10.1             |
-| `cudaStreamCopyAttributes`                                |                               | 11.0             |
-| `cudaStreamGetAttribute`                                  |                               | 11.0             |
-| `cudaStreamSetAttribute`                                  |                               | 11.0             |
-| `cudaStreamCreate`                                        | `hipStreamCreate`             |
-| `cudaStreamCreateWithFlags`                               | `hipStreamCreateWithFlags`    |
-| `cudaStreamCreateWithPriority`                            | `hipStreamCreateWithPriority` |
-| `cudaStreamDestroy`                                       | `hipStreamDestroy`            |
-| `cudaStreamGetFlags`                                      | `hipStreamGetFlags`           |
-| `cudaStreamGetPriority`                                   | `hipStreamGetPriority`        |
-| `cudaStreamQuery`                                         | `hipStreamQuery`              |
-| `cudaStreamSynchronize`                                   | `hipStreamSynchronize`        |
-| `cudaStreamWaitEvent`                                     | `hipStreamWaitEvent`          |
-| `cudaThreadExchangeStreamCaptureMode`                     |                               | 10.1             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaCtxResetPersistingL2Cache`| 11.0 |  |  ||
+|`cudaStreamAddCallback`|  |  |  |`hipStreamAddCallback`|
+|`cudaStreamAttachMemAsync`|  |  |  ||
+|`cudaStreamBeginCapture`| 10.0 |  |  ||
+|`cudaStreamCopyAttributes`| 11.0 |  |  ||
+|`cudaStreamCreate`|  |  |  |`hipStreamCreate`|
+|`cudaStreamCreateWithFlags`|  |  |  |`hipStreamCreateWithFlags`|
+|`cudaStreamCreateWithPriority`|  |  |  |`hipStreamCreateWithPriority`|
+|`cudaStreamDestroy`|  |  |  |`hipStreamDestroy`|
+|`cudaStreamEndCapture`| 10.0 |  |  ||
+|`cudaStreamGetAttribute`| 11.0 |  |  ||
+|`cudaStreamGetCaptureInfo`| 10.1 |  |  ||
+|`cudaStreamGetFlags`|  |  |  |`hipStreamGetFlags`|
+|`cudaStreamGetPriority`|  |  |  |`hipStreamGetPriority`|
+|`cudaStreamIsCapturing`| 10.0 |  |  ||
+|`cudaStreamQuery`|  |  |  |`hipStreamQuery`|
+|`cudaStreamSetAttribute`| 11.0 |  |  ||
+|`cudaStreamSynchronize`|  |  |  |`hipStreamSynchronize`|
+|`cudaStreamWaitEvent`|  |  |  |`hipStreamWaitEvent`|
+|`cudaThreadExchangeStreamCaptureMode`| 10.1 |  |  ||
 
 ## **5. Event Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaEventCreate`                                         | `hipEventCreate`              |
-| `cudaEventCreateWithFlags`                                | `hipEventCreateWithFlags`     |
-| `cudaEventDestroy`                                        | `hipEventDestroy`             |
-| `cudaEventElapsedTime`                                    | `hipEventElapsedTime`         |
-| `cudaEventQuery`                                          | `hipEventQuery`               |
-| `cudaEventRecord`                                         | `hipEventRecord`              |
-| `cudaEventSynchronize`                                    | `hipEventSynchronize`         |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaEventCreate`|  |  |  |`hipEventCreate`|
+|`cudaEventCreateWithFlags`|  |  |  |`hipEventCreateWithFlags`|
+|`cudaEventDestroy`|  |  |  |`hipEventDestroy`|
+|`cudaEventElapsedTime`|  |  |  |`hipEventElapsedTime`|
+|`cudaEventQuery`|  |  |  |`hipEventQuery`|
+|`cudaEventRecord`|  |  |  |`hipEventRecord`|
+|`cudaEventSynchronize`|  |  |  |`hipEventSynchronize`|
 
 ## **6. External Resource Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaSignalExternalSemaphoresAsync`                       |                               | 10.0             |
-| `cudaWaitExternalSemaphoresAsync`                         |                               | 10.0             |
-| `cudaImportExternalMemory`                                |                               | 10.0             |
-| `cudaExternalMemoryGetMappedBuffer`                       |                               | 10.0             |
-| `cudaExternalMemoryGetMappedMipmappedArray`               |                               | 10.0             |
-| `cudaDestroyExternalMemory`                               |                               | 10.0             |
-| `cudaImportExternalSemaphore`                             |                               | 10.0             |
-| `cudaDestroyExternalSemaphore`                            |                               | 10.0             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaDestroyExternalMemory`| 10.0 |  |  ||
+|`cudaDestroyExternalSemaphore`| 10.0 |  |  ||
+|`cudaExternalMemoryGetMappedBuffer`| 10.0 |  |  ||
+|`cudaExternalMemoryGetMappedMipmappedArray`| 10.0 |  |  ||
+|`cudaImportExternalMemory`| 10.0 |  |  ||
+|`cudaImportExternalSemaphore`| 10.0 |  |  ||
+|`cudaSignalExternalSemaphoresAsync`| 10.0 |  |  ||
+|`cudaWaitExternalSemaphoresAsync`| 10.0 |  |  ||
 
 ## **7. Execution Control**
 
-|   **CUDA**                                                |   **HIP**                             |**CUDA version\***|
-|-----------------------------------------------------------|---------------------------------------|:----------------:|
-| `cudaFuncGetAttributes`                                   |`hipFuncGetAttributes`                 |
-| `cudaFuncSetAttribute`                                    |                                       | 9.0              |
-| `cudaFuncSetCacheConfig`                                  |`hipFuncSetCacheConfig`                |
-| `cudaFuncSetSharedMemConfig`                              |                                       |
-| `cudaGetParameterBuffer`                                  |                                       |
-| `cudaGetParameterBufferV2`                                |                                       |
-| `cudaLaunchKernel`                                        |`hipLaunchKernel`                      |
-| `cudaSetDoubleForDevice`                                  |                                       |
-| `cudaSetDoubleForHost`                                    |                                       |
-| `cudaLaunchCooperativeKernel`                             |`hipLaunchCooperativeKernel`           | 9.0              |
-| `cudaLaunchCooperativeKernelMultiDevice`                  |`hipLaunchCooperativeKernelMultiDevice`| 9.0              |
-| `cudaLaunchHostFunc`                                      |                                       | 10.0             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaFuncGetAttributes`|  |  |  |`hipFuncGetAttributes`|
+|`cudaFuncSetAttribute`| 9.0 |  |  ||
+|`cudaFuncSetCacheConfig`|  |  |  |`hipFuncSetCacheConfig`|
+|`cudaFuncSetSharedMemConfig`|  |  |  ||
+|`cudaGetParameterBuffer`|  |  |  ||
+|`cudaGetParameterBufferV2`|  |  |  ||
+|`cudaLaunchCooperativeKernel`| 9.0 |  |  |`hipLaunchCooperativeKernel`|
+|`cudaLaunchCooperativeKernelMultiDevice`| 9.0 |  |  |`hipLaunchCooperativeKernelMultiDevice`|
+|`cudaLaunchHostFunc`| 10.0 |  |  ||
+|`cudaLaunchKernel`|  |  |  |`hipLaunchKernel`|
+|`cudaSetDoubleForDevice`|  | 10.0 |  ||
+|`cudaSetDoubleForHost`|  | 10.0 |  ||
 
 ## **8. Occupancy**
 
-|   **CUDA**                                                |   **HIP**                                             |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------------|:----------------:|
-| `cudaOccupancyAvailableDynamicSMemPerBlock`               |                                                       | 11.0             |
-| `cudaOccupancyMaxActiveBlocksPerMultiprocessor`           |`hipOccupancyMaxActiveBlocksPerMultiprocessor`         |
-| `cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`  |`hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`|
-
-## **Former 9. Execution Control [DEPRECATED since 7.0, REMOVED since 10.1]**
-
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaConfigureCall`                                       | `hipConfigureCall`            |
-| `cudaLaunch`                                              | `hipLaunchByPtr`              |
-| `cudaSetupArgument`                                       | `hipSetupArgument`            |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaOccupancyAvailableDynamicSMemPerBlock`| 11.0 |  |  ||
+|`cudaOccupancyMaxActiveBlocksPerMultiprocessor`|  |  |  |`hipOccupancyMaxActiveBlocksPerMultiprocessor`|
+|`cudaOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`|  |  |  |`hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags`|
+|`cudaOccupancyMaxPotentialBlockSize`|  |  |  |`hipOccupancyMaxPotentialBlockSize`|
+|`cudaOccupancyMaxPotentialBlockSizeVariableSMem`|  |  |  ||
+|`cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags`|  |  |  ||
+|`cudaOccupancyMaxPotentialBlockSizeWithFlags`|  |  |  ||
 
 ## **9. Memory Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaArrayGetInfo`                                        |                               |
-| `cudaFree`                                                | `hipFree`                     |
-| `cudaFreeArray`                                           | `hipFreeArray`                |
-| `cudaFreeHost`                                            | `hipHostFree`                 |
-| `cudaFreeMipmappedArray`                                  |                               |
-| `cudaGetMipmappedArrayLevel`                              |                               |
-| `cudaGetSymbolAddress`                                    | `hipGetSymbolAddress`         |
-| `cudaGetSymbolSize`                                       | `hipGetSymbolSize`            |
-| `cudaHostAlloc`                                           | `hipHostMalloc`               |
-| `cudaHostGetDevicePointer`                                | `hipHostGetDevicePointer`     |
-| `cudaHostGetFlags`                                        | `hipHostGetFlags`             |
-| `cudaHostRegister`                                        | `hipHostRegister`             |
-| `cudaHostUnregister`                                      | `hipHostUnregister`           |
-| `cudaMalloc`                                              | `hipMalloc`                   |
-| `cudaMalloc3D`                                            | `hipMalloc3D`                 |
-| `cudaMalloc3DArray`                                       | `hipMalloc3DArray`            |
-| `cudaMallocArray`                                         | `hipMallocArray`              |
-| `cudaMallocHost`                                          | `hipHostMalloc`               |
-| `cudaMallocManaged`                                       | `hipMallocManaged`            |
-| `cudaMallocMipmappedArray`                                |                               |
-| `cudaMallocPitch`                                         |                               |
-| `cudaMemGetInfo`                                          | `hipMemGetInfo`               |
-| `cudaMemPrefetchAsync`                                    |                               | 8.0              |
-| `cudaMemcpy`                                              | `hipMemcpy`                   |
-| `cudaMemcpy2D`                                            | `hipMemcpy2D`                 |
-| `cudaMemcpy2DArrayToArray`                                |                               |
-| `cudaMemcpy2DAsync`                                       | `hipMemcpy2DAsync`            |
-| `cudaMemcpy2DFromArray`                                   | `hipMemcpy2DFromArray`        |
-| `cudaMemcpy2DFromArrayAsync`                              | `hipMemcpy2DFromArrayAsync`   |
-| `cudaMemcpy2DToArray`                                     | `hipMemcpy2DToArray`          |
-| `cudaMemcpy2DToArrayAsync`                                |                               |
-| `cudaMemcpy3D`                                            | `hipMemcpy3D`                 |
-| `cudaMemcpy3DAsync`                                       | `hipMemcpy3DAsync`            |
-| `cudaMemcpy3DPeer`                                        |                               |
-| `cudaMemcpy3DPeerAsync`                                   |                               |
-| `cudaMemcpyAsync`                                         | `hipMemcpyAsync`              |
-| `cudaMemcpyFromSymbol`                                    | `hipMemcpyFromSymbol`         |
-| `cudaMemcpyFromSymbolAsync`                               | `hipMemcpyFromSymbolAsync`    |
-| `cudaMemcpyPeer`                                          | `hipMemcpyPeer`               |
-| `cudaMemcpyPeerAsync`                                     | `hipMemcpyPeerAsync`          |
-| `cudaMemcpyToSymbol`                                      | `hipMemcpyToSymbol`           |
-| `cudaMemcpyToSymbolAsync`                                 | `hipMemcpyToSymbolAsync`      |
-| `cudaMemset`                                              | `hipMemset`                   |
-| `cudaMemset2D`                                            | `hipMemset2D`                 |
-| `cudaMemset2DAsync`                                       | `hipMemset2DAsync`            |
-| `cudaMemset3D`                                            | `hipMemset3D`                 |
-| `cudaMemset3DAsync`                                       | `hipMemset3DAsync`            |
-| `cudaMemsetAsync`                                         | `hipMemsetAsync`              |
-| `make_cudaExtent`                                         | `make_hipExtent`              |
-| `make_cudaPitchedPtr`                                     | `make_hipPitchedPtr`          |
-| `make_cudaPos`                                            | `make_hipPos`                 |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaArrayGetInfo`|  |  |  ||
+|`cudaFree`|  |  |  |`hipFree`|
+|`cudaFreeArray`|  |  |  |`hipFreeArray`|
+|`cudaFreeHost`|  |  |  |`hipHostFree`|
+|`cudaFreeMipmappedArray`|  |  |  ||
+|`cudaGetMipmappedArrayLevel`|  |  |  ||
+|`cudaGetSymbolAddress`|  |  |  |`hipGetSymbolAddress`|
+|`cudaGetSymbolSize`|  |  |  |`hipGetSymbolSize`|
+|`cudaHostAlloc`|  |  |  |`hipHostMalloc`|
+|`cudaHostGetDevicePointer`|  |  |  |`hipHostGetDevicePointer`|
+|`cudaHostGetFlags`|  |  |  |`hipHostGetFlags`|
+|`cudaHostRegister`|  |  |  |`hipHostRegister`|
+|`cudaHostUnregister`|  |  |  |`hipHostUnregister`|
+|`cudaMalloc`|  |  |  |`hipMalloc`|
+|`cudaMalloc3D`|  |  |  |`hipMalloc3D`|
+|`cudaMalloc3DArray`|  |  |  |`hipMalloc3DArray`|
+|`cudaMallocArray`|  |  |  |`hipMallocArray`|
+|`cudaMallocHost`|  |  |  |`hipHostMalloc`|
+|`cudaMallocManaged`|  |  |  |`hipMallocManaged`|
+|`cudaMallocMipmappedArray`|  |  |  ||
+|`cudaMallocPitch`|  |  |  |`hipMallocPitch`|
+|`cudaMemAdvise`| 8.0 |  |  ||
+|`cudaMemGetInfo`|  |  |  |`hipMemGetInfo`|
+|`cudaMemPrefetchAsync`| 8.0 |  |  ||
+|`cudaMemRangeGetAttribute`| 8.0 |  |  ||
+|`cudaMemRangeGetAttributes`| 8.0 |  |  ||
+|`cudaMemcpy`|  |  |  |`hipMemcpy`|
+|`cudaMemcpy2D`|  |  |  |`hipMemcpy2D`|
+|`cudaMemcpy2DArrayToArray`|  |  |  ||
+|`cudaMemcpy2DAsync`|  |  |  |`hipMemcpy2DAsync`|
+|`cudaMemcpy2DFromArray`|  |  |  |`hipMemcpy2DFromArray`|
+|`cudaMemcpy2DFromArrayAsync`|  |  |  |`hipMemcpy2DFromArrayAsync`|
+|`cudaMemcpy2DToArray`|  |  |  |`hipMemcpy2DToArray`|
+|`cudaMemcpy2DToArrayAsync`|  |  |  ||
+|`cudaMemcpy3D`|  |  |  |`hipMemcpy3D`|
+|`cudaMemcpy3DAsync`|  |  |  |`hipMemcpy3DAsync`|
+|`cudaMemcpy3DPeer`|  |  |  ||
+|`cudaMemcpy3DPeerAsync`|  |  |  ||
+|`cudaMemcpyAsync`|  |  |  |`hipMemcpyAsync`|
+|`cudaMemcpyFromSymbol`|  |  |  |`hipMemcpyFromSymbol`|
+|`cudaMemcpyFromSymbolAsync`|  |  |  |`hipMemcpyFromSymbolAsync`|
+|`cudaMemcpyPeer`|  |  |  |`hipMemcpyPeer`|
+|`cudaMemcpyPeerAsync`|  |  |  |`hipMemcpyPeerAsync`|
+|`cudaMemcpyToSymbol`|  |  |  |`hipMemcpyToSymbol`|
+|`cudaMemcpyToSymbolAsync`|  |  |  |`hipMemcpyToSymbolAsync`|
+|`cudaMemset`|  |  |  |`hipMemset`|
+|`cudaMemset2D`|  |  |  |`hipMemset2D`|
+|`cudaMemset2DAsync`|  |  |  |`hipMemset2DAsync`|
+|`cudaMemset3D`|  |  |  |`hipMemset3D`|
+|`cudaMemset3DAsync`|  |  |  |`hipMemset3DAsync`|
+|`cudaMemsetAsync`|  |  |  |`hipMemsetAsync`|
+|`make_cudaExtent`|  |  |  |`make_hipExtent`|
+|`make_cudaPitchedPtr`|  |  |  |`make_hipPitchedPtr`|
+|`make_cudaPos`|  |  |  |`make_hipPos`|
 
-## **10. Memory Management [DEPRECATED since 10.1]**
+## **10. Memory Management [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaMemcpyArrayToArray`                                  |                               |
-| `cudaMemcpyFromArray`                                     | `hipMemcpyFromArray`          |
-| `cudaMemcpyFromArrayAsync`                                |                               |
-| `cudaMemcpyToArray`                                       | `hipMemcpyToArray`            |
-| `cudaMemcpyToArrayAsync`                                  |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaMemcpyArrayToArray`|  | 10.1 |  ||
+|`cudaMemcpyFromArray`|  | 10.1 |  |`hipMemcpyFromArray`|
+|`cudaMemcpyFromArrayAsync`|  | 10.1 |  ||
+|`cudaMemcpyToArray`|  | 10.1 |  |`hipMemcpyToArray`|
+|`cudaMemcpyToArrayAsync`|  | 10.1 |  |`hipMemcpyToArrayAsync`|
 
 ## **11. Unified Addressing**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaPointerGetAttributes`                                | `hipPointerGetAttributes`     |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaPointerGetAttributes`|  |  |  |`hipPointerGetAttributes`|
 
 ## **12. Peer Device Memory Access**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaDeviceCanAccessPeer`                                 | `hipDeviceCanAccessPeer`      |
-| `cudaDeviceDisablePeerAccess`                             | `hipDeviceDisablePeerAccess`  |
-| `cudaDeviceEnablePeerAccess`                              | `hipDeviceEnablePeerAccess`   |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaDeviceCanAccessPeer`|  |  |  |`hipDeviceCanAccessPeer`|
+|`cudaDeviceDisablePeerAccess`|  |  |  |`hipDeviceDisablePeerAccess`|
+|`cudaDeviceEnablePeerAccess`|  |  |  |`hipDeviceEnablePeerAccess`|
 
 ## **13. OpenGL Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaGLGetDevices`                                        |                               |
-| `cudaGraphicsGLRegisterBuffer`                            |                               |
-| `cudaGraphicsGLRegisterImage`                             |                               |
-| `cudaWGLGetDevice`                                        |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaGLGetDevices`|  |  |  ||
+|`cudaGraphicsGLRegisterBuffer`|  |  |  ||
+|`cudaGraphicsGLRegisterImage`|  |  |  ||
+|`cudaWGLGetDevice`|  |  |  ||
 
 ## **14. OpenGL Interoperability [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaGLMapBufferObject`                                   |                               |
-| `cudaGLMapBufferObjectAsync`                              |                               |
-| `cudaGLRegisterBufferObject`                              |                               |
-| `cudaGLSetBufferObjectMapFlags`                           |                               |
-| `cudaGLSetGLDevice`                                       |                               |
-| `cudaGLUnmapBufferObject`                                 |                               |
-| `cudaGLUnmapBufferObjectAsync`                            |                               |
-| `cudaGLUnregisterBufferObject`                            |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaGLMapBufferObject`|  | 10.0 |  ||
+|`cudaGLMapBufferObjectAsync`|  | 10.0 |  ||
+|`cudaGLRegisterBufferObject`|  | 10.0 |  ||
+|`cudaGLSetBufferObjectMapFlags`|  | 10.0 |  ||
+|`cudaGLSetGLDevice`|  | 10.0 |  ||
+|`cudaGLUnmapBufferObject`|  | 10.0 |  ||
+|`cudaGLUnmapBufferObjectAsync`|  | 10.0 |  ||
+|`cudaGLUnregisterBufferObject`|  | 10.0 |  ||
 
 ## **15. Direct3D 9 Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaD3D9GetDevice`                                       |                               |
-| `cudaD3D9GetDevices`                                      |                               |
-| `cudaD3D9GetDirect3DDevice`                               |                               |
-| `cudaD3D9SetDirect3DDevice`                               |                               |
-| `cudaGraphicsD3D9RegisterResource`                        |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaD3D9GetDevice`|  |  |  ||
+|`cudaD3D9GetDevices`|  |  |  ||
+|`cudaD3D9GetDirect3DDevice`|  |  |  ||
+|`cudaD3D9SetDirect3DDevice`|  |  |  ||
+|`cudaGraphicsD3D9RegisterResource`|  |  |  ||
 
 ## **16. Direct3D 9 Interoperability [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaD3D9MapResources`                                    |                               |
-| `cudaD3D9RegisterResource`                                |                               |
-| `cudaD3D9ResourceGetMappedArray`                          |                               |
-| `cudaD3D9ResourceGetMappedPitch`                          |                               |
-| `cudaD3D9ResourceGetMappedPointer`                        |                               |
-| `cudaD3D9ResourceGetMappedSize`                           |                               |
-| `cudaD3D9ResourceGetSurfaceDimensions`                    |                               |
-| `cudaD3D9ResourceSetMapFlags`                             |                               |
-| `cudaD3D9UnmapResources`                                  |                               |
-| `cudaD3D9UnregisterResource`                              |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaD3D9MapResources`|  | 10.0 |  ||
+|`cudaD3D9RegisterResource`|  |  |  ||
+|`cudaD3D9ResourceGetMappedArray`|  | 10.0 |  ||
+|`cudaD3D9ResourceGetMappedPitch`|  | 10.0 |  ||
+|`cudaD3D9ResourceGetMappedPointer`|  | 10.0 |  ||
+|`cudaD3D9ResourceGetMappedSize`|  | 10.0 |  ||
+|`cudaD3D9ResourceGetSurfaceDimensions`|  | 10.0 |  ||
+|`cudaD3D9ResourceSetMapFlags`|  | 10.0 |  ||
+|`cudaD3D9UnmapResources`|  | 10.0 |  ||
+|`cudaD3D9UnregisterResource`|  | 10.0 |  ||
 
 ## **17. Direct3D 10 Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaD3D10GetDevice`                                      |                               |
-| `cudaD3D10GetDevices`                                     |                               |
-| `cudaGraphicsD3D10RegisterResource`                       |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaD3D10GetDevice`|  |  |  ||
+|`cudaD3D10GetDevices`|  |  |  ||
+|`cudaGraphicsD3D10RegisterResource`|  |  |  ||
 
 ## **18. Direct3D 10 Interoperability [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaD3D10GetDirect3DDevice`                              |                               |
-| `cudaD3D10MapResources`                                   |                               |
-| `cudaD3D10RegisterResource`                               |                               |
-| `cudaD3D10ResourceGetMappedArray`                         |                               |
-| `cudaD3D10ResourceGetMappedPitch`                         |                               |
-| `cudaD3D10ResourceGetMappedPointer`                       |                               |
-| `cudaD3D10ResourceGetMappedSize`                          |                               |
-| `cudaD3D10ResourceGetSurfaceDimensions`                   |                               |
-| `cudaD3D10ResourceSetMapFlags`                            |                               |
-| `cudaD3D10SetDirect3DDevice`                              |                               |
-| `cudaD3D10UnmapResources`                                 |                               |
-| `cudaD3D10UnregisterResource`                             |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaD3D10GetDirect3DDevice`|  | 10.0 |  ||
+|`cudaD3D10MapResources`|  | 10.0 |  ||
+|`cudaD3D10RegisterResource`|  | 10.0 |  ||
+|`cudaD3D10ResourceGetMappedArray`|  | 10.0 |  ||
+|`cudaD3D10ResourceGetMappedPitch`|  | 10.0 |  ||
+|`cudaD3D10ResourceGetMappedPointer`|  | 10.0 |  ||
+|`cudaD3D10ResourceGetMappedSize`|  | 10.0 |  ||
+|`cudaD3D10ResourceGetSurfaceDimensions`|  | 10.0 |  ||
+|`cudaD3D10ResourceSetMapFlags`|  | 10.0 |  ||
+|`cudaD3D10SetDirect3DDevice`|  | 10.0 |  ||
+|`cudaD3D10UnmapResources`|  | 10.0 |  ||
+|`cudaD3D10UnregisterResource`|  | 10.0 |  ||
 
 ## **19. Direct3D 11 Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaD3D11GetDevice`                                      |                               |
-| `cudaD3D11GetDevices`                                     |                               |
-| `cudaGraphicsD3D11RegisterResource`                       |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaD3D11GetDevice`|  |  |  ||
+|`cudaD3D11GetDevices`|  |  |  ||
+|`cudaGraphicsD3D11RegisterResource`|  |  |  ||
 
 ## **20. Direct3D 11 Interoperability [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaD3D11GetDirect3DDevice`                              |                               |
-| `cudaD3D11SetDirect3DDevice`                              |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaD3D11GetDirect3DDevice`|  | 10.0 |  ||
+|`cudaD3D11SetDirect3DDevice`|  | 10.0 |  ||
 
 ## **21. VDPAU Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaGraphicsVDPAURegisterOutputSurface`                  |                               |
-| `cudaGraphicsVDPAURegisterVideoSurface`                   |                               |
-| `cudaVDPAUGetDevice`                                      |                               |
-| `cudaVDPAUSetVDPAUDevice`                                 |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaGraphicsVDPAURegisterOutputSurface`|  |  |  ||
+|`cudaGraphicsVDPAURegisterVideoSurface`|  |  |  ||
+|`cudaVDPAUGetDevice`|  |  |  ||
+|`cudaVDPAUSetVDPAUDevice`|  |  |  ||
 
 ## **22. EGL Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaEGLStreamConsumerAcquireFrame`                       |                               | 8.0              |
-| `cudaEGLStreamConsumerConnect`                            |                               | 8.0              |
-| `cudaEGLStreamConsumerConnectWithFlags`                   |                               | 8.0              |
-| `cudaEGLStreamConsumerDisconnect`                         |                               | 8.0              |
-| `cudaEGLStreamConsumerReleaseFrame`                       |                               | 8.0              |
-| `cudaEGLStreamProducerConnect`                            |                               | 8.0              |
-| `cudaEGLStreamProducerDisconnect`                         |                               | 8.0              |
-| `cudaEGLStreamProducerPresentFrame`                       |                               | 8.0              |
-| `cudaEGLStreamProducerReturnFrame`                        |                               | 8.0              |
-| `cudaEventCreateFromEGLSync`                              |                               | 9.0              |
-| `cudaGraphicsEGLRegisterImage`                            |                               | 8.0              |
-| `cudaGraphicsResourceGetMappedEglFrame`                   |                               | 8.0              |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaEGLStreamConsumerAcquireFrame`| 9.1 |  |  ||
+|`cudaEGLStreamConsumerConnect`| 9.1 |  |  ||
+|`cudaEGLStreamConsumerConnectWithFlags`| 9.1 |  |  ||
+|`cudaEGLStreamConsumerDisconnect`| 9.1 |  |  ||
+|`cudaEGLStreamConsumerReleaseFrame`| 9.1 |  |  ||
+|`cudaEGLStreamProducerConnect`| 9.1 |  |  ||
+|`cudaEGLStreamProducerDisconnect`| 9.1 |  |  ||
+|`cudaEGLStreamProducerPresentFrame`| 9.1 |  |  ||
+|`cudaEGLStreamProducerReturnFrame`| 9.1 |  |  ||
+|`cudaEventCreateFromEGLSync`| 9.1 |  |  ||
+|`cudaGraphicsEGLRegisterImage`| 9.1 |  |  ||
+|`cudaGraphicsResourceGetMappedEglFrame`| 9.1 |  |  ||
 
 ## **23. Graphics Interoperability**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaGraphicsMapResources`                                |                               |
-| `cudaGraphicsResourceGetMappedMipmappedArray`             |                               |
-| `cudaGraphicsResourceGetMappedPointer`                    |                               |
-| `cudaGraphicsResourceSetMapFlags`                         |                               |
-| `cudaGraphicsSubResourceGetMappedArray`                   |                               |
-| `cudaGraphicsUnmapResources`                              |                               |
-| `cudaGraphicsUnregisterResource`                          |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaGraphicsMapResources`|  |  |  ||
+|`cudaGraphicsResourceGetMappedMipmappedArray`|  |  |  ||
+|`cudaGraphicsResourceGetMappedPointer`|  |  |  ||
+|`cudaGraphicsResourceSetMapFlags`|  |  |  ||
+|`cudaGraphicsSubResourceGetMappedArray`|  |  |  ||
+|`cudaGraphicsUnmapResources`|  |  |  ||
+|`cudaGraphicsUnregisterResource`|  |  |  ||
 
 ## **24. Texture Reference Management [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                        |**CUDA version\***|
-|-----------------------------------------------------------|----------------------------------|:----------------:|
-| `cudaBindTexture`                                         | `hipBindTexture`                 |
-| `cudaBindTexture2D`                                       | `hipBindTexture2D`               |
-| `cudaBindTextureToArray`                                  | `hipBindTextureToArray`          |
-| `cudaBindTextureToMipmappedArray`                         | `hipBindTextureToMipmappedArray` |
-| `cudaCreateChannelDesc`                                   | `hipCreateChannelDesc`           |
-| `cudaGetChannelDesc`                                      | `hipGetChannelDesc`              |
-| `cudaGetTextureAlignmentOffset`                           | `hipGetTextureAlignmentOffset`   |
-| `cudaGetTextureReference`                                 | `hipGetTextureReference`         |
-| `cudaUnbindTexture`                                       | `hipUnbindTexture`               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaBindTexture`|  | 11.0 |  |`hipBindTexture`|
+|`cudaBindTexture2D`|  | 11.0 |  |`hipBindTexture2D`|
+|`cudaBindTextureToArray`|  | 11.0 |  |`hipBindTextureToArray`|
+|`cudaBindTextureToMipmappedArray`|  | 11.0 |  |`hipBindTextureToMipmappedArray`|
+|`cudaCreateChannelDesc`|  |  |  |`hipCreateChannelDesc`|
+|`cudaGetChannelDesc`|  |  |  |`hipGetChannelDesc`|
+|`cudaGetTextureAlignmentOffset`|  | 11.0 |  |`hipGetTextureAlignmentOffset`|
+|`cudaGetTextureReference`|  | 11.0 |  |`hipGetTextureReference`|
+|`cudaUnbindTexture`|  | 11.0 |  |`hipUnbindTexture`|
 
 ## **25. Surface Reference Management [DEPRECATED]**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaBindSurfaceToArray`                                  |                               |
-| `cudaGetSurfaceReference`                                 |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaBindSurfaceToArray`|  | 11.0 |  ||
+|`cudaGetSurfaceReference`|  | 11.0 |  ||
 
 ## **26. Texture Object Management**
 
-|   **CUDA**                                                |   **HIP**                            |**CUDA version\***|
-|-----------------------------------------------------------|--------------------------------------|:----------------:|
-| `cudaCreateTextureObject`                                 |`hipCreateTextureObject`              |
-| `cudaDestroyTextureObject`                                |`hipDestroyTextureObject`             |
-| `cudaGetTextureObjectResourceDesc`                        |`hipGetTextureObjectResourceDesc`     |
-| `cudaGetTextureObjectResourceViewDesc`                    |`hipGetTextureObjectResourceViewDesc` |
-| `cudaGetTextureObjectTextureDesc`                         |`hipGetTextureObjectTextureDesc`      |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuTexObjectGetTextureDesc`| 9.0 |  |  |`hipGetTextureObjectTextureDesc`|
+|`cudaCreateTextureObject`|  |  |  |`hipCreateTextureObject`|
+|`cudaDestroyTextureObject`|  |  |  |`hipDestroyTextureObject`|
+|`cudaGetTextureObjectResourceDesc`|  |  |  |`hipGetTextureObjectResourceDesc`|
+|`cudaGetTextureObjectResourceViewDesc`|  |  |  |`hipGetTextureObjectResourceViewDesc`|
 
 ## **27. Surface Object Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaCreateSurfaceObject`                                 | `hipCreateSurfaceObject`      |
-| `cudaDestroySurfaceObject`                                | `hipDestroySurfaceObject`     |
-| `cudaGetSurfaceObjectResourceDesc`                        |                               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaCreateSurfaceObject`| 9.0 |  |  |`hipCreateSurfaceObject`|
+|`cudaDestroySurfaceObject`| 9.0 |  |  |`hipDestroySurfaceObject`|
+|`cudaGetSurfaceObjectResourceDesc`| 9.0 |  |  ||
 
 ## **28. Version Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaDriverGetVersion`                                    | `hipDriverGetVersion`         |
-| `cudaRuntimeGetVersion`                                   | `hipRuntimeGetVersion`        |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaDriverGetVersion`| 9.0 |  |  |`hipDriverGetVersion`|
+|`cudaRuntimeGetVersion`| 9.0 |  |  |`hipRuntimeGetVersion`|
 
 ## **29. Graph Management**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaGraphAddChildGraphNode`                              |                               | 10.0             |
-| `cudaGraphAddDependencies`                                |                               | 10.0             |
-| `cudaGraphAddEmptyNode`                                   |                               | 10.0             |
-| `cudaGraphAddHostNode`                                    |                               | 10.0             |
-| `cudaGraphAddKernelNode`                                  |                               | 10.0             |
-| `cudaGraphAddMemcpyNode`                                  |                               | 10.0             |
-| `cudaGraphAddMemsetNode`                                  |                               | 10.0             |
-| `cudaGraphChildGraphNodeGetGraph`                         |                               | 10.0             |
-| `cudaGraphClone`                                          |                               | 10.0             |
-| `cudaGraphCreate`                                         |                               | 10.0             |
-| `cudaGraphDestroy`                                        |                               | 10.0             |
-| `cudaGraphDestroyNode`                                    |                               | 10.0             |
-| `cudaGraphExecDestroy`                                    |                               | 10.0             |
-| `cudaGraphGetEdges`                                       |                               | 10.0             |
-| `cudaGraphGetNodes`                                       |                               | 10.0             |
-| `cudaGraphGetRootNodes`                                   |                               | 10.0             |
-| `cudaGraphHostNodeGetParams`                              |                               | 10.0             |
-| `cudaGraphHostNodeSetParams`                              |                               | 10.0             |
-| `cudaGraphInstantiate`                                    |                               | 10.0             |
-| `cudaGraphKernelNodeCopyAttributes`                       |                               | 11.0             |
-| `cudaGraphKernelNodeGetAttribute`                         |                               | 11.0             |
-| `cudaGraphKernelNodeSetAttribute`                         |                               | 11.0             |
-| `cudaGraphExecKernelNodeSetParams`                        |                               | 10.1             |
-| `cudaGraphExecMemcpyNodeSetParams`                        |                               | 10.2             |
-| `cudaGraphExecMemsetNodeSetParams`                        |                               | 10.2             |
-| `cudaGraphExecHostNodeSetParams`                          |                               | 10.2             |
-| `cudaGraphExecUpdate`                                     |                               | 10.2             |
-| `cudaGraphKernelNodeGetParams`                            |                               | 10.0             |
-| `cudaGraphKernelNodeSetParams`                            |                               | 10.0             |
-| `cudaGraphLaunch`                                         |                               | 10.0             |
-| `cudaGraphMemcpyNodeGetParams`                            |                               | 10.0             |
-| `cudaGraphMemcpyNodeSetParams`                            |                               | 10.0             |
-| `cudaGraphMemsetNodeGetParams`                            |                               | 10.0             |
-| `cudaGraphMemsetNodeSetParams`                            |                               | 10.0             |
-| `cudaGraphNodeFindInClone`                                |                               | 10.0             |
-| `cudaGraphNodeGetDependencies`                            |                               | 10.0             |
-| `cudaGraphNodeGetDependentNodes`                          |                               | 10.0             |
-| `cudaGraphNodeGetType`                                    |                               | 10.0             |
-| `cudaGraphRemoveDependencies`                             |                               | 10.0             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaGraphAddChildGraphNode`| 10.0 |  |  ||
+|`cudaGraphAddDependencies`| 10.0 |  |  ||
+|`cudaGraphAddEmptyNode`| 10.0 |  |  ||
+|`cudaGraphAddHostNode`| 10.0 |  |  ||
+|`cudaGraphAddKernelNode`| 10.0 |  |  ||
+|`cudaGraphAddMemcpyNode`| 10.0 |  |  ||
+|`cudaGraphAddMemsetNode`| 10.0 |  |  ||
+|`cudaGraphChildGraphNodeGetGraph`| 10.0 |  |  ||
+|`cudaGraphClone`| 10.0 |  |  ||
+|`cudaGraphCreate`| 10.0 |  |  ||
+|`cudaGraphDestroy`| 10.0 |  |  ||
+|`cudaGraphDestroyNode`| 10.0 |  |  ||
+|`cudaGraphExecDestroy`| 10.0 |  |  ||
+|`cudaGraphExecHostNodeSetParams`| 11.0 |  |  ||
+|`cudaGraphExecKernelNodeSetParams`| 11.0 |  |  ||
+|`cudaGraphExecMemcpyNodeSetParams`| 11.0 |  |  ||
+|`cudaGraphExecMemsetNodeSetParams`| 11.0 |  |  ||
+|`cudaGraphExecUpdate`| 11.0 |  |  ||
+|`cudaGraphGetEdges`| 10.0 |  |  ||
+|`cudaGraphGetNodes`| 10.0 |  |  ||
+|`cudaGraphGetRootNodes`| 10.0 |  |  ||
+|`cudaGraphHostNodeGetParams`| 10.0 |  |  ||
+|`cudaGraphHostNodeSetParams`| 10.0 |  |  ||
+|`cudaGraphInstantiate`| 10.0 |  |  ||
+|`cudaGraphKernelNodeCopyAttributes`| 11.0 |  |  ||
+|`cudaGraphKernelNodeGetAttribute`| 11.0 |  |  ||
+|`cudaGraphKernelNodeGetParams`| 11.0 |  |  ||
+|`cudaGraphKernelNodeSetAttribute`| 11.0 |  |  ||
+|`cudaGraphKernelNodeSetParams`| 11.0 |  |  ||
+|`cudaGraphLaunch`| 11.0 |  |  ||
+|`cudaGraphMemcpyNodeGetParams`| 11.0 |  |  ||
+|`cudaGraphMemcpyNodeSetParams`| 11.0 |  |  ||
+|`cudaGraphMemsetNodeGetParams`| 11.0 |  |  ||
+|`cudaGraphMemsetNodeSetParams`| 11.0 |  |  ||
+|`cudaGraphNodeFindInClone`| 11.0 |  |  ||
+|`cudaGraphNodeGetDependencies`| 11.0 |  |  ||
+|`cudaGraphNodeGetDependentNodes`| 11.0 |  |  ||
+|`cudaGraphNodeGetType`| 11.0 |  |  ||
+|`cudaGraphRemoveDependencies`| 11.0 |  |  ||
 
-## **30. C++ API Routines [DEPRECATED since 7.5]**
+## **30. C++ API Routines**
 
-|   **CUDA**                                                |   **HIP**                                             |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------------|:----------------:|
-| `cudaBindSurfaceToArray`                                  |                                                       |
-| `cudaBindTexture`                                         |`hipBindTexture`                                       |
-| `cudaBindTexture2D`                                       |                                                       |
-| `cudaBindTextureToArray`                                  |                                                       |
-| `cudaBindTextureToMipmappedArray`                         |                                                       |
-| `cudaCreateChannelDesc`                                   |`hipCreateChannelDesc`                                 |
-| `cudaEventCreate`                                         |                                                       |
-| `cudaFuncGetAttributes`                                   |                                                       |
-| `cudaFuncSetAttribute`                                    |                                                       |
-| `cudaFuncSetCacheConfig`                                  |                                                       |
-| `cudaGetSymbolAddress`                                    |`hipGetSymbolAddress`                                  |
-| `cudaGetSymbolSize`                                       |`hipGetSymbolSize`                                     |
-| `cudaGetTextureAlignmentOffset`                           |                                                       |
-| `cudaLaunch`                                              |                                                       |
-| `cudaLaunchCooperativeKernel`                             |`hipLaunchCooperativeKernel`                           |
-| `cudaLaunchCooperativeKernelMultiDevice`                  |`hipLaunchCooperativeKernelMultiDevice`                |
-| `cudaLaunchKernel`                                        |                                                       |
-| `cudaMallocHost`                                          |                                                       |
-| `cudaMallocManaged`                                       |                                                       |
-| `cudaMemcpyFromSymbol`                                    |                                                       |
-| `cudaMemcpyFromSymbolAsync`                               |                                                       |
-| `cudaMemcpyToSymbol`                                      |                                                       |
-| `cudaMemcpyToSymbolAsync`                                 |                                                       |
-| `cudaOccupancyMaxPotentialBlockSize`                      |`hipOccupancyMaxPotentialBlockSize`                    |
-| `cudaOccupancyMaxPotentialBlockSizeWithFlags`             |                                                       |
-| `cudaOccupancyMaxPotentialBlockSizeVariableSMem`          |                                                       |
-| `cudaOccupancyMaxPotentialBlockSizeVariableSMemWithFlags` |                                                       |
-| `cudaSetupArgument`                                       |                                                       |
-| `cudaStreamAttachMemAsync`                                |                                                       |
-| `cudaUnbindTexture`                                       |`hipUnbindTexture`                                     |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
 
-## **32. Profiler Control**
+## **31. Interactions with the CUDA Driver API**
 
-|   **CUDA**                                                |   **HIP**                     |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------|:----------------:|
-| `cudaProfilerInitialize`                                  |                               |
-| `cudaProfilerStart`                                       | `hipProfilerStart`            |
-| `cudaProfilerStop`                                        | `hipProfilerStop`             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaGetFuncBySymbol`| 11.0 |  |  ||
 
-# Data types used by CUDA Runtime API and supported by HIP
+## **32. Profiler Control [DEPRECATED]**
 
-## **33. Data types**
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaProfilerInitialize`|  | 11.0 |  ||
 
-| **type**     |   **CUDA**                                          |**CUDA version\***|   **HIP**                                                  |**HIP value** (if differs) |
-|-------------:|-----------------------------------------------------|:----------------:|------------------------------------------------------------|---------------------------|
-| struct       |`cudaChannelFormatDesc`                              |                  |`hipChannelFormatDesc`                                      |
-| struct       |`cudaDeviceProp`                                     |                  |`hipDeviceProp_t`                                           |
-| struct       |`cudaEglFrame`                                       | 9.1              |                                                            |
-| typedef      |`cudaEglFrame_st`                                    | 9.1              |                                                            |
-| struct       |`cudaEglPlaneDesc`                                   | 9.1              |                                                            |
-| typedef      |`cudaEglPlaneDesc_st`                                | 9.1              |                                                            |
-| struct       |`cudaExtent`                                         |                  |`hipExtent`                                                 |
-| struct       |`cudaFuncAttributes`                                 |                  |`hipFuncAttributes`                                         |
-| struct       |`cudaIpcEventHandle_t`                               |                  |`hipIpcEventHandle_t`                                       |
-| struct       |`cudaIpcMemHandle_t`                                 |                  |`hipIpcMemHandle_t`                                         |
-| struct       |`cudaMemcpy3DParms`                                  |                  |`hipMemcpy3DParms`                                          |
-| struct       |`cudaMemcpy3DPeerParms`                              |                  |                                                            |
-| struct       |`cudaPitchedPtr`                                     |                  |`hipPitchedPtr`                                             |
-| struct       |`cudaPointerAttributes`                              |                  |`hipPointerAttribute_t`                                     |
-| struct       |`cudaPos`                                            |                  |`hipPos`                                                    |
-| struct       |`cudaResourceDesc`                                   |                  |`hipResourceDesc`                                           |
-| struct       |`cudaResourceViewDesc`                               |                  |`hipResourceViewDesc`                                       |
-| struct       |`cudaTextureDesc`                                    |                  |`hipTextureDesc`                                            |
-| struct       |`textureReference`                                   |                  |`textureReference`                                          |
-| struct       |`surfaceReference`                                   |                  |                                                            |
-| enum         |***`cudaCGScope`***                                  | 9.0              |                                                            |
-|            0 |*`cudaCGScopeInvalid`*                               | 9.0              |                                                            |
-|            1 |*`cudaCGScopeGrid`*                                  | 9.0              |                                                            |
-|            2 |*`cudaCGScopeMultiGrid`*                             | 9.0              |                                                            |
-| enum         |***`cudaChannelFormatKind`***                        |                  |***`hipChannelFormatKind`***                                |
-|            0 |*`cudaChannelFormatKindSigned`*                      |                  |*`hipChannelFormatKindSigned`*                              |
-|            1 |*`cudaChannelFormatKindUnsigned`*                    |                  |*`hipChannelFormatKindUnsigned`*                            |
-|            2 |*`cudaChannelFormatKindFloat`*                       |                  |*`hipChannelFormatKindFloat`*                               |
-|            3 |*`cudaChannelFormatKindNone`*                        |                  |*`hipChannelFormatKindNone`*                                |
-| enum         |***`cudaComputeMode`***                              |                  |***`hipComputeMode`***                                      |
-|            0 |*`cudaComputeModeDefault`*                           |                  |*`hipComputeModeDefault`*                                   |
-|            1 |*`cudaComputeModeExclusive`*                         |                  |*`hipComputeModeExclusive`*                                 |
-|            2 |*`cudaComputeModeProhibited`*                        |                  |*`hipComputeModeProhibited`*                                |
-|            3 |*`cudaComputeModeExclusiveProcess`*                  |                  |*`hipComputeModeExclusiveProcess`*                          |
-| enum         |***`cudaDeviceAttr`***                               |                  |***`hipDeviceAttribute_t`***                                |
-|            1 |*`cudaDevAttrMaxThreadsPerBlock`*                    |                  |*`hipDeviceAttributeMaxThreadsPerBlock`*                    |
-|            2 |*`cudaDevAttrMaxBlockDimX`*                          |                  |*`hipDeviceAttributeMaxBlockDimX`*                          |
-|            3 |*`cudaDevAttrMaxBlockDimY`*                          |                  |*`hipDeviceAttributeMaxBlockDimY`*                          |
-|            4 |*`cudaDevAttrMaxBlockDimZ`*                          |                  |*`hipDeviceAttributeMaxBlockDimZ`*                          |
-|            5 |*`cudaDevAttrMaxGridDimX`*                           |                  |*`hipDeviceAttributeMaxGridDimX`*                           |
-|            6 |*`cudaDevAttrMaxGridDimY`*                           |                  |*`hipDeviceAttributeMaxGridDimY`*                           |
-|            7 |*`cudaDevAttrMaxGridDimZ`*                           |                  |*`hipDeviceAttributeMaxGridDimZ`*                           |
-|            8 |*`cudaDevAttrMaxSharedMemoryPerBlock`*               |                  |*`hipDeviceAttributeMaxSharedMemoryPerBlock`*               |
-|            9 |*`cudaDevAttrTotalConstantMemory`*                   |                  |*`hipDeviceAttributeTotalConstantMemory`*                   |
-|           10 |*`cudaDevAttrWarpSize`*                              |                  |*`hipDeviceAttributeWarpSize`*                              |
-|           11 |*`cudaDevAttrMaxPitch`*                              |                  |*`hipDeviceAttributeMaxPitch`*                              |
-|           12 |*`cudaDevAttrMaxRegistersPerBlock`*                  |                  |*`hipDeviceAttributeMaxRegistersPerBlock`*                  |
-|           13 |*`cudaDevAttrClockRate`*                             |                  |*`hipDeviceAttributeClockRate`*                             |
-|           14 |*`cudaDevAttrTextureAlignment`*                      |                  |*`hipDeviceAttributeTextureAlignment`*                      |
-|           15 |*`cudaDevAttrGpuOverlap`*                            |                  |                                                            |
-|           16 |*`cudaDevAttrMultiProcessorCount`*                   |                  |*`hipDeviceAttributeMultiprocessorCount`*                   |
-|           17 |*`cudaDevAttrKernelExecTimeout`*                     |                  |*`hipDeviceAttributeKernelExecTimeout`*                     |
-|           18 |*`cudaDevAttrIntegrated`*                            |                  |*`hipDeviceAttributeIntegrated`*                            |
-|           19 |*`cudaDevAttrCanMapHostMemory`*                      |                  |*`hipDeviceAttributeCanMapHostMemory`*                      |
-|           20 |*`cudaDevAttrComputeMode`*                           |                  |*`hipDeviceAttributeComputeMode`*                           |
-|           21 |*`cudaDevAttrMaxTexture1DWidth`*                     |                  |*`hipDeviceAttributeMaxTexture1DWidth`*                     |
-|           22 |*`cudaDevAttrMaxTexture2DWidth`*                     |                  |*`hipDeviceAttributeMaxTexture2DWidth`*                     |
-|           23 |*`cudaDevAttrMaxTexture2DHeight`*                    |                  |*`hipDeviceAttributeMaxTexture2DHeight`*                    |
-|           24 |*`cudaDevAttrMaxTexture3DWidth`*                     |                  |*`hipDeviceAttributeMaxTexture3DWidth`*                     |
-|           25 |*`cudaDevAttrMaxTexture3DHeight`*                    |                  |*`hipDeviceAttributeMaxTexture3DHeight`*                    |
-|           26 |*`cudaDevAttrMaxTexture3DDepth`*                     |                  |*`hipDeviceAttributeMaxTexture3DDepth`*                     |
-|           27 |*`cudaDevAttrMaxTexture2DLayeredWidth`*              |                  |                                                            |
-|           28 |*`cudaDevAttrMaxTexture2DLayeredHeight`*             |                  |                                                            |
-|           29 |*`cudaDevAttrMaxTexture2DLayeredLayers`*             |                  |                                                            |
-|           30 |*`cudaDevAttrSurfaceAlignment`*                      |                  |                                                            |
-|           31 |*`cudaDevAttrConcurrentKernels`*                     |                  |*`hipDeviceAttributeConcurrentKernels`*                     |
-|           32 |*`cudaDevAttrEccEnabled`*                            |                  |*`hipDeviceAttributeEccEnabled`*                            |
-|           33 |*`cudaDevAttrPciBusId`*                              |                  |*`hipDeviceAttributePciBusId`*                              |
-|           34 |*`cudaDevAttrPciDeviceId`*                           |                  |*`hipDeviceAttributePciDeviceId`*                           |
-|           35 |*`cudaDevAttrTccDriver`*                             |                  |                                                            |
-|           36 |*`cudaDevAttrMemoryClockRate`*                       |                  |*`hipDeviceAttributeMemoryClockRate`*                       |
-|           37 |*`cudaDevAttrGlobalMemoryBusWidth`*                  |                  |*`hipDeviceAttributeMemoryBusWidth`*                        |
-|           38 |*`cudaDevAttrL2CacheSize`*                           |                  |*`hipDeviceAttributeL2CacheSize`*                           |
-|           39 |*`cudaDevAttrMaxThreadsPerMultiProcessor`*           |                  |*`hipDeviceAttributeMaxThreadsPerMultiProcessor`*           |
-|           40 |*`cudaDevAttrAsyncEngineCount`*                      |                  |                                                            |
-|           41 |*`cudaDevAttrUnifiedAddressing`*                     |                  |                                                            |
-|           42 |*`cudaDevAttrMaxTexture1DLayeredWidth`*              |                  |                                                            |
-|           43 |*`cudaDevAttrMaxTexture1DLayeredLayers`*             |                  |                                                            |
-|           44 |                                                     |                  |                                                            |
-|           45 |*`cudaDevAttrMaxTexture2DGatherWidth`*               |                  |                                                            |
-|           46 |*`cudaDevAttrMaxTexture2DGatherHeight`*              |                  |                                                            |
-|           47 |*`cudaDevAttrMaxTexture3DWidthAlt`*                  |                  |                                                            |
-|           48 |*`cudaDevAttrMaxTexture3DHeightAlt`*                 |                  |                                                            |
-|           49 |*`cudaDevAttrMaxTexture3DDepthAlt`*                  |                  |                                                            |
-|           50 |*`cudaDevAttrPciDomainId`*                           |                  |                                                            |
-|           51 |*`cudaDevAttrTexturePitchAlignment`*                 |                  |                                                            |
-|           52 |*`cudaDevAttrMaxTextureCubemapWidth`*                |                  |                                                            |
-|           53 |*`cudaDevAttrMaxTextureCubemapLayeredWidth`*         |                  |                                                            |
-|           54 |*`cudaDevAttrMaxTextureCubemapLayeredLayers`*        |                  |                                                            |
-|           55 |*`cudaDevAttrMaxSurface1DWidth`*                     |                  |                                                            |
-|           56 |*`cudaDevAttrMaxSurface2DWidth`*                     |                  |                                                            |
-|           57 |*`cudaDevAttrMaxSurface2DHeight`*                    |                  |                                                            |
-|           58 |*`cudaDevAttrMaxSurface3DWidth`*                     |                  |                                                            |
-|           59 |*`cudaDevAttrMaxSurface3DHeight`*                    |                  |                                                            |
-|           60 |*`cudaDevAttrMaxSurface3DDepth`*                     |                  |                                                            |
-|           61 |*`cudaDevAttrMaxSurface1DLayeredWidth`*              |                  |                                                            |
-|           62 |*`cudaDevAttrMaxSurface1DLayeredLayers`*             |                  |                                                            |
-|           63 |*`cudaDevAttrMaxSurface2DLayeredWidth`*              |                  |                                                            |
-|           64 |*`cudaDevAttrMaxSurface2DLayeredHeight`*             |                  |                                                            |
-|           65 |*`cudaDevAttrMaxSurface2DLayeredLayers`*             |                  |                                                            |
-|           66 |*`cudaDevAttrMaxSurfaceCubemapWidth`*                |                  |                                                            |
-|           67 |*`cudaDevAttrMaxSurfaceCubemapLayeredWidth`*         |                  |                                                            |
-|           68 |*`cudaDevAttrMaxSurfaceCubemapLayeredLayers`*        |                  |                                                            |
-|           69 |*`cudaDevAttrMaxTexture1DLinearWidth`*               |                  |                                                            |
-|           70 |*`cudaDevAttrMaxTexture2DLinearWidth`*               |                  |                                                            |
-|           71 |*`cudaDevAttrMaxTexture2DLinearHeight`*              |                  |                                                            |
-|           72 |*`cudaDevAttrMaxTexture2DLinearPitch`*               |                  |                                                            |
-|           73 |*`cudaDevAttrMaxTexture2DMipmappedWidth*             |                  |                                                            |
-|           74 |*`cudaDevAttrMaxTexture2DMipmappedHeight`*           |                  |                                                            |
-|           75 |*`cudaDevAttrComputeCapabilityMajor`*                |                  |*`hipDeviceAttributeComputeCapabilityMajor`*                |
-|           76 |*`cudaDevAttrComputeCapabilityMinor`*                |                  |*`hipDeviceAttributeComputeCapabilityMinor`*                |
-|           77 |*`cudaDevAttrMaxTexture1DMipmappedWidth`*            |                  |                                                            |
-|           78 |*`cudaDevAttrStreamPrioritiesSupported`*             |                  |                                                            |
-|           79 |*`cudaDevAttrGlobalL1CacheSupported`*                |                  |                                                            |
-|           80 |*`cudaDevAttrLocalL1CacheSupported`*                 |                  |                                                            |
-|           81 |*`cudaDevAttrMaxSharedMemoryPerMultiprocessor`*      |                  |*`hipDeviceAttributeMaxSharedMemoryPerMultiprocessor`*      |
-|           82 |*`cudaDevAttrMaxRegistersPerMultiprocessor`*         |                  |                                                            |
-|           83 |*`cudaDevAttrManagedMemory`*                         |                  |                                                            |
-|           84 |*`cudaDevAttrIsMultiGpuBoard`*                       |                  |*`hipDeviceAttributeIsMultiGpuBoard`*                       |
-|           85 |*`cudaDevAttrMultiGpuBoardGroupID`*                  |                  |                                                            |
-|           86 |*`cudaDevAttrHostNativeAtomicSupported`*             | 8.0              |                                                            |
-|           87 |*`cudaDevAttrSingleToDoublePrecisionPerfRatio`*      | 8.0              |                                                            |
-|           88 |*`cudaDevAttrPageableMemoryAccess`*                  | 8.0              |                                                            |
-|           89 |*`cudaDevAttrConcurrentManagedAccess`*               | 8.0              |                                                            |
-|           90 |*`cudaDevAttrComputePreemptionSupported`*            | 8.0              |                                                            |
-|           91 |*`cudaDevAttrCanUseHostPointerForRegisteredMem`*     | 8.0              |                                                            |
-|           92 |*`cudaDevAttrReserved92`*                            | 9.0              |                                                            |
-|           93 |*`cudaDevAttrReserved93`*                            | 9.0              |                                                            |
-|           94 |*`cudaDevAttrReserved94`*                            | 9.0              |                                                            |
-|           95 |*`cudaDevAttrCooperativeLaunch`*                     | 9.0              |*`hipDeviceAttributeCooperativeLaunch`*                     |
-|           96 |*`cudaDevAttrCooperativeMultiDeviceLaunch`*          | 9.0              |*`hipDeviceAttributeCooperativeMultiDeviceLaunch`*          |
-|           97 |*`cudaDevAttrMaxSharedMemoryPerBlockOptin`*          | 9.0              |                                                            |
-|           98 |*`cudaDevAttrCanFlushRemoteWrites`*                  | 9.2              |                                                            |
-|           99 |*`cudaDevAttrHostRegisterSupported`*                 | 9.2              |                                                            |
-|          100 |*`cudaDevAttrPageableMemoryAccessUsesHostPageTables`*| 9.2              |                                                            |
-|          101 |*`cudaDevAttrDirectManagedMemAccessFromHost`*        | 9.2              |                                                            |
-|          106 |*`cudaDevAttrMaxBlocksPerMultiprocessor`*            | 11.0             |                                                            |
-|          111 |*`cudaDevAttrReservedSharedMemoryPerBlock`*          | 11.0             |                                                            |
-| enum         |***`cudaDeviceP2PAttr`***                            | 8.0              |                                                            |
-|            1 |*`cudaDevP2PAttrPerformanceRank`*                    | 8.0              |                                                            |
-|            2 |*`cudaDevP2PAttrAccessSupported`*                    | 8.0              |                                                            |
-|            3 |*`cudaDevP2PAttrNativeAtomicSupported`*              | 8.0              |                                                            |
-|            4 |*`cudaDevP2PAttrCudaArrayAccessSupported`*           | 9.2              |                                                            |
-| enum         |***`cudaEglColorFormat`***                           | 9.1              |                                                            |
-|            0 |*`cudaEglColorFormatYUV420Planar`*                   | 9.1              |                                                            |
-|            1 |*`cudaEglColorFormatYUV420SemiPlanar`*               | 9.1              |                                                            |
-|            2 |*`cudaEglColorFormatYUV422Planar`*                   | 9.1              |                                                            |
-|            3 |*`cudaEglColorFormatYUV422SemiPlanar`*               | 9.1              |                                                            |
-|            4 |*`cudaEglColorFormatRGB`*                            | 9.1              |                                                            |
-|            5 |*`cudaEglColorFormatBGR`*                            | 9.1              |                                                            |
-|            6 |*`cudaEglColorFormatARGB`*                           | 9.1              |                                                            |
-|            7 |*`cudaEglColorFormatRGBA`*                           | 9.1              |                                                            |
-|            8 |*`cudaEglColorFormatL`*                              | 9.1              |                                                            |
-|            9 |*`cudaEglColorFormatR`*                              | 9.1              |                                                            |
-|           10 |*`cudaEglColorFormatYUV444Planar`*                   | 9.1              |                                                            |
-|           11 |*`cudaEglColorFormatYUV444SemiPlanar`*               | 9.1              |                                                            |
-|           12 |*`cudaEglColorFormatYUYV422`*                        | 9.1              |                                                            |
-|           13 |*`cudaEglColorFormatUYVY422`*                        | 9.1              |                                                            |
-|           14 |*`cudaEglColorFormatABGR`*                           | 9.1              |                                                            |
-|           15 |*`cudaEglColorFormatBGRA`*                           | 9.1              |                                                            |
-|           16 |*`cudaEglColorFormatA`*                              | 9.1              |                                                            |
-|           17 |*`cudaEglColorFormatRG`*                             | 9.1              |                                                            |
-|           18 |*`cudaEglColorFormatAYUV`*                           | 9.1              |                                                            |
-|           19 |*`cudaEglColorFormatYVU444SemiPlanar`*               | 9.1              |                                                            |
-|           20 |*`cudaEglColorFormatYVU422SemiPlanar`*               | 9.1              |                                                            |
-|           21 |*`cudaEglColorFormatYVU420SemiPlanar`*               | 9.1              |                                                            |
-|           22 |*`cudaEglColorFormatY10V10U10_444SemiPlanar`*        | 9.1              |                                                            |
-|           23 |*`cudaEglColorFormatY10V10U10_420SemiPlanar`*        | 9.1              |                                                            |
-|           24 |*`cudaEglColorFormatY12V12U12_444SemiPlanar`*        | 9.1              |                                                            |
-|           25 |*`cudaEglColorFormatY12V12U12_420SemiPlanar`*        | 9.1              |                                                            |
-|           26 |*`cudaEglColorFormatVYUY_ER`*                        | 9.1              |                                                            |
-|           27 |*`cudaEglColorFormatUYVY_ER`*                        | 9.1              |                                                            |
-|           28 |*`cudaEglColorFormatYUYV_ER`*                        | 9.1              |                                                            |
-|           29 |*`cudaEglColorFormatYVYU_ER`*                        | 9.1              |                                                            |
-|           30 |*`cudaEglColorFormatYUV_ER`*                         | 9.1              |                                                            |
-|           31 |*`cudaEglColorFormatYUVA_ER`*                        | 9.1              |                                                            |
-|           32 |*`cudaEglColorFormatAYUV_ER`*                        | 9.1              |                                                            |
-|           33 |*`cudaEglColorFormatYUV444Planar_ER`*                | 9.1              |                                                            |
-|           34 |*`cudaEglColorFormatYUV422Planar_ER`*                | 9.1              |                                                            |
-|           35 |*`cudaEglColorFormatYUV420Planar_ER`*                | 9.1              |                                                            |
-|           36 |*`cudaEglColorFormatYUV444SemiPlanar_ER`*            | 9.1              |                                                            |
-|           37 |*`cudaEglColorFormatYUV422SemiPlanar_ER`*            | 9.1              |                                                            |
-|           38 |*`cudaEglColorFormatYUV420SemiPlanar_ER`*            | 9.1              |                                                            |
-|           39 |*`cudaEglColorFormatYVU444Planar_ER`*                | 9.1              |                                                            |
-|           40 |*`cudaEglColorFormatYVU422Planar_ER`*                | 9.1              |                                                            |
-|           41 |*`cudaEglColorFormatYVU420Planar_ER`*                | 9.1              |                                                            |
-|           42 |*`cudaEglColorFormatYVU444SemiPlanar_ER`*            | 9.1              |                                                            |
-|           43 |*`cudaEglColorFormatYVU422SemiPlanar_ER`*            | 9.1              |                                                            |
-|           44 |*`cudaEglColorFormatYVU420SemiPlanar_ER`*            | 9.1              |                                                            |
-|           45 |*`cudaEglColorFormatBayerRGGB`*                      | 9.1              |                                                            |
-|           46 |*`cudaEglColorFormatBayerBGGR`*                      | 9.1              |                                                            |
-|           47 |*`cudaEglColorFormatBayerGRBG`*                      | 9.1              |                                                            |
-|           48 |*`cudaEglColorFormatBayerGBRG`*                      | 9.1              |                                                            |
-|           49 |*`cudaEglColorFormatBayer10RGGB`*                    | 9.1              |                                                            |
-|           50 |*`cudaEglColorFormatBayer10BGGR`*                    | 9.1              |                                                            |
-|           51 |*`cudaEglColorFormatBayer10GRBG`*                    | 9.1              |                                                            |
-|           52 |*`cudaEglColorFormatBayer10GBRG`*                    | 9.1              |                                                            |
-|           53 |*`cudaEglColorFormatBayer12RGGB`*                    | 9.1              |                                                            |
-|           54 |*`cudaEglColorFormatBayer12BGGR`*                    | 9.1              |                                                            |
-|           55 |*`cudaEglColorFormatBayer12GRBG`*                    | 9.1              |                                                            |
-|           56 |*`cudaEglColorFormatBayer12GBRG`*                    | 9.1              |                                                            |
-|           57 |*`cudaEglColorFormatBayer14RGGB`*                    | 9.1              |                                                            |
-|           58 |*`cudaEglColorFormatBayer14BGGR`*                    | 9.1              |                                                            |
-|           59 |*`cudaEglColorFormatBayer14GRBG`*                    | 9.1              |                                                            |
-|           60 |*`cudaEglColorFormatBayer14GBRG`*                    | 9.1              |                                                            |
-|           61 |*`cudaEglColorFormatBayer20RGGB`*                    | 9.1              |                                                            |
-|           62 |*`cudaEglColorFormatBayer20BGGR`*                    | 9.1              |                                                            |
-|           63 |*`cudaEglColorFormatBayer20GRBG`*                    | 9.1              |                                                            |
-|           64 |*`cudaEglColorFormatBayer20GBRG`*                    | 9.1              |                                                            |
-|           65 |*`cudaEglColorFormatYVU444Planar`*                   | 9.1              |                                                            |
-|           66 |*`cudaEglColorFormatYVU422Planar`*                   | 9.1              |                                                            |
-|           67 |*`cudaEglColorFormatYVU420Planar`*                   | 9.1              |                                                            |
-|           68 |*`cudaEglColorFormatBayerIspRGGB`*                   | 9.2              |                                                            |
-|           69 |*`cudaEglColorFormatBayerIspBGGR`*                   | 9.2              |                                                            |
-|           70 |*`cudaEglColorFormatBayerIspGRBG`*                   | 9.2              |                                                            |
-|           71 |*`cudaEglColorFormatBayerIspGBRG`*                   | 9.2              |                                                            |
-| enum         |***`cudaEglFrameType`***                             | 9.1              |                                                            |
-|            0 |*`cudaEglFrameTypeArray`*                            | 9.1              |                                                            |
-|            1 |*`cudaEglFrameTypePitch`*                            | 9.1              |                                                            |
-| enum         |***`cudaExternalMemoryHandleType`***                 | 10.0             |                                                            |
-|            1 |*`cudaExternalMemoryHandleTypeOpaqueFd`*             | 10.0             |                                                            |
-|            2 |*`cudaExternalMemoryHandleTypeOpaqueWin32`*          | 10.0             |                                                            |
-|            3 |*`cudaExternalMemoryHandleTypeOpaqueWin32Kmt`*       | 10.0             |                                                            |
-|            4 |*`cudaExternalMemoryHandleTypeD3D12Heap`*            | 10.0             |                                                            |
-|            5 |*`cudaExternalMemoryHandleTypeD3D12Resource`*        | 10.0             |                                                            |
-|            6 |*`cudaExternalMemoryHandleTypeD3D11Resource`*        | 10.2             |                                                            |
-|            7 |*`cudaExternalMemoryHandleTypeD3D11ResourceKmt`*     | 10.2             |                                                            |
-|            8 |*`cudaExternalMemoryHandleTypeNvSciBuf`*             | 10.2             |                                                            |
-| enum         |***`cudaExternalSemaphoreHandleType`***              | 10.0             |                                                            |
-|            1 |*`cudaExternalSemaphoreHandleTypeOpaqueFd`*          | 10.0             |                                                            |
-|            2 |*`cudaExternalSemaphoreHandleTypeOpaqueWin32`*       | 10.0             |                                                            |
-|            3 |*`cudaExternalSemaphoreHandleTypeOpaqueWin32Kmt`*    | 10.0             |                                                            |
-|            4 |*`cudaExternalSemaphoreHandleTypeD3D12Fence`*        | 10.0             |                                                            |
-|            5 |*`cudaExternalSemaphoreHandleTypeD3D11Fence`*        | 10.2             |                                                            |
-|            6 |*`cudaExternalSemaphoreHandleTypeNvSciSync`*         | 10.2             |                                                            |
-|            7 |*`cudaExternalSemaphoreHandleTypeKeyedMutex`*        | 10.2             |                                                            |
-|            8 |*`cudaExternalSemaphoreHandleTypeKeyedMutexKmt`*     | 10.2             |                                                            |
-| enum         |***`cudaFuncAttribute`***                            | 9.0              |                                                            |
-|            8 |*`cudaFuncAttributeMaxDynamicSharedMemorySize`*      | 9.0              |                                                            |
-|            9 |*`cudaFuncAttributePreferredSharedMemoryCarveout`*   | 9.0              |                                                            |
-|           10 |*`cudaFuncAttributeMax`*                             | 9.0              |                                                            |
-| enum         |***`cudaEglResourceLocationFlags`***                 | 9.1              |                                                            |
-|         0x00 |*`cudaEglResourceLocationSysmem`*                    | 9.1              |                                                            |
-|         0x01 |*`cudaEglResourceLocationVidmem`*                    | 9.1              |                                                            |
-| enum         |***`cudaError`***                                    |                  |***`hipError_t`***                                          |
-| typedef      |***`cudaError_t`***                                  |                  |***`hipError_t`***                                          |
-|            0 |*`cudaSuccess`*                                      |                  |*`hipSuccess`*                                              |
-|            1 |*`cudaErrorInvalidValue`*                            |                  |*`hipErrorInvalidValue`*                                    |
-|            2 |*`cudaErrorMemoryAllocation`*                        |                  |*`hipErrorOutOfMemory`*                                     |
-|            3 |*`cudaErrorInitializationError`*                     |                  |*`hipErrorNotInitialized`*                                  |
-|            4 |*`cudaErrorCudartUnloading`*                         |                  |*`hipErrorDeinitialized`*                                   |
-|            5 |*`cudaErrorProfilerDisabled`*                        |                  |*`hipErrorProfilerDisabled`*                                |
-|            6 |*`cudaErrorProfilerNotInitialized`*                  |                  |*`hipErrorProfilerNotInitialized`*                          |
-|            7 |*`cudaErrorProfilerAlreadyStarted`*                  |                  |*`hipErrorProfilerAlreadyStarted`*                          |
-|            8 |*`cudaErrorProfilerAlreadyStopped`*                  |                  |*`hipErrorProfilerAlreadyStopped`*                          |
-|            9 |*`cudaErrorInvalidConfiguration`*                    |                  |*`hipErrorInvalidConfiguration`*                            |
-|           12 |*`cudaErrorInvalidPitchValue`*                       |                  |                                                            |
-|           13 |*`cudaErrorInvalidSymbol`*                           |                  |*`hipErrorInvalidSymbol`*                                   |
-|           16 |*`cudaErrorInvalidHostPointer`*                      |                  |                                                            |
-|           17 |*`cudaErrorInvalidDevicePointer`*                    |                  |*`hipErrorInvalidDevicePointer`*                            |
-|           18 |*`cudaErrorInvalidTexture`*                          |                  |                                                            |
-|           19 |*`cudaErrorInvalidTextureBinding`*                   |                  |                                                            |
-|           20 |*`cudaErrorInvalidChannelDescriptor`*                |                  |                                                            |
-|           21 |*`cudaErrorInvalidMemcpyDirection`*                  |                  |*`hipErrorInvalidMemcpyDirection`*                          |
-|           22 |*`cudaErrorAddressOfConstant`*                       |                  |                                                            |
-|           23 |*`cudaErrorTextureFetchFailed`*                      |                  |                                                            |
-|           24 |*`cudaErrorTextureNotBound`*                         |                  |                                                            |
-|           25 |*`cudaErrorSynchronizationError`*                    |                  |                                                            |
-|           26 |*`cudaErrorInvalidFilterSetting`*                    |                  |                                                            |
-|           27 |*`cudaErrorInvalidNormSetting`*                      |                  |                                                            |
-|           28 |*`cudaErrorMixedDeviceExecution`*                    |                  |                                                            |
-|           31 |*`cudaErrorNotYetImplemented`*                       |                  |                                                            |
-|           32 |*`cudaErrorMemoryValueTooLarge`*                     |                  |                                                            |
-|           35 |*`cudaErrorInsufficientDriver`*                      |                  |*`hipErrorInsufficientDriver`*                              |
-|           37 |*`cudaErrorInvalidSurface`*                          |                  |                                                            |
-|           43 |*`cudaErrorDuplicateVariableName`*                   |                  |                                                            |
-|           44 |*`cudaErrorDuplicateTextureName`*                    |                  |                                                            |
-|           45 |*`cudaErrorDuplicateSurfaceName`*                    |                  |                                                            |
-|           46 |*`cudaErrorDevicesUnavailable`*                      |                  |                                                            |
-|           49 |*`cudaErrorIncompatibleDriverContext`*               |                  |                                                            |
-|           52 |*`cudaErrorMissingConfiguration`*                    |                  |*`hipErrorMissingConfiguration`*                            |
-|           53 |*`cudaErrorPriorLaunchFailure`*                      |                  |*`hipErrorPriorLaunchFailure`*                              |
-|           65 |*`cudaErrorLaunchMaxDepthExceeded`*                  |                  |                                                            |
-|           66 |*`cudaErrorLaunchFileScopedTex`*                     |                  |                                                            |
-|           67 |*`cudaErrorLaunchFileScopedSurf`*                    |                  |                                                            |
-|           68 |*`cudaErrorSyncDepthExceeded`*                       |                  |                                                            |
-|           69 |*`cudaErrorLaunchPendingCountExceeded`*              |                  |                                                            |
-|           98 |*`cudaErrorInvalidDeviceFunction`*                   |                  |*`hipErrorInvalidDeviceFunction`*                           |
-|          100 |*`cudaErrorNoDevice`*                                |                  |*`hipErrorNoDevice`*                                        |
-|          101 |*`cudaErrorInvalidDevice`*                           |                  |*`hipErrorInvalidDevice`*                                   |
-|          127 |*`cudaErrorStartupFailure`*                          | 10.0             |                                                            |
-|          200 |*`cudaErrorInvalidKernelImage`*                      |                  |*`hipErrorInvalidImage`*                                    |
-|          201 |*`cudaErrorDeviceUninitilialized`*                   |                  |*`hipErrorInvalidContext`*                                  |
-|          205 |*`cudaErrorMapBufferObjectFailed`*                   |                  |*`hipErrorMapFailed`*                                       |
-|          206 |*`cudaErrorUnmapBufferObjectFailed`*                 |                  |*`hipErrorUnmapFailed`*                                     |
-|          209 |*`cudaErrorNoKernelImageForDevice`*                  |                  |*`hipErrorNoBinaryForGpu`*                                  |
-|          214 |*`cudaErrorECCUncorrectable`*                        |                  |*`hipErrorECCNotCorrectable`*                               |
-|          215 |*`cudaErrorUnsupportedLimit`*                        |                  |*`hipErrorUnsupportedLimit`*                                |
-|          216 |*`cudaErrorDeviceAlreadyInUse`*                      |                  |                                                            |
-|          217 |*`cudaErrorPeerAccessUnsupported`*                   |                  |*`hipErrorPeerAccessUnsupported`*                           |
-|          218 |*`cudaErrorInvalidPtx`*                              |                  |*`hipErrorInvalidKernelFile`*                               |
-|          219 |*`cudaErrorInvalidGraphicsContext`*                  |                  |*`hipErrorInvalidGraphicsContext`*                          |
-|          220 |*`cudaErrorNvlinkUncorrectable`*                     | 8.0              |                                                            |
-|          221 |*`cudaErrorJitCompilerNotFound`*                     | 9.0              |                                                            |
-|          300 |*`cudaErrorInvalidSource`*                           | 10.1             |*`hipErrorInvalidSource`*                                   |
-|          301 |*`cudaErrorFileNotFound`*                            | 10.1             |*`hipErrorFileNotFound`*                                    |
-|          302 |*`cudaErrorSharedObjectSymbolNotFound`*              |                  |*`hipErrorSharedObjectSymbolNotFound`*                      |
-|          303 |*`cudaErrorSharedObjectInitFailed`*                  |                  |*`hipErrorSharedObjectInitFailed`*                          |
-|          304 |*`cudaErrorOperatingSystem`*                         |                  |*`hipErrorOperatingSystem`*                                 |
-|          400 |*`cudaErrorInvalidResourceHandle`*                   |                  |*`hipErrorInvalidHandle`*                                   |
-|          401 |*`cudaErrorIllegalState`*                            | 10.0             |                                                            |
-|          500 |*`cudaErrorSymbolNotFound`*                          | 10.1             |*`hipErrorNotFound`*                                        |
-|          600 |*`cudaErrorNotReady`*                                |                  |*`hipErrorNotReady`*                                        |
-|          700 |*`cudaErrorIllegalAddress`*                          |                  |*`hipErrorIllegalAddress`*                                  |
-|          701 |*`cudaErrorLaunchOutOfResources`*                    |                  |*`hipErrorLaunchOutOfResources`*                            |
-|          702 |*`cudaErrorLaunchTimeout`*                           |                  |*`hipErrorLaunchTimeOut`*                                   |
-|          703 |*`cudaErrorLaunchIncompatibleTexturing`*             |                  |                                                            |
-|          704 |*`cudaErrorPeerAccessAlreadyEnabled`*                |                  |*`hipErrorPeerAccessAlreadyEnabled`*                        |
-|          705 |*`cudaErrorPeerAccessNotEnabled`*                    |                  |*`hipErrorPeerAccessNotEnabled`*                            |
-|          708 |*`cudaErrorSetOnActiveProcess`*                      |                  |*`hipErrorSetOnActiveProcess`*                              |
-|          709 |*`cudaErrorContextIsDestroyed`*                      |                  |                                                            |
-|          710 |*`cudaErrorAssert`*                                  |                  |*`hipErrorAssert`*                                          |
-|          711 |*`cudaErrorTooManyPeers`*                            |                  |                                                            |
-|          712 |*`cudaErrorHostMemoryAlreadyRegistered`*             |                  |*`hipErrorHostMemoryAlreadyRegistered`*                     |
-|          713 |*`cudaErrorHostMemoryNotRegistered`*                 |                  |*`hipErrorHostMemoryNotRegistered`*                         |
-|          714 |*`cudaErrorHardwareStackError`*                      |                  |                                                            |
-|          715 |*`cudaErrorIllegalInstruction`*                      |                  |                                                            |
-|          716 |*`cudaErrorMisalignedAddress`*                       |                  |                                                            |
-|          717 |*`cudaErrorInvalidAddressSpace`*                     |                  |                                                            |
-|          718 |*`cudaErrorInvalidPc`*                               |                  |                                                            |
-|          719 |*`cudaErrorLaunchFailure`*                           |                  |*`hipErrorLaunchFailure`*                                   |
-|          720 |*`cudaErrorCooperativeLaunchTooLarge`*               | 9.0              |*`hipErrorCooperativeLaunchTooLarge`*                       |
-|          800 |*`cudaErrorNotPermitted`*                            |                  |                                                            |
-|          801 |*`cudaErrorNotSupported`*                            |                  |*`hipErrorNotSupported`*                                    |
-|          802 |*`cudaErrorSystemNotReady`*                          | 10.0             |                                                            |
-|          803 |*`cudaErrorSystemDriverMismatch`*                    | 10.0             |                                                            |
-|          804 |*`cudaErrorCompatNotSupportedOnDevice`*              | 10.0             |                                                            |
-|          900 |*`cudaErrorStreamCaptureUnsupported`*                | 10.0             |                                                            |
-|          901 |*`cudaErrorStreamCaptureInvalidated`*                | 10.0             |                                                            |
-|          902 |*`cudaErrorStreamCaptureMerge`*                      | 10.0             |                                                            |
-|          903 |*`cudaErrorStreamCaptureUnmatched`*                  | 10.0             |                                                            |
-|          904 |*`cudaErrorStreamCaptureUnjoined`*                   | 10.0             |                                                            |
-|          905 |*`cudaErrorStreamCaptureIsolation`*                  | 10.0             |                                                            |
-|          906 |*`cudaErrorStreamCaptureImplicit`*                   | 10.0             |                                                            |
-|          907 |*`cudaErrorCapturedEvent`*                           | 10.0             |                                                            |
-|          908 |*`cudaErrorStreamCaptureWrongThread`*                | 10.1             |                                                            |
-|          909 |*`cudaErrorTimeout`*                                 | 10.2             |                                                            |
-|          910 |*`cudaErrorGraphExecUpdateFailure`*                  | 10.2             |                                                            |
-|          999 |*`cudaErrorUnknown`*                                 |                  |*`hipErrorUnknown`*                                         |
-|        10000 |*`cudaErrorApiFailureBase`*                          |                  |                                                            |
-| enum         |***`cudaFuncCache`***                                |                  |***`hipFuncCache_t`***                                      |
-|            0 |*`cudaFuncCachePreferNone`*                          |                  |*`hipFuncCachePreferNone`*                                  |
-|            1 |*`cudaFuncCachePreferShared`*                        |                  |*`hipFuncCachePreferShared`*                                |
-|            2 |*`cudaFuncCachePreferL1`*                            |                  |*`hipFuncCachePreferL1`*                                    |
-|            3 |*`cudaFuncCachePreferEqual`*                         |                  |*`hipFuncCachePreferEqual`*                                 |
-| enum         |***`cudaGraphicsCubeFace`***                         |                  |                                                            |
-|         0x00 |*`cudaGraphicsCubeFacePositiveX`*                    |                  |                                                            |
-|         0x01 |*`cudaGraphicsCubeFaceNegativeX`*                    |                  |                                                            |
-|         0x02 |*`cudaGraphicsCubeFacePositiveY`*                    |                  |                                                            |
-|         0x03 |*`cudaGraphicsCubeFaceNegativeY`*                    |                  |                                                            |
-|         0x04 |*`cudaGraphicsCubeFacePositiveZ`*                    |                  |                                                            |
-|         0x05 |*`cudaGraphicsCubeFaceNegativeZ`*                    |                  |                                                            |
-| enum         |***`cudaGraphicsMapFlags`***                         |                  |                                                            |
-|            0 |*`cudaGraphicsMapFlagsNone`*                         |                  |                                                            |
-|            1 |*`cudaGraphicsMapFlagsReadOnly`*                     |                  |                                                            |
-|            2 |*`cudaGraphicsMapFlagsWriteDiscard`*                 |                  |                                                            |
-| enum         |***`cudaGraphicsRegisterFlags`***                    |                  |                                                            |
-|            0 |*`cudaGraphicsRegisterFlagsNone`*                    |                  |                                                            |
-|            1 |*`cudaGraphicsRegisterFlagsReadOnly`*                |                  |                                                            |
-|            2 |*`cudaGraphicsRegisterFlagsWriteDiscard`*            |                  |                                                            |
-|            4 |*`cudaGraphicsRegisterFlagsSurfaceLoadStore`*        |                  |                                                            |
-|            8 |*`cudaGraphicsRegisterFlagsTextureGather`*           |                  |                                                            |
-| enum         |***`cudaGraphNodeType`***                            | 10.0             |                                                            |
-|         0x00 |*`cudaGraphNodeTypeKernel`*                          | 10.0             |                                                            |
-|         0x01 |*`cudaGraphNodeTypeMemcpy`*                          | 10.0             |                                                            |
-|         0x02 |*`cudaGraphNodeTypeMemset`*                          | 10.0             |                                                            |
-|         0x03 |*`cudaGraphNodeTypeHost`*                            | 10.0             |                                                            |
-|         0x04 |*`cudaGraphNodeTypeGraph`*                           | 10.0             |                                                            |
-|         0x05 |*`cudaGraphNodeTypeEmpty`*                           | 10.0             |                                                            |
-|              |*`cudaGraphNodeTypeCount`*                           | 10.0             |                                                            |
-| enum         |***`cudaLimit`***                                    |                  |***`hipLimit_t`***                                          |
-|         0x00 |*`cudaLimitStackSize`*                               |                  |                                                            |
-|         0x01 |*`cudaLimitPrintfFifoSize`*                          |                  |                                                            |
-|         0x02 |*`cudaLimitMallocHeapSize`*                          |                  |*`hipLimitMallocHeapSize`*                                  |
-|         0x03 |*`cudaLimitDevRuntimeSyncDepth`*                     |                  |                                                            |
-|         0x04 |*`cudaLimitDevRuntimePendingLaunchCount`*            |                  |                                                            |
-|         0x05 |*`cudaLimitMaxL2FetchGranularity`*                   | 10.0             |                                                            |
-|         0x06 |*`cudaLimitPersistingL2CacheSize`*                   | 11.0             |                                                            |
-| enum         |***`cudaMemcpyKind`***                               |                  |***`hipMemcpyKind`***                                       |
-|            0 |*`cudaMemcpyHostToHost`*                             |                  |*`hipMemcpyHostToHost`*                                     |
-|            1 |*`cudaMemcpyHostToDevice`*                           |                  |*`hipMemcpyHostToDevice`*                                   |
-|            2 |*`cudaMemcpyDeviceToHost`*                           |                  |*`hipMemcpyDeviceToHost`*                                   |
-|            3 |*`cudaMemcpyDeviceToDevice`*                         |                  |*`hipMemcpyDeviceToDevice`*                                 |
-|            4 |*`cudaMemcpyDefault`*                                |                  |*`hipMemcpyDefault`*                                        |
-| enum         |***`cudaMemoryAdvise`***                             | 8.0              |                                                            |
-|            1 |*`cudaMemAdviseSetReadMostly`*                       | 8.0              |                                                            |
-|            2 |*`cudaMemAdviseUnsetReadMostly`*                     | 8.0              |                                                            |
-|            3 |*`cudaMemAdviseSetPreferredLocation`*                | 8.0              |                                                            |
-|            4 |*`cudaMemAdviseUnsetPreferredLocation`*              | 8.0              |                                                            |
-|            5 |*`cudaMemAdviseSetAccessedBy`*                       | 8.0              |                                                            |
-|            6 |*`cudaMemAdviseUnsetAccessedBy`*                     | 8.0              |                                                            |
-| enum         |***`cudaMemoryType`***                               |                  |                                                            |
-|            0 |*`cudaMemoryTypeUnregistered`*                       |                  |                                                            |
-|            1 |*`cudaMemoryTypeHost`*                               |                  |                                                            |
-|            2 |*`cudaMemoryTypeDevice`*                             |                  |                                                            |
-|            3 |*`cudaMemoryTypeManaged`*                            | 10.0             |                                                            |
-| enum         |***`cudaMemRangeAttribute`***                        | 8.0              |                                                            |
-|            1 |*`cudaMemRangeAttributeReadMostly`*                  | 8.0              |                                                            |
-|            2 |*`cudaMemRangeAttributePreferredLocation`*           | 8.0              |                                                            |
-|            3 |*`cudaMemRangeAttributeAccessedBy`*                  | 8.0              |                                                            |
-|            4 |*`cudaMemRangeAttributeLastPrefetchLocation`*        | 8.0              |                                                            |
-| enum         |***`cudaResourceType`***                             |                  |***`hipResourceType`***                                     |
-|         0x00 |*`cudaResourceTypeArray`*                            |                  |*`hipResourceTypeArray`*                                    |
-|         0x01 |*`cudaResourceTypeMipmappedArray`*                   |                  |*`hipResourceTypeMipmappedArray`*                           |
-|         0x02 |*`cudaResourceTypeLinear`*                           |                  |*`hipResourceTypeLinear`*                                   |
-|         0x03 |*`cudaResourceTypePitch2D`*                          |                  |*`hipResourceTypePitch2D`*                                  |
-| enum         |***`cudaResourceViewFormat`***                       |                  |***`hipResourceViewFormat`***                               |
-|         0x00 |*`cudaResViewFormatNone`*                            |                  |*`hipResViewFormatNone`*                                    |
-|         0x01 |*`cudaResViewFormatUnsignedChar1`*                   |                  |*`hipResViewFormatUnsignedChar1`*                           |
-|         0x02 |*`cudaResViewFormatUnsignedChar2`*                   |                  |*`hipResViewFormatUnsignedChar2`*                           |
-|         0x03 |*`cudaResViewFormatUnsignedChar4`*                   |                  |*`hipResViewFormatUnsignedChar4`*                           |
-|         0x04 |*`cudaResViewFormatSignedChar1`*                     |                  |*`hipResViewFormatSignedChar1`*                             |
-|         0x05 |*`cudaResViewFormatSignedChar2`*                     |                  |*`hipResViewFormatSignedChar2`*                             |
-|         0x06 |*`cudaResViewFormatSignedChar4`*                     |                  |*`hipResViewFormatSignedChar4`*                             |
-|         0x07 |*`cudaResViewFormatUnsignedShort1`*                  |                  |*`hipResViewFormatUnsignedShort1`*                          |
-|         0x08 |*`cudaResViewFormatUnsignedShort2`*                  |                  |*`hipResViewFormatUnsignedShort2`*                          |
-|         0x09 |*`cudaResViewFormatUnsignedShort4`*                  |                  |*`hipResViewFormatUnsignedShort4`*                          |
-|         0x0a |*`cudaResViewFormatSignedShort1`*                    |                  |*`hipResViewFormatSignedShort1`*                            |
-|         0x0b |*`cudaResViewFormatSignedShort2`*                    |                  |*`hipResViewFormatSignedShort2`*                            |
-|         0x0c |*`cudaResViewFormatSignedShort4`*                    |                  |*`hipResViewFormatSignedShort4`*                            |
-|         0x0d |*`cudaResViewFormatUnsignedInt1`*                    |                  |*`hipResViewFormatUnsignedInt1`*                            |
-|         0x0e |*`cudaResViewFormatUnsignedInt2`*                    |                  |*`hipResViewFormatUnsignedInt2`*                            |
-|         0x0f |*`cudaResViewFormatUnsignedInt4`*                    |                  |*`hipResViewFormatUnsignedInt4`*                            |
-|         0x10 |*`cudaResViewFormatSignedInt1`*                      |                  |*`hipResViewFormatSignedInt1`*                              |
-|         0x11 |*`cudaResViewFormatSignedInt2`*                      |                  |*`hipResViewFormatSignedInt2`*                              |
-|         0x12 |*`cudaResViewFormatSignedInt4`*                      |                  |*`hipResViewFormatSignedInt4`*                              |
-|         0x13 |*`cudaResViewFormatHalf1`*                           |                  |*`hipResViewFormatHalf1`*                                   |
-|         0x14 |*`cudaResViewFormatHalf2`*                           |                  |*`hipResViewFormatHalf2`*                                   |
-|         0x15 |*`cudaResViewFormatHalf4`*                           |                  |*`hipResViewFormatHalf4`*                                   |
-|         0x16 |*`cudaResViewFormatFloat1`*                          |                  |*`hipResViewFormatFloat1`*                                  |
-|         0x17 |*`cudaResViewFormatFloat2`*                          |                  |*`hipResViewFormatFloat2`*                                  |
-|         0x18 |*`cudaResViewFormatFloat4`*                          |                  |*`hipResViewFormatFloat4`*                                  |
-|         0x19 |*`cudaResViewFormatUnsignedBlockCompressed1`*        |                  |*`hipResViewFormatUnsignedBlockCompressed1`*                |
-|         0x1a |*`cudaResViewFormatUnsignedBlockCompressed2`*        |                  |*`hipResViewFormatUnsignedBlockCompressed2`*                |
-|         0x1b |*`cudaResViewFormatUnsignedBlockCompressed3`*        |                  |*`hipResViewFormatUnsignedBlockCompressed3`*                |
-|         0x1c |*`cudaResViewFormatUnsignedBlockCompressed4`*        |                  |*`hipResViewFormatUnsignedBlockCompressed4`*                |
-|         0x1d |*`cudaResViewFormatSignedBlockCompressed4`*          |                  |*`hipResViewFormatSignedBlockCompressed4`*                  |
-|         0x1e |*`cudaResViewFormatUnsignedBlockCompressed5`*        |                  |*`hipResViewFormatUnsignedBlockCompressed5`*                |
-|         0x1f |*`cudaResViewFormatSignedBlockCompressed5`*          |                  |*`hipResViewFormatSignedBlockCompressed5`*                  |
-|         0x20 |*`cudaResViewFormatUnsignedBlockCompressed6H`*       |                  |*`hipResViewFormatUnsignedBlockCompressed6H`*               |
-|         0x21 |*`cudaResViewFormatSignedBlockCompressed6H`*         |                  |*`hipResViewFormatSignedBlockCompressed6H`*                 |
-|         0x22 |*`cudaResViewFormatUnsignedBlockCompressed7`*        |                  |*`hipResViewFormatUnsignedBlockCompressed7`*                |
-| enum         |***`cudaSharedMemConfig`***                          |                  |***`hipSharedMemConfig`***                                  |
-|            0 |*`cudaSharedMemBankSizeDefault`*                     |                  |*`hipSharedMemBankSizeDefault`*                             |
-|            1 |*`cudaSharedMemBankSizeFourByte`*                    |                  |*`hipSharedMemBankSizeFourByte`*                            |
-|            2 |*`cudaSharedMemBankSizeEightByte`*                   |                  |*`hipSharedMemBankSizeEightByte`*                           |
-| enum         |***`cudaSharedCarveout`***                           | 9.0              |                                                            |
-|           -1 |*`cudaSharedmemCarveoutDefault`*                     | 9.0              |                                                            |
-|          100 |*`cudaSharedmemCarveoutMaxShared`*                   | 9.0              |                                                            |
-|            0 |*`cudaSharedmemCarveoutMaxL1`*                       | 9.0              |                                                            |
-| enum         |***`cudaStreamCaptureStatus`***                      | 10.0             |                                                            |
-|            0 |*`cudaStreamCaptureStatusNone`*                      | 10.0             |                                                            |
-|            1 |*`cudaStreamCaptureStatusActive`*                    | 10.0             |                                                            |
-|            2 |*`cudaStreamCaptureStatusInvalidated`*               | 10.0             |                                                            |
-| enum         |***`cudaStreamCaptureMode`***                        | 10.1             |                                                            |
-|            0 |*`cudaStreamCaptureModeGlobal`*                      | 10.1             |                                                            |
-|            1 |*`cudaStreamCaptureModeThreadLocal`*                 | 10.1             |                                                            |
-|            2 |*`cudaStreamCaptureModeRelaxed`*                     | 10.1             |                                                            |
-| enum         |***`cudaSurfaceBoundaryMode`***                      |                  |***`hipSurfaceBoundaryMode`***                              |
-|            0 |*`cudaBoundaryModeZero`*                             |                  |*`hipBoundaryModeZero`*                                     |
-|            1 |*`cudaBoundaryModeClamp`*                            |                  |*`hipBoundaryModeClamp`*                                    |
-|            2 |*`cudaBoundaryModeTrap`*                             |                  |*`hipBoundaryModeTrap`*                                     |
-| enum         |***`cudaSurfaceFormatMode`***                        |                  |                                                            |
-|            0 |*`cudaFormatModeForced`*                             |                  |                                                            |
-|            1 |*`cudaFormatModeAuto`*                               |                  |                                                            |
-| enum         |***`cudaTextureAddressMode`***                       |                  |***`hipTextureAddressMode`***                               |
-|            0 |*`cudaAddressModeWrap`*                              |                  |*`hipAddressModeWrap`*                                      |
-|            1 |*`cudaAddressModeClamp`*                             |                  |*`hipAddressModeClamp`*                                     |
-|            2 |*`cudaAddressModeMirror`*                            |                  |*`hipAddressModeMirror`*                                    |
-|            3 |*`cudaAddressModeBorder`*                            |                  |*`hipAddressModeBorder`*                                    |
-| enum         |***`cudaTextureFilterMode`***                        |                  |***`hipTextureFilterMode`***                                |
-|            0 |*`cudaFilterModePoint`*                              |                  |*`hipFilterModePoint`*                                      |
-|            1 |*`cudaFilterModeLinear`*                             |                  |*`hipFilterModeLinear`*                                     |
-| enum         |***`cudaTextureReadMode`***                          |                  |***`hipTextureReadMode`***                                  |
-|            0 |*`cudaReadModeElementType`*                          |                  |*`hipReadModeElementType`*                                  |
-|            1 |*`cudaReadModeNormalizedFloat`*                      |                  |*`hipReadModeNormalizedFloat`*                              |
-| enum         |***`cudaGLDeviceList`***                             |                  |                                                            |
-|            1 |*`cudaGLDeviceListAll`*                              |                  |                                                            |
-|            2 |*`cudaGLDeviceListCurrentFrame`*                     |                  |                                                            |
-|            3 |*`cudaGLDeviceListNextFrame`*                        |                  |                                                            |
-| enum         |***`cudaGLMapFlags`***                               |                  |                                                            |
-|            0 |*`cudaGLMapFlagsNone`*                               |                  |                                                            |
-|            1 |*`cudaGLMapFlagsReadOnly`*                           |                  |                                                            |
-|            2 |*`cudaGLMapFlagsWriteDiscard`*                       |                  |                                                            |
-| enum         |***`cudaD3D9DeviceList`***                           |                  |                                                            |
-|            1 |*`cudaD3D9DeviceListAll`*                            |                  |                                                            |
-|            2 |*`cudaD3D9DeviceListCurrentFrame`*                   |                  |                                                            |
-|            3 |*`cudaD3D9DeviceListNextFrame`*                      |                  |                                                            |
-| enum         |***`cudaD3D9MapFlags`***                             |                  |                                                            |
-|            0 |*`cudaD3D9MapFlagsNone`*                             |                  |                                                            |
-|            1 |*`cudaD3D9MapFlagsReadOnly`*                         |                  |                                                            |
-|            2 |*`cudaD3D9MapFlagsWriteDiscard`*                     |                  |                                                            |
-| enum         |***`cudaD3D9RegisterFlags`***                        |                  |                                                            |
-|            0 |*`cudaD3D9RegisterFlagsNone`*                        |                  |                                                            |
-|            1 |*`cudaD3D9RegisterFlagsArray`*                       |                  |                                                            |
-| enum         |***`cudaD3D10DeviceList`***                          |                  |                                                            |
-|            1 |*`cudaD3D10DeviceListAll`*                           |                  |                                                            |
-|            2 |*`cudaD3D10DeviceListCurrentFrame`*                  |                  |                                                            |
-|            3 |*`cudaD3D10DeviceListNextFrame`*                     |                  |                                                            |
-| enum         |***`cudaD3D10MapFlags`***                            |                  |                                                            |
-|            0 |*`cudaD3D10MapFlagsNone`*                            |                  |                                                            |
-|            1 |*`cudaD3D10MapFlagsReadOnly`*                        |                  |                                                            |
-|            2 |*`cudaD3D10MapFlagsWriteDiscard`*                    |                  |                                                            |
-| enum         |***`cudaD3D10RegisterFlags`***                       |                  |                                                            |
-|            0 |*`cudaD3D10RegisterFlagsNone`*                       |                  |                                                            |
-|            1 |*`cudaD3D10RegisterFlagsArray`*                      |                  |                                                            |
-| enum         |***`cudaD3D11DeviceList`***                          |                  |                                                            |
-|            1 |*`cudaD3D11DeviceListAll`*                           |                  |                                                            |
-|            2 |*`cudaD3D11DeviceListCurrentFrame`*                  |                  |                                                            |
-|            3 |*`cudaD3D11DeviceListNextFrame`*                     |                  |                                                            |
-| struct       |`cudaArray`                                          |                  |`hipArray`                                                  |
-| typedef      |`cudaArray_t`                                        |                  |`hipArray_t`                                                |
-| typedef      |`cudaArray_const_t`                                  |                  |`hipArray_const_t`                                          |
-| typedef      |`cudaEvent_t`                                        |                  |`hipEvent_t`                                                |
-| struct       |`CUevent_st`                                         |                  |`ihipEvent_t`                                               |
-| struct       |`cudaMipmappedArray`                                 |                  |`hipMipmappedArray`                                         |
-| typedef      |`cudaMipmappedArray_t`                               |                  |`hipMipmappedArray_t`                                       |
-| typedef      |`cudaMipmappedArray_const_t`                         |                  |`hipMipmappedArray_const_t`                                 |
-| enum         |***`cudaOutputMode`***                               |                  |                                                            |
-| typedef      |***`cudaOutputMode_t`***                             |                  |                                                            |
-|         0x00 |*`cudaKeyValuePair`*                                 |                  |                                                            |
-|         0x01 |*`cudaCSV`*                                          |                  |                                                            |
-| typedef      |`cudaStream_t`                                       |                  |`hipStream_t`                                               |
-| struct       |`CUstream_st`                                        |                  |`ihipStream_t`                                              |
-| typedef      |`cudaStreamCallback_t`                               |                  |`hipStreamCallback_t`                                       |
-| typedef      |`cudaSurfaceObject_t`                                |                  |`hipSurfaceObject_t`                                        |
-| typedef      |`cudaTextureObject_t`                                |                  |`hipTextureObject_t`                                        |
-| struct       |`CUuuid_st`                                          |                  |                                                            |
-| typedef      |`cudaUUID_t`                                         |                  |                                                            |
-| define       |`CUDA_EGL_MAX_PLANES`                                | 9.1              |                                                            |
-| define       |`CUDA_IPC_HANDLE_SIZE`                               |                  |                                                            |
-| define       |`cudaArrayColorAttachment`                           | 10.0             |                                                            |
-| define       |`cudaArrayCubemap`                                   |                  |`hipArrayCubemap`                                           |
-| define       |`cudaArrayDefault`                                   |                  |`hipArrayDefault`                                           |
-| define       |`cudaArrayLayered`                                   |                  |`hipArrayLayered`                                           |
-| define       |`cudaArraySurfaceLoadStore`                          |                  |`hipArraySurfaceLoadStore`                                  |
-| define       |`cudaArrayTextureGather`                             |                  |`hipArrayTextureGather`                                     |
-| define       |`cudaCooperativeLaunchMultiDeviceNoPreSync`          | 9.0              |                                                            |
-| define       |`cudaCooperativeLaunchMultiDeviceNoPostSync`         | 9.0              |                                                            |
-| define       |`cudaCpuDeviceId`                                    | 8.0              |                                                            |
-| define       |`cudaInvalidDeviceId`                                | 8.0              |                                                            |
-| define       |`cudaDeviceBlockingSync`                             |                  |`hipDeviceScheduleBlockingSync`                             |
-| define       |`cudaDeviceLmemResizeToMax`                          |                  |`hipDeviceLmemResizeToMax`                                  | 0x16                      |
-| define       |`cudaDeviceMapHost`                                  |                  |`hipDeviceMapHost`                                          |
-| define       |`cudaDeviceMask`                                     |                  |                                                            |
-| define       |`cudaDevicePropDontCare`                             |                  |                                                            |
-| define       |`cudaDeviceScheduleAuto`                             |                  |`hipDeviceScheduleAuto`                                     |
-| define       |`cudaDeviceScheduleBlockingSync`                     |                  |`hipDeviceScheduleBlockingSync`                             |
-| define       |`cudaDeviceScheduleMask`                             |                  |`hipDeviceScheduleMask`                                     |
-| define       |`cudaDeviceScheduleSpin`                             |                  |`hipDeviceScheduleSpin`                                     |
-| define       |`cudaDeviceScheduleYield`                            |                  |`hipDeviceScheduleYield`                                    |
-| define       |`cudaEventDefault`                                   |                  |`hipEventDefault`                                           |
-| define       |`cudaEventBlockingSync`                              |                  |`hipEventBlockingSync`                                      |
-| define       |`cudaEventDisableTiming`                             |                  |`hipEventDisableTiming`                                     |
-| define       |`cudaEventInterprocess`                              |                  |`hipEventInterprocess`                                      |
-| define       |`cudaHostAllocDefault`                               |                  |`hipHostMallocDefault`                                      |
-| define       |`cudaHostAllocMapped`                                |                  |`hipHostMallocMapped`                                       |
-| define       |`cudaHostAllocPortable`                              |                  |`hipHostMallocPortable`                                     |
-| define       |`cudaHostAllocWriteCombined`                         |                  |`hipHostMallocWriteCombined`                                |
-| define       |`cudaHostRegisterDefault`                            |                  |`hipHostRegisterDefault`                                    |
-| define       |`cudaHostRegisterIoMemory`                           | 7.5              |`hipHostRegisterIoMemory`                                   |
-| define       |`cudaHostRegisterMapped`                             |                  |`hipHostRegisterMapped`                                     |
-| define       |`cudaHostRegisterPortable`                           |                  |`hipHostRegisterPortable`                                   |
-| define       |`cudaIpcMemLazyEnablePeerAccess`                     |                  |`hipIpcMemLazyEnablePeerAccess`                             | 0                         |
-| define       |`cudaMemAttachGlobal`                                |                  |`hipMemAttachGlobal`                                        |
-| define       |`cudaMemAttachHost`                                  |                  |`hipMemAttachHost`                                          |
-| define       |`cudaMemAttachSingle`                                |                  |                                                            |
-| define       |`cudaOccupancyDefault`                               |                  |`hipOccupancyDefault`                                    |
-| define       |`cudaOccupancyDisableCachingOverride`                |                  |                                                            |
-| define       |`cudaPeerAccessDefault`                              |                  |                                                            |
-| define       |`cudaStreamDefault`                                  |                  |`hipStreamDefault`                                          |
-| define       |`cudaStreamNonBlocking`                              |                  |`hipStreamNonBlocking`                                      |
-| define       |`cudaStreamLegacy`                                   |                  |                                                            |
-| define       |`cudaStreamPerThread`                                |                  |                                                            |
-| define       |`cudaTextureType1D`                                  |                  |`hipTextureType1D`                                          |
-| define       |`cudaTextureType2D`                                  |                  |`hipTextureType2D`                                          |
-| define       |`cudaTextureType3D`                                  |                  |`hipTextureType3D`                                          |
-| define       |`cudaTextureTypeCubemap`                             |                  |`hipTextureTypeCubemap`                                     |
-| define       |`cudaTextureType1DLayered`                           |                  |`hipTextureType1DLayered`                                   |
-| define       |`cudaTextureType2DLayered`                           |                  |`hipTextureType2DLayered`                                   |
-| define       |`cudaTextureTypeCubemapLayered`                      |                  |`hipTextureTypeCubemapLayered`                              |
-| enum         |***`cudaDataType_t`***                               | 8.0              |***`hipblasDatatype_t`***                                   |
-| enum         |***`cudaDataType`***                                 | 8.0              |***`hipblasDatatype_t`***                                   |
-|            2 |*`CUDA_R_16F`*                                       | 8.0              |*`HIPBLAS_R_16F`*                                           | 150                       |
-|            6 |*`CUDA_C_16F`*                                       | 8.0              |*`HIPBLAS_C_16F`*                                           | 153                       |
-|            0 |*`CUDA_R_32F`*                                       | 8.0              |*`HIPBLAS_R_32F`*                                           | 151                       |
-|            4 |*`CUDA_C_32F`*                                       | 8.0              |*`HIPBLAS_C_32F`*                                           | 154                       |
-|            1 |*`CUDA_R_64F`*                                       | 8.0              |*`HIPBLAS_R_64F`*                                           | 152                       |
-|            5 |*`CUDA_C_64F`*                                       | 8.0              |*`HIPBLAS_C_64F`*                                           | 155                       |
-|            3 |*`CUDA_R_8I`*                                        | 8.0              |*`HIPBLAS_R_8I`*                                            | 160                       |
-|            7 |*`CUDA_C_8I`*                                        | 8.0              |*`HIPBLAS_C_8I`*                                            | 164                       |
-|            8 |*`CUDA_R_8U`*                                        | 8.0              |*`HIPBLAS_R_8U`*                                            | 161                       |
-|            9 |*`CUDA_C_8U`*                                        | 8.0              |*`HIPBLAS_C_8U`*                                            | 165                       |
-|           10 |*`CUDA_R_32I`*                                       | 8.0              |*`HIPBLAS_R_32I`*                                           | 162                       |
-|           11 |*`CUDA_C_32I`*                                       | 8.0              |*`HIPBLAS_C_32I`*                                           | 166                       |
-|           12 |*`CUDA_R_32U`*                                       | 8.0              |*`HIPBLAS_R_32U`*                                           | 163                       |
-|           13 |*`CUDA_C_32U`*                                       | 8.0              |*`HIPBLAS_C_32U`*                                           | 167                       |
-| struct       |`cudaExternalMemoryBufferDesc`                       | 10.0             |                                                            |
-| struct       |`cudaExternalMemoryHandleDesc`                       | 10.0             |                                                            |
-| struct       |`cudaExternalMemoryMipmappedArrayDesc`               | 10.0             |                                                            |
-| struct       |`cudaExternalSemaphoreHandleDesc`                    | 10.0             |                                                            |
-| struct       |`cudaExternalSemaphoreSignalParams`                  | 10.0             |                                                            |
-| struct       |`cudaExternalSemaphoreWaitParams`                    | 10.0             |                                                            |
-| struct       |`cudaHostNodeParams`                                 | 10.0             |                                                            |
-| struct       |`cudaLaunchParams`                                   | 9.0              |`hipLaunchParams`                                           |
-| struct       |`cudaMemsetParams`                                   | 10.0             |                                                            |
-| struct       |`CUeglStreamConnection_st`                           | 9.1              |                                                            |
-| typedef      |`cudaEglStreamConnection`                            | 9.1              |                                                            |
-| define       |`cudaExternalMemoryDedicated`                        | 10.0             |                                                            |
-| define       |`cudaExternalSemaphoreSignalSkipNvSciBufMemSync`     | 10.2             |                                                            |
-| define       |`cudaExternalSemaphoreWaitSkipNvSciBufMemSync`       | 10.2             |                                                            |
-| define       |`cudaNvSciSyncAttrSignal`                            | 10.2             |                                                            |
-| define       |`cudaNvSciSyncAttrWait`                              | 10.2             |                                                            |
-| typedef      |`cudaExternalMemory_t`                               | 10.0             |                                                            |
-| struct       |`CUexternalMemory_st`                                | 10.0             |                                                            |
-| typedef      |`cudaExternalSemaphore_t`                            | 10.0             |                                                            |
-| struct       |`CUexternalSemaphore_st`                             | 10.0             |                                                            |
-| typedef      |`cudaGraph_t`                                        | 10.0             |                                                            |
-| struct       |`CUgraph_st`                                         | 10.0             |                                                            |
-| typedef      |`cudaGraphNode_t`                                    | 10.0             |                                                            |
-| struct       |`CUgraphNode_st`                                     | 10.0             |                                                            |
-| typedef      |`cudaGraphExec_t`                                    | 10.0             |                                                            |
-| struct       |`CUgraphExec_st`                                     | 10.0             |                                                            |
-| typedef      |`cudaGraphicsResource_t`                             |                  |                                                            |
-| struct       |`cudaGraphicsResource`                               |                  |                                                            |
-| typedef      |`cudaHostFn_t`                                       | 10.0             |                                                            |
-| enum         |***`libraryPropertyType`***                          | 8.0              |                                                            |
-| typedef      |***`libraryPropertyType_t`***                        | 8.0              |                                                            |
-|            0 |*`MAJOR_VERSION`*                                    | 8.0              |                                                            |
-|            1 |*`MINOR_VERSION`*                                    | 8.0              |                                                            |
-|            2 |*`PATCH_LEVEL`*                                      | 8.0              |                                                            |
-| enum         |***`cudaGraphExecUpdateResult`***                    | 10.2             |                                                            |
-|          0x0 |*`cudaGraphExecUpdateSuccess`*                       | 10.2             |                                                            |
-|          0x1 |*`cudaGraphExecUpdateError`*                         | 10.2             |                                                            |
-|          0x2 |*`cudaGraphExecUpdateErrorTopologyChanged`*          | 10.2             |                                                            |
-|          0x3 |*`cudaGraphExecUpdateErrorNodeTypeChanged`*          | 10.2             |                                                            |
-|          0x4 |*`cudaGraphExecUpdateErrorFunctionChanged`*          | 10.2             |                                                            |
-|          0x5 |*`cudaGraphExecUpdateErrorParametersChanged`*        | 10.2             |                                                            |
-|          0x6 |*`cudaGraphExecUpdateErrorNotSupported`*             | 10.2             |                                                            |
-| enum         |***`cudaAccessProperty`***                           | 11.0             |                                                            |
-|            0 |*`cudaAccessPropertyNormal`*                         | 11.0             |                                                            |
-|            1 |*`cudaAccessPropertyStreaming`*                      | 11.0             |                                                            |
-|            2 |*`cudaAccessPropertyPersisting`*                     | 11.0             |                                                            |
-| struct       |`cudaAccessPolicyWindow`                             | 11.0             |                                                            |
-| enum         |***`cudaSynchronizationPolicy`***                    | 11.0             |                                                            |
-|            1 |*`cudaSyncPolicyAuto`*                               | 11.0             |                                                            |
-|            2 |*`cudaSyncPolicySpin`*                               | 11.0             |                                                            |
-|            3 |*`cudaSyncPolicyYield`*                              | 11.0             |                                                            |
-|            4 |*`cudaSyncPolicyBlockingSync`*                       | 11.0             |                                                            |
-| enum         |***`cudaStreamAttrID`***                             | 11.0             |                                                            |
-|            1 |*`cudaStreamAttributeAccessPolicyWindow`*            | 11.0             |                                                            |
-|            3 |*`cudaStreamAttributeSynchronizationPolicy`*         | 11.0             |                                                            |
-| union        |`cudaStreamAttrValue`*                               | 11.0             |                                                            |
-| enum         |***`cudaKernelNodeAttrID`***                         | 11.0             |                                                            |
-|            1 |*`cudaKernelNodeAttributeAccessPolicyWindow`*        | 11.0             |                                                            |
-|            2 |*`cudaKernelNodeAttributeCooperative`*               | 11.0             |                                                            |
-| union        |`cudaKernelNodeAttrValue`*                           | 11.0             |                                                            |
-| typedef      |`cudaFunction_t`                                     | 11.0             | `hipFunction_t`                                            |
+## **33. Profiler Control**
 
-\* CUDA version, in which API has appeared and (optional) last version before abandoning it; no value in case of earlier versions < 7.5.
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaProfilerStart`|  |  |  |`hipProfilerStart`|
+|`cudaProfilerStop`|  |  |  |`hipProfilerStop`|
+
+## **34. Data types used by CUDA Runtime**
+
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`CUDA_EGL_MAX_PLANES`| 9.1 |  |  ||
+|`CUDA_IPC_HANDLE_SIZE`|  |  |  ||
+|`CUeglStreamConnection_st`| 9.1 |  |  ||
+|`CUevent_st`|  |  |  |`ihipEvent_t`|
+|`CUexternalMemory_st`| 10.0 |  |  ||
+|`CUexternalSemaphore_st`| 10.0 |  |  ||
+|`CUgraphExec_st`| 10.0 |  |  ||
+|`CUgraphNode_st`| 10.0 |  |  ||
+|`CUgraph_st`| 10.0 |  |  ||
+|`CUstream_st`|  |  |  |`ihipStream_t`|
+|`CUuuid_st`|  |  |  ||
+|`MAJOR_VERSION`| 8.0 |  |  ||
+|`MINOR_VERSION`| 8.0 |  |  ||
+|`PATCH_LEVEL`| 8.0 |  |  ||
+|`cudaAccessPolicyWindow`| 11.0 |  |  ||
+|`cudaAccessProperty`| 11.0 |  |  ||
+|`cudaAccessPropertyNormal`| 11.0 |  |  ||
+|`cudaAccessPropertyPersisting`| 11.0 |  |  ||
+|`cudaAccessPropertyStreaming`| 11.0 |  |  ||
+|`cudaAddressModeBorder`|  |  |  |`hipAddressModeBorder`|
+|`cudaAddressModeClamp`|  |  |  |`hipAddressModeClamp`|
+|`cudaAddressModeMirror`|  |  |  |`hipAddressModeMirror`|
+|`cudaAddressModeWrap`|  |  |  |`hipAddressModeWrap`|
+|`cudaArray`|  |  |  |`hipArray`|
+|`cudaArrayColorAttachment`| 10.0 |  |  ||
+|`cudaArrayCubemap`|  |  |  |`hipArrayCubemap`|
+|`cudaArrayDefault`|  |  |  |`hipArrayDefault`|
+|`cudaArrayLayered`|  |  |  |`hipArrayLayered`|
+|`cudaArraySurfaceLoadStore`|  |  |  |`hipArraySurfaceLoadStore`|
+|`cudaArrayTextureGather`|  |  |  |`hipArrayTextureGather`|
+|`cudaArray_const_t`|  |  |  |`hipArray_const_t`|
+|`cudaArray_t`|  |  |  |`hipArray_t`|
+|`cudaBoundaryModeClamp`|  |  |  |`hipBoundaryModeClamp`|
+|`cudaBoundaryModeTrap`|  |  |  |`hipBoundaryModeTrap`|
+|`cudaBoundaryModeZero`|  |  |  |`hipBoundaryModeZero`|
+|`cudaCGScope`| 9.0 |  |  ||
+|`cudaCGScopeGrid`| 9.0 |  |  ||
+|`cudaCGScopeInvalid`| 9.0 |  |  ||
+|`cudaCGScopeMultiGrid`| 9.0 |  |  ||
+|`cudaCSV`|  |  |  ||
+|`cudaChannelFormatDesc`|  |  |  |`hipChannelFormatDesc`|
+|`cudaChannelFormatKind`|  |  |  |`hipChannelFormatKind`|
+|`cudaChannelFormatKindFloat`|  |  |  |`hipChannelFormatKindFloat`|
+|`cudaChannelFormatKindNone`|  |  |  |`hipChannelFormatKindNone`|
+|`cudaChannelFormatKindSigned`|  |  |  |`hipChannelFormatKindSigned`|
+|`cudaChannelFormatKindUnsigned`|  |  |  |`hipChannelFormatKindUnsigned`|
+|`cudaComputeMode`|  |  |  |`hipComputeMode`|
+|`cudaComputeModeDefault`|  |  |  |`hipComputeModeDefault`|
+|`cudaComputeModeExclusive`|  |  |  |`hipComputeModeExclusive`|
+|`cudaComputeModeExclusiveProcess`|  |  |  |`hipComputeModeExclusiveProcess`|
+|`cudaComputeModeProhibited`|  |  |  |`hipComputeModeProhibited`|
+|`cudaCooperativeLaunchMultiDeviceNoPostSync`| 9.0 |  |  |`hipCooperativeLaunchMultiDeviceNoPostSync`|
+|`cudaCooperativeLaunchMultiDeviceNoPreSync`| 9.0 |  |  |`hipCooperativeLaunchMultiDeviceNoPreSync`|
+|`cudaCpuDeviceId`| 8.0 |  |  ||
+|`cudaD3D10DeviceList`|  |  |  ||
+|`cudaD3D10DeviceListAll`|  |  |  ||
+|`cudaD3D10DeviceListCurrentFrame`|  |  |  ||
+|`cudaD3D10DeviceListNextFrame`|  |  |  ||
+|`cudaD3D10MapFlags`|  |  |  ||
+|`cudaD3D10MapFlagsNone`|  |  |  ||
+|`cudaD3D10MapFlagsReadOnly`|  |  |  ||
+|`cudaD3D10MapFlagsWriteDiscard`|  |  |  ||
+|`cudaD3D10RegisterFlags`|  |  |  ||
+|`cudaD3D10RegisterFlagsArray`|  |  |  ||
+|`cudaD3D10RegisterFlagsNone`|  |  |  ||
+|`cudaD3D11DeviceList`|  |  |  ||
+|`cudaD3D11DeviceListAll`|  |  |  ||
+|`cudaD3D11DeviceListCurrentFrame`|  |  |  ||
+|`cudaD3D11DeviceListNextFrame`|  |  |  ||
+|`cudaD3D9DeviceList`|  |  |  ||
+|`cudaD3D9DeviceListAll`|  |  |  ||
+|`cudaD3D9DeviceListCurrentFrame`|  |  |  ||
+|`cudaD3D9DeviceListNextFrame`|  |  |  ||
+|`cudaD3D9MapFlags`|  |  |  ||
+|`cudaD3D9MapFlagsNone`|  |  |  ||
+|`cudaD3D9MapFlagsReadOnly`|  |  |  ||
+|`cudaD3D9MapFlagsWriteDiscard`|  |  |  ||
+|`cudaD3D9RegisterFlags`|  |  |  ||
+|`cudaD3D9RegisterFlagsArray`|  |  |  ||
+|`cudaD3D9RegisterFlagsNone`|  |  |  ||
+|`cudaDevAttrAsyncEngineCount`|  |  |  ||
+|`cudaDevAttrCanFlushRemoteWrites`| 9.2 |  |  ||
+|`cudaDevAttrCanMapHostMemory`|  |  |  |`hipDeviceAttributeCanMapHostMemory`|
+|`cudaDevAttrCanUseHostPointerForRegisteredMem`| 8.0 |  |  ||
+|`cudaDevAttrClockRate`|  |  |  |`hipDeviceAttributeClockRate`|
+|`cudaDevAttrComputeCapabilityMajor`|  |  |  |`hipDeviceAttributeComputeCapabilityMajor`|
+|`cudaDevAttrComputeCapabilityMinor`|  |  |  |`hipDeviceAttributeComputeCapabilityMinor`|
+|`cudaDevAttrComputeMode`|  |  |  |`hipDeviceAttributeComputeMode`|
+|`cudaDevAttrComputePreemptionSupported`| 8.0 |  |  ||
+|`cudaDevAttrConcurrentKernels`|  |  |  |`hipDeviceAttributeConcurrentKernels`|
+|`cudaDevAttrConcurrentManagedAccess`| 8.0 |  |  ||
+|`cudaDevAttrCooperativeLaunch`| 9.0 |  |  |`hipDeviceAttributeCooperativeLaunch`|
+|`cudaDevAttrCooperativeMultiDeviceLaunch`| 9.0 |  |  |`hipDeviceAttributeCooperativeMultiDeviceLaunch`|
+|`cudaDevAttrDirectManagedMemAccessFromHost`| 9.2 |  |  ||
+|`cudaDevAttrEccEnabled`|  |  |  |`hipDeviceAttributeEccEnabled`|
+|`cudaDevAttrGlobalL1CacheSupported`|  |  |  ||
+|`cudaDevAttrGlobalMemoryBusWidth`|  |  |  |`hipDeviceAttributeMemoryBusWidth`|
+|`cudaDevAttrGpuOverlap`|  |  |  ||
+|`cudaDevAttrHostNativeAtomicSupported`| 8.0 |  |  ||
+|`cudaDevAttrHostRegisterSupported`| 9.2 |  |  ||
+|`cudaDevAttrIntegrated`|  |  |  |`hipDeviceAttributeIntegrated`|
+|`cudaDevAttrIsMultiGpuBoard`|  |  |  |`hipDeviceAttributeIsMultiGpuBoard`|
+|`cudaDevAttrKernelExecTimeout`|  |  |  |`hipDeviceAttributeKernelExecTimeout`|
+|`cudaDevAttrL2CacheSize`|  |  |  |`hipDeviceAttributeL2CacheSize`|
+|`cudaDevAttrLocalL1CacheSupported`|  |  |  ||
+|`cudaDevAttrManagedMemory`|  |  |  ||
+|`cudaDevAttrMaxBlockDimX`|  |  |  |`hipDeviceAttributeMaxBlockDimX`|
+|`cudaDevAttrMaxBlockDimY`|  |  |  |`hipDeviceAttributeMaxBlockDimY`|
+|`cudaDevAttrMaxBlockDimZ`|  |  |  |`hipDeviceAttributeMaxBlockDimZ`|
+|`cudaDevAttrMaxBlocksPerMultiprocessor`| 11.0 |  |  ||
+|`cudaDevAttrMaxGridDimX`|  |  |  |`hipDeviceAttributeMaxGridDimX`|
+|`cudaDevAttrMaxGridDimY`|  |  |  |`hipDeviceAttributeMaxGridDimY`|
+|`cudaDevAttrMaxGridDimZ`|  |  |  |`hipDeviceAttributeMaxGridDimZ`|
+|`cudaDevAttrMaxPitch`|  |  |  |`hipDeviceAttributeMaxPitch`|
+|`cudaDevAttrMaxRegistersPerBlock`|  |  |  |`hipDeviceAttributeMaxRegistersPerBlock`|
+|`cudaDevAttrMaxRegistersPerMultiprocessor`|  |  |  ||
+|`cudaDevAttrMaxSharedMemoryPerBlock`|  |  |  |`hipDeviceAttributeMaxSharedMemoryPerBlock`|
+|`cudaDevAttrMaxSharedMemoryPerBlockOptin`| 9.0 |  |  ||
+|`cudaDevAttrMaxSharedMemoryPerMultiprocessor`|  |  |  |`hipDeviceAttributeMaxSharedMemoryPerMultiprocessor`|
+|`cudaDevAttrMaxSurface1DLayeredLayers`|  |  |  ||
+|`cudaDevAttrMaxSurface1DLayeredWidth`|  |  |  ||
+|`cudaDevAttrMaxSurface1DWidth`|  |  |  ||
+|`cudaDevAttrMaxSurface2DHeight`|  |  |  ||
+|`cudaDevAttrMaxSurface2DLayeredHeight`|  |  |  ||
+|`cudaDevAttrMaxSurface2DLayeredLayers`|  |  |  ||
+|`cudaDevAttrMaxSurface2DLayeredWidth`|  |  |  ||
+|`cudaDevAttrMaxSurface2DWidth`|  |  |  ||
+|`cudaDevAttrMaxSurface3DDepth`|  |  |  ||
+|`cudaDevAttrMaxSurface3DHeight`|  |  |  ||
+|`cudaDevAttrMaxSurface3DWidth`|  |  |  ||
+|`cudaDevAttrMaxSurfaceCubemapLayeredLayers`|  |  |  ||
+|`cudaDevAttrMaxSurfaceCubemapLayeredWidth`|  |  |  ||
+|`cudaDevAttrMaxSurfaceCubemapWidth`|  |  |  ||
+|`cudaDevAttrMaxTexture1DLayeredLayers`|  |  |  ||
+|`cudaDevAttrMaxTexture1DLayeredWidth`|  |  |  ||
+|`cudaDevAttrMaxTexture1DLinearWidth`|  |  |  ||
+|`cudaDevAttrMaxTexture1DMipmappedWidth`|  |  |  ||
+|`cudaDevAttrMaxTexture1DWidth`|  |  |  |`hipDeviceAttributeMaxTexture1DWidth`|
+|`cudaDevAttrMaxTexture2DGatherHeight`|  |  |  ||
+|`cudaDevAttrMaxTexture2DGatherWidth`|  |  |  ||
+|`cudaDevAttrMaxTexture2DHeight`|  |  |  |`hipDeviceAttributeMaxTexture2DHeight`|
+|`cudaDevAttrMaxTexture2DLayeredHeight`|  |  |  ||
+|`cudaDevAttrMaxTexture2DLayeredLayers`|  |  |  ||
+|`cudaDevAttrMaxTexture2DLayeredWidth`|  |  |  ||
+|`cudaDevAttrMaxTexture2DLinearHeight`|  |  |  ||
+|`cudaDevAttrMaxTexture2DLinearPitch`|  |  |  ||
+|`cudaDevAttrMaxTexture2DLinearWidth`|  |  |  ||
+|`cudaDevAttrMaxTexture2DMipmappedHeight`|  |  |  ||
+|`cudaDevAttrMaxTexture2DMipmappedWidth`|  |  |  ||
+|`cudaDevAttrMaxTexture2DWidth`|  |  |  |`hipDeviceAttributeMaxTexture2DWidth`|
+|`cudaDevAttrMaxTexture3DDepth`|  |  |  |`hipDeviceAttributeMaxTexture3DDepth`|
+|`cudaDevAttrMaxTexture3DDepthAlt`|  |  |  ||
+|`cudaDevAttrMaxTexture3DHeight`|  |  |  |`hipDeviceAttributeMaxTexture3DHeight`|
+|`cudaDevAttrMaxTexture3DHeightAlt`|  |  |  ||
+|`cudaDevAttrMaxTexture3DWidth`|  |  |  |`hipDeviceAttributeMaxTexture3DWidth`|
+|`cudaDevAttrMaxTexture3DWidthAlt`|  |  |  ||
+|`cudaDevAttrMaxTextureCubemapLayeredLayers`|  |  |  ||
+|`cudaDevAttrMaxTextureCubemapLayeredWidth`|  |  |  ||
+|`cudaDevAttrMaxTextureCubemapWidth`|  |  |  ||
+|`cudaDevAttrMaxThreadsPerBlock`|  |  |  |`hipDeviceAttributeMaxThreadsPerBlock`|
+|`cudaDevAttrMaxThreadsPerMultiProcessor`|  |  |  |`hipDeviceAttributeMaxThreadsPerMultiProcessor`|
+|`cudaDevAttrMemoryClockRate`|  |  |  |`hipDeviceAttributeMemoryClockRate`|
+|`cudaDevAttrMultiGpuBoardGroupID`|  |  |  ||
+|`cudaDevAttrMultiProcessorCount`|  |  |  |`hipDeviceAttributeMultiprocessorCount`|
+|`cudaDevAttrPageableMemoryAccess`| 8.0 |  |  ||
+|`cudaDevAttrPageableMemoryAccessUsesHostPageTables`| 9.2 |  |  ||
+|`cudaDevAttrPciBusId`|  |  |  |`hipDeviceAttributePciBusId`|
+|`cudaDevAttrPciDeviceId`|  |  |  |`hipDeviceAttributePciDeviceId`|
+|`cudaDevAttrPciDomainId`|  |  |  ||
+|`cudaDevAttrReserved92`| 9.0 |  |  ||
+|`cudaDevAttrReserved93`| 9.0 |  |  ||
+|`cudaDevAttrReserved94`| 9.0 |  |  ||
+|`cudaDevAttrReservedSharedMemoryPerBlock`| 11.0 |  |  ||
+|`cudaDevAttrSingleToDoublePrecisionPerfRatio`| 8.0 |  |  ||
+|`cudaDevAttrStreamPrioritiesSupported`|  |  |  ||
+|`cudaDevAttrSurfaceAlignment`|  |  |  ||
+|`cudaDevAttrTccDriver`|  |  |  ||
+|`cudaDevAttrTextureAlignment`|  |  |  |`hipDeviceAttributeTextureAlignment`|
+|`cudaDevAttrTexturePitchAlignment`|  |  |  ||
+|`cudaDevAttrTotalConstantMemory`|  |  |  |`hipDeviceAttributeTotalConstantMemory`|
+|`cudaDevAttrUnifiedAddressing`|  |  |  ||
+|`cudaDevAttrWarpSize`|  |  |  |`hipDeviceAttributeWarpSize`|
+|`cudaDevP2PAttrAccessSupported`| 8.0 |  |  ||
+|`cudaDevP2PAttrCudaArrayAccessSupported`| 9.2 |  |  ||
+|`cudaDevP2PAttrNativeAtomicSupported`| 8.0 |  |  ||
+|`cudaDevP2PAttrPerformanceRank`| 8.0 |  |  ||
+|`cudaDeviceAttr`|  |  |  |`hipDeviceAttribute_t`|
+|`cudaDeviceBlockingSync`|  |  |  |`hipDeviceScheduleBlockingSync`|
+|`cudaDeviceLmemResizeToMax`|  |  |  |`hipDeviceLmemResizeToMax`|
+|`cudaDeviceMapHost`|  |  |  |`hipDeviceMapHost`|
+|`cudaDeviceMask`|  |  |  ||
+|`cudaDeviceP2PAttr`| 8.0 |  |  ||
+|`cudaDeviceProp`|  |  |  |`hipDeviceProp_t`|
+|`cudaDevicePropDontCare`|  |  |  ||
+|`cudaDeviceScheduleAuto`|  |  |  |`hipDeviceScheduleAuto`|
+|`cudaDeviceScheduleBlockingSync`|  |  |  |`hipDeviceScheduleBlockingSync`|
+|`cudaDeviceScheduleMask`|  |  |  |`hipDeviceScheduleMask`|
+|`cudaDeviceScheduleSpin`|  |  |  |`hipDeviceScheduleSpin`|
+|`cudaDeviceScheduleYield`|  |  |  |`hipDeviceScheduleYield`|
+|`cudaEglColorFormat`| 9.1 |  |  ||
+|`cudaEglColorFormatA`| 9.1 |  |  ||
+|`cudaEglColorFormatABGR`| 9.1 |  |  ||
+|`cudaEglColorFormatARGB`| 9.1 |  |  ||
+|`cudaEglColorFormatAYUV`| 9.1 |  |  ||
+|`cudaEglColorFormatAYUV_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatBGR`| 9.1 |  |  ||
+|`cudaEglColorFormatBGRA`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer10BGGR`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer10GBRG`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer10GRBG`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer10RGGB`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer12BGGR`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer12GBRG`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer12GRBG`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer12RGGB`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer14BGGR`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer14GBRG`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer14GRBG`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer14RGGB`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer20BGGR`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer20GBRG`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer20GRBG`| 9.1 |  |  ||
+|`cudaEglColorFormatBayer20RGGB`| 9.1 |  |  ||
+|`cudaEglColorFormatBayerBGGR`| 9.1 |  |  ||
+|`cudaEglColorFormatBayerGBRG`| 9.1 |  |  ||
+|`cudaEglColorFormatBayerGRBG`| 9.1 |  |  ||
+|`cudaEglColorFormatBayerIspBGGR`| 9.2 |  |  ||
+|`cudaEglColorFormatBayerIspGBRG`| 9.2 |  |  ||
+|`cudaEglColorFormatBayerIspGRBG`| 9.2 |  |  ||
+|`cudaEglColorFormatBayerIspRGGB`| 9.2 |  |  ||
+|`cudaEglColorFormatBayerRGGB`| 9.1 |  |  ||
+|`cudaEglColorFormatL`| 9.1 |  |  ||
+|`cudaEglColorFormatR`| 9.1 |  |  ||
+|`cudaEglColorFormatRG`| 9.1 |  |  ||
+|`cudaEglColorFormatRGB`| 9.1 |  |  ||
+|`cudaEglColorFormatRGBA`| 9.1 |  |  ||
+|`cudaEglColorFormatUYVY422`| 9.1 |  |  ||
+|`cudaEglColorFormatUYVY_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatVYUY_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatY10V10U10_420SemiPlanar`| 9.1 |  |  ||
+|`cudaEglColorFormatY10V10U10_444SemiPlanar`| 9.1 |  |  ||
+|`cudaEglColorFormatY12V12U12_420SemiPlanar`| 9.1 |  |  ||
+|`cudaEglColorFormatY12V12U12_444SemiPlanar`| 9.1 |  |  ||
+|`cudaEglColorFormatYUV420Planar`| 9.1 |  |  ||
+|`cudaEglColorFormatYUV420Planar_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYUV420SemiPlanar`| 9.1 |  |  ||
+|`cudaEglColorFormatYUV420SemiPlanar_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYUV422Planar`| 9.1 |  |  ||
+|`cudaEglColorFormatYUV422Planar_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYUV422SemiPlanar`| 9.1 |  |  ||
+|`cudaEglColorFormatYUV422SemiPlanar_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYUV444Planar`| 9.1 |  |  ||
+|`cudaEglColorFormatYUV444Planar_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYUV444SemiPlanar`| 9.1 |  |  ||
+|`cudaEglColorFormatYUV444SemiPlanar_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYUVA_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYUV_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYUYV422`| 9.1 |  |  ||
+|`cudaEglColorFormatYUYV_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYVU420Planar`| 9.1 |  |  ||
+|`cudaEglColorFormatYVU420Planar_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYVU420SemiPlanar`| 9.1 |  |  ||
+|`cudaEglColorFormatYVU420SemiPlanar_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYVU422Planar`| 9.1 |  |  ||
+|`cudaEglColorFormatYVU422Planar_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYVU422SemiPlanar`| 9.1 |  |  ||
+|`cudaEglColorFormatYVU422SemiPlanar_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYVU444Planar`| 9.1 |  |  ||
+|`cudaEglColorFormatYVU444Planar_ER`| 9.1 |  |  ||
+|`cudaEglColorFormatYVU444SemiPlanar`| 9.1 |  |  ||
+|`cudaEglColorFormatYVU444SemiPlanar_ER`|  |  |  ||
+|`cudaEglColorFormatYVYU_ER`| 9.1 |  |  ||
+|`cudaEglFrame`| 9.1 |  |  ||
+|`cudaEglFrameType`| 9.1 |  |  ||
+|`cudaEglFrameTypeArray`| 9.1 |  |  ||
+|`cudaEglFrameTypePitch`| 9.1 |  |  ||
+|`cudaEglFrame_st`| 9.1 |  |  ||
+|`cudaEglPlaneDesc`| 9.1 |  |  ||
+|`cudaEglPlaneDesc_st`| 9.1 |  |  ||
+|`cudaEglResourceLocationFlags`| 9.1 |  |  ||
+|`cudaEglResourceLocationSysmem`| 9.1 |  |  ||
+|`cudaEglResourceLocationVidmem`| 9.1 |  |  ||
+|`cudaEglStreamConnection`| 9.1 |  |  ||
+|`cudaError`|  |  |  |`hipError_t`|
+|`cudaErrorAddressOfConstant`|  | 3.1 |  ||
+|`cudaErrorAlreadyAcquired`| 10.1 |  |  |`hipErrorAlreadyAcquired`|
+|`cudaErrorAlreadyMapped`| 10.1 |  |  |`hipErrorAlreadyMapped`|
+|`cudaErrorApiFailureBase`|  | 4.1 |  ||
+|`cudaErrorArrayIsMapped`| 10.1 |  |  |`hipErrorArrayIsMapped`|
+|`cudaErrorAssert`|  |  |  |`hipErrorAssert`|
+|`cudaErrorCapturedEvent`| 10.0 |  |  ||
+|`cudaErrorCompatNotSupportedOnDevice`| 10.1 |  |  ||
+|`cudaErrorContextIsDestroyed`| 10.1 |  |  ||
+|`cudaErrorCooperativeLaunchTooLarge`| 9.0 |  |  |`hipErrorCooperativeLaunchTooLarge`|
+|`cudaErrorCudartUnloading`|  |  |  |`hipErrorDeinitialized`|
+|`cudaErrorDeviceAlreadyInUse`|  |  |  |`hipErrorContextAlreadyInUse`|
+|`cudaErrorDeviceUninitialized`| 10.2 |  |  |`hipErrorInvalidContext`|
+|`cudaErrorDeviceUninitilialized`| 10.1 |  | 10.2 |`hipErrorInvalidContext`|
+|`cudaErrorDevicesUnavailable`|  |  |  ||
+|`cudaErrorDuplicateSurfaceName`|  |  |  ||
+|`cudaErrorDuplicateTextureName`|  |  |  ||
+|`cudaErrorDuplicateVariableName`|  |  |  ||
+|`cudaErrorECCUncorrectable`|  |  |  |`hipErrorECCNotCorrectable`|
+|`cudaErrorFileNotFound`| 10.1 |  |  |`hipErrorFileNotFound`|
+|`cudaErrorGraphExecUpdateFailure`| 10.2 |  |  ||
+|`cudaErrorHardwareStackError`|  |  |  ||
+|`cudaErrorHostMemoryAlreadyRegistered`|  |  |  |`hipErrorHostMemoryAlreadyRegistered`|
+|`cudaErrorHostMemoryNotRegistered`|  |  |  |`hipErrorHostMemoryNotRegistered`|
+|`cudaErrorIllegalAddress`|  |  |  |`hipErrorIllegalAddress`|
+|`cudaErrorIllegalInstruction`|  |  |  ||
+|`cudaErrorIllegalState`| 10.0 |  |  ||
+|`cudaErrorIncompatibleDriverContext`|  |  |  ||
+|`cudaErrorInitializationError`|  |  |  |`hipErrorNotInitialized`|
+|`cudaErrorInsufficientDriver`|  |  |  |`hipErrorInsufficientDriver`|
+|`cudaErrorInvalidAddressSpace`|  |  |  ||
+|`cudaErrorInvalidChannelDescriptor`|  |  |  ||
+|`cudaErrorInvalidConfiguration`|  |  |  |`hipErrorInvalidConfiguration`|
+|`cudaErrorInvalidDevice`|  |  |  |`hipErrorInvalidDevice`|
+|`cudaErrorInvalidDeviceFunction`|  |  |  |`hipErrorInvalidDeviceFunction`|
+|`cudaErrorInvalidDevicePointer`|  | 10.1 |  |`hipErrorInvalidDevicePointer`|
+|`cudaErrorInvalidFilterSetting`|  |  |  ||
+|`cudaErrorInvalidGraphicsContext`|  |  |  |`hipErrorInvalidGraphicsContext`|
+|`cudaErrorInvalidHostPointer`|  | 10.1 |  ||
+|`cudaErrorInvalidKernelImage`|  |  |  |`hipErrorInvalidImage`|
+|`cudaErrorInvalidMemcpyDirection`|  |  |  |`hipErrorInvalidMemcpyDirection`|
+|`cudaErrorInvalidNormSetting`|  |  |  ||
+|`cudaErrorInvalidPc`|  |  |  ||
+|`cudaErrorInvalidPitchValue`|  |  |  ||
+|`cudaErrorInvalidPtx`|  |  |  |`hipErrorInvalidKernelFile`|
+|`cudaErrorInvalidResourceHandle`|  |  |  |`hipErrorInvalidHandle`|
+|`cudaErrorInvalidSource`| 10.1 |  |  |`hipErrorInvalidSource`|
+|`cudaErrorInvalidSurface`|  |  |  ||
+|`cudaErrorInvalidSymbol`|  |  |  |`hipErrorInvalidSymbol`|
+|`cudaErrorInvalidTexture`|  |  |  ||
+|`cudaErrorInvalidTextureBinding`|  |  |  ||
+|`cudaErrorInvalidValue`|  |  |  |`hipErrorInvalidValue`|
+|`cudaErrorJitCompilerNotFound`| 9.0 |  |  ||
+|`cudaErrorLaunchFailure`|  |  |  |`hipErrorLaunchFailure`|
+|`cudaErrorLaunchFileScopedSurf`|  |  |  ||
+|`cudaErrorLaunchFileScopedTex`|  |  |  ||
+|`cudaErrorLaunchIncompatibleTexturing`| 10.1 |  |  ||
+|`cudaErrorLaunchMaxDepthExceeded`|  |  |  ||
+|`cudaErrorLaunchOutOfResources`|  |  |  |`hipErrorLaunchOutOfResources`|
+|`cudaErrorLaunchPendingCountExceeded`|  |  |  ||
+|`cudaErrorLaunchTimeout`|  |  |  |`hipErrorLaunchTimeOut`|
+|`cudaErrorMapBufferObjectFailed`|  |  |  |`hipErrorMapFailed`|
+|`cudaErrorMemoryAllocation`|  |  |  |`hipErrorOutOfMemory`|
+|`cudaErrorMemoryValueTooLarge`|  | 3.1 |  ||
+|`cudaErrorMisalignedAddress`|  |  |  ||
+|`cudaErrorMissingConfiguration`|  |  |  |`hipErrorMissingConfiguration`|
+|`cudaErrorMixedDeviceExecution`|  | 3.1 |  ||
+|`cudaErrorNoDevice`|  |  |  |`hipErrorNoDevice`|
+|`cudaErrorNoKernelImageForDevice`|  |  |  |`hipErrorNoBinaryForGpu`|
+|`cudaErrorNotMapped`| 10.1 |  |  |`hipErrorNotMapped`|
+|`cudaErrorNotMappedAsArray`| 10.1 |  |  |`hipErrorNotMappedAsArray`|
+|`cudaErrorNotMappedAsPointer`| 10.1 |  |  |`hipErrorNotMappedAsPointer`|
+|`cudaErrorNotPermitted`|  |  |  ||
+|`cudaErrorNotReady`|  |  |  |`hipErrorNotReady`|
+|`cudaErrorNotSupported`|  |  |  |`hipErrorNotSupported`|
+|`cudaErrorNotYetImplemented`|  | 4.1 |  ||
+|`cudaErrorNvlinkUncorrectable`| 8.0 |  |  ||
+|`cudaErrorOperatingSystem`|  |  |  |`hipErrorOperatingSystem`|
+|`cudaErrorPeerAccessAlreadyEnabled`|  |  |  |`hipErrorPeerAccessAlreadyEnabled`|
+|`cudaErrorPeerAccessNotEnabled`|  |  |  |`hipErrorPeerAccessNotEnabled`|
+|`cudaErrorPeerAccessUnsupported`|  |  |  |`hipErrorPeerAccessUnsupported`|
+|`cudaErrorPriorLaunchFailure`|  | 3.1 |  |`hipErrorPriorLaunchFailure`|
+|`cudaErrorProfilerAlreadyStarted`|  | 5.0 |  |`hipErrorProfilerAlreadyStarted`|
+|`cudaErrorProfilerAlreadyStopped`|  | 5.0 |  |`hipErrorProfilerAlreadyStopped`|
+|`cudaErrorProfilerDisabled`|  |  |  |`hipErrorProfilerDisabled`|
+|`cudaErrorProfilerNotInitialized`|  | 5.0 |  |`hipErrorProfilerNotInitialized`|
+|`cudaErrorSetOnActiveProcess`|  |  |  |`hipErrorSetOnActiveProcess`|
+|`cudaErrorSharedObjectInitFailed`|  |  |  |`hipErrorSharedObjectInitFailed`|
+|`cudaErrorSharedObjectSymbolNotFound`|  |  |  |`hipErrorSharedObjectSymbolNotFound`|
+|`cudaErrorStartupFailure`|  |  |  ||
+|`cudaErrorStreamCaptureImplicit`| 10.0 |  |  ||
+|`cudaErrorStreamCaptureInvalidated`| 10.0 |  |  ||
+|`cudaErrorStreamCaptureIsolation`| 10.0 |  |  ||
+|`cudaErrorStreamCaptureMerge`| 10.0 |  |  ||
+|`cudaErrorStreamCaptureUnjoined`| 10.0 |  |  ||
+|`cudaErrorStreamCaptureUnmatched`| 10.0 |  |  ||
+|`cudaErrorStreamCaptureUnsupported`| 10.0 |  |  ||
+|`cudaErrorStreamCaptureWrongThread`| 10.1 |  |  ||
+|`cudaErrorSymbolNotFound`| 10.1 |  |  |`hipErrorNotFound`|
+|`cudaErrorSyncDepthExceeded`|  |  |  ||
+|`cudaErrorSynchronizationError`|  | 3.1 |  ||
+|`cudaErrorSystemDriverMismatch`| 10.1 |  |  ||
+|`cudaErrorSystemNotReady`| 10.0 |  |  ||
+|`cudaErrorTextureFetchFailed`|  | 3.1 |  ||
+|`cudaErrorTextureNotBound`|  | 3.1 |  ||
+|`cudaErrorTimeout`| 10.2 |  |  ||
+|`cudaErrorTooManyPeers`|  |  |  ||
+|`cudaErrorUnknown`|  |  |  |`hipErrorUnknown`|
+|`cudaErrorUnmapBufferObjectFailed`|  |  |  |`hipErrorUnmapFailed`|
+|`cudaErrorUnsupportedLimit`|  |  |  |`hipErrorUnsupportedLimit`|
+|`cudaError_t`|  |  |  |`hipError_t`|
+|`cudaEventBlockingSync`|  |  |  |`hipEventBlockingSync`|
+|`cudaEventDefault`|  |  |  |`hipEventDefault`|
+|`cudaEventDisableTiming`|  |  |  |`hipEventDisableTiming`|
+|`cudaEventInterprocess`|  |  |  |`hipEventInterprocess`|
+|`cudaEvent_t`|  |  |  |`hipEvent_t`|
+|`cudaExtent`|  |  |  |`hipExtent`|
+|`cudaExternalMemoryBufferDesc`| 10.0 |  |  ||
+|`cudaExternalMemoryDedicated`| 10.0 |  |  ||
+|`cudaExternalMemoryHandleDesc`| 10.0 |  |  ||
+|`cudaExternalMemoryHandleType`| 10.0 |  |  ||
+|`cudaExternalMemoryHandleTypeD3D11Resource`| 10.0 |  |  ||
+|`cudaExternalMemoryHandleTypeD3D11ResourceKmt`| 10.2 |  |  ||
+|`cudaExternalMemoryHandleTypeD3D12Heap`| 10.0 |  |  ||
+|`cudaExternalMemoryHandleTypeD3D12Resource`| 10.0 |  |  ||
+|`cudaExternalMemoryHandleTypeNvSciBuf`| 10.2 |  |  ||
+|`cudaExternalMemoryHandleTypeOpaqueFd`| 10.0 |  |  ||
+|`cudaExternalMemoryHandleTypeOpaqueWin32`| 10.0 |  |  ||
+|`cudaExternalMemoryHandleTypeOpaqueWin32Kmt`| 10.0 |  |  ||
+|`cudaExternalMemoryMipmappedArrayDesc`| 10.0 |  |  ||
+|`cudaExternalMemory_t`| 10.0 |  |  ||
+|`cudaExternalSemaphoreHandleDesc`| 10.0 |  |  ||
+|`cudaExternalSemaphoreHandleType`| 10.0 |  |  ||
+|`cudaExternalSemaphoreHandleTypeD3D11Fence`| 10.2 |  |  ||
+|`cudaExternalSemaphoreHandleTypeD3D12Fence`| 10.0 |  |  ||
+|`cudaExternalSemaphoreHandleTypeKeyedMutex`| 10.2 |  |  ||
+|`cudaExternalSemaphoreHandleTypeKeyedMutexKmt`| 10.2 |  |  ||
+|`cudaExternalSemaphoreHandleTypeNvSciSync`| 10.2 |  |  ||
+|`cudaExternalSemaphoreHandleTypeOpaqueFd`| 10.0 |  |  ||
+|`cudaExternalSemaphoreHandleTypeOpaqueWin32`| 10.0 |  |  ||
+|`cudaExternalSemaphoreHandleTypeOpaqueWin32Kmt`| 10.0 |  |  ||
+|`cudaExternalSemaphoreSignalParams`| 10.0 |  |  ||
+|`cudaExternalSemaphoreSignalSkipNvSciBufMemSync`| 10.2 |  |  ||
+|`cudaExternalSemaphoreWaitParams`| 10.0 |  |  ||
+|`cudaExternalSemaphoreWaitSkipNvSciBufMemSync`| 10.2 |  |  ||
+|`cudaExternalSemaphore_t`| 10.0 |  |  ||
+|`cudaFilterModeLinear`|  |  |  |`hipFilterModeLinear`|
+|`cudaFilterModePoint`|  |  |  |`hipFilterModePoint`|
+|`cudaFormatModeAuto`|  |  |  ||
+|`cudaFormatModeForced`|  |  |  ||
+|`cudaFuncAttribute`| 9.0 |  |  ||
+|`cudaFuncAttributeMax`| 9.0 |  |  ||
+|`cudaFuncAttributeMaxDynamicSharedMemorySize`| 9.0 |  |  ||
+|`cudaFuncAttributePreferredSharedMemoryCarveout`| 9.0 |  |  ||
+|`cudaFuncAttributes`|  |  |  |`hipFuncAttributes`|
+|`cudaFuncCache`|  |  |  |`hipFuncCache_t`|
+|`cudaFuncCachePreferEqual`|  |  |  |`hipFuncCachePreferEqual`|
+|`cudaFuncCachePreferL1`|  |  |  |`hipFuncCachePreferL1`|
+|`cudaFuncCachePreferNone`|  |  |  |`hipFuncCachePreferNone`|
+|`cudaFuncCachePreferShared`|  |  |  |`hipFuncCachePreferShared`|
+|`cudaGLDeviceList`|  |  |  ||
+|`cudaGLDeviceListAll`|  |  |  ||
+|`cudaGLDeviceListCurrentFrame`|  |  |  ||
+|`cudaGLDeviceListNextFrame`|  |  |  ||
+|`cudaGLMapFlags`|  |  |  ||
+|`cudaGLMapFlagsNone`|  |  |  ||
+|`cudaGLMapFlagsReadOnly`|  |  |  ||
+|`cudaGLMapFlagsWriteDiscard`|  |  |  ||
+|`cudaGraphExecUpdateError`| 10.2 |  |  ||
+|`cudaGraphExecUpdateErrorFunctionChanged`| 10.2 |  |  ||
+|`cudaGraphExecUpdateErrorNodeTypeChanged`| 10.2 |  |  ||
+|`cudaGraphExecUpdateErrorNotSupported`| 10.2 |  |  ||
+|`cudaGraphExecUpdateErrorParametersChanged`| 10.2 |  |  ||
+|`cudaGraphExecUpdateErrorTopologyChanged`| 10.2 |  |  ||
+|`cudaGraphExecUpdateResult`| 10.2 |  |  ||
+|`cudaGraphExecUpdateSuccess`| 10.2 |  |  ||
+|`cudaGraphExec_t`| 10.0 |  |  ||
+|`cudaGraphNodeType`| 10.0 |  |  ||
+|`cudaGraphNodeTypeCount`| 10.0 |  |  ||
+|`cudaGraphNodeTypeEmpty`| 10.0 |  |  ||
+|`cudaGraphNodeTypeGraph`| 10.0 |  |  ||
+|`cudaGraphNodeTypeHost`| 10.0 |  |  ||
+|`cudaGraphNodeTypeKernel`| 10.0 |  |  ||
+|`cudaGraphNodeTypeMemcpy`| 10.0 |  |  ||
+|`cudaGraphNodeTypeMemset`| 10.0 |  |  ||
+|`cudaGraphNode_t`| 10.0 |  |  ||
+|`cudaGraph_t`| 10.0 |  |  ||
+|`cudaGraphicsCubeFace`|  |  |  ||
+|`cudaGraphicsCubeFaceNegativeX`|  |  |  ||
+|`cudaGraphicsCubeFaceNegativeY`|  |  |  ||
+|`cudaGraphicsCubeFaceNegativeZ`|  |  |  ||
+|`cudaGraphicsCubeFacePositiveX`|  |  |  ||
+|`cudaGraphicsCubeFacePositiveY`|  |  |  ||
+|`cudaGraphicsCubeFacePositiveZ`|  |  |  ||
+|`cudaGraphicsMapFlags`|  |  |  ||
+|`cudaGraphicsMapFlagsNone`|  |  |  ||
+|`cudaGraphicsMapFlagsReadOnly`|  |  |  ||
+|`cudaGraphicsMapFlagsWriteDiscard`|  |  |  ||
+|`cudaGraphicsRegisterFlags`|  |  |  ||
+|`cudaGraphicsRegisterFlagsNone`|  |  |  ||
+|`cudaGraphicsRegisterFlagsReadOnly`|  |  |  ||
+|`cudaGraphicsRegisterFlagsSurfaceLoadStore`|  |  |  ||
+|`cudaGraphicsRegisterFlagsTextureGather`|  |  |  ||
+|`cudaGraphicsRegisterFlagsWriteDiscard`|  |  |  ||
+|`cudaGraphicsResource`|  |  |  ||
+|`cudaGraphicsResource_t`|  |  |  ||
+|`cudaHostAllocDefault`|  |  |  |`hipHostMallocDefault`|
+|`cudaHostAllocMapped`|  |  |  |`hipHostMallocMapped`|
+|`cudaHostAllocPortable`|  |  |  |`hipHostMallocPortable`|
+|`cudaHostAllocWriteCombined`|  |  |  |`hipHostMallocWriteCombined`|
+|`cudaHostFn_t`| 10.0 |  |  ||
+|`cudaHostNodeParams`| 10.0 |  |  ||
+|`cudaHostRegisterDefault`|  |  |  |`hipHostRegisterDefault`|
+|`cudaHostRegisterIoMemory`| 7.5 |  |  |`hipHostRegisterIoMemory`|
+|`cudaHostRegisterMapped`|  |  |  |`hipHostRegisterMapped`|
+|`cudaHostRegisterPortable`|  |  |  |`hipHostRegisterPortable`|
+|`cudaInvalidDeviceId`| 8.0 |  |  ||
+|`cudaIpcEventHandle_st`|  |  |  |`ihipIpcEventHandle_t`|
+|`cudaIpcEventHandle_t`|  |  |  |`ihipIpcEventHandle_t`|
+|`cudaIpcMemHandle_st`|  |  |  |`hipIpcMemHandle_st`|
+|`cudaIpcMemHandle_t`|  |  |  |`hipIpcMemHandle_t`|
+|`cudaIpcMemLazyEnablePeerAccess`|  |  |  |`hipIpcMemLazyEnablePeerAccess`|
+|`cudaKernelNodeAttrID`| 11.0 |  |  ||
+|`cudaKernelNodeAttrValue`| 11.0 |  |  ||
+|`cudaKernelNodeAttributeAccessPolicyWindow`| 11.0 |  |  ||
+|`cudaKernelNodeAttributeCooperative`| 11.0 |  |  ||
+|`cudaKernelNodeParams`| 10.0 |  |  ||
+|`cudaKeyValuePair`|  |  |  ||
+|`cudaLaunchParams`| 9.0 |  |  |`hipLaunchParams`|
+|`cudaLimit`|  |  |  |`hipLimit_t`|
+|`cudaLimitDevRuntimePendingLaunchCount`|  |  |  ||
+|`cudaLimitDevRuntimeSyncDepth`|  |  |  ||
+|`cudaLimitMallocHeapSize`|  |  |  |`hipLimitMallocHeapSize`|
+|`cudaLimitMaxL2FetchGranularity`| 10.0 |  |  ||
+|`cudaLimitPersistingL2CacheSize`| 11.0 |  |  ||
+|`cudaLimitPrintfFifoSize`|  |  |  ||
+|`cudaLimitStackSize`|  |  |  ||
+|`cudaMemAdviseSetAccessedBy`| 8.0 |  |  ||
+|`cudaMemAdviseSetPreferredLocation`| 8.0 |  |  ||
+|`cudaMemAdviseSetReadMostly`| 8.0 |  |  ||
+|`cudaMemAdviseUnsetAccessedBy`| 8.0 |  |  ||
+|`cudaMemAdviseUnsetPreferredLocation`| 8.0 |  |  ||
+|`cudaMemAdviseUnsetReadMostly`| 8.0 |  |  ||
+|`cudaMemAttachGlobal`|  |  |  |`hipMemAttachGlobal`|
+|`cudaMemAttachHost`|  |  |  |`hipMemAttachHost`|
+|`cudaMemAttachSingle`|  |  |  ||
+|`cudaMemRangeAttribute`| 8.0 |  |  ||
+|`cudaMemRangeAttributeAccessedBy`| 8.0 |  |  ||
+|`cudaMemRangeAttributeLastPrefetchLocation`| 8.0 |  |  ||
+|`cudaMemRangeAttributePreferredLocation`| 8.0 |  |  ||
+|`cudaMemRangeAttributeReadMostly`| 8.0 |  |  ||
+|`cudaMemcpy3DParms`|  |  |  |`hipMemcpy3DParms`|
+|`cudaMemcpy3DPeerParms`|  |  |  ||
+|`cudaMemcpyDefault`|  |  |  |`hipMemcpyDefault`|
+|`cudaMemcpyDeviceToDevice`|  |  |  |`hipMemcpyDeviceToDevice`|
+|`cudaMemcpyDeviceToHost`|  |  |  |`hipMemcpyDeviceToHost`|
+|`cudaMemcpyHostToDevice`|  |  |  |`hipMemcpyHostToDevice`|
+|`cudaMemcpyHostToHost`|  |  |  |`hipMemcpyHostToHost`|
+|`cudaMemcpyKind`|  |  |  |`hipMemcpyKind`|
+|`cudaMemoryAdvise`| 8.0 |  |  ||
+|`cudaMemoryType`|  |  |  ||
+|`cudaMemoryTypeDevice`|  |  |  ||
+|`cudaMemoryTypeHost`|  |  |  ||
+|`cudaMemoryTypeManaged`| 10.0 |  |  ||
+|`cudaMemoryTypeUnregistered`|  |  |  ||
+|`cudaMemsetParams`| 10.0 |  |  ||
+|`cudaMipmappedArray`|  |  |  |`hipMipmappedArray`|
+|`cudaMipmappedArray_const_t`|  |  |  |`hipMipmappedArray_const_t`|
+|`cudaMipmappedArray_t`|  |  |  |`hipMipmappedArray_t`|
+|`cudaNvSciSyncAttrSignal`| 10.2 |  |  ||
+|`cudaNvSciSyncAttrWait`| 10.2 |  |  ||
+|`cudaOccupancyDefault`|  |  |  |`hipOccupancyDefault`|
+|`cudaOccupancyDisableCachingOverride`|  |  |  ||
+|`cudaOutputMode`|  |  |  ||
+|`cudaOutputMode_t`|  |  |  ||
+|`cudaPitchedPtr`|  |  |  |`hipPitchedPtr`|
+|`cudaPointerAttributes`|  |  |  |`hipPointerAttribute_t`|
+|`cudaPos`|  |  |  |`hipPos`|
+|`cudaReadModeElementType`|  |  |  |`hipReadModeElementType`|
+|`cudaReadModeNormalizedFloat`|  |  |  |`hipReadModeNormalizedFloat`|
+|`cudaResViewFormatFloat1`|  |  |  |`hipResViewFormatFloat1`|
+|`cudaResViewFormatFloat2`|  |  |  |`hipResViewFormatFloat2`|
+|`cudaResViewFormatFloat4`|  |  |  |`hipResViewFormatFloat4`|
+|`cudaResViewFormatHalf1`|  |  |  |`hipResViewFormatHalf1`|
+|`cudaResViewFormatHalf2`|  |  |  |`hipResViewFormatHalf2`|
+|`cudaResViewFormatHalf4`|  |  |  |`hipResViewFormatHalf4`|
+|`cudaResViewFormatNone`|  |  |  |`hipResViewFormatNone`|
+|`cudaResViewFormatSignedBlockCompressed4`|  |  |  |`hipResViewFormatSignedBlockCompressed4`|
+|`cudaResViewFormatSignedBlockCompressed5`|  |  |  |`hipResViewFormatSignedBlockCompressed5`|
+|`cudaResViewFormatSignedBlockCompressed6H`|  |  |  |`hipResViewFormatSignedBlockCompressed6H`|
+|`cudaResViewFormatSignedChar1`|  |  |  |`hipResViewFormatSignedChar1`|
+|`cudaResViewFormatSignedChar2`|  |  |  |`hipResViewFormatSignedChar2`|
+|`cudaResViewFormatSignedChar4`|  |  |  |`hipResViewFormatSignedChar4`|
+|`cudaResViewFormatSignedInt1`|  |  |  |`hipResViewFormatSignedInt1`|
+|`cudaResViewFormatSignedInt2`|  |  |  |`hipResViewFormatSignedInt2`|
+|`cudaResViewFormatSignedInt4`|  |  |  |`hipResViewFormatSignedInt4`|
+|`cudaResViewFormatSignedShort1`|  |  |  |`hipResViewFormatSignedShort1`|
+|`cudaResViewFormatSignedShort2`|  |  |  |`hipResViewFormatSignedShort2`|
+|`cudaResViewFormatSignedShort4`|  |  |  |`hipResViewFormatSignedShort4`|
+|`cudaResViewFormatUnsignedBlockCompressed1`|  |  |  |`hipResViewFormatUnsignedBlockCompressed1`|
+|`cudaResViewFormatUnsignedBlockCompressed2`|  |  |  |`hipResViewFormatUnsignedBlockCompressed2`|
+|`cudaResViewFormatUnsignedBlockCompressed3`|  |  |  |`hipResViewFormatUnsignedBlockCompressed3`|
+|`cudaResViewFormatUnsignedBlockCompressed4`|  |  |  |`hipResViewFormatUnsignedBlockCompressed4`|
+|`cudaResViewFormatUnsignedBlockCompressed5`|  |  |  |`hipResViewFormatUnsignedBlockCompressed5`|
+|`cudaResViewFormatUnsignedBlockCompressed6H`|  |  |  |`hipResViewFormatUnsignedBlockCompressed6H`|
+|`cudaResViewFormatUnsignedBlockCompressed7`|  |  |  |`hipResViewFormatUnsignedBlockCompressed7`|
+|`cudaResViewFormatUnsignedChar1`|  |  |  |`hipResViewFormatUnsignedChar1`|
+|`cudaResViewFormatUnsignedChar2`|  |  |  |`hipResViewFormatUnsignedChar2`|
+|`cudaResViewFormatUnsignedChar4`|  |  |  |`hipResViewFormatUnsignedChar4`|
+|`cudaResViewFormatUnsignedInt1`|  |  |  |`hipResViewFormatUnsignedInt1`|
+|`cudaResViewFormatUnsignedInt2`|  |  |  |`hipResViewFormatUnsignedInt2`|
+|`cudaResViewFormatUnsignedInt4`|  |  |  |`hipResViewFormatUnsignedInt4`|
+|`cudaResViewFormatUnsignedShort1`|  |  |  |`hipResViewFormatUnsignedShort1`|
+|`cudaResViewFormatUnsignedShort2`|  |  |  |`hipResViewFormatUnsignedShort2`|
+|`cudaResViewFormatUnsignedShort4`|  |  |  |`hipResViewFormatUnsignedShort4`|
+|`cudaResourceDesc`|  |  |  |`hipResourceDesc`|
+|`cudaResourceType`|  |  |  |`hipResourceType`|
+|`cudaResourceTypeArray`|  |  |  |`hipResourceTypeArray`|
+|`cudaResourceTypeLinear`|  |  |  |`hipResourceTypeLinear`|
+|`cudaResourceTypeMipmappedArray`|  |  |  |`hipResourceTypeMipmappedArray`|
+|`cudaResourceTypePitch2D`|  |  |  |`hipResourceTypePitch2D`|
+|`cudaResourceViewDesc`|  |  |  |`hipResourceViewDesc`|
+|`cudaResourceViewFormat`|  |  |  |`hipResourceViewFormat`|
+|`cudaSharedCarveout`| 9.0 |  |  ||
+|`cudaSharedMemBankSizeDefault`|  |  |  |`hipSharedMemBankSizeDefault`|
+|`cudaSharedMemBankSizeEightByte`|  |  |  |`hipSharedMemBankSizeEightByte`|
+|`cudaSharedMemBankSizeFourByte`|  |  |  |`hipSharedMemBankSizeFourByte`|
+|`cudaSharedMemConfig`|  |  |  |`hipSharedMemConfig`|
+|`cudaSharedmemCarveoutDefault`| 9.0 |  |  ||
+|`cudaSharedmemCarveoutMaxL1`| 9.0 |  |  ||
+|`cudaSharedmemCarveoutMaxShared`| 9.0 |  |  ||
+|`cudaStreamAttrID`| 11.0 |  |  ||
+|`cudaStreamAttrValue`| 11.0 |  |  ||
+|`cudaStreamAttributeAccessPolicyWindow`| 11.0 |  |  ||
+|`cudaStreamAttributeSynchronizationPolicy`| 11.0 |  |  ||
+|`cudaStreamCallback_t`|  |  |  |`hipStreamCallback_t`|
+|`cudaStreamCaptureMode`| 10.1 |  |  ||
+|`cudaStreamCaptureModeGlobal`| 10.1 |  |  ||
+|`cudaStreamCaptureModeRelaxed`| 10.1 |  |  ||
+|`cudaStreamCaptureModeThreadLocal`| 10.1 |  |  ||
+|`cudaStreamCaptureStatus`| 10.0 |  |  ||
+|`cudaStreamCaptureStatusActive`| 10.0 |  |  ||
+|`cudaStreamCaptureStatusInvalidated`| 10.0 |  |  ||
+|`cudaStreamCaptureStatusNone`| 10.0 |  |  ||
+|`cudaStreamDefault`|  |  |  |`hipStreamDefault`|
+|`cudaStreamLegacy`|  |  |  ||
+|`cudaStreamNonBlocking`|  |  |  |`hipStreamNonBlocking`|
+|`cudaStreamPerThread`|  |  |  ||
+|`cudaStream_t`|  |  |  |`hipStream_t`|
+|`cudaSuccess`|  |  |  |`hipSuccess`|
+|`cudaSurfaceBoundaryMode`|  |  |  |`hipSurfaceBoundaryMode`|
+|`cudaSurfaceFormatMode`|  |  |  ||
+|`cudaSurfaceObject_t`|  |  |  |`hipSurfaceObject_t`|
+|`cudaSyncPolicyAuto`| 11.0 |  |  ||
+|`cudaSyncPolicyBlockingSync`| 11.0 |  |  ||
+|`cudaSyncPolicySpin`| 11.0 |  |  ||
+|`cudaSyncPolicyYield`| 11.0 |  |  ||
+|`cudaSynchronizationPolicy`| 11.0 |  |  ||
+|`cudaTextureAddressMode`|  |  |  |`hipTextureAddressMode`|
+|`cudaTextureDesc`|  |  |  |`hipTextureDesc`|
+|`cudaTextureFilterMode`|  |  |  |`hipTextureFilterMode`|
+|`cudaTextureObject_t`|  |  |  |`hipTextureObject_t`|
+|`cudaTextureReadMode`|  |  |  |`hipTextureReadMode`|
+|`cudaTextureType1D`|  |  |  |`hipTextureType1D`|
+|`cudaTextureType1DLayered`|  |  |  |`hipTextureType1DLayered`|
+|`cudaTextureType2D`|  |  |  |`hipTextureType2D`|
+|`cudaTextureType2DLayered`|  |  |  |`hipTextureType2DLayered`|
+|`cudaTextureType3D`|  |  |  |`hipTextureType3D`|
+|`cudaTextureTypeCubemap`|  |  |  |`hipTextureTypeCubemap`|
+|`cudaTextureTypeCubemapLayered`|  |  |  |`hipTextureTypeCubemapLayered`|
+|`cudaUUID_t`|  |  |  ||
+|`libraryPropertyType`| 8.0 |  |  ||
+|`libraryPropertyType_t`| 8.0 |  |  ||
+|`surfaceReference`|  |  |  ||
+
+## **35. Execution Control [REMOVED]**
+
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudaConfigureCall`|  |  | 10.1 |`hipConfigureCall`|
+|`cudaLaunch`|  |  | 10.1 |`hipLaunchByPtr`|
+|`cudaSetupArgument`|  |  | 10.1 |`hipSetupArgument`|
+
+
+\* A - Added, D - Deprecated, R - Removed

--- a/docs/markdown/CUDNN_API_supported_by_HIP.md
+++ b/docs/markdown/CUDNN_API_supported_by_HIP.md
@@ -1,586 +1,604 @@
 # CUDNN API supported by HIP
 
-## **1. CUDNN Data types**
+## **1. CUNN Data types**
 
-| **type**     |   **CUDA**                                                    |**CUDA version\***|   **HIP**                                                  |**HIP value** (if differs) |
-|-------------:|---------------------------------------------------------------|:----------------:|------------------------------------------------------------|---------------------------|
-| define       |`CUDNN_VERSION`                                                |                  |`HIPDNN_VERSION`                                            |
-| struct       |`cudnnContext`                                                 |                  |                                                            |
-| struct*      |`cudnnHandle_t`                                                |                  |`hipdnnHandle_t`                                            |
-| enum         |***`cudnnStatus_t`***                                          |                  |***`hipdnnStatus_t`***                                      |
-|            0 |*`CUDNN_STATUS_SUCCESS`*                                       |                  |*`HIPDNN_STATUS_SUCCESS`*                                   |
-|            1 |*`CUDNN_STATUS_NOT_INITIALIZED`*                               |                  |*`HIPDNN_STATUS_NOT_INITIALIZED`*                           |
-|            2 |*`CUDNN_STATUS_ALLOC_FAILED`*                                  |                  |*`HIPDNN_STATUS_ALLOC_FAILED`*                              |
-|            3 |*`CUDNN_STATUS_BAD_PARAM`*                                     |                  |*`HIPDNN_STATUS_BAD_PARAM`*                                 |
-|            4 |*`CUDNN_STATUS_INTERNAL_ERROR`*                                |                  |*`HIPDNN_STATUS_INTERNAL_ERROR`*                            |
-|            5 |*`CUDNN_STATUS_INVALID_VALUE`*                                 |                  |*`HIPDNN_STATUS_INVALID_VALUE`*                             |
-|            6 |*`CUDNN_STATUS_ARCH_MISMATCH`*                                 |                  |*`HIPDNN_STATUS_ARCH_MISMATCH`*                             |
-|            7 |*`CUDNN_STATUS_MAPPING_ERROR`*                                 |                  |*`HIPDNN_STATUS_MAPPING_ERROR`*                             |
-|            8 |*`CUDNN_STATUS_EXECUTION_FAILED`*                              |                  |*`HIPDNN_STATUS_EXECUTION_FAILED`*                          |
-|            9 |*`CUDNN_STATUS_NOT_SUPPORTED`*                                 |                  |*`HIPDNN_STATUS_NOT_SUPPORTED`*                             |
-|           10 |*`CUDNN_STATUS_LICENSE_ERROR`*                                 |                  |*`HIPDNN_STATUS_LICENSE_ERROR`*                             |
-|           11 |*`CUDNN_STATUS_RUNTIME_PREREQUISITE_MISSING`*                  | 7.5              |*`HIPDNN_STATUS_RUNTIME_PREREQUISITE_MISSING`*              |
-|           12 |*`CUDNN_STATUS_RUNTIME_IN_PROGRESS`*                           | 8.0              |                                                            |
-|           13 |*`CUDNN_STATUS_RUNTIME_FP_OVERFLOW`*                           | 8.0              |                                                            |
-| struct       |`cudnnRuntimeTag_t`                                            | 8.0              |                                                            |
-| enum         |***`cudnnErrQueryMode_t`***                                    | 8.0              |                                                            |
-|            0 |*`CUDNN_ERRQUERY_RAWCODE`*                                     | 8.0              |                                                            |
-|            1 |*`CUDNN_ERRQUERY_NONBLOCKING`*                                 | 8.0              |                                                            |
-|            2 |*`CUDNN_ERRQUERY_BLOCKING`*                                    | 8.0              |                                                            |
-| struct       |`cudnnTensorStruct`                                            |                  |                                                            |
-| struct*      |`cudnnTensorDescriptor_t`                                      |                  |`hipdnnTensorDescriptor_t`                                  |
-| struct       |`cudnnConvolutionStruct`                                       |                  |                                                            |
-| struct*      |`cudnnConvolutionDescriptor_t`                                 |                  |`hipdnnConvolutionDescriptor_t`                             |
-| struct       |`cudnnPoolingStruct`                                           |                  |                                                            |
-| struct*      |`cudnnPoolingDescriptor_t`                                     |                  |`hipdnnPoolingDescriptor_t`                                 |
-| struct       |`cudnnFilterStruct`                                            |                  |                                                            |
-| struct*      |`cudnnFilterDescriptor_t`                                      |                  |`hipdnnFilterDescriptor_t`                                  |
-| struct       |`cudnnLRNStruct`                                               |                  |                                                            |
-| struct*      |`cudnnLRNDescriptor_t`                                         |                  |`hipdnnLRNDescriptor_t`                                     |
-| struct       |`cudnnActivationStruct`                                        |                  |                                                            |
-| struct*      |`cudnnActivationDescriptor_t`                                  |                  |`hipdnnActivationDescriptor_t`                              |
-| struct       |`cudnnSpatialTransformerStruct`                                | 7.5              |                                                            |
-| struct*      |`cudnnSpatialTransformerDescriptor_t`                          | 7.5              |                                                            |
-| struct       |`cudnnOpTensorStruct`                                          | 7.5              |                                                            |
-| struct*      |`cudnnOpTensorDescriptor_t`                                    | 7.5              |`hipdnnOpTensorDescriptor_t`                                |
-| struct       |`cudnnReduceTensorStruct`                                      | 7.5              |                                                            |
-| struct*      |`cudnnReduceTensorDescriptor_t`                                | 7.5              |`hipdnnReduceTensorDescriptor_t`                            |
-| struct       |`cudnnCTCLossStruct`                                           | 8.0              |                                                            |
-| struct*      |`cudnnCTCLossDescriptor_t`                                     | 8.0              |                                                            |
-| struct       |`cudnnTensorTransformStruct`                                   | 9.0              |                                                            |
-| struct*      |`cudnnTensorTransformDescriptor_t`                             | 9.0              |                                                            |
-| enum         |***`cudnnDataType_t`***                                        |                  |***`hipdnnDataType_t`***                                    |
-|            0 |*`CUDNN_DATA_FLOAT`*                                           |                  |*`HIPDNN_DATA_FLOAT`*                                       |
-|            1 |*`CUDNN_DATA_DOUBLE`*                                          |                  |*`HIPDNN_DATA_DOUBLE`*                                      |
-|            2 |*`CUDNN_DATA_HALF`*                                            |                  |*`HIPDNN_DATA_HALF`*                                        |
-|            3 |*`CUDNN_DATA_INT8`*                                            | 7.5              |*`HIPDNN_DATA_INT8`*                                        |
-|            4 |*`CUDNN_DATA_INT32`*                                           | 7.5              |*`HIPDNN_DATA_INT32`*                                       |
-|            5 |*`CUDNN_DATA_INT8x4`*                                          | 7.5              |*`HIPDNN_DATA_INT8x4`*                                      |
-|            6 |*`CUDNN_DATA_UINT8`*                                           | 8.0              |                                                            |
-|            7 |*`CUDNN_DATA_UINT8x4`*                                         | 8.0              |                                                            |
-|            8 |*`CUDNN_DATA_INT8x32`*                                         | 9.0              |                                                            |
-| enum         |***`cudnnMathType_t`***                                        | 8.0              |***`hipdnnMathType_t`***                                    |
-|            0 |*`CUDNN_DEFAULT_MATH`*                                         | 8.0              |*`HIPDNN_DEFAULT_MATH`*                                     |
-|            1 |*`CUDNN_TENSOR_OP_MATH`*                                       | 8.0              |*`HIPDNN_TENSOR_OP_MATH`*                                   |
-| enum         |***`cudnnNanPropagation_t`***                                  |                  |***`hipdnnNanPropagation_t`***                              |
-|            0 |*`CUDNN_NOT_PROPAGATE_NAN`*                                    |                  |*`HIPDNN_NOT_PROPAGATE_NAN`*                                |
-|            1 |*`CUDNN_PROPAGATE_NAN`*                                        |                  |*`HIPDNN_PROPAGATE_NAN`*                                    |
-| enum         |***`cudnnDeterminism_t`***                                     | 7.5              |                                                            |
-|            0 |*`CUDNN_NON_DETERMINISTIC`*                                    | 7.5              |                                                            |
-|            1 |*`CUDNN_DETERMINISTIC`*                                        | 7.5              |                                                            |
-| define       |`CUDNN_DIM_MAX`                                                |                  |                                                            |
-| enum         |***`cudnnTensorFormat_t`***                                    |                  |***`hipdnnTensorFormat_t`***                                |
-|            0 |*`CUDNN_TENSOR_NCHW`*                                          |                  |*`HIPDNN_TENSOR_NCHW`*                                      |
-|            1 |*`CUDNN_TENSOR_NHWC`*                                          |                  |*`HIPDNN_TENSOR_NHWC`*                                      |
-|            2 |*`CUDNN_TENSOR_NCHW_VECT_C`*                                   | 7.5              |*`HIPDNN_TENSOR_NCHW_VECT_C`*                               |
-| enum         |***`cudnnFoldingDirection_t`***                                | 9.0              |                                                            |
-|            0 |*`CUDNN_TRANSFORM_FOLD`*                                       | 9.0              |                                                            |
-|            1 |*`CUDNN_TRANSFORM_UNFOLD`*                                     | 9.0              |                                                            |
-| enum         |***`cudnnOpTensorOp_t`***                                      | 7.5              |***`hipdnnOpTensorOp_t`***                                  |
-|            0 |*`CUDNN_OP_TENSOR_ADD`*                                        | 7.5              |*`HIPDNN_OP_TENSOR_ADD`*                                    |
-|            1 |*`CUDNN_OP_TENSOR_MUL`*                                        | 7.5              |*`HIPDNN_OP_TENSOR_MUL`*                                    |
-|            2 |*`CUDNN_OP_TENSOR_MIN`*                                        | 7.5              |*`HIPDNN_OP_TENSOR_MIN`*                                    |
-|            3 |*`CUDNN_OP_TENSOR_MAX`*                                        | 7.5              |*`HIPDNN_OP_TENSOR_MAX`*                                    |
-|            4 |*`CUDNN_OP_TENSOR_SQRT`*                                       | 7.5              |*`HIPDNN_OP_TENSOR_SQRT`*                                   |
-|            5 |*`CUDNN_OP_TENSOR_NOT`*                                        | 8.0              |*`HIPDNN_OP_TENSOR_NOT`*                                    |
-| enum         |***`cudnnReduceTensorOp_t`***                                  | 7.5              |***`hipdnnReduceTensorOp_t`***                              |
-|            0 |*`CUDNN_REDUCE_TENSOR_ADD`*                                    | 7.5              |*`HIPDNN_REDUCE_TENSOR_ADD`*                                |
-|            1 |*`CUDNN_REDUCE_TENSOR_MUL`*                                    | 7.5              |*`HIPDNN_REDUCE_TENSOR_MUL`*                                |
-|            2 |*`CUDNN_REDUCE_TENSOR_MIN`*                                    | 7.5              |*`HIPDNN_REDUCE_TENSOR_MIN`*                                |
-|            3 |*`CUDNN_REDUCE_TENSOR_MAX`*                                    | 7.5              |*`HIPDNN_REDUCE_TENSOR_MAX`*                                |
-|            4 |*`CUDNN_REDUCE_TENSOR_AMAX`*                                   | 7.5              |*`HIPDNN_REDUCE_TENSOR_AMAX`*                               |
-|            5 |*`CUDNN_REDUCE_TENSOR_AVG`*                                    | 7.5              |*`HIPDNN_REDUCE_TENSOR_AVG`*                                |
-|            6 |*`CUDNN_REDUCE_TENSOR_NORM1`*                                  | 7.5              |*`HIPDNN_REDUCE_TENSOR_NORM1`*                              |
-|            7 |*`CUDNN_REDUCE_TENSOR_NORM2`*                                  | 7.5              |*`HIPDNN_REDUCE_TENSOR_NORM2`*                              |
-|            8 |*`CUDNN_REDUCE_TENSOR_MUL_NO_ZEROS`*                           | 8.0              |*`HIPDNN_REDUCE_TENSOR_MUL_NO_ZEROS`*                       |
-| enum         |***`cudnnReduceTensorIndices_t`***                             | 7.5              |***`hipdnnReduceTensorIndices_t`***                         |
-|            0 |*`CUDNN_REDUCE_TENSOR_NO_INDICES`*                             | 7.5              |*`HIPDNN_REDUCE_TENSOR_NO_INDICES`*                         |
-|            1 |*`CUDNN_REDUCE_TENSOR_FLATTENED_INDICES`*                      | 7.5              |*`HIPDNN_REDUCE_TENSOR_FLATTENED_INDICES`*                  |
-| enum         |***`cudnnIndicesType_t`***                                     | 7.5              |***`hipdnnIndicesType_t`***                                 |
-|            0 |*`CUDNN_32BIT_INDICES`*                                        | 7.5              |*`HIPDNN_32BIT_INDICES`*                                    |
-|            1 |*`CUDNN_64BIT_INDICES`*                                        | 7.5              |*`HIPDNN_64BIT_INDICES`*                                    |
-|            2 |*`CUDNN_16BIT_INDICES`*                                        | 7.5              |*`HIPDNN_16BIT_INDICES`*                                    |
-|            3 |*`CUDNN_8BIT_INDICES`*                                         | 7.5              |*`HIPDNN_8BIT_INDICES`*                                     |
-| enum         |***`cudnnConvolutionMode_t`***                                 |                  |***`hipdnnConvolutionMode_t`***                             |
-|            0 |*`CUDNN_CONVOLUTION`*                                          |                  |*`HIPDNN_CONVOLUTION`*                                      |
-|            1 |*`CUDNN_CROSS_CORRELATION`*                                    |                  |*`HIPDNN_CROSS_CORRELATION`*                                |
-| enum         |***`cudnnConvolutionFwdPreference_t`***                        |                  |***`hipdnnConvolutionFwdPreference_t`***                    |
-|            0 |*`CUDNN_CONVOLUTION_FWD_NO_WORKSPACE`*                         |                  |*`HIPDNN_CONVOLUTION_FWD_NO_WORKSPACE`*                     |
-|            1 |*`CUDNN_CONVOLUTION_FWD_PREFER_FASTEST`*                       |                  |*`HIPDNN_CONVOLUTION_FWD_PREFER_FASTEST`*                   |
-|            2 |*`CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT`*              |                  |*`HIPDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT`*          |
-| enum         |***`cudnnConvolutionFwdAlgo_t`***                              |                  |***`hipdnnConvolutionFwdAlgo_t`***                          |
-|            0 |*`CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM`*                   |                  |*`HIPDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM`*               |
-|            1 |*`CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM`*           |                  |*`HIPDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM`*       |
-|            2 |*`CUDNN_CONVOLUTION_FWD_ALGO_GEMM`*                            |                  |*`HIPDNN_CONVOLUTION_FWD_ALGO_GEMM`*                        |
-|            3 |*`CUDNN_CONVOLUTION_FWD_ALGO_DIRECT`*                          |                  |*`HIPDNN_CONVOLUTION_FWD_ALGO_DIRECT`*                      |
-|            4 |*`CUDNN_CONVOLUTION_FWD_ALGO_FFT`*                             |                  |*`HIPDNN_CONVOLUTION_FWD_ALGO_FFT`*                         |
-|            5 |*`CUDNN_CONVOLUTION_FWD_ALGO_FFT_TILING`*                      |                  |*`HIPDNN_CONVOLUTION_FWD_ALGO_FFT_TILING`*                  |
-|            6 |*`CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD`*                        | 7.5              |*`HIPDNN_CONVOLUTION_FWD_ALGO_WINOGRAD`*                    |
-|            7 |*`CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED`*               | 7.5              |*`HIPDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED`*           |
-|            8 |*`CUDNN_CONVOLUTION_FWD_ALGO_COUNT`*                           | 7.5              |*`HIPDNN_CONVOLUTION_FWD_ALGO_COUNT`*                       |
-| struct       |`cudnnConvolutionFwdAlgoPerf_t`                                |                  |`hipdnnConvolutionFwdAlgoPerf_t`                            |
-| enum         |***`cudnnConvolutionBwdFilterPreference_t`***                  |                  |***`hipdnnConvolutionBwdFilterPreference_t`***              |
-|            0 |*`CUDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE`*                  |                  |*`HIPDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE`*              |
-|            1 |*`CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST`*                |                  |*`HIPDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST`*            |
-|            2 |*`CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT`*       |                  |*`HIPDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT`*   |
-| enum         |***`cudnnConvolutionBwdFilterAlgo_t`***                        |                  |***`hipdnnConvolutionBwdFilterAlgo_t`***                    |
-|            0 |*`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0`*                        |                  |*`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_0`*                    |
-|            1 |*`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1`*                        |                  |*`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_1`*                    |
-|            2 |*`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_FFT`*                      |                  |*`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_FFT`*                  |
-|            3 |*`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_3`*                        |                  |*`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_3`*                    |
-|            4 |*`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD`*                 | 7.5              |*`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD`*             |
-|            5 |*`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD_NONFUSED`*        | 7.5              |*`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD_NONFUSED`*    |
-|            6 |*`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_FFT_TILING`*               | 7.5              |*`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_FFT_TILING`*           |
-|            7 |*`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_COUNT`*                    | 7.5              |*`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_COUNT`*                |
-| struct       |`cudnnConvolutionBwdDataAlgoPerf_t`                            |                  |`hipdnnConvolutionBwdDataAlgoPerf_t`                        |
-| enum         |***`cudnnSoftmaxAlgorithm_t`***                                |                  |***`hipdnnSoftmaxAlgorithm_t`***                            |
-|            0 |*`CUDNN_SOFTMAX_FAST`*                                         |                  |*`HIPDNN_SOFTMAX_FAST`*                                     |
-|            1 |*`CUDNN_SOFTMAX_ACCURATE`*                                     |                  |*`HIPDNN_SOFTMAX_ACCURATE`*                                 |
-|            2 |*`CUDNN_SOFTMAX_LOG`*                                          |                  |*`HIPDNN_SOFTMAX_LOG`*                                      |
-| enum         |***`cudnnSoftmaxMode_t`***                                     |                  |***`hipdnnSoftmaxMode_t`***                                 |
-|            0 |*`CUDNN_SOFTMAX_MODE_INSTANCE`*                                |                  |*`HIPDNN_SOFTMAX_MODE_INSTANCE`*                            |
-|            1 |*`CUDNN_SOFTMAX_MODE_CHANNEL`*                                 |                  |*`HIPDNN_SOFTMAX_MODE_CHANNEL`*                             |
-| enum         |***`cudnnPoolingMode_t`***                                     |                  |***`hipdnnPoolingMode_t`***                                 |
-|            0 |*`CUDNN_POOLING_MAX`*                                          |                  |*`HIPDNN_POOLING_MAX`*                                      |
-|            1 |*`CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING`*                |                  |*`HIPDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING`*            |
-|            2 |*`CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING`*                |                  |*`HIPDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING`*            |
-|            3 |*`CUDNN_POOLING_MAX_DETERMINISTIC`*                            | 7.5              |*`HIPDNN_POOLING_MAX_DETERMINISTIC`*                        |
-| enum         |***`cudnnActivationMode_t`***                                  |                  |***`hipdnnActivationMode_t`***                              |
-|            0 |*`CUDNN_ACTIVATION_SIGMOID`*                                   |                  |*`HIPDNN_ACTIVATION_SIGMOID`*                               |
-|            1 |*`CUDNN_ACTIVATION_RELU`*                                      |                  |*`HIPDNN_ACTIVATION_RELU`*                                  |
-|            2 |*`CUDNN_ACTIVATION_TANH`*                                      |                  |*`HIPDNN_ACTIVATION_TANH`*                                  |
-|            3 |*`CUDNN_ACTIVATION_CLIPPED_RELU`*                              |                  |*`HIPDNN_ACTIVATION_CLIPPED_RELU`*                          |
-|            4 |*`CUDNN_ACTIVATION_ELU`*                                       | 7.5              |*`HIPDNN_ACTIVATION_ELU`*                                   |
-|            5 |*`CUDNN_ACTIVATION_IDENTITY`*                                  | 8.0              |*`HIPDNN_ACTIVATION_PATHTRU`*                               |
-| define       |`CUDNN_LRN_MIN_N`                                              |                  |                                                            |
-| define       |`CUDNN_LRN_MAX_N`                                              |                  |                                                            |
-| define       |`CUDNN_LRN_MIN_K`                                              |                  |                                                            |
-| define       |`CUDNN_LRN_MIN_BETA`                                           |                  |                                                            |
-| enum         |***`cudnnLRNMode_t`***                                         |                  |***`hipdnnLRNMode_t`***                                     |
-|            0 |*`CUDNN_LRN_CROSS_CHANNEL_DIM1`*                               |                  |*`HIPDNN_LRN_CROSS_CHANNEL`*                                |
-| enum         |***`cudnnDivNormMode_t`***                                     |                  |                                                            |
-|            0 |*`CUDNN_DIVNORM_PRECOMPUTED_MEANS`*                            |                  |                                                            |
-| enum         |***`cudnnBatchNormMode_t`***                                   |                  |***`hipdnnBatchNormMode_t`***                               |
-|            0 |*`CUDNN_BATCHNORM_PER_ACTIVATION`*                             |                  |*`HIPDNN_BATCHNORM_PER_ACTIVATION`*                         |
-|            1 |*`CUDNN_BATCHNORM_SPATIAL`*                                    |                  |*`HIPDNN_BATCHNORM_SPATIAL`*                                |
-|            2 |*`CUDNN_BATCHNORM_SPATIAL_PERSISTENT`*                         | 8.0              |*`HIPDNN_BATCHNORM_SPATIAL_PERSISTENT`*                     |
-| define       |`CUDNN_BN_MIN_EPSILON`                                         |                  |`HIPDNN_BN_MIN_EPSILON`                                     |
-| enum         |***`cudnnSamplerType_t`***                                     | 7.5              |                                                            |
-|            0 |*`CUDNN_SAMPLER_BILINEAR`*                                     | 7.5              |                                                            |
-| struct       |`cudnnDropoutStruct`                                           | 7.5              |                                                            |
-| struct*      |`cudnnDropoutDescriptor_t`                                     | 7.5              |`hipdnnDropoutDescriptor_t`                                 |
-| enum         |***`cudnnRNNMode_t`***                                         | 7.5              |***`hipdnnRNNMode_t`***                                     |
-|            0 |*`CUDNN_RNN_RELU`*                                             | 7.5              |*`HIPDNN_RNN_RELU`*                                         |
-|            1 |*`CUDNN_RNN_TANH`*                                             | 7.5              |*`HIPDNN_RNN_TANH`*                                         |
-|            2 |*`CUDNN_LSTM`*                                                 | 7.5              |*`HIPDNN_LSTM`*                                             |
-|            3 |*`CUDNN_GRU`*                                                  | 7.5              |*`HIPDNN_GRU`*                                              |
-| enum         |***`cudnnRNNBiasMode_t`***                                     | 9.0              |***`hipdnnRNNBiasMode_t`***                                 |
-|            0 |*`CUDNN_RNN_NO_BIAS`*                                          | 9.0              |*`HIPDNN_RNN_NO_BIAS`*                                      |
-|            1 |*`CUDNN_RNN_SINGLE_INP_BIAS`*                                  | 9.0              |*`HIPDNN_RNN_WITH_BIAS`*                                    |
-|            2 |*`CUDNN_RNN_DOUBLE_BIAS`*                                      | 9.0              |*`HIPDNN_RNN_WITH_BIAS`*                                    | 1                         |
-|            3 |*`CUDNN_RNN_SINGLE_REC_BIAS`*                                  | 9.0              |*`HIPDNN_RNN_WITH_BIAS`*                                    | 1                         |
-| enum         |***`cudnnDirectionMode_t`***                                   | 7.5              |***`hipdnnDirectionMode_t`***                               |
-|            0 |*`CUDNN_UNIDIRECTIONAL`*                                       | 7.5              |*`HIPDNN_UNIDIRECTIONAL`*                                   |
-|            1 |*`CUDNN_BIDIRECTIONAL`*                                        | 7.5              |*`HIPDNN_BIDIRECTIONAL`*                                    |
-| enum         |***`cudnnRNNAlgo_t`***                                         | 7.5              |***`hipdnnRNNAlgo_t`***                                     |
-|            0 |*`CUDNN_RNN_ALGO_STANDARD`*                                    | 7.5              |*`HIPDNN_RNN_ALGO_STANDARD`*                                |
-|            1 |*`CUDNN_RNN_ALGO_PERSIST_STATIC`*                              | 7.5              |*`HIPDNN_RNN_ALGO_PERSIST_STATIC`*                          |
-|            2 |*`CUDNN_RNN_ALGO_PERSIST_DYNAMIC`*                             | 7.5              |*`HIPDNN_RNN_ALGO_PERSIST_DYNAMIC`*                         |
-|            3 |*`CUDNN_RNN_ALGO_COUNT`*                                       | 8.0              |                                                            |
-| struct       |`cudnnAlgorithmStruct`                                         | 8.0              |                                                            |
-| struct*      |`cudnnAlgorithmDescriptor_t`                                   | 8.0              |                                                            |
-| struct       |`cudnnAlgorithmPerformanceStruct`                              | 8.0              |                                                            |
-| struct*      |`cudnnAlgorithmPerformance_t`                                  | 8.0              |                                                            |
-| struct       |`cudnnRNNStruct`                                               | 7.5              |                                                            |
-| struct*      |`cudnnRNNDescriptor_t`                                         | 7.5              |`hipdnnRNNDescriptor_t`                                     |
-| struct       |`cudnnPersistentRNNPlan`                                       | 7.5              |                                                            |
-| struct*      |`cudnnPersistentRNNPlan_t`                                     | 7.5              |`hipdnnPersistentRNNPlan_t`                                 |
-| enum         |***`cudnnCTCLossAlgo_t`***                                     | 8.0              |                                                            |
-|            0 |*`CUDNN_CTC_LOSS_ALGO_DETERMINISTIC`*                          | 8.0              |                                                            |
-|            1 |*`CUDNN_CTC_LOSS_ALGO_NON_DETERMINISTIC`*                      | 8.0              |                                                            |
-| struct       |`cudnnAlgorithm_t`                                             | 8.0              |                                                            |
-| enum         |***`cudnnSeverity_t`***                                        | 8.0              |                                                            |
-|            0 |*`CUDNN_SEV_FATAL`*                                            | 8.0              |                                                            |
-|            1 |*`CUDNN_SEV_ERROR`*                                            | 8.0              |                                                            |
-|            2 |*`CUDNN_SEV_WARNING`*                                          | 8.0              |                                                            |
-|            3 |*`CUDNN_SEV_INFO`*                                             | 8.0              |                                                            |
-| define       |`CUDNN_SEV_ERROR_EN`                                           | 8.0              |                                                            |
-| define       |`CUDNN_SEV_WARNING_EN`                                         | 8.0              |                                                            |
-| define       |`CUDNN_SEV_INFO_EN`                                            | 8.0              |                                                            |
-| struct       |`cudnnDebug_t`                                                 | 8.0              |                                                            |
-| struct       |`cudnnCallback_t`                                              | 8.0              |                                                            |
-| enum         |***`cudnnBatchNormOps_t`***                                    | 9.0              |                                                            |
-|            0 |*`CUDNN_BATCHNORM_OPS_BN`*                                     | 9.0              |                                                            |
-|            1 |*`CUDNN_BATCHNORM_OPS_BN_ACTIVATION`*                          | 9.0              |                                                            |
-|            2 |*`CUDNN_BATCHNORM_OPS_BN_ADD_ACTIVATION`*                      | 9.0              |                                                            |
-| enum         |***`cudnnRNNClipMode_t`***                                     | 9.0              |                                                            |
-|            0 |*`CUDNN_RNN_CLIP_NONE`*                                        | 9.0              |                                                            |
-|            1 |*`CUDNN_RNN_CLIP_MINMAX`*                                      | 9.0              |                                                            |
-| struct       |`cudnnRNNDataStruct`                                           | 9.0              |                                                            |
-| struct*      |`cudnnRNNDataDescriptor_t`                                     | 9.0              |                                                            |
-| enum         |***`cudnnRNNDataLayout_t`***                                   | 9.0              |                                                            |
-|            0 |*`CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_UNPACKED`*                   | 9.0              |                                                            |
-|            1 |*`CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_PACKED`*                     | 9.0              |                                                            |
-|            2 |*`CUDNN_RNN_DATA_LAYOUT_BATCH_MAJOR_UNPACKED`*                 | 9.0              |                                                            |
-| enum         |***`cudnnRNNPaddingMode_t`***                                  | 9.0              |                                                            |
-|            0 |*`CUDNN_RNN_PADDED_IO_DISABLED`*                               | 9.0              |                                                            |
-|            1 |*`CUDNN_RNN_PADDED_IO_ENABLED`*                                | 9.0              |                                                            |
-| enum         |***`cudnnSeqDataAxis_t`***                                     | 9.0              |                                                            |
-|            0 |*`CUDNN_SEQDATA_TIME_DIM`*                                     | 9.0              |                                                            |
-|            1 |*`CUDNN_SEQDATA_BATCH_DIM`*                                    | 9.0              |                                                            |
-|            2 |*`CUDNN_SEQDATA_BEAM_DIM`*                                     | 9.0              |                                                            |
-|            3 |*`CUDNN_SEQDATA_VECT_DIM`*                                     | 9.0              |                                                            |
-| define       |`CUDNN_SEQDATA_DIM_COUNT`                                      | 9.0              |                                                            |
-| struct       |`cudnnSeqDataStruct`                                           | 9.0              |                                                            |
-| struct*      |`cudnnSeqDataDescriptor_t`                                     | 9.0              |                                                            |
-| unsigned     |***`cudnnAttnQueryMap_t`***                                    | 9.0              |                                                            |
-|            0 |*`CUDNN_ATTN_QUERYMAP_ALL_TO_ONE`*                             | 9.0              |                                                            |
-|      1U << 0 |*`CUDNN_ATTN_QUERYMAP_ONE_TO_ONE`*                             | 9.0              |                                                            |
-|            1 |*`CUDNN_ATTN_DISABLE_PROJ_BIASES`*                             | 10.1 Update 2    |                                                            |
-|      1U << 1 |*`CUDNN_ATTN_ENABLE_PROJ_BIASES`*                              | 10.1 Update 2    |                                                            |
-| struct       |`cudnnAttnStruct`                                              | 9.0              |                                                            |
-| struct*      |`cudnnAttnDescriptor_t`                                        | 9.0              |                                                            |
-| enum         |***`cudnnMultiHeadAttnWeightKind_t`***                         | 9.0              |                                                            |
-|            0 |*`CUDNN_MH_ATTN_Q_WEIGHTS`*                                    | 9.0              |                                                            |
-|            1 |*`CUDNN_MH_ATTN_K_WEIGHTS`*                                    | 9.0              |                                                            |
-|            2 |*`CUDNN_MH_ATTN_V_WEIGHTS`*                                    | 9.0              |                                                            |
-|            3 |*`CUDNN_MH_ATTN_O_WEIGHTS`*                                    | 9.0              |                                                            |
-|            4 |*`CUDNN_MH_ATTN_Q_BIASES`*                                     | 10.1 Update 2    |                                                            |
-|            5 |*`CUDNN_MH_ATTN_K_BIASES`*                                     | 10.1 Update 2    |                                                            |
-|            6 |*`CUDNN_MH_ATTN_V_BIASES`*                                     | 10.1 Update 2    |                                                            |
-|            7 |*`CUDNN_MH_ATTN_O_BIASES`*                                     | 10.1 Update 2    |                                                            |
-| define     8 |`CUDNN_ATTN_WKIND_COUNT`                                       | 10.1 Update 2    |                                                            |
-| enum         |***`cudnnWgradMode_t`***                                       | 9.0              |                                                            |
-|            0 |*`CUDNN_WGRAD_MODE_ADD`*                                       | 9.0              |                                                            |
-|            1 |*`CUDNN_WGRAD_MODE_SET`*                                       | 9.0              |                                                            |
-| enum         |***`cudnnReorderType_t`***                                     | 10.1             |                                                            |
-|            0 |*`CUDNN_DEFAULT_REORDER`*                                      | 10.1             |                                                            |
-|            1 |*`CUDNN_NO_REORDER`*                                           | 10.1             |                                                            |
-| enum         |***`cudnnLossNormalizationMode_t`***                           | 10.1             |                                                            |
-|            0 |*`CUDNN_LOSS_NORMALIZATION_NONE`*                              | 10.1             |                                                            |
-|            1 |*`CUDNN_LOSS_NORMALIZATION_SOFTMAX`*                           | 10.1             |                                                            |
-| struct       |`cudnnFusedOpsConstParamStruct`                                | 10.1             |                                                            |
-| struct*      |`cudnnFusedOpsConstParamPack_t`                                | 10.1             |                                                            |
-| struct       |`cudnnFusedOpsVariantParamStruct`                              | 10.1             |                                                            |
-| struct*      |`cudnnFusedOpsVariantParamPack_t`                              | 10.1             |                                                            |
-| struct       |`cudnnFusedOpsPlanStruct`                                      | 10.1             |                                                            |
-| struct*      |`cudnnFusedOpsPlan_t`                                          | 10.1             |                                                            |
-| enum         |***`cudnnFusedOps_t`***                                        | 10.1             |                                                            |
-|            0 |*`CUDNN_FUSED_SCALE_BIAS_ACTIVATION_CONV_BNSTATS`*             | 10.1             |                                                            |
-|            1 |*`CUDNN_FUSED_SCALE_BIAS_ACTIVATION_WGRAD`*                    | 10.1             |                                                            |
-|            2 |*`CUDNN_FUSED_BN_FINALIZE_STATISTICS_TRAINING`*                | 10.1             |                                                            |
-|            3 |*`CUDNN_FUSED_BN_FINALIZE_STATISTICS_INFERENCE`*               | 10.1             |                                                            |
-|            4 |*`CUDNN_FUSED_CONV_SCALE_BIAS_ADD_ACTIVATION`*                 | 10.1             |                                                            |
-|            5 |*`CUDNN_FUSED_SCALE_BIAS_ADD_ACTIVATION_GEN_BITMASK`*          | 10.1             |                                                            |
-|            6 |*`CUDNN_FUSED_DACTIVATION_FORK_DBATCHNORM`*                    | 10.1             |                                                            |
-| enum         |***`cudnnFusedOpsConstParamLabel_t`***                         | 10.1             |                                                            |
-|            0 |*`CUDNN_PARAM_XDESC`*                                          | 10.1             |                                                            |
-|            1 |*`CUDNN_PARAM_XDATA_PLACEHOLDER`*                              | 10.1             |                                                            |
-|            2 |*`CUDNN_PARAM_BN_MODE`*                                        | 10.1             |                                                            |
-|            3 |*`CUDNN_PARAM_BN_EQSCALEBIAS_DESC`*                            | 10.1             |                                                            |
-|            4 |*`CUDNN_PARAM_BN_EQSCALE_PLACEHOLDER`*                         | 10.1             |                                                            |
-|            5 |*`CUDNN_PARAM_BN_EQBIAS_PLACEHOLDER`*                          | 10.1             |                                                            |
-|            6 |*`CUDNN_PARAM_ACTIVATION_DESC`*                                | 10.1             |                                                            |
-|            7 |*`CUDNN_PARAM_CONV_DESC`*                                      | 10.1             |                                                            |
-|            8 |*`CUDNN_PARAM_WDESC`*                                          | 10.1             |                                                            |
-|            9 |*`CUDNN_PARAM_WDATA_PLACEHOLDER`*                              | 10.1             |                                                            |
-|           10 |*`CUDNN_PARAM_DWDESC`*                                         | 10.1             |                                                            |
-|           11 |*`CUDNN_PARAM_DWDATA_PLACEHOLDER`*                             | 10.1             |                                                            |
-|           12 |*`CUDNN_PARAM_YDESC`*                                          | 10.1             |                                                            |
-|           13 |*`CUDNN_PARAM_YDATA_PLACEHOLDER`*                              | 10.1             |                                                            |
-|           14 |*`CUDNN_PARAM_DYDESC`*                                         | 10.1             |                                                            |
-|           15 |*`CUDNN_PARAM_DYDATA_PLACEHOLDER`*                             | 10.1             |                                                            |
-|           16 |*`CUDNN_PARAM_YSTATS_DESC`*                                    | 10.1             |                                                            |
-|           17 |*`CUDNN_PARAM_YSUM_PLACEHOLDER`*                               | 10.1             |                                                            |
-|           18 |*`CUDNN_PARAM_YSQSUM_PLACEHOLDER`*                             | 10.1             |                                                            |
-|           19 |*`CUDNN_PARAM_BN_SCALEBIAS_MEANVAR_DESC`*                      | 10.1             |                                                            |
-|           20 |*`CUDNN_PARAM_BN_SCALE_PLACEHOLDER`*                           | 10.1             |                                                            |
-|           21 |*`CUDNN_PARAM_BN_BIAS_PLACEHOLDER`*                            | 10.1             |                                                            |
-|           22 |*`CUDNN_PARAM_BN_SAVED_MEAN_PLACEHOLDER`*                      | 10.1             |                                                            |
-|           23 |*`CUDNN_PARAM_BN_SAVED_INVSTD_PLACEHOLDER`*                    | 10.1             |                                                            |
-|           24 |*`CUDNN_PARAM_BN_RUNNING_MEAN_PLACEHOLDER`*                    | 10.1             |                                                            |
-|           25 |*`CUDNN_PARAM_BN_RUNNING_VAR_PLACEHOLDER`*                     | 10.1             |                                                            |
-|           26 |*`CUDNN_PARAM_ZDESC`*                                          | 10.1             |                                                            |
-|           27 |*`CUDNN_PARAM_ZDATA_PLACEHOLDER`*                              | 10.1             |                                                            |
-|           28 |*`CUDNN_PARAM_BN_Z_EQSCALEBIAS_DESC`*                          | 10.1             |                                                            |
-|           29 |*`CUDNN_PARAM_BN_Z_EQSCALE_PLACEHOLDER`*                       | 10.1             |                                                            |
-|           30 |*`CUDNN_PARAM_BN_Z_EQBIAS_PLACEHOLDER`*                        | 10.1             |                                                            |
-|           31 |*`CUDNN_PARAM_ACTIVATION_BITMASK_DESC`*                        | 10.1             |                                                            |
-|           32 |*`CUDNN_PARAM_ACTIVATION_BITMASK_PLACEHOLDER`*                 | 10.1             |                                                            |
-|           33 |*`CUDNN_PARAM_DXDESC`*                                         | 10.1             |                                                            |
-|           34 |*`CUDNN_PARAM_DXDATA_PLACEHOLDER`*                             | 10.1             |                                                            |
-|           35 |*`CUDNN_PARAM_DZDESC`*                                         | 10.1             |                                                            |
-|           36 |*`CUDNN_PARAM_DZDATA_PLACEHOLDER`*                             | 10.1             |                                                            |
-|           37 |*`CUDNN_PARAM_BN_DSCALE_PLACEHOLDER`*                          | 10.1             |                                                            |
-|           38 |*`CUDNN_PARAM_BN_DBIAS_PLACEHOLDER`*                           | 10.1             |                                                            |
-| enum         |***`cudnnFusedOpsPointerPlaceHolder_t`***                      | 10.1             |                                                            |
-|            0 |*`CUDNN_PTR_NULL`*                                             | 10.1             |                                                            |
-|            1 |*`CUDNN_PTR_ELEM_ALIGNED`*                                     | 10.1             |                                                            |
-|            2 |*`CUDNN_PTR_16B_ALIGNED`*                                      | 10.1             |                                                            |
-| enum         |***`cudnnFusedOpsVariantParamLabel_t`***                       | 10.1             |                                                            |
-|            0 |*`CUDNN_PTR_XDATA`*                                            | 10.1             |                                                            |
-|            1 |*`CUDNN_PTR_BN_EQSCALE`*                                       | 10.1             |                                                            |
-|            2 |*`CUDNN_PTR_BN_EQBIAS`*                                        | 10.1             |                                                            |
-|            3 |*`CUDNN_PTR_WDATA`*                                            | 10.1             |                                                            |
-|            4 |*`CUDNN_PTR_DWDATA`*                                           | 10.1             |                                                            |
-|            5 |*`CUDNN_PTR_YDATA`*                                            | 10.1             |                                                            |
-|            6 |*`CUDNN_PTR_DYDATA`*                                           | 10.1             |                                                            |
-|            7 |*`CUDNN_PTR_YSUM`*                                             | 10.1             |                                                            |
-|            8 |*`CUDNN_PTR_YSQSUM`*                                           | 10.1             |                                                            |
-|            9 |*`CUDNN_PTR_WORKSPACE`*                                        | 10.1             |                                                            |
-|           10 |*`CUDNN_PTR_BN_SCALE`*                                         | 10.1             |                                                            |
-|           11 |*`CUDNN_PTR_BN_BIAS`*                                          | 10.1             |                                                            |
-|           12 |*`CUDNN_PTR_BN_SAVED_MEAN`*                                    | 10.1             |                                                            |
-|           13 |*`CUDNN_PTR_BN_SAVED_INVSTD`*                                  | 10.1             |                                                            |
-|           14 |*`CUDNN_PTR_BN_RUNNING_MEAN`*                                  | 10.1             |                                                            |
-|           15 |*`CUDNN_PTR_BN_RUNNING_VAR`*                                   | 10.1             |                                                            |
-|           16 |*`CUDNN_PTR_ZDATA`*                                            | 10.1             |                                                            |
-|           17 |*`CUDNN_PTR_BN_Z_EQSCALE`*                                     | 10.1             |                                                            |
-|           18 |*`CUDNN_PTR_BN_Z_EQBIAS`*                                      | 10.1             |                                                            |
-|           19 |*`CUDNN_PTR_ACTIVATION_BITMASK`*                               | 10.1             |                                                            |
-|           20 |*`CUDNN_PTR_DXDATA`*                                           | 10.1             |                                                            |
-|           21 |*`CUDNN_PTR_DZDATA`*                                           | 10.1             |                                                            |
-|           22 |*`CUDNN_PTR_BN_DSCALE`*                                        | 10.1             |                                                            |
-|           23 |*`CUDNN_PTR_BN_DBIAS`*                                         | 10.1             |                                                            |
-|          100 |*`CUDNN_SCALAR_SIZE_T_WORKSPACE_SIZE_IN_BYTES`*                | 10.1             |                                                            |
-|          101 |*`CUDNN_SCALAR_INT64_T_BN_ACCUMULATION_COUNT`*                 | 10.1             |                                                            |
-|          102 |*`CUDNN_SCALAR_DOUBLE_BN_EXP_AVG_FACTOR`*                      | 10.1             |                                                            |
-|          103 |*`CUDNN_SCALAR_DOUBLE_BN_EPSILON`*                             | 10.1             |                                                            |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`CUDNN_16BIT_INDICES`|  |  |  |`HIPDNN_16BIT_INDICES`|
+|`CUDNN_32BIT_INDICES`|  |  |  |`HIPDNN_32BIT_INDICES`|
+|`CUDNN_64BIT_INDICES`|  |  |  |`HIPDNN_64BIT_INDICES`|
+|`CUDNN_8BIT_INDICES`|  |  |  |`HIPDNN_8BIT_INDICES`|
+|`CUDNN_ACTIVATION_CLIPPED_RELU`|  |  |  |`HIPDNN_ACTIVATION_CLIPPED_RELU`|
+|`CUDNN_ACTIVATION_ELU`|  |  |  |`HIPDNN_ACTIVATION_ELU`|
+|`CUDNN_ACTIVATION_IDENTITY`|  |  |  |`HIPDNN_ACTIVATION_PATHTRU`|
+|`CUDNN_ACTIVATION_RELU`|  |  |  |`HIPDNN_ACTIVATION_RELU`|
+|`CUDNN_ACTIVATION_SIGMOID`|  |  |  |`HIPDNN_ACTIVATION_SIGMOID`|
+|`CUDNN_ACTIVATION_TANH`|  |  |  |`HIPDNN_ACTIVATION_TANH`|
+|`CUDNN_ATTN_DISABLE_PROJ_BIASES`|  |  |  ||
+|`CUDNN_ATTN_ENABLE_PROJ_BIASES`|  |  |  ||
+|`CUDNN_ATTN_QUERYMAP_ALL_TO_ONE`|  |  |  ||
+|`CUDNN_ATTN_QUERYMAP_ONE_TO_ONE`|  |  |  ||
+|`CUDNN_ATTN_WKIND_COUNT`|  |  |  ||
+|`CUDNN_BATCHNORM_OPS_BN`|  |  |  ||
+|`CUDNN_BATCHNORM_OPS_BN_ACTIVATION`|  |  |  ||
+|`CUDNN_BATCHNORM_OPS_BN_ADD_ACTIVATION`|  |  |  ||
+|`CUDNN_BATCHNORM_PER_ACTIVATION`|  |  |  |`HIPDNN_BATCHNORM_PER_ACTIVATION`|
+|`CUDNN_BATCHNORM_SPATIAL`|  |  |  |`HIPDNN_BATCHNORM_SPATIAL`|
+|`CUDNN_BATCHNORM_SPATIAL_PERSISTENT`|  |  |  |`HIPDNN_BATCHNORM_SPATIAL_PERSISTENT`|
+|`CUDNN_BIDIRECTIONAL`|  |  |  |`HIPDNN_BIDIRECTIONAL`|
+|`CUDNN_BN_MIN_EPSILON`|  |  |  |`HIPDNN_BN_MIN_EPSILON`|
+|`CUDNN_CONVOLUTION`|  |  |  |`HIPDNN_CONVOLUTION`|
+|`CUDNN_CONVOLUTION_BWD_DATA_ALGO_0`|  |  |  |`HIPDNN_CONVOLUTION_BWD_DATA_ALGO_0`|
+|`CUDNN_CONVOLUTION_BWD_DATA_ALGO_1`|  |  |  |`HIPDNN_CONVOLUTION_BWD_DATA_ALGO_1`|
+|`CUDNN_CONVOLUTION_BWD_DATA_ALGO_COUNT`|  |  |  |`HIPDNN_CONVOLUTION_BWD_DATA_ALGO_TRANSPOSE_GEMM`|
+|`CUDNN_CONVOLUTION_BWD_DATA_ALGO_FFT`|  |  |  |`HIPDNN_CONVOLUTION_BWD_DATA_ALGO_FFT`|
+|`CUDNN_CONVOLUTION_BWD_DATA_ALGO_FFT_TILING`|  |  |  |`HIPDNN_CONVOLUTION_BWD_DATA_ALGO_FFT_TILING`|
+|`CUDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD`|  |  |  |`HIPDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD`|
+|`CUDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD_NONFUSED`|  |  |  |`HIPDNN_CONVOLUTION_BWD_DATA_ALGO_WINOGRAD_NONFUSED`|
+|`CUDNN_CONVOLUTION_BWD_DATA_NO_WORKSPACE`|  |  |  |`HIPDNN_CONVOLUTION_BWD_DATA_NO_WORKSPACE`|
+|`CUDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST`|  |  |  |`HIPDNN_CONVOLUTION_BWD_DATA_PREFER_FASTEST`|
+|`CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT`|  |  |  |`HIPDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT`|
+|`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0`|  |  |  |`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_0`|
+|`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_1`|  |  |  |`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_1`|
+|`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_3`|  |  |  |`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_3`|
+|`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_COUNT`|  |  |  |`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_COUNT`|
+|`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_FFT`|  |  |  |`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_FFT`|
+|`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_FFT_TILING`|  |  |  |`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_FFT_TILING`|
+|`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD`|  |  |  |`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD`|
+|`CUDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD_NONFUSED`|  |  |  |`HIPDNN_CONVOLUTION_BWD_FILTER_ALGO_WINOGRAD_NONFUSED`|
+|`CUDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE`|  |  |  |`HIPDNN_CONVOLUTION_BWD_FILTER_NO_WORKSPACE`|
+|`CUDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST`|  |  |  |`HIPDNN_CONVOLUTION_BWD_FILTER_PREFER_FASTEST`|
+|`CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT`|  |  |  |`HIPDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT`|
+|`CUDNN_CONVOLUTION_FWD_ALGO_COUNT`|  |  |  |`HIPDNN_CONVOLUTION_FWD_ALGO_COUNT`|
+|`CUDNN_CONVOLUTION_FWD_ALGO_DIRECT`|  |  |  |`HIPDNN_CONVOLUTION_FWD_ALGO_DIRECT`|
+|`CUDNN_CONVOLUTION_FWD_ALGO_FFT`|  |  |  |`HIPDNN_CONVOLUTION_FWD_ALGO_FFT`|
+|`CUDNN_CONVOLUTION_FWD_ALGO_FFT_TILING`|  |  |  |`HIPDNN_CONVOLUTION_FWD_ALGO_FFT_TILING`|
+|`CUDNN_CONVOLUTION_FWD_ALGO_GEMM`|  |  |  |`HIPDNN_CONVOLUTION_FWD_ALGO_GEMM`|
+|`CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM`|  |  |  |`HIPDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM`|
+|`CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM`|  |  |  |`HIPDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM`|
+|`CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD`|  |  |  |`HIPDNN_CONVOLUTION_FWD_ALGO_WINOGRAD`|
+|`CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED`|  |  |  |`HIPDNN_CONVOLUTION_FWD_ALGO_WINOGRAD_NONFUSED`|
+|`CUDNN_CONVOLUTION_FWD_NO_WORKSPACE`|  |  |  |`HIPDNN_CONVOLUTION_FWD_NO_WORKSPACE`|
+|`CUDNN_CONVOLUTION_FWD_PREFER_FASTEST`|  |  |  |`HIPDNN_CONVOLUTION_FWD_PREFER_FASTEST`|
+|`CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT`|  |  |  |`HIPDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT`|
+|`CUDNN_CROSS_CORRELATION`|  |  |  |`HIPDNN_CROSS_CORRELATION`|
+|`CUDNN_CTC_LOSS_ALGO_DETERMINISTIC`|  |  |  ||
+|`CUDNN_CTC_LOSS_ALGO_NON_DETERMINISTIC`|  |  |  ||
+|`CUDNN_DATA_DOUBLE`|  |  |  |`HIPDNN_DATA_DOUBLE`|
+|`CUDNN_DATA_FLOAT`|  |  |  |`HIPDNN_DATA_FLOAT`|
+|`CUDNN_DATA_HALF`|  |  |  |`HIPDNN_DATA_HALF`|
+|`CUDNN_DATA_INT32`|  |  |  |`HIPDNN_DATA_INT32`|
+|`CUDNN_DATA_INT8`|  |  |  |`HIPDNN_DATA_INT8`|
+|`CUDNN_DATA_INT8x32`|  |  |  ||
+|`CUDNN_DATA_INT8x4`|  |  |  |`HIPDNN_DATA_INT8x4`|
+|`CUDNN_DATA_UINT8`|  |  |  ||
+|`CUDNN_DATA_UINT8x4`|  |  |  ||
+|`CUDNN_DEFAULT_MATH`|  |  |  |`HIPDNN_DEFAULT_MATH`|
+|`CUDNN_DEFAULT_REORDER`|  |  |  ||
+|`CUDNN_DETERMINISTIC`|  |  |  ||
+|`CUDNN_DIM_MAX`|  |  |  ||
+|`CUDNN_DIVNORM_PRECOMPUTED_MEANS`|  |  |  ||
+|`CUDNN_ERRQUERY_BLOCKING`|  |  |  ||
+|`CUDNN_ERRQUERY_NONBLOCKING`|  |  |  ||
+|`CUDNN_ERRQUERY_RAWCODE`|  |  |  ||
+|`CUDNN_FUSED_BN_FINALIZE_STATISTICS_INFERENCE`|  |  |  ||
+|`CUDNN_FUSED_BN_FINALIZE_STATISTICS_TRAINING`|  |  |  ||
+|`CUDNN_FUSED_CONV_SCALE_BIAS_ADD_ACTIVATION`|  |  |  ||
+|`CUDNN_FUSED_DACTIVATION_FORK_DBATCHNORM`|  |  |  ||
+|`CUDNN_FUSED_SCALE_BIAS_ACTIVATION_CONV_BNSTATS`|  |  |  ||
+|`CUDNN_FUSED_SCALE_BIAS_ACTIVATION_WGRAD`|  |  |  ||
+|`CUDNN_FUSED_SCALE_BIAS_ADD_ACTIVATION_GEN_BITMASK`|  |  |  ||
+|`CUDNN_GRU`|  |  |  |`HIPDNN_GRU`|
+|`CUDNN_LINEAR_INPUT`|  |  |  |`HIPDNN_LINEAR_INPUT`|
+|`CUDNN_LOSS_NORMALIZATION_NONE`|  |  |  ||
+|`CUDNN_LOSS_NORMALIZATION_SOFTMAX`|  |  |  ||
+|`CUDNN_LRN_CROSS_CHANNEL_DIM1`|  |  |  |`HIPDNN_LRN_CROSS_CHANNEL`|
+|`CUDNN_LRN_MAX_N`|  |  |  ||
+|`CUDNN_LRN_MIN_BETA`|  |  |  ||
+|`CUDNN_LRN_MIN_K`|  |  |  ||
+|`CUDNN_LRN_MIN_N`|  |  |  ||
+|`CUDNN_LSTM`|  |  |  |`HIPDNN_LSTM`|
+|`CUDNN_MH_ATTN_K_BIASES`|  |  |  ||
+|`CUDNN_MH_ATTN_K_WEIGHTS`|  |  |  ||
+|`CUDNN_MH_ATTN_O_BIASES`|  |  |  ||
+|`CUDNN_MH_ATTN_O_WEIGHTS`|  |  |  ||
+|`CUDNN_MH_ATTN_Q_BIASES`|  |  |  ||
+|`CUDNN_MH_ATTN_Q_WEIGHTS`|  |  |  ||
+|`CUDNN_MH_ATTN_V_BIASES`|  |  |  ||
+|`CUDNN_MH_ATTN_V_WEIGHTS`|  |  |  ||
+|`CUDNN_NON_DETERMINISTIC`|  |  |  ||
+|`CUDNN_NOT_PROPAGATE_NAN`|  |  |  |`HIPDNN_NOT_PROPAGATE_NAN`|
+|`CUDNN_NO_REORDER`|  |  |  ||
+|`CUDNN_OP_TENSOR_ADD`|  |  |  |`HIPDNN_OP_TENSOR_ADD`|
+|`CUDNN_OP_TENSOR_MAX`|  |  |  |`HIPDNN_OP_TENSOR_MAX`|
+|`CUDNN_OP_TENSOR_MIN`|  |  |  |`HIPDNN_OP_TENSOR_MIN`|
+|`CUDNN_OP_TENSOR_MUL`|  |  |  |`HIPDNN_OP_TENSOR_MUL`|
+|`CUDNN_OP_TENSOR_NOT`|  |  |  ||
+|`CUDNN_OP_TENSOR_SQRT`|  |  |  |`HIPDNN_OP_TENSOR_SQRT`|
+|`CUDNN_PARAM_ACTIVATION_BITMASK_DESC`|  |  |  ||
+|`CUDNN_PARAM_ACTIVATION_BITMASK_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_ACTIVATION_DESC`|  |  |  ||
+|`CUDNN_PARAM_BN_BIAS_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_BN_DBIAS_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_BN_DSCALE_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_BN_EQBIAS_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_BN_EQSCALEBIAS_DESC`|  |  |  ||
+|`CUDNN_PARAM_BN_EQSCALE_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_BN_MODE`|  |  |  ||
+|`CUDNN_PARAM_BN_RUNNING_MEAN_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_BN_RUNNING_VAR_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_BN_SAVED_INVSTD_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_BN_SAVED_MEAN_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_BN_SCALEBIAS_MEANVAR_DESC`|  |  |  ||
+|`CUDNN_PARAM_BN_SCALE_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_BN_Z_EQBIAS_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_BN_Z_EQSCALEBIAS_DESC`|  |  |  ||
+|`CUDNN_PARAM_BN_Z_EQSCALE_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_CONV_DESC`|  |  |  ||
+|`CUDNN_PARAM_DWDATA_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_DWDESC`|  |  |  ||
+|`CUDNN_PARAM_DXDATA_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_DXDESC`|  |  |  ||
+|`CUDNN_PARAM_DYDATA_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_DYDESC`|  |  |  ||
+|`CUDNN_PARAM_DZDATA_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_DZDESC`|  |  |  ||
+|`CUDNN_PARAM_WDATA_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_WDESC`|  |  |  ||
+|`CUDNN_PARAM_XDATA_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_XDESC`|  |  |  ||
+|`CUDNN_PARAM_YDATA_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_YDESC`|  |  |  ||
+|`CUDNN_PARAM_YSQSUM_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_YSTATS_DESC`|  |  |  ||
+|`CUDNN_PARAM_YSUM_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_ZDATA_PLACEHOLDER`|  |  |  ||
+|`CUDNN_PARAM_ZDESC`|  |  |  ||
+|`CUDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING`|  |  |  |`HIPDNN_POOLING_AVERAGE_COUNT_EXCLUDE_PADDING`|
+|`CUDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING`|  |  |  |`HIPDNN_POOLING_AVERAGE_COUNT_INCLUDE_PADDING`|
+|`CUDNN_POOLING_MAX`|  |  |  |`HIPDNN_POOLING_MAX`|
+|`CUDNN_POOLING_MAX_DETERMINISTIC`|  |  |  |`HIPDNN_POOLING_MAX_DETERMINISTIC`|
+|`CUDNN_PROPAGATE_NAN`|  |  |  |`HIPDNN_PROPAGATE_NAN`|
+|`CUDNN_PTR_16B_ALIGNED`|  |  |  ||
+|`CUDNN_PTR_ACTIVATION_BITMASK`|  |  |  ||
+|`CUDNN_PTR_BN_BIAS`|  |  |  ||
+|`CUDNN_PTR_BN_DBIAS`|  |  |  ||
+|`CUDNN_PTR_BN_DSCALE`|  |  |  ||
+|`CUDNN_PTR_BN_EQBIAS`|  |  |  ||
+|`CUDNN_PTR_BN_EQSCALE`|  |  |  ||
+|`CUDNN_PTR_BN_RUNNING_MEAN`|  |  |  ||
+|`CUDNN_PTR_BN_RUNNING_VAR`|  |  |  ||
+|`CUDNN_PTR_BN_SAVED_INVSTD`|  |  |  ||
+|`CUDNN_PTR_BN_SAVED_MEAN`|  |  |  ||
+|`CUDNN_PTR_BN_SCALE`|  |  |  ||
+|`CUDNN_PTR_BN_Z_EQBIAS`|  |  |  ||
+|`CUDNN_PTR_BN_Z_EQSCALE`|  |  |  ||
+|`CUDNN_PTR_DWDATA`|  |  |  ||
+|`CUDNN_PTR_DXDATA`|  |  |  ||
+|`CUDNN_PTR_DYDATA`|  |  |  ||
+|`CUDNN_PTR_DZDATA`|  |  |  ||
+|`CUDNN_PTR_ELEM_ALIGNED`|  |  |  ||
+|`CUDNN_PTR_NULL`|  |  |  ||
+|`CUDNN_PTR_WDATA`|  |  |  ||
+|`CUDNN_PTR_WORKSPACE`|  |  |  ||
+|`CUDNN_PTR_XDATA`|  |  |  ||
+|`CUDNN_PTR_YDATA`|  |  |  ||
+|`CUDNN_PTR_YSQSUM`|  |  |  ||
+|`CUDNN_PTR_YSUM`|  |  |  ||
+|`CUDNN_PTR_ZDATA`|  |  |  ||
+|`CUDNN_REDUCE_TENSOR_ADD`|  |  |  |`HIPDNN_REDUCE_TENSOR_ADD`|
+|`CUDNN_REDUCE_TENSOR_AMAX`|  |  |  |`HIPDNN_REDUCE_TENSOR_AMAX`|
+|`CUDNN_REDUCE_TENSOR_AVG`|  |  |  |`HIPDNN_REDUCE_TENSOR_AVG`|
+|`CUDNN_REDUCE_TENSOR_FLATTENED_INDICES`|  |  |  |`HIPDNN_REDUCE_TENSOR_FLATTENED_INDICES`|
+|`CUDNN_REDUCE_TENSOR_MAX`|  |  |  |`HIPDNN_REDUCE_TENSOR_MAX`|
+|`CUDNN_REDUCE_TENSOR_MIN`|  |  |  |`HIPDNN_REDUCE_TENSOR_MIN`|
+|`CUDNN_REDUCE_TENSOR_MUL`|  |  |  |`HIPDNN_REDUCE_TENSOR_MUL`|
+|`CUDNN_REDUCE_TENSOR_MUL_NO_ZEROS`|  |  |  |`HIPDNN_REDUCE_TENSOR_MUL_NO_ZEROS`|
+|`CUDNN_REDUCE_TENSOR_NORM1`|  |  |  |`HIPDNN_REDUCE_TENSOR_NORM1`|
+|`CUDNN_REDUCE_TENSOR_NORM2`|  |  |  |`HIPDNN_REDUCE_TENSOR_NORM2`|
+|`CUDNN_REDUCE_TENSOR_NO_INDICES`|  |  |  |`HIPDNN_REDUCE_TENSOR_NO_INDICES`|
+|`CUDNN_RNN_ALGO_COUNT`|  |  |  ||
+|`CUDNN_RNN_ALGO_PERSIST_DYNAMIC`|  |  |  |`HIPDNN_RNN_ALGO_PERSIST_DYNAMIC`|
+|`CUDNN_RNN_ALGO_PERSIST_STATIC`|  |  |  |`HIPDNN_RNN_ALGO_PERSIST_STATIC`|
+|`CUDNN_RNN_ALGO_STANDARD`|  |  |  |`HIPDNN_RNN_ALGO_STANDARD`|
+|`CUDNN_RNN_CLIP_MINMAX`|  |  |  ||
+|`CUDNN_RNN_CLIP_NONE`|  |  |  ||
+|`CUDNN_RNN_DATA_LAYOUT_BATCH_MAJOR_UNPACKED`|  |  |  ||
+|`CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_PACKED`|  |  |  ||
+|`CUDNN_RNN_DATA_LAYOUT_SEQ_MAJOR_UNPACKED`|  |  |  ||
+|`CUDNN_RNN_DOUBLE_BIAS`|  |  |  |`HIPDNN_RNN_WITH_BIAS`|
+|`CUDNN_RNN_NO_BIAS`|  |  |  |`HIPDNN_RNN_NO_BIAS`|
+|`CUDNN_RNN_PADDED_IO_DISABLED`|  |  |  ||
+|`CUDNN_RNN_PADDED_IO_ENABLED`|  |  |  ||
+|`CUDNN_RNN_RELU`|  |  |  |`HIPDNN_RNN_RELU`|
+|`CUDNN_RNN_SINGLE_INP_BIAS`|  |  |  |`HIPDNN_RNN_WITH_BIAS`|
+|`CUDNN_RNN_SINGLE_REC_BIAS`|  |  |  |`HIPDNN_RNN_WITH_BIAS`|
+|`CUDNN_RNN_TANH`|  |  |  |`HIPDNN_RNN_TANH`|
+|`CUDNN_SAMPLER_BILINEAR`|  |  |  ||
+|`CUDNN_SCALAR_DOUBLE_BN_EPSILON`|  |  |  ||
+|`CUDNN_SCALAR_DOUBLE_BN_EXP_AVG_FACTOR`|  |  |  ||
+|`CUDNN_SCALAR_INT64_T_BN_ACCUMULATION_COUNT`|  |  |  ||
+|`CUDNN_SCALAR_SIZE_T_WORKSPACE_SIZE_IN_BYTES`|  |  |  ||
+|`CUDNN_SEQDATA_BATCH_DIM`|  |  |  ||
+|`CUDNN_SEQDATA_BEAM_DIM`|  |  |  ||
+|`CUDNN_SEQDATA_DIM_COUNT`|  |  |  ||
+|`CUDNN_SEQDATA_TIME_DIM`|  |  |  ||
+|`CUDNN_SEQDATA_VECT_DIM`|  |  |  ||
+|`CUDNN_SEV_ERROR`|  |  |  ||
+|`CUDNN_SEV_ERROR_EN`|  |  |  ||
+|`CUDNN_SEV_FATAL`|  |  |  ||
+|`CUDNN_SEV_INFO`|  |  |  ||
+|`CUDNN_SEV_INFO_EN`|  |  |  ||
+|`CUDNN_SEV_WARNING`|  |  |  ||
+|`CUDNN_SEV_WARNING_EN`|  |  |  ||
+|`CUDNN_SKIP_INPUT`|  |  |  |`HIPDNN_SKIP_INPUT`|
+|`CUDNN_SOFTMAX_ACCURATE`|  |  |  |`HIPDNN_SOFTMAX_ACCURATE`|
+|`CUDNN_SOFTMAX_FAST`|  |  |  |`HIPDNN_SOFTMAX_FAST`|
+|`CUDNN_SOFTMAX_LOG`|  |  |  |`HIPDNN_SOFTMAX_LOG`|
+|`CUDNN_SOFTMAX_MODE_CHANNEL`|  |  |  |`HIPDNN_SOFTMAX_MODE_CHANNEL`|
+|`CUDNN_SOFTMAX_MODE_INSTANCE`|  |  |  |`HIPDNN_SOFTMAX_MODE_INSTANCE`|
+|`CUDNN_STATUS_ALLOC_FAILED`|  |  |  |`HIPDNN_STATUS_ALLOC_FAILED`|
+|`CUDNN_STATUS_ARCH_MISMATCH`|  |  |  |`HIPDNN_STATUS_ARCH_MISMATCH`|
+|`CUDNN_STATUS_BAD_PARAM`|  |  |  |`HIPDNN_STATUS_BAD_PARAM`|
+|`CUDNN_STATUS_EXECUTION_FAILED`|  |  |  |`HIPDNN_STATUS_EXECUTION_FAILED`|
+|`CUDNN_STATUS_INTERNAL_ERROR`|  |  |  |`HIPDNN_STATUS_INTERNAL_ERROR`|
+|`CUDNN_STATUS_INVALID_VALUE`|  |  |  |`HIPDNN_STATUS_INVALID_VALUE`|
+|`CUDNN_STATUS_LICENSE_ERROR`|  |  |  |`HIPDNN_STATUS_LICENSE_ERROR`|
+|`CUDNN_STATUS_MAPPING_ERROR`|  |  |  |`HIPDNN_STATUS_MAPPING_ERROR`|
+|`CUDNN_STATUS_NOT_INITIALIZED`|  |  |  |`HIPDNN_STATUS_NOT_INITIALIZED`|
+|`CUDNN_STATUS_NOT_SUPPORTED`|  |  |  |`HIPDNN_STATUS_NOT_SUPPORTED`|
+|`CUDNN_STATUS_RUNTIME_FP_OVERFLOW`|  |  |  ||
+|`CUDNN_STATUS_RUNTIME_IN_PROGRESS`|  |  |  ||
+|`CUDNN_STATUS_RUNTIME_PREREQUISITE_MISSING`|  |  |  |`HIPDNN_STATUS_RUNTIME_PREREQUISITE_MISSING`|
+|`CUDNN_STATUS_SUCCESS`|  |  |  |`HIPDNN_STATUS_SUCCESS`|
+|`CUDNN_TENSOR_NCHW`|  |  |  |`HIPDNN_TENSOR_NCHW`|
+|`CUDNN_TENSOR_NCHW_VECT_C`|  |  |  |`HIPDNN_TENSOR_NCHW_VECT_C`|
+|`CUDNN_TENSOR_NHWC`|  |  |  |`HIPDNN_TENSOR_NHWC`|
+|`CUDNN_TENSOR_OP_MATH`|  |  |  |`HIPDNN_TENSOR_OP_MATH`|
+|`CUDNN_TENSOR_OP_MATH_ALLOW_CONVERSION`|  |  |  ||
+|`CUDNN_TRANSFORM_FOLD`|  |  |  ||
+|`CUDNN_TRANSFORM_UNFOLD`|  |  |  ||
+|`CUDNN_UNIDIRECTIONAL`|  |  |  |`HIPDNN_UNIDIRECTIONAL`|
+|`CUDNN_VERSION`|  |  |  |`HIPDNN_VERSION`|
+|`CUDNN_WGRAD_MODE_ADD`|  |  |  ||
+|`CUDNN_WGRAD_MODE_SET`|  |  |  ||
+|`cudnnActivationDescriptor_t`|  |  |  |`hipdnnActivationDescriptor_t`|
+|`cudnnActivationMode_t`|  |  |  |`hipdnnActivationMode_t`|
+|`cudnnActivationStruct`|  |  |  ||
+|`cudnnAlgorithmDescriptor_t`|  |  |  ||
+|`cudnnAlgorithmPerformanceStruct`|  |  |  ||
+|`cudnnAlgorithmPerformance_t`|  |  |  ||
+|`cudnnAlgorithmStruct`|  |  |  ||
+|`cudnnAlgorithm_t`|  |  |  ||
+|`cudnnAttnDescriptor_t`|  |  |  ||
+|`cudnnAttnQueryMap_t`|  |  |  ||
+|`cudnnAttnStruct`|  |  |  ||
+|`cudnnBatchNormMode_t`|  |  |  |`hipdnnBatchNormMode_t`|
+|`cudnnBatchNormOps_t`|  |  |  ||
+|`cudnnCTCLossAlgo_t`|  |  |  ||
+|`cudnnCTCLossDescriptor_t`|  |  |  ||
+|`cudnnCTCLossStruct`|  |  |  ||
+|`cudnnCallback_t`|  |  |  ||
+|`cudnnContext`|  |  |  ||
+|`cudnnConvolutionBwdDataAlgoPerf_t`|  |  |  |`hipdnnConvolutionBwdDataAlgoPerf_t`|
+|`cudnnConvolutionBwdDataAlgo_t`|  |  |  |`hipdnnConvolutionBwdDataAlgo_t`|
+|`cudnnConvolutionBwdDataPreference_t`|  |  |  |`hipdnnConvolutionBwdDataPreference_t`|
+|`cudnnConvolutionBwdFilterAlgoPerf_t`|  |  |  |`hipdnnConvolutionBwdFilterAlgoPerf_t`|
+|`cudnnConvolutionBwdFilterAlgo_t`|  |  |  |`hipdnnConvolutionBwdFilterAlgo_t`|
+|`cudnnConvolutionBwdFilterPreference_t`|  |  |  |`hipdnnConvolutionBwdFilterPreference_t`|
+|`cudnnConvolutionDescriptor_t`|  |  |  |`hipdnnConvolutionDescriptor_t`|
+|`cudnnConvolutionFwdAlgoPerf_t`|  |  |  |`hipdnnConvolutionFwdAlgoPerf_t`|
+|`cudnnConvolutionFwdAlgo_t`|  |  |  |`hipdnnConvolutionFwdAlgo_t`|
+|`cudnnConvolutionFwdPreference_t`|  |  |  |`hipdnnConvolutionFwdPreference_t`|
+|`cudnnConvolutionMode_t`|  |  |  |`hipdnnConvolutionMode_t`|
+|`cudnnConvolutionStruct`|  |  |  ||
+|`cudnnDataType_t`|  |  |  |`hipdnnDataType_t`|
+|`cudnnDebug_t`|  |  |  ||
+|`cudnnDeterminism_t`|  |  |  ||
+|`cudnnDirectionMode_t`|  |  |  |`hipdnnDirectionMode_t`|
+|`cudnnDivNormMode_t`|  |  |  ||
+|`cudnnDropoutDescriptor_t`|  |  |  |`hipdnnDropoutDescriptor_t`|
+|`cudnnDropoutStruct`|  |  |  ||
+|`cudnnErrQueryMode_t`|  |  |  ||
+|`cudnnFilterDescriptor_t`|  |  |  |`hipdnnFilterDescriptor_t`|
+|`cudnnFilterStruct`|  |  |  ||
+|`cudnnFoldingDirection_t`|  |  |  ||
+|`cudnnFusedOpsConstParamLabel_t`|  |  |  ||
+|`cudnnFusedOpsConstParamPack_t`|  |  |  ||
+|`cudnnFusedOpsConstParamStruct`|  |  |  ||
+|`cudnnFusedOpsPlanStruct`|  |  |  ||
+|`cudnnFusedOpsPlan_t`|  |  |  ||
+|`cudnnFusedOpsPointerPlaceHolder_t`|  |  |  ||
+|`cudnnFusedOpsVariantParamLabel_t`|  |  |  ||
+|`cudnnFusedOpsVariantParamPack_t`|  |  |  ||
+|`cudnnFusedOpsVariantParamStruct`|  |  |  ||
+|`cudnnFusedOps_t`|  |  |  ||
+|`cudnnHandle_t`|  |  |  |`hipdnnHandle_t`|
+|`cudnnIndicesType_t`|  |  |  |`hipdnnIndicesType_t`|
+|`cudnnLRNDescriptor_t`|  |  |  |`hipdnnLRNDescriptor_t`|
+|`cudnnLRNMode_t`|  |  |  |`hipdnnLRNMode_t`|
+|`cudnnLRNStruct`|  |  |  ||
+|`cudnnLossNormalizationMode_t`|  |  |  ||
+|`cudnnMathType_t`|  |  |  |`hipdnnMathType_t`|
+|`cudnnMultiHeadAttnWeightKind_t`|  |  |  ||
+|`cudnnNanPropagation_t`|  |  |  |`hipdnnNanPropagation_t`|
+|`cudnnOpTensorDescriptor_t`|  |  |  |`hipdnnOpTensorDescriptor_t`|
+|`cudnnOpTensorOp_t`|  |  |  |`hipdnnOpTensorOp_t`|
+|`cudnnOpTensorStruct`|  |  |  ||
+|`cudnnPersistentRNNPlan`|  |  |  ||
+|`cudnnPersistentRNNPlan_t`|  |  |  |`hipdnnPersistentRNNPlan_t`|
+|`cudnnPoolingDescriptor_t`|  |  |  |`hipdnnPoolingDescriptor_t`|
+|`cudnnPoolingMode_t`|  |  |  |`hipdnnPoolingMode_t`|
+|`cudnnPoolingStruct`|  |  |  ||
+|`cudnnRNNAlgo_t`|  |  |  |`hipdnnRNNAlgo_t`|
+|`cudnnRNNBiasMode_t`|  |  |  |`hipdnnRNNBiasMode_t`|
+|`cudnnRNNClipMode_t`|  |  |  ||
+|`cudnnRNNDataDescriptor_t`|  |  |  ||
+|`cudnnRNNDataLayout_t`|  |  |  ||
+|`cudnnRNNDataStruct`|  |  |  ||
+|`cudnnRNNDescriptor_t`|  |  |  |`hipdnnRNNDescriptor_t`|
+|`cudnnRNNInputMode_t`|  |  |  |`hipdnnRNNInputMode_t`|
+|`cudnnRNNMode_t`|  |  |  |`hipdnnRNNMode_t`|
+|`cudnnRNNPaddingMode_t`|  |  |  ||
+|`cudnnRNNStruct`|  |  |  ||
+|`cudnnReduceTensorDescriptor_t`|  |  |  |`hipdnnReduceTensorDescriptor_t`|
+|`cudnnReduceTensorIndices_t`|  |  |  |`hipdnnReduceTensorIndices_t`|
+|`cudnnReduceTensorOp_t`|  |  |  |`hipdnnReduceTensorOp_t`|
+|`cudnnReduceTensorStruct`|  |  |  ||
+|`cudnnReorderType_t`|  |  |  ||
+|`cudnnRuntimeTag_t`|  |  |  ||
+|`cudnnSamplerType_t`|  |  |  ||
+|`cudnnSeqDataAxis_t`|  |  |  ||
+|`cudnnSeqDataDescriptor_t`|  |  |  ||
+|`cudnnSeqDataStruct`|  |  |  ||
+|`cudnnSeverity_t`|  |  |  ||
+|`cudnnSoftmaxAlgorithm_t`|  |  |  |`hipdnnSoftmaxAlgorithm_t`|
+|`cudnnSoftmaxMode_t`|  |  |  |`hipdnnSoftmaxMode_t`|
+|`cudnnSpatialTransformerDescriptor_t`|  |  |  ||
+|`cudnnSpatialTransformerStruct`|  |  |  ||
+|`cudnnStatus_t`|  |  |  |`hipdnnStatus_t`|
+|`cudnnTensorDescriptor_t`|  |  |  |`hipdnnTensorDescriptor_t`|
+|`cudnnTensorFormat_t`|  |  |  |`hipdnnTensorFormat_t`|
+|`cudnnTensorStruct`|  |  |  ||
+|`cudnnTensorTransformDescriptor_t`|  |  |  ||
+|`cudnnTensorTransformStruct`|  |  |  ||
+|`cudnnWgradMode_t`|  |  |  ||
 
-## **2. CUDNN API functions**
+## **2. CUNN Functions**
 
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:-----------------|
-|`cudnnGetVersion`                                          |`hipdnnGetVersion`                               |
-|`cudnnGetCudartVersion`                                    |                                                 | 7.5              |
-|`cudnnGetErrorString`                                      |`hipdnnGetErrorString`                           |
-|`cudnnQueryRuntimeError`                                   |                                                 | 8.0              |
-|`cudnnGetProperty`                                         |                                                 | 7.5              |
-|`cudnnCreate`                                              |`hipdnnCreate`                                   |
-|`cudnnDestroy`                                             |`hipdnnDestroy`                                  |
-|`cudnnSetStream`                                           |`hipdnnSetStream`                                |
-|`cudnnGetStream`                                           |`hipdnnGetStream`                                |
-|`cudnnCreateTensorDescriptor`                              |`hipdnnCreateTensorDescriptor`                   |
-|`cudnnSetTensor4dDescriptor`                               |`hipdnnSetTensor4dDescriptor`                    |
-|`cudnnSetTensor4dDescriptorEx`                             |`hipdnnSetTensor4dDescriptorEx`                  |
-|`cudnnGetTensor4dDescriptor`                               |`hipdnnGetTensor4dDescriptor`                    |
-|`cudnnSetTensorNdDescriptor`                               |`hipdnnSetTensorNdDescriptor`                    |
-|`cudnnSetTensorNdDescriptorEx`                             |                                                 | 7.5              |
-|`cudnnGetTensorNdDescriptor`                               |`hipdnnGetTensorNdDescriptor`                    |
-|`cudnnGetTensorSizeInBytes`                                |                                                 | 7.5              |
-|`cudnnDestroyTensorDescriptor`                             |`hipdnnDestroyTensorDescriptor`                  |
-|`cudnnTransformTensor`                                     |                                                 |
-|`cudnnTransformTensorEx`                                   |                                                 | 9.0              |
-|`cudnnInitTransformDest`                                   |                                                 | 9.0              |
-|`cudnnCreateTensorTransformDescriptor`                     |                                                 | 9.0              |
-|`cudnnSetTensorTransformDescriptor`                        |                                                 | 9.0              |
-|`cudnnGetTensorTransformDescriptor`                        |                                                 | 9.0              |
-|`cudnnDestroyTensorTransformDescriptor`                    |                                                 | 9.0              |
-|`cudnnAddTensor`                                           |`hipdnnAddTensor`                                |
-|`cudnnCreateOpTensorDescriptor`                            |`hipdnnCreateOpTensorDescriptor`                 | 7.5              |
-|`cudnnSetOpTensorDescriptor`                               |`hipdnnSetOpTensorDescriptor`                    | 7.5              |
-|`cudnnGetOpTensorDescriptor`                               |`hipdnnGetOpTensorDescriptor`                    | 7.5              |
-|`cudnnDestroyOpTensorDescriptor`                           |`hipdnnDestroyOpTensorDescriptor`                | 7.5              |
-|`cudnnOpTensor`                                            |`hipdnnOpTensor`                                 | 7.5              |
-|`cudnnGetFoldedConvBackwardDataDescriptors`                |                                                 | 10.1             |
-|`cudnnCreateReduceTensorDescriptor`                        |`hipdnnCreateReduceTensorDescriptor`             | 7.5              |
-|`cudnnSetReduceTensorDescriptor`                           |`hipdnnSetReduceTensorDescriptor`                | 7.5              |
-|`cudnnGetReduceTensorDescriptor`                           |`hipdnnGetReduceTensorDescriptor`                | 7.5              |
-|`cudnnDestroyReduceTensorDescriptor`                       |`hipdnnDestroyReduceTensorDescriptor`            | 7.5              |
-|`cudnnGetReductionIndicesSize`                             |                                                 | 7.5              |
-|`cudnnGetReductionWorkspaceSize`                           |`hipdnnGetReductionWorkspaceSize`                | 7.5              |
-|`cudnnReduceTensor`                                        |`hipdnnReduceTensor`                             | 7.5              |
-|`cudnnSetTensor`                                           |`hipdnnSetTensor`                                |
-|`cudnnScaleTensor`                                         |`hipdnnScaleTensor`                              |
-|`cudnnCreateFilterDescriptor`                              |`hipdnnCreateFilterDescriptor`                   |
-|`cudnnSetFilter4dDescriptor`                               |`hipdnnSetFilter4dDescriptor`                    |
-|`cudnnGetFilter4dDescriptor`                               |`hipdnnGetFilter4dDescriptor`                    |
-|`cudnnSetFilterNdDescriptor`                               |`hipdnnSetFilterNdDescriptor`                    |
-|`cudnnGetFilterNdDescriptor`                               |`hipdnnGetFilterNdDescriptor`                    |
-|`cudnnGetFilterSizeInBytes`                                |                                                 | 10.1             |
-|`cudnnTransformFilter`                                     |                                                 | 10.1             |
-|`cudnnDestroyFilterDescriptor`                             |`hipdnnDestroyFilterDescriptor`                  |
-|`cudnnReorderFilterAndBias`                                |                                                 | 10.1             |
-|`cudnnCreateConvolutionDescriptor`                         |`hipdnnCreateConvolutionDescriptor`              |
-|`cudnnSetConvolutionMathType`                              |`hipdnnSetConvolutionMathType`                   | 8.0              |
-|`cudnnGetConvolutionMathType`                              |                                                 | 8.0              |
-|`cudnnSetConvolutionGroupCount`                            |`hipdnnSetConvolutionGroupCount`                 | 8.0              |
-|`cudnnGetConvolutionGroupCount`                            |                                                 | 8.0              |
-|`cudnnSetConvolutionReorderType`                           |                                                 | 10.1             |
-|`cudnnGetConvolutionReorderType`                           |                                                 | 10.1             |
-|`cudnnSetConvolution2dDescriptor`                          |`hipdnnSetConvolution2dDescriptor`               |
-|`cudnnGetConvolution2dDescriptor`                          |`hipdnnGetConvolution2dDescriptor`               |
-|`cudnnGetConvolution2dForwardOutputDim`                    |`hipdnnGetConvolution2dForwardOutputDim`         |
-|`cudnnSetConvolutionNdDescriptor`                          |`hipdnnSetConvolutionNdDescriptor`               |
-|`cudnnGetConvolutionNdDescriptor`                          |                                                 |
-|`cudnnGetConvolutionNdForwardOutputDim`                    |                                                 |
-|`cudnnDestroyConvolutionDescriptor`                        |                                                 |
-|`cudnnGetConvolutionForwardAlgorithmMaxCount`              |                                                 | 8.0              |
-|`cudnnFindConvolutionForwardAlgorithm`                     |`hipdnnFindConvolutionForwardAlgorithm`          |
-|`cudnnFindConvolutionForwardAlgorithmEx`                   |`hipdnnFindConvolutionForwardAlgorithmEx`        | 7.5              |
-|`cudnnGetConvolutionForwardAlgorithm`                      |`hipdnnGetConvolutionForwardAlgorithm`           |
-|`cudnnGetConvolutionForwardAlgorithm_v7`                   |                                                 | 8.0              |
-|`cudnnGetConvolutionForwardWorkspaceSize`                  |`hipdnnGetConvolutionForwardWorkspaceSize`       |
-|`cudnnConvolutionForward`                                  |`hipdnnConvolutionForward`                       |
-|`cudnnConvolutionBiasActivationForward`                    |                                                 | 7.5              |
-|`cudnnConvolutionBackwardBias`                             |`hipdnnConvolutionBackwardBias`                  |
-|`cudnnGetConvolutionBackwardFilterAlgorithmMaxCount`       |                                                 | 8.0              |
-|`cudnnFindConvolutionBackwardFilterAlgorithm`              |`hipdnnFindConvolutionBackwardFilterAlgorithm`   |
-|`cudnnFindConvolutionBackwardFilterAlgorithmEx`            |`hipdnnFindConvolutionBackwardFilterAlgorithmEx` | 7.5              |
-|`cudnnGetConvolutionBackwardFilterAlgorithm`               |`hipdnnGetConvolutionBackwardFilterAlgorithm`    |
-|`cudnnGetConvolutionBackwardFilterAlgorithm_v7`            |                                                 | 8.0              |
-|`cudnnGetConvolutionBackwardFilterWorkspaceSize`           |`hipdnnGetConvolutionBackwardFilterWorkspaceSize`|
-|`cudnnConvolutionBackwardFilter`                           |`hipdnnConvolutionBackwardFilter`                |
-|`cudnnGetConvolutionBackwardDataAlgorithmMaxCount`         |                                                 | 8.0              |
-|`cudnnFindConvolutionBackwardDataAlgorithm`                |`hipdnnFindConvolutionBackwardDataAlgorithm`     |
-|`cudnnFindConvolutionBackwardDataAlgorithmEx`              |`hipdnnFindConvolutionBackwardDataAlgorithmEx`   | 7.5              |
-|`cudnnGetConvolutionBackwardDataAlgorithm`                 |`hipdnnGetConvolutionBackwardDataAlgorithm`      |
-|`cudnnGetConvolutionBackwardDataAlgorithm_v7`              |                                                 | 8.0              |
-|`cudnnGetConvolutionBackwardDataWorkspaceSize`             |`hipdnnGetConvolutionBackwardDataWorkspaceSize`  |
-|`cudnnConvolutionBackwardData`                             |`hipdnnConvolutionBackwardData`                  |
-|`cudnnIm2Col`                                              |                                                 |
-|`cudnnSoftmaxForward`                                      |`hipdnnSoftmaxForward`                           |
-|`cudnnSoftmaxBackward`                                     |`hipdnnSoftmaxBackward`                          |
-|`cudnnCreatePoolingDescriptor`                             |`hipdnnCreatePoolingDescriptor`                  |
-|`cudnnSetPooling2dDescriptor`                              |`hipdnnSetPooling2dDescriptor`                   |
-|`cudnnGetPooling2dDescriptor`                              |`hipdnnGetPooling2dDescriptor`                   |
-|`cudnnSetPoolingNdDescriptor`                              |`hipdnnSetPoolingNdDescriptor`                   |
-|`cudnnGetPoolingNdDescriptor`                              |                                                 |
-|`cudnnGetPoolingNdForwardOutputDim`                        |                                                 |
-|`cudnnGetPooling2dForwardOutputDim`                        |`hipdnnGetPooling2dForwardOutputDim`             |
-|`cudnnDestroyPoolingDescriptor`                            |`hipdnnDestroyPoolingDescriptor`                 |
-|`cudnnPoolingForward`                                      |`hipdnnPoolingForward`                           |
-|`cudnnPoolingBackward`                                     |`hipdnnPoolingBackward`                          |
-|`cudnnCreateActivationDescriptor`                          |`hipdnnCreateActivationDescriptor`               |
-|`cudnnSetActivationDescriptor`                             |`hipdnnSetActivationDescriptor`                  |
-|`cudnnGetActivationDescriptor`                             |`hipdnnGetActivationDescriptor`                  |
-|`cudnnDestroyActivationDescriptor`                         |`hipdnnDestroyActivationDescriptor`              |
-|`cudnnActivationForward`                                   |`hipdnnActivationForward`                        |
-|`cudnnActivationBackward`                                  |`hipdnnActivationBackward`                       |
-|`cudnnCreateLRNDescriptor`                                 |`hipdnnCreateLRNDescriptor`                      |
-|`cudnnSetLRNDescriptor`                                    |`hipdnnSetLRNDescriptor`                         |
-|`cudnnGetLRNDescriptor`                                    |`hipdnnGetLRNDescriptor`                         |
-|`cudnnDestroyLRNDescriptor`                                |`hipdnnDestroyLRNDescriptor`                     |
-|`cudnnLRNCrossChannelForward`                              |`hipdnnLRNCrossChannelForward`                   |
-|`cudnnLRNCrossChannelBackward`                             |`hipdnnLRNCrossChannelBackward`                  |
-|`cudnnDivisiveNormalizationForward`                        |                                                 |
-|`cudnnDivisiveNormalizationBackward`                       |                                                 |
-|`cudnnDeriveBNTensorDescriptor`                            |`hipdnnDeriveBNTensorDescriptor`                 |
-|`cudnnBatchNormalizationForwardTraining`                   |`hipdnnBatchNormalizationForwardTraining`        |
-|`cudnnBatchNormalizationForwardTrainingEx`                 |                                                 | 9.0              |
-|`cudnnBatchNormalizationForwardInference`                  |`hipdnnBatchNormalizationForwardInference`       |
-|`cudnnBatchNormalizationBackward`                          |`hipdnnBatchNormalizationBackward`               |
-|`cudnnBatchNormalizationBackwardEx`                        |                                                 | 9.0              |
-|`cudnnCreateSpatialTransformerDescriptor`                  |                                                 | 7.5              |
-|`cudnnSetSpatialTransformerNdDescriptor`                   |                                                 | 7.5              |
-|`cudnnDestroySpatialTransformerDescriptor`                 |                                                 | 7.5              |
-|`cudnnSpatialTfGridGeneratorForward`                       |                                                 | 7.5              |
-|`cudnnSpatialTfGridGeneratorBackward`                      |                                                 | 7.5              |
-|`cudnnSpatialTfSamplerForward`                             |                                                 | 7.5              |
-|`cudnnSpatialTfSamplerBackward`                            |                                                 | 7.5              |
-|`cudnnCreateDropoutDescriptor`                             |`hipdnnCreateDropoutDescriptor`                  | 7.5              |
-|`cudnnDestroyDropoutDescriptor`                            |`hipdnnDestroyDropoutDescriptor`                 | 7.5              |
-|`cudnnDropoutGetStatesSize`                                |`hipdnnDropoutGetStatesSize`                     | 7.5              |
-|`cudnnDropoutGetReserveSpaceSize`                          |                                                 | 7.5              |
-|`cudnnSetDropoutDescriptor`                                |`hipdnnSetDropoutDescriptor`                     | 7.5              |
-|`cudnnGetDropoutDescriptor`                                |                                                 | 8.0              |
-|`cudnnRestoreDropoutDescriptor`                            |                                                 | 8.0              |
-|`cudnnDropoutForward`                                      |                                                 | 7.5              |
-|`cudnnDropoutBackward`                                     |                                                 | 7.5              |
-|`cudnnCreateRNNDescriptor`                                 |`hipdnnCreateRNNDescriptor`                      | 7.5              |
-|`cudnnDestroyRNNDescriptor`                                |`hipdnnDestroyRNNDescriptor`                     | 7.5              |
-|`cudnnGetRNNForwardInferenceAlgorithmMaxCount`             |                                                 | 8.0              |
-|`cudnnFindRNNForwardInferenceAlgorithmEx`                  |                                                 | 8.0              |
-|`cudnnGetRNNForwardTrainingAlgorithmMaxCount`              |                                                 | 8.0              |
-|`cudnnFindRNNForwardTrainingAlgorithmEx`                   |                                                 | 8.0              |
-|`cudnnGetRNNBackwardDataAlgorithmMaxCount`                 |                                                 | 8.0              |
-|`cudnnFindRNNBackwardDataAlgorithmEx`                      |                                                 | 8.0              |
-|`cudnnGetRNNBackwardWeightsAlgorithmMaxCount`              |                                                 | 8.0              |
-|`cudnnFindRNNBackwardWeightsAlgorithmEx`                   |                                                 | 8.0              |
-|`cudnnCreatePersistentRNNPlan`                             |`hipdnnCreatePersistentRNNPlan`                  | 7.5              |
-|`cudnnSetPersistentRNNPlan`                                |`hipdnnSetPersistentRNNPlan`                     | 7.5              |
-|`cudnnDestroyPersistentRNNPlan`                            |`hipdnnDestroyPersistentRNNPlan`                 | 7.5              |
-|`cudnnSetRNNDescriptor`                                    |`hipdnnSetRNNDescriptor`                         | 7.5              |
-|`cudnnGetRNNDescriptor`                                    |`hipdnnGetRNNDescriptor`                         | 8.0              |
-|`cudnnSetRNNProjectionLayers`                              |                                                 | 8.0              |
-|`cudnnGetRNNProjectionLayers`                              |                                                 | 8.0              |
-|`cudnnSetRNNAlgorithmDescriptor`                           |                                                 | 8.0              |
-|`cudnnSetRNNMatrixMathType`                                |                                                 | 8.0              |
-|`cudnnGetRNNMatrixMathType`                                |                                                 | 8.0              |
-|`cudnnGetRNNWorkspaceSize`                                 |`hipdnnGetRNNWorkspaceSize`                      | 7.5              |
-|`cudnnGetRNNTrainingReserveSize`                           |`hipdnnGetRNNTrainingReserveSize`                | 7.5              |
-|`cudnnGetRNNParamsSize`                                    |`hipdnnGetRNNParamsSize`                         | 7.5              |
-|`cudnnGetRNNLinLayerMatrixParams`                          |`hipdnnGetRNNLinLayerMatrixParams`               | 7.5              |
-|`cudnnGetRNNLinLayerBiasParams`                            |`hipdnnGetRNNLinLayerBiasParams`                 | 7.5              |
-|`cudnnRNNForwardInference`                                 |`hipdnnRNNForwardInference`                      | 7.5              |
-|`cudnnRNNForwardInferenceEx`                               |                                                 | 9.0              |
-|`cudnnRNNForwardTraining`                                  |`hipdnnRNNForwardTraining`                       | 7.5              |
-|`cudnnRNNForwardTrainingEx`                                |                                                 | 9.0              |
-|`cudnnRNNBackwardData`                                     |`hipdnnRNNBackwardData`                          | 7.5              |
-|`cudnnRNNBackwardDataEx`                                   |                                                 | 9.0              |
-|`cudnnRNNBackwardWeights`                                  |`hipdnnRNNBackwardWeights`                       | 7.5              |
-|`cudnnRNNBackwardWeightsEx`                                |                                                 | 9.0              |
-|`cudnnSetRNNPaddingMode`                                   |                                                 | 9.0              |
-|`cudnnGetRNNPaddingMode`                                   |                                                 | 9.0              |
-|`cudnnCreateRNNDataDescriptor`                             |                                                 | 9.0              |
-|`cudnnDestroyRNNDataDescriptor`                            |                                                 | 9.0              |
-|`cudnnSetRNNDataDescriptor`                                |                                                 | 9.0              |
-|`cudnnGetRNNDataDescriptor`                                |                                                 | 9.0              |
-|`cudnnSetRNNBiasMode`                                      |                                                 | 9.0              |
-|`cudnnGetRNNBiasMode`                                      |                                                 | 9.0              |
-|`cudnnCreateCTCLossDescriptor`                             |                                                 | 8.0              |
-|`cudnnSetCTCLossDescriptor`                                |                                                 | 8.0              |
-|`cudnnSetCTCLossDescriptorEx`                              |                                                 | 10.1             |
-|`cudnnGetCTCLossDescriptor`                                |                                                 | 8.0              |
-|`cudnnGetCTCLossDescriptorEx`                              |                                                 | 10.1             |
-|`cudnnDestroyCTCLossDescriptor`                            |                                                 | 8.0              |
-|`cudnnCTCLoss`                                             |                                                 | 8.0              |
-|`cudnnGetCTCLossWorkspaceSize`                             |                                                 | 8.0              |
-|`cudnnCreateAlgorithmDescriptor`                           |                                                 | 8.0              |
-|`cudnnSetAlgorithmDescriptor`                              |                                                 | 8.0              |
-|`cudnnGetAlgorithmDescriptor`                              |                                                 | 8.0              |
-|`cudnnCopyAlgorithmDescriptor`                             |                                                 | 8.0              |
-|`cudnnDestroyAlgorithmDescriptor`                          |                                                 | 8.0              |
-|`cudnnCreateAlgorithmPerformance`                          |                                                 | 8.0              |
-|`cudnnSetAlgorithmPerformance`                             |                                                 | 8.0              |
-|`cudnnGetAlgorithmPerformance`                             |                                                 | 8.0              |
-|`cudnnDestroyAlgorithmPerformance`                         |                                                 | 8.0              |
-|`cudnnGetAlgorithmSpaceSize`                               |                                                 | 8.0              |
-|`cudnnSaveAlgorithm`                                       |                                                 | 8.0              |
-|`cudnnRestoreAlgorithm`                                    |                                                 | 8.0              |
-|`cudnnSetRNNDescriptor_v5`                                 |`hipdnnSetRNNDescriptor_v5`                      | 8.0              |
-|`cudnnSetRNNDescriptor_v6`                                 |`hipdnnSetRNNDescriptor_v6`                      | 7.5              |
-|`cudnnSetCallback`                                         |                                                 | 8.0              |
-|`cudnnGetCallback`                                         |                                                 | 8.0              |
-|`cudnnGetBatchNormalizationForwardTrainingExWorkspaceSize` |                                                 | 9.0              |
-|`cudnnGetBatchNormalizationBackwardExWorkspaceSize`        |                                                 | 9.0              |
-|`cudnnGetBatchNormalizationTrainingExReserveSpaceSize`     |                                                 | 9.0              |
-|`cudnnRNNSetClip`                                          |                                                 | 9.0              |
-|`cudnnRNNGetClip`                                          |                                                 | 9.0              |
-|`cudnnCreateSeqDataDescriptor`                             |                                                 | 9.0              |
-|`cudnnDestroySeqDataDescriptor`                            |                                                 | 9.0              |
-|`cudnnSetSeqDataDescriptor`                                |                                                 | 9.0              |
-|`cudnnGetSeqDataDescriptor`                                |                                                 | 9.0              |
-|`cudnnCreateAttnDescriptor`                                |                                                 | 9.0              |
-|`cudnnDestroyAttnDescriptor`                               |                                                 | 9.0              |
-|`cudnnSetAttnDescriptor`                                   |                                                 | 9.0              |
-|`cudnnGetAttnDescriptor`                                   |                                                 | 9.0              |
-|`cudnnGetMultiHeadAttnBuffers`                             |                                                 | 9.0              |
-|`cudnnGetMultiHeadAttnWeights`                             |                                                 | 9.0              |
-|`cudnnMultiHeadAttnForward`                                |                                                 | 9.0              |
-|`cudnnMultiHeadAttnBackwardData`                           |                                                 | 9.0              |
-|`cudnnMultiHeadAttnBackwardWeights`                        |                                                 | 9.0              |
-|`cudnnCreateFusedOpsConstParamPack`                        |                                                 | 10.1             |
-|`cudnnDestroyFusedOpsConstParamPack`                       |                                                 | 10.1             |
-|`cudnnSetFusedOpsConstParamPackAttribute`                  |                                                 | 10.1             |
-|`cudnnGetFusedOpsConstParamPackAttribute`                  |                                                 | 10.1             |
-|`cudnnCreateFusedOpsVariantParamPack`                      |                                                 | 10.1             |
-|`cudnnDestroyFusedOpsVariantParamPack`                     |                                                 | 10.1             |
-|`cudnnSetFusedOpsVariantParamPackAttribute`                |                                                 | 10.1             |
-|`cudnnGetFusedOpsVariantParamPackAttribute`                |                                                 | 10.1             |
-|`cudnnCreateFusedOpsPlan`                                  |                                                 | 10.1             |
-|`cudnnDestroyFusedOpsPlan`                                 |                                                 | 10.1             |
-|`cudnnMakeFusedOpsPlan`                                    |                                                 | 10.1             |
-|`cudnnFusedOpsExecute`                                     |                                                 | 10.1             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cudnnActivationBackward`|  |  |  |`hipdnnActivationBackward`|
+|`cudnnActivationForward`|  |  |  |`hipdnnActivationForward`|
+|`cudnnAddTensor`|  |  |  |`hipdnnAddTensor`|
+|`cudnnBatchNormalizationBackward`|  |  |  |`hipdnnBatchNormalizationBackward`|
+|`cudnnBatchNormalizationBackwardEx`|  |  |  ||
+|`cudnnBatchNormalizationForwardInference`|  |  |  |`hipdnnBatchNormalizationForwardInference`|
+|`cudnnBatchNormalizationForwardTraining`|  |  |  |`hipdnnBatchNormalizationForwardTraining`|
+|`cudnnBatchNormalizationForwardTrainingEx`|  |  |  ||
+|`cudnnCTCLoss`|  |  |  ||
+|`cudnnConvolutionBackwardBias`|  |  |  |`hipdnnConvolutionBackwardBias`|
+|`cudnnConvolutionBackwardData`|  |  |  |`hipdnnConvolutionBackwardData`|
+|`cudnnConvolutionBackwardFilter`|  |  |  |`hipdnnConvolutionBackwardFilter`|
+|`cudnnConvolutionBiasActivationForward`|  |  |  ||
+|`cudnnConvolutionForward`|  |  |  |`hipdnnConvolutionForward`|
+|`cudnnCopyAlgorithmDescriptor`|  |  |  ||
+|`cudnnCreate`|  |  |  |`hipdnnCreate`|
+|`cudnnCreateActivationDescriptor`|  |  |  |`hipdnnCreateActivationDescriptor`|
+|`cudnnCreateAlgorithmDescriptor`|  |  |  ||
+|`cudnnCreateAlgorithmPerformance`|  |  |  ||
+|`cudnnCreateAttnDescriptor`|  |  |  ||
+|`cudnnCreateCTCLossDescriptor`|  |  |  ||
+|`cudnnCreateConvolutionDescriptor`|  |  |  |`hipdnnCreateConvolutionDescriptor`|
+|`cudnnCreateDropoutDescriptor`|  |  |  |`hipdnnCreateDropoutDescriptor`|
+|`cudnnCreateFilterDescriptor`|  |  |  |`hipdnnCreateFilterDescriptor`|
+|`cudnnCreateFusedOpsConstParamPack`|  |  |  ||
+|`cudnnCreateFusedOpsPlan`|  |  |  ||
+|`cudnnCreateFusedOpsVariantParamPack`|  |  |  ||
+|`cudnnCreateLRNDescriptor`|  |  |  |`hipdnnCreateLRNDescriptor`|
+|`cudnnCreateOpTensorDescriptor`|  |  |  |`hipdnnCreateOpTensorDescriptor`|
+|`cudnnCreatePersistentRNNPlan`|  |  |  |`hipdnnCreatePersistentRNNPlan`|
+|`cudnnCreatePoolingDescriptor`|  |  |  |`hipdnnCreatePoolingDescriptor`|
+|`cudnnCreateRNNDataDescriptor`|  |  |  ||
+|`cudnnCreateRNNDescriptor`|  |  |  |`hipdnnCreateRNNDescriptor`|
+|`cudnnCreateReduceTensorDescriptor`|  |  |  |`hipdnnCreateReduceTensorDescriptor`|
+|`cudnnCreateSeqDataDescriptor`|  |  |  ||
+|`cudnnCreateSpatialTransformerDescriptor`|  |  |  ||
+|`cudnnCreateTensorDescriptor`|  |  |  |`hipdnnCreateTensorDescriptor`|
+|`cudnnCreateTensorTransformDescriptor`|  |  |  ||
+|`cudnnDeriveBNTensorDescriptor`|  |  |  |`hipdnnDeriveBNTensorDescriptor`|
+|`cudnnDestroy`|  |  |  |`hipdnnDestroy`|
+|`cudnnDestroyActivationDescriptor`|  |  |  |`hipdnnDestroyActivationDescriptor`|
+|`cudnnDestroyAlgorithmDescriptor`|  |  |  ||
+|`cudnnDestroyAlgorithmPerformance`|  |  |  ||
+|`cudnnDestroyAttnDescriptor`|  |  |  ||
+|`cudnnDestroyCTCLossDescriptor`|  |  |  ||
+|`cudnnDestroyConvolutionDescriptor`|  |  |  |`hipdnnDestroyConvolutionDescriptor`|
+|`cudnnDestroyDropoutDescriptor`|  |  |  |`hipdnnDestroyDropoutDescriptor`|
+|`cudnnDestroyFilterDescriptor`|  |  |  |`hipdnnDestroyFilterDescriptor`|
+|`cudnnDestroyFusedOpsConstParamPack`|  |  |  ||
+|`cudnnDestroyFusedOpsPlan`|  |  |  ||
+|`cudnnDestroyFusedOpsVariantParamPack`|  |  |  ||
+|`cudnnDestroyLRNDescriptor`|  |  |  |`hipdnnDestroyLRNDescriptor`|
+|`cudnnDestroyOpTensorDescriptor`|  |  |  |`hipdnnDestroyOpTensorDescriptor`|
+|`cudnnDestroyPersistentRNNPlan`|  |  |  |`hipdnnDestroyPersistentRNNPlan`|
+|`cudnnDestroyPoolingDescriptor`|  |  |  |`hipdnnDestroyPoolingDescriptor`|
+|`cudnnDestroyRNNDataDescriptor`|  |  |  ||
+|`cudnnDestroyRNNDescriptor`|  |  |  |`hipdnnDestroyRNNDescriptor`|
+|`cudnnDestroyReduceTensorDescriptor`|  |  |  |`hipdnnDestroyReduceTensorDescriptor`|
+|`cudnnDestroySeqDataDescriptor`|  |  |  ||
+|`cudnnDestroySpatialTransformerDescriptor`|  |  |  ||
+|`cudnnDestroyTensorDescriptor`|  |  |  |`hipdnnDestroyTensorDescriptor`|
+|`cudnnDestroyTensorTransformDescriptor`|  |  |  ||
+|`cudnnDivisiveNormalizationBackward`|  |  |  ||
+|`cudnnDivisiveNormalizationForward`|  |  |  ||
+|`cudnnDropoutBackward`|  |  |  ||
+|`cudnnDropoutForward`|  |  |  ||
+|`cudnnDropoutGetReserveSpaceSize`|  |  |  ||
+|`cudnnDropoutGetStatesSize`|  |  |  |`hipdnnDropoutGetStatesSize`|
+|`cudnnFindConvolutionBackwardDataAlgorithm`|  |  |  |`hipdnnFindConvolutionBackwardDataAlgorithm`|
+|`cudnnFindConvolutionBackwardDataAlgorithmEx`|  |  |  |`hipdnnFindConvolutionBackwardDataAlgorithmEx`|
+|`cudnnFindConvolutionBackwardFilterAlgorithm`|  |  |  |`hipdnnFindConvolutionBackwardFilterAlgorithm`|
+|`cudnnFindConvolutionBackwardFilterAlgorithmEx`|  |  |  |`hipdnnFindConvolutionBackwardFilterAlgorithmEx`|
+|`cudnnFindConvolutionForwardAlgorithm`|  |  |  |`hipdnnFindConvolutionForwardAlgorithm`|
+|`cudnnFindConvolutionForwardAlgorithmEx`|  |  |  |`hipdnnFindConvolutionForwardAlgorithmEx`|
+|`cudnnFindRNNBackwardDataAlgorithmEx`|  |  |  ||
+|`cudnnFindRNNBackwardWeightsAlgorithmEx`|  |  |  ||
+|`cudnnFindRNNForwardInferenceAlgorithmEx`|  |  |  ||
+|`cudnnFindRNNForwardTrainingAlgorithmEx`|  |  |  ||
+|`cudnnFusedOpsExecute`|  |  |  ||
+|`cudnnGetActivationDescriptor`|  |  |  |`hipdnnGetActivationDescriptor`|
+|`cudnnGetAlgorithmDescriptor`|  |  |  ||
+|`cudnnGetAlgorithmPerformance`|  |  |  ||
+|`cudnnGetAlgorithmSpaceSize`|  |  |  ||
+|`cudnnGetAttnDescriptor`|  |  |  ||
+|`cudnnGetBatchNormalizationBackwardExWorkspaceSize`|  |  |  ||
+|`cudnnGetBatchNormalizationForwardTrainingExWorkspaceSize`|  |  |  ||
+|`cudnnGetBatchNormalizationTrainingExReserveSpaceSize`|  |  |  ||
+|`cudnnGetCTCLossDescriptor`|  |  |  ||
+|`cudnnGetCTCLossDescriptorEx`|  |  |  ||
+|`cudnnGetCTCLossWorkspaceSize`|  |  |  ||
+|`cudnnGetCallback`|  |  |  ||
+|`cudnnGetConvolution2dDescriptor`|  |  |  |`hipdnnGetConvolution2dDescriptor`|
+|`cudnnGetConvolution2dForwardOutputDim`|  |  |  |`hipdnnGetConvolution2dForwardOutputDim`|
+|`cudnnGetConvolutionBackwardDataAlgorithm`|  |  |  |`hipdnnGetConvolutionBackwardDataAlgorithm`|
+|`cudnnGetConvolutionBackwardDataAlgorithmMaxCount`|  |  |  ||
+|`cudnnGetConvolutionBackwardDataAlgorithm_v7`|  |  |  ||
+|`cudnnGetConvolutionBackwardDataWorkspaceSize`|  |  |  |`hipdnnGetConvolutionBackwardDataWorkspaceSize`|
+|`cudnnGetConvolutionBackwardFilterAlgorithm`|  |  |  |`hipdnnGetConvolutionBackwardFilterAlgorithm`|
+|`cudnnGetConvolutionBackwardFilterAlgorithmMaxCount`|  |  |  ||
+|`cudnnGetConvolutionBackwardFilterAlgorithm_v7`|  |  |  ||
+|`cudnnGetConvolutionBackwardFilterWorkspaceSize`|  |  |  |`hipdnnGetConvolutionBackwardFilterWorkspaceSize`|
+|`cudnnGetConvolutionForwardAlgorithm`|  |  |  |`hipdnnGetConvolutionForwardAlgorithm`|
+|`cudnnGetConvolutionForwardAlgorithmMaxCount`|  |  |  ||
+|`cudnnGetConvolutionForwardAlgorithm_v7`|  |  |  ||
+|`cudnnGetConvolutionForwardWorkspaceSize`|  |  |  |`hipdnnGetConvolutionForwardWorkspaceSize`|
+|`cudnnGetConvolutionGroupCount`|  |  |  ||
+|`cudnnGetConvolutionMathType`|  |  |  ||
+|`cudnnGetConvolutionNdDescriptor`|  |  |  ||
+|`cudnnGetConvolutionNdForwardOutputDim`|  |  |  ||
+|`cudnnGetConvolutionReorderType`|  |  |  ||
+|`cudnnGetCudartVersion`|  |  |  ||
+|`cudnnGetDropoutDescriptor`|  |  |  ||
+|`cudnnGetErrorString`|  |  |  |`hipdnnGetErrorString`|
+|`cudnnGetFilter4dDescriptor`|  |  |  |`hipdnnGetFilter4dDescriptor`|
+|`cudnnGetFilterNdDescriptor`|  |  |  |`hipdnnGetFilterNdDescriptor`|
+|`cudnnGetFilterSizeInBytes`|  |  |  ||
+|`cudnnGetFoldedConvBackwardDataDescriptors`|  |  |  ||
+|`cudnnGetFusedOpsConstParamPackAttribute`|  |  |  ||
+|`cudnnGetFusedOpsVariantParamPackAttribute`|  |  |  ||
+|`cudnnGetLRNDescriptor`|  |  |  |`hipdnnGetLRNDescriptor`|
+|`cudnnGetMultiHeadAttnBuffers`|  |  |  ||
+|`cudnnGetMultiHeadAttnWeights`|  |  |  ||
+|`cudnnGetOpTensorDescriptor`|  |  |  |`hipdnnGetOpTensorDescriptor`|
+|`cudnnGetPooling2dDescriptor`|  |  |  |`hipdnnGetPooling2dDescriptor`|
+|`cudnnGetPooling2dForwardOutputDim`|  |  |  |`hipdnnGetPooling2dForwardOutputDim`|
+|`cudnnGetPoolingNdDescriptor`|  |  |  ||
+|`cudnnGetPoolingNdForwardOutputDim`|  |  |  ||
+|`cudnnGetProperty`|  |  |  ||
+|`cudnnGetRNNBackwardDataAlgorithmMaxCount`|  |  |  ||
+|`cudnnGetRNNBackwardWeightsAlgorithmMaxCount`|  |  |  ||
+|`cudnnGetRNNBiasMode`|  |  |  ||
+|`cudnnGetRNNDataDescriptor`|  |  |  ||
+|`cudnnGetRNNDescriptor`|  |  |  |`hipdnnGetRNNDescriptor`|
+|`cudnnGetRNNForwardInferenceAlgorithmMaxCount`|  |  |  ||
+|`cudnnGetRNNForwardTrainingAlgorithmMaxCount`|  |  |  ||
+|`cudnnGetRNNLinLayerBiasParams`|  |  |  |`hipdnnGetRNNLinLayerBiasParams`|
+|`cudnnGetRNNLinLayerMatrixParams`|  |  |  |`hipdnnGetRNNLinLayerMatrixParams`|
+|`cudnnGetRNNMatrixMathType`|  |  |  ||
+|`cudnnGetRNNPaddingMode`|  |  |  ||
+|`cudnnGetRNNParamsSize`|  |  |  |`hipdnnGetRNNParamsSize`|
+|`cudnnGetRNNProjectionLayers`|  |  |  ||
+|`cudnnGetRNNTrainingReserveSize`|  |  |  |`hipdnnGetRNNTrainingReserveSize`|
+|`cudnnGetRNNWorkspaceSize`|  |  |  |`hipdnnGetRNNWorkspaceSize`|
+|`cudnnGetReduceTensorDescriptor`|  |  |  |`hipdnnGetReduceTensorDescriptor`|
+|`cudnnGetReductionIndicesSize`|  |  |  ||
+|`cudnnGetReductionWorkspaceSize`|  |  |  |`hipdnnGetReductionWorkspaceSize`|
+|`cudnnGetSeqDataDescriptor`|  |  |  ||
+|`cudnnGetStream`|  |  |  |`hipdnnGetStream`|
+|`cudnnGetTensor4dDescriptor`|  |  |  |`hipdnnGetTensor4dDescriptor`|
+|`cudnnGetTensorNdDescriptor`|  |  |  |`hipdnnGetTensorNdDescriptor`|
+|`cudnnGetTensorSizeInBytes`|  |  |  ||
+|`cudnnGetTensorTransformDescriptor`|  |  |  ||
+|`cudnnGetVersion`|  |  |  |`hipdnnGetVersion`|
+|`cudnnIm2Col`|  |  |  ||
+|`cudnnInitTransformDest`|  |  |  ||
+|`cudnnLRNCrossChannelBackward`|  |  |  |`hipdnnLRNCrossChannelBackward`|
+|`cudnnLRNCrossChannelForward`|  |  |  |`hipdnnLRNCrossChannelForward`|
+|`cudnnMakeFusedOpsPlan`|  |  |  ||
+|`cudnnMultiHeadAttnBackwardData`|  |  |  ||
+|`cudnnMultiHeadAttnBackwardWeights`|  |  |  ||
+|`cudnnMultiHeadAttnForward`|  |  |  ||
+|`cudnnOpTensor`|  |  |  |`hipdnnOpTensor`|
+|`cudnnPoolingBackward`|  |  |  |`hipdnnPoolingBackward`|
+|`cudnnPoolingForward`|  |  |  |`hipdnnPoolingForward`|
+|`cudnnQueryRuntimeError`|  |  |  ||
+|`cudnnRNNBackwardData`|  |  |  |`hipdnnRNNBackwardData`|
+|`cudnnRNNBackwardDataEx`|  |  |  ||
+|`cudnnRNNBackwardWeights`|  |  |  |`hipdnnRNNBackwardWeights`|
+|`cudnnRNNBackwardWeightsEx`|  |  |  ||
+|`cudnnRNNForwardInference`|  |  |  |`hipdnnRNNForwardInference`|
+|`cudnnRNNForwardInferenceEx`|  |  |  ||
+|`cudnnRNNForwardTraining`|  |  |  |`hipdnnRNNForwardTraining`|
+|`cudnnRNNForwardTrainingEx`|  |  |  ||
+|`cudnnRNNGetClip`|  |  |  ||
+|`cudnnRNNSetClip`|  |  |  ||
+|`cudnnReduceTensor`|  |  |  |`hipdnnReduceTensor`|
+|`cudnnReorderFilterAndBias`|  |  |  ||
+|`cudnnRestoreAlgorithm`|  |  |  ||
+|`cudnnRestoreDropoutDescriptor`|  |  |  ||
+|`cudnnSaveAlgorithm`|  |  |  ||
+|`cudnnScaleTensor`|  |  |  |`hipdnnScaleTensor`|
+|`cudnnSetActivationDescriptor`|  |  |  |`hipdnnSetActivationDescriptor`|
+|`cudnnSetAlgorithmDescriptor`|  |  |  ||
+|`cudnnSetAlgorithmPerformance`|  |  |  ||
+|`cudnnSetAttnDescriptor`|  |  |  ||
+|`cudnnSetCTCLossDescriptor`|  |  |  ||
+|`cudnnSetCTCLossDescriptorEx`|  |  |  ||
+|`cudnnSetCallback`|  |  |  ||
+|`cudnnSetConvolution2dDescriptor`|  |  |  |`hipdnnSetConvolution2dDescriptor`|
+|`cudnnSetConvolutionGroupCount`|  |  |  |`hipdnnSetConvolutionGroupCount`|
+|`cudnnSetConvolutionMathType`|  |  |  |`hipdnnSetConvolutionMathType`|
+|`cudnnSetConvolutionNdDescriptor`|  |  |  |`hipdnnSetConvolutionNdDescriptor`|
+|`cudnnSetConvolutionReorderType`|  |  |  ||
+|`cudnnSetDropoutDescriptor`|  |  |  |`hipdnnSetDropoutDescriptor`|
+|`cudnnSetFilter4dDescriptor`|  |  |  |`hipdnnSetFilter4dDescriptor`|
+|`cudnnSetFilterNdDescriptor`|  |  |  |`hipdnnSetFilterNdDescriptor`|
+|`cudnnSetFusedOpsConstParamPackAttribute`|  |  |  ||
+|`cudnnSetFusedOpsVariantParamPackAttribute`|  |  |  ||
+|`cudnnSetLRNDescriptor`|  |  |  |`hipdnnSetLRNDescriptor`|
+|`cudnnSetOpTensorDescriptor`|  |  |  |`hipdnnSetOpTensorDescriptor`|
+|`cudnnSetPersistentRNNPlan`|  |  |  |`hipdnnSetPersistentRNNPlan`|
+|`cudnnSetPooling2dDescriptor`|  |  |  |`hipdnnSetPooling2dDescriptor`|
+|`cudnnSetPoolingNdDescriptor`|  |  |  |`hipdnnSetPoolingNdDescriptor`|
+|`cudnnSetRNNAlgorithmDescriptor`|  |  |  ||
+|`cudnnSetRNNBiasMode`|  |  |  ||
+|`cudnnSetRNNDataDescriptor`|  |  |  ||
+|`cudnnSetRNNDescriptor`|  |  |  |`hipdnnSetRNNDescriptor`|
+|`cudnnSetRNNDescriptor_v5`|  |  |  |`hipdnnSetRNNDescriptor_v5`|
+|`cudnnSetRNNDescriptor_v6`|  |  |  |`hipdnnSetRNNDescriptor_v6`|
+|`cudnnSetRNNMatrixMathType`|  |  |  ||
+|`cudnnSetRNNPaddingMode`|  |  |  ||
+|`cudnnSetRNNProjectionLayers`|  |  |  ||
+|`cudnnSetReduceTensorDescriptor`|  |  |  |`hipdnnSetReduceTensorDescriptor`|
+|`cudnnSetSeqDataDescriptor`|  |  |  ||
+|`cudnnSetSpatialTransformerNdDescriptor`|  |  |  ||
+|`cudnnSetStream`|  |  |  |`hipdnnSetStream`|
+|`cudnnSetTensor`|  |  |  |`hipdnnSetTensor`|
+|`cudnnSetTensor4dDescriptor`|  |  |  |`hipdnnSetTensor4dDescriptor`|
+|`cudnnSetTensor4dDescriptorEx`|  |  |  |`hipdnnSetTensor4dDescriptorEx`|
+|`cudnnSetTensorNdDescriptor`|  |  |  |`hipdnnSetTensorNdDescriptor`|
+|`cudnnSetTensorNdDescriptorEx`|  |  |  ||
+|`cudnnSetTensorTransformDescriptor`|  |  |  ||
+|`cudnnSoftmaxBackward`|  |  |  |`hipdnnSoftmaxBackward`|
+|`cudnnSoftmaxForward`|  |  |  |`hipdnnSoftmaxForward`|
+|`cudnnSpatialTfGridGeneratorBackward`|  |  |  ||
+|`cudnnSpatialTfGridGeneratorForward`|  |  |  ||
+|`cudnnSpatialTfSamplerBackward`|  |  |  ||
+|`cudnnSpatialTfSamplerForward`|  |  |  ||
+|`cudnnTransformFilter`|  |  |  ||
+|`cudnnTransformTensor`|  |  |  ||
+|`cudnnTransformTensorEx`|  |  |  ||
 
-\* CUDA version, in which API has appeared and (optional) last version before abandoning it; no value in case of earlier versions < 7.5.
+
+\* A - Added, D - Deprecated, R - Removed

--- a/docs/markdown/CUFFT_API_supported_by_HIP.md
+++ b/docs/markdown/CUFFT_API_supported_by_HIP.md
@@ -2,80 +2,89 @@
 
 ## **1. CUFFT Data types**
 
-| **type**     |   **CUDA**                                                    |**CUDA version\***|   **HIP**                                                  |**HIP value** (if differs) |
-|-------------:|---------------------------------------------------------------|:----------------:|------------------------------------------------------------|---------------------------|
-| enum         |***`cufftResult_t`***                                          |                  |***`hipfftResult_t`***                                      |
-| enum         |***`cufftResult`***                                            |                  |***`hipfftResult`***                                        |
-|          0x0 |*`CUFFT_SUCCESS`*                                              |                  |*`HIPFFT_SUCCESS`*                                          | 0                         |
-|          0x1 |*`CUFFT_INVALID_PLAN`*                                         |                  |*`HIPFFT_INVALID_PLAN`*                                     | 1                         |
-|          0x2 |*`CUFFT_ALLOC_FAILED`*                                         |                  |*`HIPFFT_ALLOC_FAILED`*                                     | 2                         |
-|          0x3 |*`CUFFT_INVALID_TYPE`*                                         |                  |*`HIPFFT_INVALID_TYPE`*                                     | 3                         |
-|          0x4 |*`CUFFT_INVALID_VALUE`*                                        |                  |*`HIPFFT_INVALID_VALUE`*                                    | 4                         |
-|          0x5 |*`CUFFT_INTERNAL_ERROR`*                                       |                  |*`HIPFFT_INTERNAL_ERROR`*                                   | 5                         |
-|          0x6 |*`CUFFT_EXEC_FAILED`*                                          |                  |*`HIPFFT_EXEC_FAILED`*                                      | 6                         |
-|          0x7 |*`CUFFT_SETUP_FAILED`*                                         |                  |*`HIPFFT_SETUP_FAILED`*                                     | 7                         |
-|          0x8 |*`CUFFT_INVALID_SIZE`*                                         |                  |*`HIPFFT_INVALID_SIZE`*                                     | 8                         |
-|          0x9 |*`CUFFT_UNALIGNED_DATA`*                                       |                  |*`HIPFFT_UNALIGNED_DATA`*                                   | 9                         |
-|          0xA |*`CUFFT_INCOMPLETE_PARAMETER_LIST`*                            |                  |*`HIPFFT_INCOMPLETE_PARAMETER_LIST`*                        | 10                        |
-|          0xB |*`CUFFT_INVALID_DEVICE`*                                       |                  |*`HIPFFT_INVALID_DEVICE`*                                   | 11                        |
-|          0xC |*`CUFFT_PARSE_ERROR`*                                          |                  |*`HIPFFT_PARSE_ERROR`*                                      | 12                        |
-|          0xD |*`CUFFT_NO_WORKSPACE`*                                         |                  |*`HIPFFT_NO_WORKSPACE`*                                     | 13                        |
-|          0xE |*`CUFFT_NOT_IMPLEMENTED`*                                      |                  |*`HIPFFT_NOT_IMPLEMENTED`*                                  | 14                        |
-|          0xF |*`CUFFT_LICENSE_ERROR`*                                        |                  |                                                            |
-|         0x10 |*`CUFFT_NOT_SUPPORTED`*                                        | 8.0              |*`HIPFFT_NOT_SUPPORTED`*                                    | 16                        |
-| float        |***`cufftReal`***                                              |                  |***`hipfftReal`***                                          |
-| double       |***`cufftDoubleReal`***                                        |                  |***`hipfftDoubleReal`***                                    |
-| float2       |***`cufftComplex`***                                           |                  |***`hipfftComplex`***                                       |
-| double2      |***`cufftDoubleComplex`***                                     |                  |***`hipfftDoubleComplex`***                                 |
-| define       |`CUFFT_FORWARD`                                                |                  |`HIPFFT_FORWARD`                                            |
-| define       |`CUFFT_INVERSE`                                                |                  |`HIPFFT_BACKWARD`                                           |
-| enum         |***`cufftType_t`***                                            |                  |***`hipfftType_t`***                                        |
-| enum         |***`cufftType`***                                              |                  |***`hipfftType`***                                          |
-|         0x2a |*`CUFFT_R2C`*                                                  |                  |*`HIPFFT_R2C`*                                              |
-|         0x2c |*`CUFFT_C2R`*                                                  |                  |*`HIPFFT_C2R`*                                              |
-|         0x29 |*`CUFFT_C2C`*                                                  |                  |*`HIPFFT_C2C`*                                              |
-|         0x6a |*`CUFFT_D2Z`*                                                  |                  |*`HIPFFT_D2Z`*                                              |
-|         0x6c |*`CUFFT_Z2D`*                                                  |                  |*`HIPFFT_Z2D`*                                              |
-|         0x69 |*`CUFFT_Z2Z`*                                                  |                  |*`HIPFFT_Z2Z`*                                              |
-| enum         |***`cufftCompatibility_t`***                                   |                  |                                                            |
-| enum         |***`cufftCompatibility`***                                     |                  |                                                            |
-|         0x01 |*`CUFFT_COMPATIBILITY_FFTW_PADDING`*                           |                  |                                                            |
-| define       |`CUFFT_COMPATIBILITY_DEFAULT`                                  |                  |                                                            |
-| int          |***`cufftHandle`***                                            |                  |***`hipfftHandle`***                                        |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`CUFFT_ALLOC_FAILED`|  |  |  |`HIPFFT_ALLOC_FAILED`|
+|`CUFFT_C2C`|  |  |  |`HIPFFT_C2C`|
+|`CUFFT_C2R`|  |  |  |`HIPFFT_C2R`|
+|`CUFFT_COMPATIBILITY_DEFAULT`|  |  |  ||
+|`CUFFT_COMPATIBILITY_FFTW_PADDING`|  |  |  ||
+|`CUFFT_D2Z`|  |  |  |`HIPFFT_D2Z`|
+|`CUFFT_EXEC_FAILED`|  |  |  |`HIPFFT_EXEC_FAILED`|
+|`CUFFT_FORWARD`|  |  |  |`HIPFFT_FORWARD`|
+|`CUFFT_INCOMPLETE_PARAMETER_LIST`|  |  |  |`HIPFFT_INCOMPLETE_PARAMETER_LIST`|
+|`CUFFT_INTERNAL_ERROR`|  |  |  |`HIPFFT_INTERNAL_ERROR`|
+|`CUFFT_INVALID_DEVICE`|  |  |  |`HIPFFT_INVALID_DEVICE`|
+|`CUFFT_INVALID_PLAN`|  |  |  |`HIPFFT_INVALID_PLAN`|
+|`CUFFT_INVALID_SIZE`|  |  |  |`HIPFFT_INVALID_SIZE`|
+|`CUFFT_INVALID_TYPE`|  |  |  |`HIPFFT_INVALID_TYPE`|
+|`CUFFT_INVALID_VALUE`|  |  |  |`HIPFFT_INVALID_VALUE`|
+|`CUFFT_INVERSE`|  |  |  |`HIPFFT_BACKWARD`|
+|`CUFFT_LICENSE_ERROR`|  |  |  ||
+|`CUFFT_NOT_IMPLEMENTED`|  |  |  |`HIPFFT_NOT_IMPLEMENTED`|
+|`CUFFT_NOT_SUPPORTED`| 8.0 |  |  |`HIPFFT_NOT_SUPPORTED`|
+|`CUFFT_NO_WORKSPACE`|  |  |  |`HIPFFT_NO_WORKSPACE`|
+|`CUFFT_PARSE_ERROR`|  |  |  |`HIPFFT_PARSE_ERROR`|
+|`CUFFT_R2C`|  |  |  |`HIPFFT_R2C`|
+|`CUFFT_SETUP_FAILED`|  |  |  |`HIPFFT_SETUP_FAILED`|
+|`CUFFT_SUCCESS`|  |  |  |`HIPFFT_SUCCESS`|
+|`CUFFT_UNALIGNED_DATA`|  |  |  |`HIPFFT_UNALIGNED_DATA`|
+|`CUFFT_VERSION`| 10.2 |  |  ||
+|`CUFFT_VER_BUILD`| 10.2 |  |  ||
+|`CUFFT_VER_MAJOR`| 10.2 |  |  ||
+|`CUFFT_VER_MINOR`| 10.2 |  |  ||
+|`CUFFT_VER_PATCH`| 10.2 |  |  ||
+|`CUFFT_Z2D`|  |  |  |`HIPFFT_Z2D`|
+|`CUFFT_Z2Z`|  |  |  |`HIPFFT_Z2Z`|
+|`MAX_CUFFT_ERROR`|  |  |  ||
+|`cufftCompatibility`|  |  |  ||
+|`cufftCompatibility_t`|  |  |  ||
+|`cufftComplex`|  |  |  |`hipfftComplex`|
+|`cufftDoubleComplex`|  |  |  |`hipfftDoubleComplex`|
+|`cufftDoubleReal`|  |  |  |`hipfftDoubleReal`|
+|`cufftHandle`|  |  |  |`hipfftHandle`|
+|`cufftReal`|  |  |  |`hipfftReal`|
+|`cufftResult`|  |  |  |`hipfftResult`|
+|`cufftResult_t`|  |  |  |`hipfftResult_t`|
+|`cufftType`|  |  |  |`hipfftType`|
+|`cufftType_t`|  |  |  |`hipfftType_t`|
 
 ## **2. CUFFT API functions**
 
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cufftPlan1d`                                              |`hipfftPlan1d`                                   |
-|`cufftPlan2d`                                              |`hipfftPlan2d`                                   |
-|`cufftPlan3d`                                              |`hipfftPlan3d`                                   |
-|`cufftPlanMany`                                            |`hipfftPlanMany`                                 |
-|`cufftMakePlan1d`                                          |`hipfftMakePlan1d`                               |
-|`cufftMakePlan2d`                                          |`hipfftMakePlan2d`                               |
-|`cufftMakePlan3d`                                          |`hipfftMakePlan3d`                               |
-|`cufftMakePlanMany`                                        |`hipfftMakePlanMany`                             |
-|`cufftMakePlanMany64`                                      |`hipfftMakePlanMany64`                           | 7.5              |
-|`cufftGetSizeMany64`                                       |`hipfftGetSizeMany64`                            | 7.5              |
-|`cufftEstimate1d`                                          |`hipfftEstimate1d`                               |
-|`cufftEstimate2d`                                          |`hipfftEstimate2d`                               |
-|`cufftEstimate3d`                                          |`hipfftEstimate3d`                               |
-|`cufftEstimateMany`                                        |`hipfftEstimateMany`                             |
-|`cufftCreate`                                              |`hipfftCreate`                                   |
-|`cufftGetSize1d`                                           |`hipfftGetSize1d`                                |
-|`cufftGetSize2d`                                           |`hipfftGetSize2d`                                |
-|`cufftGetSize3d`                                           |`hipfftGetSize3d`                                |
-|`cufftGetSizeMany`                                         |`hipfftGetSizeMany`                              |
-|`cufftGetSize`                                             |`hipfftGetSize`                                  |
-|`cufftSetWorkArea`                                         |`hipfftSetWorkArea`                              |
-|`cufftSetAutoAllocation`                                   |`hipfftSetAutoAllocation`                        |
-|`cufftExecC2C`                                             |`hipfftExecC2C`                                  |
-|`cufftExecR2C`                                             |`hipfftExecR2C`                                  |
-|`cufftExecC2R`                                             |`hipfftExecC2R`                                  |
-|`cufftExecZ2Z`                                             |`hipfftExecZ2Z`                                  |
-|`cufftExecD2Z`                                             |`hipfftExecD2Z`                                  |
-|`cufftExecZ2D`                                             |`hipfftExecZ2D`                                  |
-|`cufftSetStream`                                           |`hipfftSetStream`                                |
-|`cufftDestroy`                                             |`hipfftDestroy`                                  |
-|`cufftGetVersion`                                          |`hipfftGetVersion`                               |
-|`cufftGetProperty`                                         |                                                 | 8.0              |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cufftCreate`|  |  |  |`hipfftCreate`|
+|`cufftDestroy`|  |  |  |`hipfftDestroy`|
+|`cufftEstimate1d`|  |  |  |`hipfftEstimate1d`|
+|`cufftEstimate2d`|  |  |  |`hipfftEstimate2d`|
+|`cufftEstimate3d`|  |  |  |`hipfftEstimate3d`|
+|`cufftEstimateMany`|  |  |  |`hipfftEstimateMany`|
+|`cufftExecC2C`|  |  |  |`hipfftExecC2C`|
+|`cufftExecC2R`|  |  |  |`hipfftExecC2R`|
+|`cufftExecD2Z`|  |  |  |`hipfftExecD2Z`|
+|`cufftExecR2C`|  |  |  |`hipfftExecR2C`|
+|`cufftExecZ2D`|  |  |  |`hipfftExecZ2D`|
+|`cufftExecZ2Z`|  |  |  |`hipfftExecZ2Z`|
+|`cufftGetProperty`| 8.0 |  |  |`hipfftGetProperty`|
+|`cufftGetSize`|  |  |  |`hipfftGetSize`|
+|`cufftGetSize1d`|  |  |  |`hipfftGetSize1d`|
+|`cufftGetSize2d`|  |  |  |`hipfftGetSize2d`|
+|`cufftGetSize3d`|  |  |  |`hipfftGetSize3d`|
+|`cufftGetSizeMany`|  |  |  |`hipfftGetSizeMany`|
+|`cufftGetSizeMany64`| 7.5 |  |  |`hipfftGetSizeMany64`|
+|`cufftGetVersion`|  |  |  |`hipfftGetVersion`|
+|`cufftMakePlan1d`|  |  |  |`hipfftMakePlan1d`|
+|`cufftMakePlan2d`|  |  |  |`hipfftMakePlan2d`|
+|`cufftMakePlan3d`|  |  |  |`hipfftMakePlan3d`|
+|`cufftMakePlanMany`|  |  |  |`hipfftMakePlanMany`|
+|`cufftMakePlanMany64`| 7.5 |  |  |`hipfftMakePlanMany64`|
+|`cufftPlan1d`|  |  |  |`hipfftPlan1d`|
+|`cufftPlan2d`|  |  |  |`hipfftPlan2d`|
+|`cufftPlan3d`|  |  |  |`hipfftPlan3d`|
+|`cufftPlanMany`|  |  |  |`hipfftPlanMany`|
+|`cufftSetAutoAllocation`|  |  |  |`hipfftSetAutoAllocation`|
+|`cufftSetStream`|  |  |  |`hipfftSetStream`|
+|`cufftSetWorkArea`|  |  |  |`hipfftSetWorkArea`|
+
+
+\* A - Added, D - Deprecated, R - Removed

--- a/docs/markdown/CURAND_API_supported_by_HIP.md
+++ b/docs/markdown/CURAND_API_supported_by_HIP.md
@@ -2,172 +2,172 @@
 
 ## **1. CURAND Data types**
 
-| **type**     |   **CUDA**                                                    |**CUDA version\***|   **HIP**                                                  | **HIP value** (if differs) |
-|-------------:|---------------------------------------------------------------|:----------------:|------------------------------------------------------------|----------------------------|
-| define       |`CURAND_VER_MAJOR`                                             | 10.1 Update 2    |                                                            |
-| define       |`CURAND_VER_MINOR`                                             | 10.1 Update 2    |                                                            |
-| define       |`CURAND_VER_PATCH`                                             | 10.1 Update 2    |                                                            |
-| define       |`CURAND_VER_BUILD`                                             | 10.1 Update 2    |                                                            |
-| define       |`CURAND_VERSION`                                               | 10.1 Update 2    |                                                            |
-| enum         |***`curandStatus`***                                           |                  |***`hiprandStatus`***                                       |
-| enum         |***`curandStatus_t`***                                         |                  |***`hiprandStatus_t`***                                     |
-|            0 |*`CURAND_STATUS_SUCCESS`*                                      |                  |*`HIPRAND_STATUS_SUCCESS`*                                  |
-|          100 |*`CURAND_STATUS_VERSION_MISMATCH`*                             |                  |*`HIPRAND_STATUS_VERSION_MISMATCH`*                         |
-|          101 |*`CURAND_STATUS_NOT_INITIALIZED`*                              |                  |*`HIPRAND_STATUS_NOT_INITIALIZED`*                          |
-|          102 |*`CURAND_STATUS_ALLOCATION_FAILED`*                            |                  |*`HIPRAND_STATUS_ALLOCATION_FAILED`*                        |
-|          103 |*`CURAND_STATUS_TYPE_ERROR`*                                   |                  |*`HIPRAND_STATUS_TYPE_ERROR`*                               |
-|          104 |*`CURAND_STATUS_OUT_OF_RANGE`*                                 |                  |*`HIPRAND_STATUS_OUT_OF_RANGE`*                             |
-|          105 |*`CURAND_STATUS_LENGTH_NOT_MULTIPLE`*                          |                  |*`HIPRAND_STATUS_LENGTH_NOT_MULTIPLE`*                      |
-|          106 |*`CURAND_STATUS_DOUBLE_PRECISION_REQUIRED`*                    |                  |*`HIPRAND_STATUS_DOUBLE_PRECISION_REQUIRED`*                |
-|          201 |*`CURAND_STATUS_LAUNCH_FAILURE`*                               |                  |*`HIPRAND_STATUS_LAUNCH_FAILURE`*                           |
-|          202 |*`CURAND_STATUS_PREEXISTING_FAILURE`*                          |                  |*`HIPRAND_STATUS_PREEXISTING_FAILURE`*                      |
-|          203 |*`CURAND_STATUS_INITIALIZATION_FAILED`*                        |                  |*`HIPRAND_STATUS_INITIALIZATION_FAILED`*                    |
-|          204 |*`CURAND_STATUS_ARCH_MISMATCH`*                                |                  |*`HIPRAND_STATUS_ARCH_MISMATCH`*                            |
-|          999 |*`CURAND_STATUS_INTERNAL_ERROR`*                               |                  |*`HIPRAND_STATUS_INTERNAL_ERROR`*                           |
-| enum         |***`curandRngType`***                                          |                  |***`hiprandRngType`***                                      |
-| enum         |***`curandRngType_t`***                                        |                  |***`hiprandRngType_t`***                                    |
-|            0 |*`CURAND_RNG_TEST`*                                            |                  |*`HIPRAND_RNG_TEST`*                                        |
-|          100 |*`CURAND_RNG_PSEUDO_DEFAULT`*                                  |                  |*`HIPRAND_RNG_PSEUDO_DEFAULT`*                              | 400                        |
-|          101 |*`CURAND_RNG_PSEUDO_XORWOW`*                                   |                  |*`HIPRAND_RNG_PSEUDO_XORWOW`*                               | 401                        |
-|          121 |*`CURAND_RNG_PSEUDO_MRG32K3A`*                                 |                  |*`HIPRAND_RNG_PSEUDO_MRG32K3A`*                             | 402                        |
-|          141 |*`CURAND_RNG_PSEUDO_MTGP32`*                                   |                  |*`HIPRAND_RNG_PSEUDO_MTGP32`*                               | 403                        |
-|          142 |*`CURAND_RNG_PSEUDO_MT19937`*                                  |                  |*`HIPRAND_RNG_PSEUDO_MT19937`*                              | 404                        |
-|          161 |*`CURAND_RNG_PSEUDO_PHILOX4_32_10`*                            |                  |*`HIPRAND_RNG_PSEUDO_PHILOX4_32_10`*                        | 405                        |
-|          200 |*`CURAND_RNG_QUASI_DEFAULT`*                                   |                  |*`HIPRAND_RNG_QUASI_DEFAULT`*                               | 500                        |
-|          201 |*`CURAND_RNG_QUASI_SOBOL32`*                                   |                  |*`HIPRAND_RNG_QUASI_SOBOL32`*                               | 501                        |
-|          202 |*`CURAND_RNG_QUASI_SCRAMBLED_SOBOL32`*                         |                  |*`HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL32`*                     | 502                        |
-|          203 |*`CURAND_RNG_QUASI_SOBOL64`*                                   |                  |*`HIPRAND_RNG_QUASI_SOBOL64`*                               | 503                        |
-|          204 |*`CURAND_RNG_QUASI_SCRAMBLED_SOBOL64`*                         |                  |*`HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL64`*                     | 504                        |
-| enum         |***`curandOrdering`***                                         |                  |                                                            |
-| enum         |***`curandOrdering_t`***                                       |                  |                                                            |
-|          100 |*`CURAND_ORDERING_PSEUDO_BEST`*                                |                  |                                                            |
-|          101 |*`CURAND_ORDERING_PSEUDO_DEFAULT`*                             |                  |                                                            |
-|          102 |*`CURAND_ORDERING_PSEUDO_SEEDED`*                              |                  |                                                            |
-|          103 |*`CURAND_ORDERING_PSEUDO_LEGACY`*                              |                  |                                                            |
-|          201 |*`CURAND_ORDERING_QUASI_DEFAULT`*                              |                  |                                                            |
-| enum         |***`curandDirectionVectorSet`***                               |                  |                                                            |
-| enum         |***`curandDirectionVectorSet_t`***                             |                  |                                                            |
-|          101 |*`CURAND_DIRECTION_VECTORS_32_JOEKUO6`*                        |                  |                                                            |
-|          102 |*`CURAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6`*              |                  |                                                            |
-|          103 |*`CURAND_DIRECTION_VECTORS_64_JOEKUO6`*                        |                  |                                                            |
-|          104 |*`CURAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6`*              |                  |                                                            |
-| uint         | `curandDirectionVectors32_t`                                  |                  | `hiprandDirectionVectors32_t`                              |
-| uint         | `curandDirectionVectors64_t`                                  |                  |                                                            |
-| struct       | `curandGenerator_st`                                          |                  | `hiprandGenerator_st`                                      |
-| struct*      | `curandGenerator_t`                                           |                  | `hiprandGenerator_t`                                       |
-| double       | `curandDistribution_st`                                       |                  |                                                            |
-| double       | `curandHistogramM2V_st`                                       |                  |                                                            |
-| double*      | `curandDistribution_t`                                        |                  |                                                            |
-| double*      | `curandHistogramM2V_t`                                        |                  |                                                            |
-| struct       | `curandDistributionShift_st`                                  |                  |                                                            |
-| struct*      | `curandDistributionShift_t`                                   |                  |                                                            |
-| struct       | `curandDistributionM2Shift_st`                                |                  |                                                            |
-| struct*      | `curandDistributionM2Shift_t`                                 |                  |                                                            |
-| struct       | `curandHistogramM2_st`                                        |                  |                                                            |
-| struct*      | `curandHistogramM2_t`                                         |                  |                                                            |
-| uint         | `curandHistogramM2K_st`                                       |                  |                                                            |
-| uint*        | `curandHistogramM2K_t`                                        |                  |                                                            |
-| struct       | `curandDiscreteDistribution_st`                               |                  | `hiprandDiscreteDistribution_st`                           |
-| struct*      | `curandDiscreteDistribution_t`                                |                  | `hiprandDiscreteDistribution_t`                            |
-| enum         |***`curandMethod`***                                           |                  |                                                            |
-| enum         |***`curandMethod_t`***                                         |                  |                                                            |
-|            0 |*`CURAND_CHOOSE_BEST`*                                         |                  |                                                            |
-|            1 |*`CURAND_ITR`*                                                 |                  |                                                            |
-|            2 |*`CURAND_KNUTH`*                                               |                  |                                                            |
-|            3 |*`CURAND_HITR`*                                                |                  |                                                            |
-|            4 |*`CURAND_M1`*                                                  |                  |                                                            |
-|            5 |*`CURAND_M2`*                                                  |                  |                                                            |
-|            6 |*`CURAND_BINARY_SEARCH`*                                       |                  |                                                            |
-|            7 |*`CURAND_DISCRETE_GAUSS`*                                      |                  |                                                            |
-|            8 |*`CURAND_REJECTION`*                                           |                  |                                                            |
-|            9 |*`CURAND_DEVICE_API`*                                          |                  |                                                            |
-|           10 |*`CURAND_FAST_REJECTION`*                                      |                  |                                                            |
-|           11 |*`CURAND_3RD`*                                                 |                  |                                                            |
-|           12 |*`CURAND_DEFINITION`*                                          |                  |                                                            |
-|           13 |*`CURAND_POISSON`*                                             |                  |                                                            |
-| struct       | `curandStateMtgp32`                                           |                  | `hiprandStateMtgp32`                                       |
-| typedef      | `curandStateMtgp32_t`                                         |                  | `hiprandStateMtgp32_t`                                     |
-| struct       | `curandStateScrambledSobol64`                                 |                  |                                                            |
-| typedef      | `curandStateScrambledSobol64_t`                               |                  |                                                            |
-| struct       | `curandStateSobol64`                                          |                  |                                                            |
-| typedef      | `curandStateSobol64_t`                                        |                  |                                                            |
-| struct       | `curandStateScrambledSobol32`                                 |                  |                                                            |
-| typedef      | `curandStateScrambledSobol32_t`                               |                  |                                                            |
-| struct       | `curandStateSobol32`                                          |                  | `hiprandStateSobol32`                                      |
-| typedef      | `curandStateSobol32_t`                                        |                  | `hiprandStateSobol32_t`                                    |
-| struct       | `curandStateMRG32k3a`                                         |                  | `hiprandStateMRG32k3a`                                     |
-| typedef      | `curandStateMRG32k3a_t`                                       |                  | `hiprandStateMRG32k3a_t`                                   |
-| struct       | `curandStatePhilox4_32_10`                                    |                  | `hiprandStatePhilox4_32_10`                                |
-| typedef      | `curandStatePhilox4_32_10_t`                                  |                  | `hiprandStatePhilox4_32_10_t`                              |
-| struct       | `curandStateXORWOW`                                           |                  | `hiprandStateXORWOW`                                       |
-| typedef      | `curandStateXORWOW_t`                                         |                  | `hiprandStateXORWOW_t`                                     |
-| struct       | `curandState`                                                 |                  | `hiprandState`                                             |
-| typedef      | `curandState_t`                                               |                  | `hiprandState_t`                                           |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`CURAND_3RD`|  |  |  ||
+|`CURAND_BINARY_SEARCH`|  |  |  ||
+|`CURAND_CHOOSE_BEST`|  |  |  ||
+|`CURAND_DEFINITION`|  |  |  ||
+|`CURAND_DEVICE_API`|  |  |  ||
+|`CURAND_DIRECTION_VECTORS_32_JOEKUO6`|  |  |  ||
+|`CURAND_DIRECTION_VECTORS_64_JOEKUO6`|  |  |  ||
+|`CURAND_DISCRETE_GAUSS`|  |  |  ||
+|`CURAND_FAST_REJECTION`|  |  |  ||
+|`CURAND_HITR`|  |  |  ||
+|`CURAND_ITR`|  |  |  ||
+|`CURAND_KNUTH`|  |  |  ||
+|`CURAND_M1`|  |  |  ||
+|`CURAND_M2`|  |  |  ||
+|`CURAND_ORDERING_PSEUDO_BEST`|  |  |  ||
+|`CURAND_ORDERING_PSEUDO_DEFAULT`|  |  |  ||
+|`CURAND_ORDERING_PSEUDO_LEGACY`| 11.0 |  |  ||
+|`CURAND_ORDERING_PSEUDO_SEEDED`|  |  |  ||
+|`CURAND_ORDERING_QUASI_DEFAULT`|  |  |  ||
+|`CURAND_POISSON`|  |  |  ||
+|`CURAND_REJECTION`|  |  |  ||
+|`CURAND_RNG_PSEUDO_DEFAULT`|  |  |  |`HIPRAND_RNG_PSEUDO_DEFAULT`|
+|`CURAND_RNG_PSEUDO_MRG32K3A`|  |  |  |`HIPRAND_RNG_PSEUDO_MRG32K3A`|
+|`CURAND_RNG_PSEUDO_MT19937`|  |  |  |`HIPRAND_RNG_PSEUDO_MT19937`|
+|`CURAND_RNG_PSEUDO_MTGP32`|  |  |  |`HIPRAND_RNG_PSEUDO_MTGP32`|
+|`CURAND_RNG_PSEUDO_PHILOX4_32_10`|  |  |  |`HIPRAND_RNG_PSEUDO_PHILOX4_32_10`|
+|`CURAND_RNG_PSEUDO_XORWOW`|  |  |  |`HIPRAND_RNG_PSEUDO_XORWOW`|
+|`CURAND_RNG_QUASI_DEFAULT`|  |  |  |`HIPRAND_RNG_QUASI_DEFAULT`|
+|`CURAND_RNG_QUASI_SCRAMBLED_SOBOL32`|  |  |  |`HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL32`|
+|`CURAND_RNG_QUASI_SCRAMBLED_SOBOL64`|  |  |  |`HIPRAND_RNG_QUASI_SCRAMBLED_SOBOL64`|
+|`CURAND_RNG_QUASI_SOBOL32`|  |  |  |`HIPRAND_RNG_QUASI_SOBOL32`|
+|`CURAND_RNG_QUASI_SOBOL64`|  |  |  |`HIPRAND_RNG_QUASI_SOBOL64`|
+|`CURAND_RNG_TEST`|  |  |  |`HIPRAND_RNG_TEST`|
+|`CURAND_SCRAMBLED_DIRECTION_VECTORS_32_JOEKUO6`|  |  |  ||
+|`CURAND_SCRAMBLED_DIRECTION_VECTORS_64_JOEKUO6`|  |  |  ||
+|`CURAND_STATUS_ALLOCATION_FAILED`|  |  |  |`HIPRAND_STATUS_ALLOCATION_FAILED`|
+|`CURAND_STATUS_ARCH_MISMATCH`|  |  |  |`HIPRAND_STATUS_ARCH_MISMATCH`|
+|`CURAND_STATUS_DOUBLE_PRECISION_REQUIRED`|  |  |  |`HIPRAND_STATUS_DOUBLE_PRECISION_REQUIRED`|
+|`CURAND_STATUS_INITIALIZATION_FAILED`|  |  |  |`HIPRAND_STATUS_INITIALIZATION_FAILED`|
+|`CURAND_STATUS_INTERNAL_ERROR`|  |  |  |`HIPRAND_STATUS_INTERNAL_ERROR`|
+|`CURAND_STATUS_LAUNCH_FAILURE`|  |  |  |`HIPRAND_STATUS_LAUNCH_FAILURE`|
+|`CURAND_STATUS_LENGTH_NOT_MULTIPLE`|  |  |  |`HIPRAND_STATUS_LENGTH_NOT_MULTIPLE`|
+|`CURAND_STATUS_NOT_INITIALIZED`|  |  |  |`HIPRAND_STATUS_NOT_INITIALIZED`|
+|`CURAND_STATUS_OUT_OF_RANGE`|  |  |  |`HIPRAND_STATUS_OUT_OF_RANGE`|
+|`CURAND_STATUS_PREEXISTING_FAILURE`|  |  |  |`HIPRAND_STATUS_PREEXISTING_FAILURE`|
+|`CURAND_STATUS_SUCCESS`|  |  |  |`HIPRAND_STATUS_SUCCESS`|
+|`CURAND_STATUS_TYPE_ERROR`|  |  |  |`HIPRAND_STATUS_TYPE_ERROR`|
+|`CURAND_STATUS_VERSION_MISMATCH`|  |  |  |`HIPRAND_STATUS_VERSION_MISMATCH`|
+|`CURAND_VERSION`| 10.2 |  |  ||
+|`CURAND_VER_BUILD`| 10.2 |  |  ||
+|`CURAND_VER_MAJOR`| 10.2 |  |  ||
+|`CURAND_VER_MINOR`| 10.2 |  |  ||
+|`CURAND_VER_PATCH`| 10.2 |  |  ||
+|`curandDirectionVectorSet`|  |  |  ||
+|`curandDirectionVectorSet_t`|  |  |  ||
+|`curandDirectionVectors32_t`|  |  |  |`hiprandDirectionVectors32_t`|
+|`curandDirectionVectors64_t`|  |  |  ||
+|`curandDiscreteDistribution_st`|  |  |  |`hiprandDiscreteDistribution_st`|
+|`curandDiscreteDistribution_t`|  |  |  |`hiprandDiscreteDistribution_t`|
+|`curandDistributionM2Shift_st`|  |  |  ||
+|`curandDistributionM2Shift_t`|  |  |  ||
+|`curandDistributionShift_st`|  |  |  ||
+|`curandDistributionShift_t`|  |  |  ||
+|`curandDistribution_st`|  |  |  ||
+|`curandDistribution_t`|  |  |  ||
+|`curandGenerator_st`|  |  |  |`hiprandGenerator_st`|
+|`curandGenerator_t`|  |  |  |`hiprandGenerator_t`|
+|`curandHistogramM2K_st`|  |  |  ||
+|`curandHistogramM2K_t`|  |  |  ||
+|`curandHistogramM2V_st`|  |  |  ||
+|`curandHistogramM2V_t`|  |  |  ||
+|`curandHistogramM2_st`|  |  |  ||
+|`curandHistogramM2_t`|  |  |  ||
+|`curandMethod`|  |  |  ||
+|`curandMethod_t`|  |  |  ||
+|`curandOrdering`|  |  |  ||
+|`curandOrdering_t`|  |  |  ||
+|`curandRngType`|  |  |  |`hiprandRngType_t`|
+|`curandRngType_t`|  |  |  |`hiprandRngType_t`|
+|`curandState`|  |  |  |`hiprandState`|
+|`curandStateMRG32k3a`|  |  |  |`hiprandStateMRG32k3a`|
+|`curandStateMRG32k3a_t`|  |  |  |`hiprandStateMRG32k3a_t`|
+|`curandStateMtgp32`|  |  |  |`hiprandStateMtgp32`|
+|`curandStateMtgp32_t`|  |  |  |`hiprandStateMtgp32_t`|
+|`curandStatePhilox4_32_10`|  |  |  |`hiprandStatePhilox4_32_10`|
+|`curandStatePhilox4_32_10_t`|  |  |  |`hiprandStatePhilox4_32_10_t`|
+|`curandStateScrambledSobol32`|  |  |  ||
+|`curandStateScrambledSobol32_t`|  |  |  ||
+|`curandStateScrambledSobol64`|  |  |  ||
+|`curandStateScrambledSobol64_t`|  |  |  ||
+|`curandStateSobol32`|  |  |  |`hiprandStateSobol32`|
+|`curandStateSobol32_t`|  |  |  |`hiprandStateSobol32_t`|
+|`curandStateSobol64`|  |  |  ||
+|`curandStateSobol64_t`|  |  |  ||
+|`curandStateXORWOW`|  |  |  |`hiprandStateXORWOW`|
+|`curandStateXORWOW_t`|  |  |  |`hiprandStateXORWOW_t`|
+|`curandState_t`|  |  |  |`hiprandState_t`|
+|`curandStatus`|  |  |  |`hiprandStatus_t`|
+|`curandStatus_t`|  |  |  |`hiprandStatus_t`|
 
 ## **2. Host API Functions**
 
-|   **CUDA**                                                |   **HIP**                                  |
-|-----------------------------------------------------------|--------------------------------------------|
-| `curandCreateGenerator`                                   | `hiprandCreateGenerator`                   |
-| `curandCreateGeneratorHost`                               | `hiprandCreateGeneratorHost`               |
-| `curandCreatePoissonDistribution`                         | `hiprandCreatePoissonDistribution`         |
-| `curandDestroyDistribution`                               | `hiprandDestroyDistribution`               |
-| `curandDestroyGenerator`                                  | `hiprandDestroyGenerator`                  |
-| `curandGenerate`                                          | `hiprandGenerate`                          |
-| `curandGenerateLogNormal`                                 | `hiprandGenerateLogNormal`                 |
-| `curandGenerateLogNormalDouble`                           | `hiprandGenerateLogNormalDouble`           |
-| `curandGenerateLongLong`                                  |                                            |
-| `curandGenerateNormal`                                    | `hiprandGenerateNormal`                    |
-| `curandGenerateNormalDouble`                              | `hiprandGenerateNormalDouble`              |
-| `curandGeneratePoisson`                                   | `hiprandGeneratePoisson`                   |
-| `curandGenerateSeeds`                                     | `hiprandGenerateSeeds`                     |
-| `curandGenerateUniform`                                   | `hiprandGenerateUniform`                   |
-| `curandGenerateUniformDouble`                             | `hiprandGenerateUniformDouble`             |
-| `curandGetDirectionVectors32`                             |                                            |
-| `curandGetDirectionVectors64`                             |                                            |
-| `curandGetProperty`                                       |                                            |
-| `curandGetScrambleConstants32`                            |                                            |
-| `curandGetScrambleConstants64`                            |                                            |
-| `curandGetVersion`                                        | `hiprandGetVersion`                        |
-| `curandSetGeneratorOffset`                                | `hiprandSetGeneratorOffset`                |
-| `curandSetGeneratorOrdering`                              |                                            |
-| `curandSetPseudoRandomGeneratorSeed`                      | `hiprandSetPseudoRandomGeneratorSeed`      |
-| `curandSetQuasiRandomGeneratorDimensions`                 | `hiprandSetQuasiRandomGeneratorDimensions` |
-| `curandSetStream`                                         | `hiprandSetStream`                         |
-| `curandMakeMTGP32Constants`                               | `hiprandMakeMTGP32Constants`               |
-| `curandMakeMTGP32KernelState`                             | `hiprandMakeMTGP32KernelState`             |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`curandCreateGenerator`|  |  |  |`hiprandCreateGenerator`|
+|`curandCreateGeneratorHost`|  |  |  |`hiprandCreateGeneratorHost`|
+|`curandCreatePoissonDistribution`|  |  |  |`hiprandCreatePoissonDistribution`|
+|`curandDestroyDistribution`|  |  |  |`hiprandDestroyDistribution`|
+|`curandDestroyGenerator`|  |  |  |`hiprandDestroyGenerator`|
+|`curandGenerate`|  |  |  |`hiprandGenerate`|
+|`curandGenerateLogNormal`|  |  |  |`hiprandGenerateLogNormal`|
+|`curandGenerateLogNormalDouble`|  |  |  |`hiprandGenerateLogNormalDouble`|
+|`curandGenerateLongLong`|  |  |  ||
+|`curandGenerateNormal`|  |  |  |`hiprandGenerateNormal`|
+|`curandGenerateNormalDouble`|  |  |  |`hiprandGenerateNormalDouble`|
+|`curandGeneratePoisson`|  |  |  |`hiprandGeneratePoisson`|
+|`curandGenerateSeeds`|  |  |  |`hiprandGenerateSeeds`|
+|`curandGenerateUniform`|  |  |  |`hiprandGenerateUniform`|
+|`curandGenerateUniformDouble`|  |  |  |`hiprandGenerateUniformDouble`|
+|`curandGetDirectionVectors32`|  |  |  ||
+|`curandGetDirectionVectors64`|  |  |  ||
+|`curandGetProperty`| 8.0 |  |  ||
+|`curandGetScrambleConstants32`|  |  |  ||
+|`curandGetScrambleConstants64`|  |  |  ||
+|`curandGetVersion`|  |  |  |`hiprandGetVersion`|
+|`curandMakeMTGP32Constants`|  |  |  |`hiprandMakeMTGP32Constants`|
+|`curandMakeMTGP32KernelState`|  |  |  |`hiprandMakeMTGP32KernelState`|
+|`curandSetGeneratorOffset`|  |  |  |`hiprandSetGeneratorOffset`|
+|`curandSetGeneratorOrdering`|  |  |  ||
+|`curandSetPseudoRandomGeneratorSeed`|  |  |  |`hiprandSetPseudoRandomGeneratorSeed`|
+|`curandSetQuasiRandomGeneratorDimensions`|  |  |  |`hiprandSetQuasiRandomGeneratorDimensions`|
+|`curandSetStream`|  |  |  |`hiprandSetStream`|
 
 ## **3. Device API Functions**
 
-|   **CUDA**                                                |   **HIP**                                  |
-|-----------------------------------------------------------|--------------------------------------------|
-| `curand`                                                  | `hiprand`                                  |
-| `curand_init`                                             | `hiprand_init`                             |
-| `curand_log_normal`                                       | `hiprand_log_normal`                       |
-| `curand_log_normal_double`                                | `hiprand_log_normal_double`                |
-| `curand_log_normal2`                                      | `hiprand_log_normal2`                      |
-| `curand_log_normal2_double`                               | `hiprand_log_normal2_double`               |
-| `curand_log_normal4`                                      | `hiprand_log_normal4`                      |
-| `curand_log_normal4_double`                               | `hiprand_log_normal4_double`               |
-| `curand_mtgp32_single`                                    |                                            |
-| `curand_mtgp32_single_specific`                           |                                            |
-| `curand_mtgp32_specific`                                  |                                            |
-| `curand_normal`                                           | `hiprand_normal`                           |
-| `curand_normal_double`                                    | `hiprand_normal_double`                    |
-| `curand_normal2`                                          | `hiprand_normal2`                          |
-| `curand_normal2_double`                                   | `hiprand_normal2_double`                   |
-| `curand_normal4`                                          | `hiprand_normal4`                          |
-| `curand_normal4_double`                                   | `hiprand_normal4_double`                   |
-| `curand_uniform`                                          | `hiprand_uniform`                          |
-| `curand_uniform_double`                                   | `hiprand_uniform_double`                   |
-| `curand_uniform2_double`                                  | `hiprand_uniform2_double`                  |
-| `curand_uniform4`                                         | `hiprand_uniform4`                         |
-| `curand_uniform4_double`                                  | `hiprand_uniform4_double`                  |
-| `curand_discrete`                                         | `hiprand_discrete`                         |
-| `curand_discrete4`                                        | `hiprand_discrete4`                        |
-| `curand_poisson`                                          | `hiprand_poisson`                          |
-| `curand_poisson4`                                         | `hiprand_poisson4`                         |
-| `curand_Philox4x32_10`                                    |                                            |
-| `skipahead`                                               | `skipahead`                                |
-| `skipahead_sequence`                                      | `skipahead_sequence`                       |
-| `skipahead_subsequence`                                   | `skipahead_subsequence`                    |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`curand`|  |  |  |`hiprand`|
+|`curand_Philox4x32_10`|  |  |  ||
+|`curand_discrete`|  |  |  |`hiprand_discrete`|
+|`curand_discrete4`|  |  |  |`hiprand_discrete4`|
+|`curand_init`|  |  |  |`hiprand_init`|
+|`curand_log_normal`|  |  |  |`hiprand_log_normal`|
+|`curand_log_normal2`|  |  |  |`hiprand_log_normal2`|
+|`curand_log_normal2_double`|  |  |  |`hiprand_log_normal2_double`|
+|`curand_log_normal4`|  |  |  |`hiprand_log_normal4`|
+|`curand_log_normal4_double`|  |  |  |`hiprand_log_normal4_double`|
+|`curand_log_normal_double`|  |  |  |`hiprand_log_normal_double`|
+|`curand_mtgp32_single`|  |  |  ||
+|`curand_mtgp32_single_specific`|  |  |  ||
+|`curand_mtgp32_specific`|  |  |  ||
+|`curand_normal`|  |  |  |`hiprand_normal`|
+|`curand_normal2`|  |  |  |`hiprand_normal2`|
+|`curand_normal2_double`|  |  |  |`hiprand_normal2_double`|
+|`curand_normal4`|  |  |  |`hiprand_normal4`|
+|`curand_normal4_double`|  |  |  |`hiprand_normal4_double`|
+|`curand_normal_double`|  |  |  |`hiprand_normal_double`|
+|`curand_poisson`|  |  |  |`hiprand_poisson`|
+|`curand_poisson4`|  |  |  |`hiprand_poisson4`|
+|`curand_uniform`|  |  |  |`hiprand_uniform`|
+|`curand_uniform2_double`|  |  |  |`hiprand_uniform2_double`|
+|`curand_uniform4`|  |  |  |`hiprand_uniform4`|
+|`curand_uniform4_double`|  |  |  |`hiprand_uniform4_double`|
+|`curand_uniform_double`|  |  |  |`hiprand_uniform_double`|
+
+
+\* A - Added, D - Deprecated, R - Removed

--- a/docs/markdown/CUSPARSE_API_supported_by_HIP.md
+++ b/docs/markdown/CUSPARSE_API_supported_by_HIP.md
@@ -1,797 +1,782 @@
 # CUSPARSE API supported by HIP
 
-## **1. cuSPARSE Data types**
+## **4. CUSPARSE Types References**
 
-| **type**     |   **CUDA**                                                    |**CUDA version\***|   **HIP**                                                  |
-|-------------:|---------------------------------------------------------------|:-----------------|------------------------------------------------------------|
-| define       |`CUSPARSE_VER_MAJOR`                                           | 10.1 Update 2    |                                                            |
-| define       |`CUSPARSE_VER_MINOR`                                           | 10.1 Update 2    |                                                            |
-| define       |`CUSPARSE_VER_PATCH`                                           | 10.1 Update 2    |                                                            |
-| define       |`CUSPARSE_VER_BUILD`                                           | 10.1 Update 2    |                                                            |
-| define       |`CUSPARSE_VERSION`                                             | 10.1 Update 2    |                                                            |
-| enum         |***`cusparseAction_t`***                                       |                  |***`hipsparseAction_t`***                                   |
-|            0 |*`CUSPARSE_ACTION_SYMBOLIC`*                                   |                  |*`HIPSPARSE_ACTION_SYMBOLIC`*                               |
-|            1 |*`CUSPARSE_ACTION_NUMERIC`*                                    |                  |*`HIPSPARSE_ACTION_NUMERIC`*                                |
-| enum         |***`cusparseDirection_t`***                                    |                  |***`hipsparseDirection_t`***                                |
-|            0 |*`CUSPARSE_DIRECTION_ROW`*                                     |                  |*`HIPSPARSE_DIRECTION_ROW`*                                 |
-|            1 |*`CUSPARSE_DIRECTION_COLUMN`*                                  |                  |*`HIPSPARSE_DIRECTION_COLUMN`*                              |
-| enum         |***`cusparseHybPartition_t`***                                 |                  |***`hipsparseHybPartition_t`***                             |
-|            0 |*`CUSPARSE_HYB_PARTITION_AUTO`*                                |                  |*`HIPSPARSE_HYB_PARTITION_AUTO`*                            |
-|            1 |*`CUSPARSE_HYB_PARTITION_USER`*                                |                  |*`HIPSPARSE_HYB_PARTITION_USER`*                            |
-|            2 |*`CUSPARSE_HYB_PARTITION_MAX`*                                 |                  |*`HIPSPARSE_HYB_PARTITION_MAX`*                             |
-| enum         |***`cusparseDiagType_t`***                                     |                  |***`hipsparseDiagType_t`***                                 |
-|            0 |*`CUSPARSE_DIAG_TYPE_NON_UNIT`*                                |                  |*`HIPSPARSE_DIAG_TYPE_NON_UNIT`*                            |
-|            1 |*`CUSPARSE_DIAG_TYPE_UNIT`*                                    |                  |*`HIPSPARSE_DIAG_TYPE_UNIT`*                                |
-| enum         |***`cusparseFillMode_t`***                                     |                  |***`hipsparseFillMode_t`***                                 |
-|            0 |*`CUSPARSE_FILL_MODE_LOWER`*                                   |                  |*`HIPSPARSE_FILL_MODE_LOWER`*                               |
-|            1 |*`CUSPARSE_FILL_MODE_UPPER`*                                   |                  |*`HIPSPARSE_FILL_MODE_UPPER`*                               |
-| enum         |***`cusparseIndexBase_t`***                                    |                  |***`hipsparseIndexBase_t`***                                |
-|            0 |*`CUSPARSE_INDEX_BASE_ZERO`*                                   |                  |*`HIPSPARSE_INDEX_BASE_ZERO`*                               |
-|            1 |*`CUSPARSE_INDEX_BASE_ONE`*                                    |                  |*`HIPSPARSE_INDEX_BASE_ONE`*                                |
-| enum         |***`cusparseMatrixType_t`***                                   |                  |***`hipsparseMatrixType_t`***                               |
-|            0 |*`CUSPARSE_MATRIX_TYPE_GENERAL`*                               |                  |*`HIPSPARSE_MATRIX_TYPE_GENERAL`*                           |
-|            1 |*`CUSPARSE_MATRIX_TYPE_SYMMETRIC`*                             |                  |*`HIPSPARSE_MATRIX_TYPE_SYMMETRIC`*                         |
-|            2 |*`CUSPARSE_MATRIX_TYPE_HERMITIAN`*                             |                  |*`HIPSPARSE_MATRIX_TYPE_HERMITIAN`*                         |
-|            3 |*`CUSPARSE_MATRIX_TYPE_TRIANGULAR`*                            |                  |*`HIPSPARSE_MATRIX_TYPE_TRIANGULAR`*                        |
-| enum         |***`cusparseOperation_t`***                                    |                  |***`hipsparseOperation_t`***                                |
-|            0 |*`CUSPARSE_OPERATION_NON_TRANSPOSE`*                           |                  |*`HIPSPARSE_OPERATION_NON_TRANSPOSE`*                       |
-|            1 |*`CUSPARSE_OPERATION_TRANSPOSE`*                               |                  |*`HIPSPARSE_OPERATION_TRANSPOSE`*                           |
-|            2 |*`CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE`*                     |                  |*`HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE`*                 |
-| enum         |***`cusparsePointerMode_t`***                                  |                  |***`hipsparsePointerMode_t`***                              |
-|            0 |*`CUSPARSE_POINTER_MODE_HOST`*                                 |                  |*`HIPSPARSE_POINTER_MODE_HOST`*                             |
-|            1 |*`CUSPARSE_POINTER_MODE_DEVICE`*                               |                  |*`HIPSPARSE_POINTER_MODE_DEVICE`*                           |
-| enum         |***`cusparseAlgMode_t`***                                      | 8.0              |                                                            |
-|            0 |*`CUSPARSE_ALG0`*                                              | 8.0              |                                                            |
-|            1 |*`CUSPARSE_ALG1`*                                              | 8.0              |                                                            |
-|            0 |*`CUSPARSE_ALG_NAIVE`*                                         | 9.2              |                                                            |
-|            1 |*`CUSPARSE_ALG_MERGE_PATH`*                                    | 9.2              |                                                            |
-| enum         |***`cusparseSolvePolicy_t`***                                  |                  |***`hipsparseSolvePolicy_t`***                              |
-|            0 |*`CUSPARSE_SOLVE_POLICY_NO_LEVEL`*                             |                  |*`HIPSPARSE_SOLVE_POLICY_NO_LEVEL`*                         |
-|            1 |*`CUSPARSE_SOLVE_POLICY_USE_LEVEL`*                            |                  |*`HIPSPARSE_SOLVE_POLICY_USE_LEVEL`*                        |
-| enum         |***`cusparseStatus_t`***                                       |                  |***`hipsparseMatrixType_t`***                               |
-|            0 |*`CUSPARSE_STATUS_SUCCESS`*                                    |                  |*`HIPSPARSE_STATUS_SUCCESS`*                                |
-|            1 |*`CUSPARSE_STATUS_NOT_INITIALIZED`*                            |                  |*`HIPSPARSE_STATUS_NOT_INITIALIZED`*                        |
-|            2 |*`CUSPARSE_STATUS_ALLOC_FAILED`*                               |                  |*`HIPSPARSE_STATUS_ALLOC_FAILED`*                           |
-|            3 |*`CUSPARSE_STATUS_INVALID_VALUE`*                              |                  |*`HIPSPARSE_STATUS_INVALID_VALUE`*                          |
-|            4 |*`CUSPARSE_STATUS_ARCH_MISMATCH`*                              |                  |*`HIPSPARSE_STATUS_ARCH_MISMATCH`*                          |
-|            5 |*`CUSPARSE_STATUS_MAPPING_ERROR`*                              |                  |*`HIPSPARSE_STATUS_MAPPING_ERROR`*                          |
-|            6 |*`CUSPARSE_STATUS_EXECUTION_FAILED`*                           |                  |*`HIPSPARSE_STATUS_EXECUTION_FAILED`*                       |
-|            7 |*`CUSPARSE_STATUS_INTERNAL_ERROR`*                             |                  |*`HIPSPARSE_STATUS_INTERNAL_ERROR`*                         |
-|            8 |*`CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED`*                  |                  |*`HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED`*              |
-|            9 |*`CUSPARSE_STATUS_ZERO_PIVOT`*                                 |                  |*`HIPSPARSE_STATUS_ZERO_PIVOT`*                             |
-| struct       |`cusparseContext`                                              |                  |                                                            |
-| typedef      |`cusparseHandle_t`                                             |                  |`hipsparseHandle_t`                                         |
-| struct       |`cusparseHybMat`                                               |                  |                                                            |
-| typedef      |`cusparseHybMat_t`                                             |                  |`hipsparseHybMat_t`                                         |
-| struct       |`cusparseMatDescr`                                             |                  |                                                            |
-| typedef      |`cusparseMatDescr_t`                                           |                  |`hipsparseMatDescr_t`                                       |
-| struct       |`cusparseSolveAnalysisInfo`                                    |                  |                                                            |
-| typedef      |`cusparseSolveAnalysisInfo_t`                                  |                  |                                                            |
-| struct       |`csrsv2Info`                                                   |                  |                                                            |
-| typedef      |`csrsv2Info_t`                                                 |                  |`csrsv2Info_t`                                              |
-| struct       |`csrsm2Info`                                                   | 9.2              |`csrsm2Info`                                                |
-| typedef      |`csrsm2Info_t`                                                 |                  |`csrsm2Info_t`                                              |
-| struct       |`bsrsv2Info`                                                   |                  |                                                            |
-| typedef      |`bsrsv2Info_t`                                                 |                  |                                                            |
-| struct       |`bsrsm2Info`                                                   |                  |                                                            |
-| typedef      |`bsrsm2Info_t`                                                 |                  |                                                            |
-| struct       |`bsric02Info`                                                  |                  |                                                            |
-| typedef      |`bsric02Info_t`                                                |                  |                                                            |
-| struct       |`csrilu02Info`                                                 |                  |                                                            |
-| typedef      |`csrilu02Info_t`                                               |                  |`csrilu02Info_t`                                            |
-| struct       |`bsrilu02Info`                                                 |                  |                                                            |
-| typedef      |`bsrilu02Info_t`                                               |                  |                                                            |
-| struct       |`csru2csrInfo`                                                 |                  |                                                            |
-| typedef      |`csru2csrInfo_t`                                               |                  |                                                            |
-| struct       |`csrgemm2Info`                                                 |                  |`csrgemm2Info`                                              |
-| typedef      |`csrgemm2Info_t`                                               |                  |`csrgemm2Info_t`                                            |
-| struct       |`cusparseColorInfo`                                            |                  |                                                            |
-| typedef      |`cusparseColorInfo_t`                                          |                  |                                                            |
-| struct       |`pruneInfo`                                                    | 9.0              |                                                            |
-| typedef      |`pruneInfo_t`                                                  | 9.0              |                                                            |
-| enum         |***`cusparseCsr2CscAlg_t`***                                   | 10.1             |                                                            |
-|            1 |*`CUSPARSE_CSR2CSC_ALG1`*                                      | 10.1             |                                                            |
-|            2 |*`CUSPARSE_CSR2CSC_ALG2`*                                      | 10.1             |                                                            |
-| enum         |***`cusparseFormat_t`***                                       | 10.1             |                                                            |
-|            1 |*`CUSPARSE_FORMAT_CSR`*                                        | 10.1             |                                                            |
-|            2 |*`CUSPARSE_FORMAT_CSC`*                                        | 10.1             |                                                            |
-|            3 |*`CUSPARSE_FORMAT_COO`*                                        | 10.1             |                                                            |
-|            4 |*`CUSPARSE_FORMAT_COO_AOS`*                                    | 10.1             |                                                            |
-| enum         |***`cusparseOrder_t`***                                        | 10.1             |                                                            |
-|            1 |*`CUSPARSE_ORDER_COL`*                                         | 10.1             |                                                            |
-|            2 |*`CUSPARSE_ORDER_ROW`*                                         | 10.1             |                                                            |
-| enum         |***`cusparseSpMVAlg_t`***                                      | 10.1             |                                                            |
-|            0 |*`CUSPARSE_MV_ALG_DEFAULT`*                                    | 10.1             |                                                            |
-|            1 |*`CUSPARSE_COOMV_ALG`*                                         | 10.1             |                                                            |
-|            2 |*`CUSPARSE_CSRMV_ALG1`*                                        | 10.1             |                                                            |
-|            3 |*`CUSPARSE_CSRMV_ALG2`*                                        | 10.1             |                                                            |
-| enum         |***`cusparseSpMMAlg_t`***                                      | 10.1             |                                                            |
-|            0 |*`CUSPARSE_MM_ALG_DEFAULT`*                                    | 10.1             |                                                            |
-|            1 |*`CUSPARSE_COOMM_ALG1`*                                        | 10.1             |                                                            |
-|            2 |*`CUSPARSE_COOMM_ALG2`*                                        | 10.1             |                                                            |
-|            3 |*`CUSPARSE_COOMM_ALG3`*                                        | 10.1             |                                                            |
-|            4 |*`CUSPARSE_CSRMM_ALG1`*                                        | 10.1             |                                                            |
-| enum         |***`cusparseIndexType_t`***                                    | 10.1             |                                                            |
-|            1 |*`CUSPARSE_INDEX_16U`*                                         | 10.1             |                                                            |
-|            2 |*`CUSPARSE_INDEX_32I`*                                         | 10.1             |                                                            |
-|            3 |*`CUSPARSE_INDEX_64I`*                                         | 10.1             |                                                            |
-| struct       |`cusparseSpMatDescr`                                           | 10.1             |                                                            |
-| typedef      |`cusparseSpMatDescr_t`                                         | 10.1             |                                                            |
-| struct       |`cusparseDnMatDescr`                                           | 10.1             |                                                            |
-| typedef      |`cusparseDnMatDescr_t`                                         | 10.1             |                                                            |
-| struct       |`cusparseSpVecDescr`                                           | 10.1             |                                                            |
-| typedef      |`cusparseSpVecDescr_t`                                         | 10.1             |                                                            |
-| struct       |`cusparseDnVecDescr`                                           | 10.1             |                                                            |
-| typedef      |`cusparseDnVecDescr_t`                                         | 10.1             |                                                            |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`CUSPARSE_ACTION_NUMERIC`|  |  |  |`HIPSPARSE_ACTION_NUMERIC`|
+|`CUSPARSE_ACTION_SYMBOLIC`|  |  |  |`HIPSPARSE_ACTION_SYMBOLIC`|
+|`CUSPARSE_ALG0`| 8.0 |  | 11.0 ||
+|`CUSPARSE_ALG1`| 8.0 |  | 11.0 ||
+|`CUSPARSE_ALG_MERGE_PATH`| 9.2 |  |  ||
+|`CUSPARSE_ALG_NAIVE`| 9.2 |  | 11.0 ||
+|`CUSPARSE_COOMM_ALG1`| 10.1 | 11.0 |  ||
+|`CUSPARSE_COOMM_ALG2`| 10.1 | 11.0 |  ||
+|`CUSPARSE_COOMM_ALG3`| 10.1 | 11.0 |  ||
+|`CUSPARSE_COOMV_ALG`| 10.2 |  |  ||
+|`CUSPARSE_CSR2CSC_ALG1`| 10.1 |  |  ||
+|`CUSPARSE_CSR2CSC_ALG2`| 10.1 |  |  ||
+|`CUSPARSE_CSRMM_ALG1`| 10.2 | 11.0 |  ||
+|`CUSPARSE_CSRMV_ALG1`| 10.2 |  |  ||
+|`CUSPARSE_CSRMV_ALG2`| 10.2 |  |  ||
+|`CUSPARSE_DIAG_TYPE_NON_UNIT`|  |  |  |`HIPSPARSE_DIAG_TYPE_NON_UNIT`|
+|`CUSPARSE_DIAG_TYPE_UNIT`|  |  |  |`HIPSPARSE_DIAG_TYPE_UNIT`|
+|`CUSPARSE_DIRECTION_COLUMN`|  |  |  |`HIPSPARSE_DIRECTION_COLUMN`|
+|`CUSPARSE_DIRECTION_ROW`|  |  |  |`HIPSPARSE_DIRECTION_ROW`|
+|`CUSPARSE_FILL_MODE_LOWER`|  |  |  |`HIPSPARSE_FILL_MODE_LOWER`|
+|`CUSPARSE_FILL_MODE_UPPER`|  |  |  |`HIPSPARSE_FILL_MODE_UPPER`|
+|`CUSPARSE_FORMAT_COO`| 10.1 |  |  ||
+|`CUSPARSE_FORMAT_COO_AOS`| 10.2 |  |  ||
+|`CUSPARSE_FORMAT_CSC`| 10.1 |  |  ||
+|`CUSPARSE_FORMAT_CSR`| 10.1 |  |  ||
+|`CUSPARSE_HYB_PARTITION_AUTO`|  | 10.2 | 11.0 |`HIPSPARSE_HYB_PARTITION_AUTO`|
+|`CUSPARSE_HYB_PARTITION_MAX`|  | 10.2 | 11.0 |`HIPSPARSE_HYB_PARTITION_MAX`|
+|`CUSPARSE_HYB_PARTITION_USER`|  | 10.2 | 11.0 |`HIPSPARSE_HYB_PARTITION_USER`|
+|`CUSPARSE_INDEX_16U`| 10.1 |  |  ||
+|`CUSPARSE_INDEX_32I`| 10.1 |  |  ||
+|`CUSPARSE_INDEX_64I`| 10.2 |  |  ||
+|`CUSPARSE_INDEX_BASE_ONE`|  |  |  |`HIPSPARSE_INDEX_BASE_ONE`|
+|`CUSPARSE_INDEX_BASE_ZERO`|  |  |  |`HIPSPARSE_INDEX_BASE_ZERO`|
+|`CUSPARSE_MATRIX_TYPE_GENERAL`|  |  |  |`HIPSPARSE_MATRIX_TYPE_GENERAL`|
+|`CUSPARSE_MATRIX_TYPE_HERMITIAN`|  |  |  |`HIPSPARSE_MATRIX_TYPE_HERMITIAN`|
+|`CUSPARSE_MATRIX_TYPE_SYMMETRIC`|  |  |  |`HIPSPARSE_MATRIX_TYPE_SYMMETRIC`|
+|`CUSPARSE_MATRIX_TYPE_TRIANGULAR`|  |  |  |`HIPSPARSE_MATRIX_TYPE_TRIANGULAR`|
+|`CUSPARSE_MM_ALG_DEFAULT`| 10.2 |  |  ||
+|`CUSPARSE_MV_ALG_DEFAULT`| 10.2 |  |  ||
+|`CUSPARSE_OPERATION_CONJUGATE_TRANSPOSE`|  |  |  |`HIPSPARSE_OPERATION_CONJUGATE_TRANSPOSE`|
+|`CUSPARSE_OPERATION_NON_TRANSPOSE`|  |  |  |`HIPSPARSE_OPERATION_NON_TRANSPOSE`|
+|`CUSPARSE_OPERATION_TRANSPOSE`|  |  |  |`HIPSPARSE_OPERATION_TRANSPOSE`|
+|`CUSPARSE_ORDER_COL`| 10.1 |  |  ||
+|`CUSPARSE_ORDER_ROW`| 10.1 |  |  ||
+|`CUSPARSE_POINTER_MODE_DEVICE`|  |  |  |`HIPSPARSE_POINTER_MODE_DEVICE`|
+|`CUSPARSE_POINTER_MODE_HOST`|  |  |  |`HIPSPARSE_POINTER_MODE_HOST`|
+|`CUSPARSE_SOLVE_POLICY_NO_LEVEL`|  |  |  |`HIPSPARSE_SOLVE_POLICY_NO_LEVEL`|
+|`CUSPARSE_SOLVE_POLICY_USE_LEVEL`|  |  |  |`HIPSPARSE_SOLVE_POLICY_USE_LEVEL`|
+|`CUSPARSE_SPGEMM_DEFAULT`| 11.0 |  |  ||
+|`CUSPARSE_SPMM_ALG_DEFAULT`| 11.0 |  |  ||
+|`CUSPARSE_SPMM_COO_ALG1`| 11.0 |  |  ||
+|`CUSPARSE_SPMM_COO_ALG2`| 11.0 |  |  ||
+|`CUSPARSE_SPMM_COO_ALG3`| 11.0 |  |  ||
+|`CUSPARSE_SPMM_COO_ALG4`| 11.0 |  |  ||
+|`CUSPARSE_SPMM_CSR_ALG1`| 11.0 |  |  ||
+|`CUSPARSE_SPMM_CSR_ALG2`| 11.0 |  |  ||
+|`CUSPARSE_STATUS_ALLOC_FAILED`|  |  |  |`HIPSPARSE_STATUS_ALLOC_FAILED`|
+|`CUSPARSE_STATUS_ARCH_MISMATCH`|  |  |  |`HIPSPARSE_STATUS_ARCH_MISMATCH`|
+|`CUSPARSE_STATUS_EXECUTION_FAILED`|  |  |  |`HIPSPARSE_STATUS_EXECUTION_FAILED`|
+|`CUSPARSE_STATUS_INSUFFICIENT_RESOURCES`| 11.0 |  |  ||
+|`CUSPARSE_STATUS_INTERNAL_ERROR`|  |  |  |`HIPSPARSE_STATUS_INTERNAL_ERROR`|
+|`CUSPARSE_STATUS_INVALID_VALUE`|  |  |  |`HIPSPARSE_STATUS_INVALID_VALUE`|
+|`CUSPARSE_STATUS_MAPPING_ERROR`|  |  |  |`HIPSPARSE_STATUS_MAPPING_ERROR`|
+|`CUSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED`|  |  |  |`HIPSPARSE_STATUS_MATRIX_TYPE_NOT_SUPPORTED`|
+|`CUSPARSE_STATUS_NOT_INITIALIZED`|  |  |  |`HIPSPARSE_STATUS_NOT_INITIALIZED`|
+|`CUSPARSE_STATUS_NOT_SUPPORTED`| 10.2 |  |  ||
+|`CUSPARSE_STATUS_SUCCESS`|  |  |  |`HIPSPARSE_STATUS_SUCCESS`|
+|`CUSPARSE_STATUS_ZERO_PIVOT`|  |  |  |`HIPSPARSE_STATUS_ZERO_PIVOT`|
+|`CUSPARSE_VERSION`| 10.2 |  |  ||
+|`CUSPARSE_VER_BUILD`| 10.2 |  |  ||
+|`CUSPARSE_VER_MAJOR`| 10.2 |  |  ||
+|`CUSPARSE_VER_MINOR`| 10.2 |  |  ||
+|`CUSPARSE_VER_PATCH`| 10.2 |  |  ||
+|`bsric02Info`|  |  |  ||
+|`bsric02Info_t`|  |  |  ||
+|`bsrilu02Info`|  |  |  ||
+|`bsrilu02Info_t`|  |  |  ||
+|`bsrsm2Info`|  |  |  ||
+|`bsrsm2Info_t`|  |  |  ||
+|`bsrsv2Info`|  |  |  ||
+|`bsrsv2Info_t`|  |  |  ||
+|`csrgemm2Info`|  |  |  |`csrgemm2Info`|
+|`csrgemm2Info_t`|  |  |  |`csrgemm2Info_t`|
+|`csrilu02Info`|  |  |  ||
+|`csrilu02Info_t`|  |  |  |`csrilu02Info_t`|
+|`csrsm2Info`| 9.2 |  |  |`csrsm2Info`|
+|`csrsm2Info_t`| 9.2 |  |  |`csrsm2Info_t`|
+|`csrsv2Info`|  |  |  ||
+|`csrsv2Info_t`|  |  |  |`csrsv2Info_t`|
+|`csru2csrInfo`|  |  |  ||
+|`csru2csrInfo_t`|  |  |  ||
+|`cusparseAction_t`|  |  |  |`hipsparseAction_t`|
+|`cusparseAlgMode_t`| 8.0 |  |  ||
+|`cusparseColorInfo`|  |  |  ||
+|`cusparseColorInfo_t`|  |  |  ||
+|`cusparseContext`|  |  |  ||
+|`cusparseCsr2CscAlg_t`| 10.1 |  |  ||
+|`cusparseDiagType_t`|  |  |  |`hipsparseDiagType_t`|
+|`cusparseDirection_t`|  |  |  |`hipsparseDirection_t`|
+|`cusparseDnMatDescr`| 10.1 |  |  ||
+|`cusparseDnMatDescr_t`| 10.1 |  |  ||
+|`cusparseDnVecDescr`| 10.2 |  |  ||
+|`cusparseDnVecDescr_t`| 10.2 |  |  ||
+|`cusparseFillMode_t`|  |  |  |`hipsparseFillMode_t`|
+|`cusparseFormat_t`| 10.1 |  |  ||
+|`cusparseHandle_t`|  |  |  |`hipsparseHandle_t`|
+|`cusparseHybMat`|  | 10.2 | 11.0 ||
+|`cusparseHybMat_t`|  | 10.2 | 11.0 |`hipsparseHybMat_t`|
+|`cusparseHybPartition_t`|  | 10.2 | 11.0 |`hipsparseHybPartition_t`|
+|`cusparseIndexBase_t`|  |  |  |`hipsparseIndexBase_t`|
+|`cusparseIndexType_t`| 10.1 |  |  ||
+|`cusparseMatDescr`|  |  |  ||
+|`cusparseMatDescr_t`|  |  |  |`hipsparseMatDescr_t`|
+|`cusparseMatrixType_t`|  |  |  |`hipsparseMatrixType_t`|
+|`cusparseOperation_t`|  |  |  |`hipsparseOperation_t`|
+|`cusparseOrder_t`| 10.1 |  |  ||
+|`cusparsePointerMode_t`|  |  |  |`hipsparsePointerMode_t`|
+|`cusparseSolveAnalysisInfo`|  | 10.2 | 11.0 ||
+|`cusparseSolveAnalysisInfo_t`|  | 10.2 | 11.0 ||
+|`cusparseSolvePolicy_t`|  |  |  |`hipsparseSolvePolicy_t`|
+|`cusparseSpGEMMAlg_t`| 11.0 |  |  ||
+|`cusparseSpGEMMDescr`| 11.0 |  |  ||
+|`cusparseSpGEMMDescr_t`| 11.0 |  |  ||
+|`cusparseSpMMAlg_t`| 10.1 |  |  ||
+|`cusparseSpMVAlg_t`| 10.2 |  |  ||
+|`cusparseSpMatDescr`| 10.1 |  |  ||
+|`cusparseSpMatDescr_t`| 10.1 |  |  ||
+|`cusparseSpVecDescr`| 10.2 |  |  ||
+|`cusparseSpVecDescr_t`| 10.2 |  |  ||
+|`cusparseStatus_t`|  |  |  |`hipsparseStatus_t`|
+|`pruneInfo`| 9.0 |  |  ||
+|`pruneInfo_t`| 9.0 |  |  ||
 
-## **2. cuSPARSE Helper Function Reference**
+## **5. CUSPARSE Management Function Reference**
 
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseCreate`                                           |`hipsparseCreate`                                |
-|`cusparseCreateSolveAnalysisInfo`                          |                                                 |
-|`cusparseCreateHybMat`                                     |`hipsparseCreateHybMat`                          |
-|`cusparseCreateMatDescr`                                   |`hipsparseCreateMatDescr`                        |
-|`cusparseDestroy`                                          |`hipsparseDestroy`                               |
-|`cusparseDestroySolveAnalysisInfo`                         |                                                 |
-|`cusparseDestroyHybMat`                                    |`hipsparseDestroyHybMat`                         |
-|`cusparseDestroyMatDescr`                                  |`hipsparseDestroyMatDescr`                       |
-|`cusparseGetLevelInfo`                                     |                                                 |
-|`cusparseGetMatDiagType`                                   |`hipsparseGetMatDiagType`                        |
-|`cusparseGetMatFillMode`                                   |`hipsparseGetMatFillMode`                        |
-|`cusparseGetMatIndexBase`                                  |`hipsparseGetMatIndexBase`                       |
-|`cusparseGetMatType`                                       |`hipsparseGetMatType`                            |
-|`cusparseGetPointerMode`                                   |`hipsparseGetPointerMode`                        |
-|`cusparseGetVersion`                                       |`hipsparseGetVersion`                            |
-|`cusparseSetMatDiagType`                                   |`hipsparseSetMatDiagType`                        |
-|`cusparseSetMatFillMode`                                   |`hipsparseSetMatFillMode`                        |
-|`cusparseSetMatType`                                       |`hipsparseSetMatType`                            |
-|`cusparseSetPointerMode`                                   |`hipsparseSetPointerMode`                        |
-|`cusparseSetStream`                                        |`hipsparseSetStream`                             |
-|`cusparseGetStream`                                        |`hipsparseGetStream`                             | 8.0              |
-|`cusparseCreateCsrsv2Info`                                 |`hipsparseCreateCsrsv2Info`                      |
-|`cusparseDestroyCsrsv2Info`                                |`hipsparseDestroyCsrsv2Info`                     |
-|`cusparseCreateCsrsm2Info`                                 |`hipsparseCreateCsrsm2Info`                      | 9.2              |
-|`cusparseDestroyCsrsm2Info`                                |`hipsparseDestroyCsrsm2Info`                     | 9.2              |
-|`cusparseCreateCsric02Info`                                |`hipsparseCreateCsric02Info`                     |
-|`cusparseDestroyCsric02Info`                               |`hipsparseDestroyCsric02Info`                    |
-|`cusparseCreateCsrilu02Info`                               |`hipsparseCreateCsrilu02Info`                    |
-|`cusparseDestroyCsrilu02Info`                              |`hipsparseDestroyCsrilu02Info`                   |
-|`cusparseCreateBsrsv2Info`                                 |                                                 |
-|`cusparseDestroyBsrsv2Info`                                |                                                 |
-|`cusparseCreateBsrsm2Info`                                 |                                                 |
-|`cusparseDestroyBsrsm2Info`                                |                                                 |
-|`cusparseCreateBsric02Info`                                |                                                 |
-|`cusparseDestroyBsric02Info`                               |                                                 |
-|`cusparseCreateBsrilu02Info`                               |                                                 |
-|`cusparseDestroyBsrilu02Info`                              |                                                 |
-|`cusparseCreateCsrgemm2Info`                               |`hipsparseCreateCsrgemm2Info`                    |
-|`cusparseDestroyCsrgemm2Info`                              |`hipsparseDestroyCsrgemm2Info`                   |
-|`cusparseCreatePruneInfo`                                  |                                                 | 9.0              |
-|`cusparseDestroyPruneInfo`                                 |                                                 | 9.0              |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cusparseCreate`|  |  |  |`hipsparseCreate`|
+|`cusparseDestroy`|  |  |  |`hipsparseDestroy`|
+|`cusparseGetPointerMode`|  |  |  |`hipsparseGetPointerMode`|
+|`cusparseGetStream`|  |  |  |`hipsparseGetStream`|
+|`cusparseGetVersion`|  |  |  |`hipsparseGetVersion`|
+|`cusparseSetPointerMode`|  |  |  |`hipsparseSetPointerMode`|
+|`cusparseSetStream`|  |  |  |`hipsparseSetStream`|
 
-## **3. cuSPARSE Level 1 Function Reference**
+## **6. CUSPARSE Helper Function Reference**
 
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseSaxpyi`                                           |`hipsparseSaxpyi`                                |
-|`cusparseDaxpyi`                                           |`hipsparseDaxpyi`                                |
-|`cusparseCaxpyi`                                           |`hipsparseCaxpyi`                                |
-|`cusparseZaxpyi`                                           |`hipsparseZaxpyi`                                |
-|`cusparseSdoti`                                            |`hipsparseSdoti`                                 |
-|`cusparseDdoti`                                            |`hipsparseDdoti`                                 |
-|`cusparseCdoti`                                            |`hipsparseCdoti`                                 |
-|`cusparseZdoti`                                            |`hipsparseZdoti`                                 |
-|`cusparseCdotci`                                           |`hipsparseCdotci`                                |
-|`cusparseZdotci`                                           |`hipsparseZdotci`                                |
-|`cusparseSgthr`                                            |`hipsparseSgthr`                                 |
-|`cusparseDgthr`                                            |`hipsparseDgthr`                                 |
-|`cusparseCgthr`                                            |`hipsparseCgthr`                                 |
-|`cusparseZgthr`                                            |`hipsparseZgthr`                                 |
-|`cusparseSgthrz`                                           |`hipsparseSgthrz`                                |
-|`cusparseDgthrz`                                           |`hipsparseDgthrz`                                |
-|`cusparseCgthrz`                                           |`hipsparseCgthrz`                                |
-|`cusparseZgthrz`                                           |`hipsparseZgthrz`                                |
-|`cusparseSroti`                                            |`hipsparseSroti`                                 |
-|`cusparseDroti`                                            |`hipsparseDroti`                                 |
-|`cusparseSsctr`                                            |`hipsparseSsctr`                                 |
-|`cusparseDsctr`                                            |`hipsparseDsctr`                                 |
-|`cusparseCsctr`                                            |`hipsparseCsctr`                                 |
-|`cusparseZsctr`                                            |`hipsparseZsctr`                                 |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cusparseCreateBsric02Info`|  |  |  ||
+|`cusparseCreateBsrilu02Info`|  |  |  ||
+|`cusparseCreateBsrsm2Info`|  |  |  ||
+|`cusparseCreateBsrsv2Info`|  |  |  ||
+|`cusparseCreateCsrgemm2Info`|  | 11.0 |  |`hipsparseCreateCsrgemm2Info`|
+|`cusparseCreateCsric02Info`|  |  |  |`hipsparseCreateCsric02Info`|
+|`cusparseCreateCsrilu02Info`|  |  |  |`hipsparseCreateCsrilu02Info`|
+|`cusparseCreateCsrsm2Info`| 10.0 |  |  |`hipsparseCreateCsrsm2Info`|
+|`cusparseCreateCsrsv2Info`|  |  |  |`hipsparseCreateCsrsv2Info`|
+|`cusparseCreateHybMat`|  | 10.2 | 11.0 |`hipsparseCreateHybMat`|
+|`cusparseCreateMatDescr`|  |  |  |`hipsparseCreateMatDescr`|
+|`cusparseCreatePruneInfo`| 9.0 |  |  ||
+|`cusparseCreateSolveAnalysisInfo`|  | 10.2 | 11.0 ||
+|`cusparseDestroyBsric02Info`|  |  |  ||
+|`cusparseDestroyBsrilu02Info`|  |  |  ||
+|`cusparseDestroyBsrsm2Info`|  |  |  ||
+|`cusparseDestroyBsrsv2Info`|  |  |  ||
+|`cusparseDestroyCsrgemm2Info`|  | 11.0 |  |`hipsparseDestroyCsrgemm2Info`|
+|`cusparseDestroyCsric02Info`|  |  |  |`hipsparseDestroyCsric02Info`|
+|`cusparseDestroyCsrilu02Info`|  |  |  |`hipsparseDestroyCsrilu02Info`|
+|`cusparseDestroyCsrsm2Info`| 10.0 |  |  |`hipsparseDestroyCsrsm2Info`|
+|`cusparseDestroyCsrsv2Info`|  |  |  |`hipsparseDestroyCsrsv2Info`|
+|`cusparseDestroyHybMat`|  | 10.2 | 11.0 |`hipsparseDestroyHybMat`|
+|`cusparseDestroyMatDescr`|  |  |  |`hipsparseDestroyMatDescr`|
+|`cusparseDestroyPruneInfo`| 9.0 |  |  ||
+|`cusparseDestroySolveAnalysisInfo`|  | 10.2 | 11.0 ||
+|`cusparseGetLevelInfo`|  |  | 11.0 ||
+|`cusparseGetMatDiagType`|  |  |  |`hipsparseGetMatDiagType`|
+|`cusparseGetMatFillMode`|  |  |  |`hipsparseGetMatFillMode`|
+|`cusparseGetMatIndexBase`|  |  |  |`hipsparseGetMatIndexBase`|
+|`cusparseGetMatType`|  |  |  |`hipsparseGetMatType`|
+|`cusparseSetMatDiagType`|  |  |  |`hipsparseSetMatDiagType`|
+|`cusparseSetMatFillMode`|  |  |  |`hipsparseSetMatFillMode`|
+|`cusparseSetMatIndexBase`|  |  |  |`hipsparseSetMatIndexBase`|
+|`cusparseSetMatType`|  |  |  |`hipsparseSetMatType`|
 
-## **4. cuSPARSE Level 2 Function Reference**
+## **7. CUSPARSE Level 1 Function Reference**
 
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseSbsrmv`                                           |`hipsparseSbsrmv`                                |
-|`cusparseDbsrmv`                                           |`hipsparseDbsrmv`                                |
-|`cusparseCbsrmv`                                           |`hipsparseCbsrmv`                                |
-|`cusparseZbsrmv`                                           |`hipsparseZbsrmv`                                |
-|`cusparseSbsrxmv`                                          |                                                 |
-|`cusparseDbsrxmv`                                          |                                                 |
-|`cusparseCbsrxmv`                                          |                                                 |
-|`cusparseZbsrxmv`                                          |                                                 |
-|`cusparseScsrmv`                                           |`hipsparseScsrmv`                                |
-|`cusparseDcsrmv`                                           |`hipsparseDcsrmv`                                |
-|`cusparseCcsrmv`                                           |`hipsparseCcsrmv`                                |
-|`cusparseZcsrmv`                                           |`hipsparseZcsrmv`                                |
-|`cusparseCsrmvEx`                                          |                                                 | 8.0              |
-|`cusparseCsrmvEx_bufferSize`                               |                                                 | 8.0              |
-|`cusparseScsrmv_mp`                                        |                                                 | 8.0              |
-|`cusparseDcsrmv_mp`                                        |                                                 | 8.0              |
-|`cusparseCcsrmv_mp`                                        |                                                 | 8.0              |
-|`cusparseZcsrmv_mp`                                        |                                                 | 8.0              |
-|`cusparseSgemvi`                                           |                                                 | 7.5              |
-|`cusparseDgemvi`                                           |                                                 | 7.5              |
-|`cusparseCgemvi`                                           |                                                 | 7.5              |
-|`cusparseZgemvi`                                           |                                                 | 7.5              |
-|`cusparseSgemvi_bufferSize`                                |                                                 | 7.5              |
-|`cusparseDgemvi_bufferSize`                                |                                                 | 7.5              |
-|`cusparseCgemvi_bufferSize`                                |                                                 | 7.5              |
-|`cusparseZgemvi_bufferSize`                                |                                                 | 7.5              |
-|`cusparseSbsrsv2_bufferSize`                               |                                                 |
-|`cusparseSbsrsv2_bufferSizeExt`                            |                                                 |
-|`cusparseDbsrsv2_bufferSize`                               |                                                 |
-|`cusparseDbsrsv2_bufferSizeExt`                            |                                                 |
-|`cusparseCbsrsv2_bufferSize`                               |                                                 |
-|`cusparseCbsrsv2_bufferSizeExt`                            |                                                 |
-|`cusparseZbsrsv2_bufferSize`                               |                                                 |
-|`cusparseZbsrsv2_bufferSizeExt`                            |                                                 |
-|`cusparseSbsrsv2_analysis`                                 |                                                 |
-|`cusparseDbsrsv2_analysis`                                 |                                                 |
-|`cusparseCbsrsv2_analysis`                                 |                                                 |
-|`cusparseZbsrsv2_analysis`                                 |                                                 |
-|`cusparseXbsrsv2_zeroPivot`                                |                                                 |
-|`cusparseSbsrsv2_solve                                     |                                                 |
-|`cusparseDbsrsv2_solve                                     |                                                 |
-|`cusparseCbsrsv2_solve                                     |                                                 |
-|`cusparseZbsrsv2_solve                                     |                                                 |
-|`cusparseScsrsv_analysis`                                  |                                                 |
-|`cusparseDcsrsv_analysis`                                  |                                                 |
-|`cusparseCcsrsv_analysis`                                  |                                                 |
-|`cusparseZcsrsv_analysis`                                  |                                                 |
-|`cusparseCsrsv_analysisEx`                                 |                                                 | 8.0              |
-|`cusparseScsrsv_solve`                                     |                                                 |
-|`cusparseDcsrsv_solve`                                     |                                                 |
-|`cusparseCcsrsv_solve`                                     |                                                 |
-|`cusparseZcsrsv_solve`                                     |                                                 |
-|`cusparseCsrsv_solveEx`                                    |                                                 | 8.0              |
-|`cusparseScsrsv2_bufferSize`                               |`hipsparseScsrsv2_bufferSize`                    |
-|`cusparseScsrsv2_bufferSizeExt`                            |`hipsparseScsrsv2_bufferSizeExt`                 |
-|`cusparseDcsrsv2_bufferSize`                               |`hipsparseDcsrsv2_bufferSize`                    |
-|`cusparseDcsrsv2_bufferSizeExt`                            |`hipsparseDcsrsv2_bufferSizeExt`                 |
-|`cusparseCcsrsv2_bufferSize`                               |`hipsparseCcsrsv2_bufferSize`                    |
-|`cusparseCcsrsv2_bufferSizeExt`                            |`hipsparseCcsrsv2_bufferSizeExt`                 |
-|`cusparseZcsrsv2_bufferSize`                               |`hipsparseZcsrsv2_bufferSize`                    |
-|`cusparseZcsrsv2_bufferSizeExt`                            |`hipsparseZcsrsv2_bufferSizeExt`                 |
-|`cusparseScsrsv2_analysis`                                 |`hipsparseScsrsv2_analysis`                      |
-|`cusparseDcsrsv2_analysis`                                 |`hipsparseDcsrsv2_analysis`                      |
-|`cusparseCcsrsv2_analysis`                                 |`hipsparseCcsrsv2_analysis`                      |
-|`cusparseZcsrsv2_analysis`                                 |`hipsparseZcsrsv2_analysis`                      |
-|`cusparseScsrsv2_solve`                                    |`hipsparseScsrsv2_solve`                         |
-|`cusparseDcsrsv2_solve`                                    |`hipsparseDcsrsv2_solve`                         |
-|`cusparseCcsrsv2_solve`                                    |`hipsparseCcsrsv2_solve`                         |
-|`cusparseZcsrsv2_solve`                                    |`hipsparseZcsrsv2_solve`                         |
-|`cusparseXcsrsv2_zeroPivot`                                |`hipsparseXcsrsv2_zeroPivot`                     |
-|`cusparseShybmv`                                           |`hipsparseShybmv`                                |
-|`cusparseDhybmv`                                           |`hipsparseDhybmv`                                |
-|`cusparseChybmv`                                           |`hipsparseChybmv`                                |
-|`cusparseZhybmv`                                           |`hipsparseZhybmv`                                |
-|`cusparseShybsv_analysis`                                  |                                                 |
-|`cusparseDhybsv_analysis`                                  |                                                 |
-|`cusparseChybsv_analysis`                                  |                                                 |
-|`cusparseZhybsv_analysis`                                  |                                                 |
-|`cusparseShybsv_solve`                                     |                                                 |
-|`cusparseDhybsv_solve`                                     |                                                 |
-|`cusparseChybsv_solve`                                     |                                                 |
-|`cusparseZhybsv_solve`                                     |                                                 |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cusparseCaxpyi`|  | 11.0 |  |`hipsparseCaxpyi`|
+|`cusparseCdotci`|  | 10.2 | 11.0 |`hipsparseCdotci`|
+|`cusparseCdoti`|  | 10.2 | 11.0 |`hipsparseCdoti`|
+|`cusparseCgthr`|  | 11.0 |  |`hipsparseCgthr`|
+|`cusparseCgthrz`|  | 11.0 |  |`hipsparseCgthrz`|
+|`cusparseCsctr`|  | 11.0 |  |`hipsparseCsctr`|
+|`cusparseDaxpyi`|  | 11.0 |  |`hipsparseDaxpyi`|
+|`cusparseDdoti`|  | 10.2 | 11.0 |`hipsparseDdoti`|
+|`cusparseDgthr`|  | 11.0 |  |`hipsparseDgthr`|
+|`cusparseDgthrz`|  | 11.0 |  |`hipsparseDgthrz`|
+|`cusparseDroti`|  | 11.0 |  |`hipsparseDroti`|
+|`cusparseDsctr`|  | 11.0 |  |`hipsparseDsctr`|
+|`cusparseSaxpyi`|  | 11.0 |  |`hipsparseSaxpyi`|
+|`cusparseSdoti`|  | 10.2 | 11.0 |`hipsparseSdoti`|
+|`cusparseSgthr`|  | 11.0 |  |`hipsparseSgthr`|
+|`cusparseSgthrz`|  | 11.0 |  |`hipsparseSgthrz`|
+|`cusparseSroti`|  | 11.0 |  |`hipsparseSroti`|
+|`cusparseSsctr`|  | 11.0 |  |`hipsparseSsctr`|
+|`cusparseZaxpyi`|  | 11.0 |  |`hipsparseZaxpyi`|
+|`cusparseZdotci`|  | 10.2 | 11.0 |`hipsparseZdotci`|
+|`cusparseZdoti`|  | 10.2 | 11.0 |`hipsparseZdoti`|
+|`cusparseZgthr`|  | 11.0 |  |`hipsparseZgthr`|
+|`cusparseZgthrz`|  | 11.0 |  |`hipsparseZgthrz`|
+|`cusparseZsctr`|  | 11.0 |  |`hipsparseZsctr`|
 
-## **5. cuSPARSE Level 3 Function Reference**
+## **8. CUSPARSE Level 2 Function Reference**
 
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseScsrmm`                                           |`hipsparseScsrmm`                                |
-|`cusparseDcsrmm`                                           |`hipsparseDcsrmm`                                |
-|`cusparseCcsrmm`                                           |`hipsparseCcsrmm`                                |
-|`cusparseZcsrmm`                                           |`hipsparseZcsrmm`                                |
-|`cusparseScsrmm2`                                          |`hipsparseScsrmm2`                               |
-|`cusparseDcsrmm2`                                          |`hipsparseDcsrmm2`                               |
-|`cusparseCcsrmm2`                                          |`hipsparseCcsrmm2`                               |
-|`cusparseZcsrmm2`                                          |`hipsparseZcsrmm2`                               |
-|`cusparseScsrsm_analysis`                                  |                                                 |
-|`cusparseDcsrsm_analysis`                                  |                                                 |
-|`cusparseCcsrsm_analysis`                                  |                                                 |
-|`cusparseZcsrsm_analysis`                                  |                                                 |
-|`cusparseScsrsm_solve`                                     |                                                 |
-|`cusparseDcsrsm_solve`                                     |                                                 |
-|`cusparseCcsrsm_solve`                                     |                                                 |
-|`cusparseZcsrsm_solve`                                     |                                                 |
-|`cusparseScsrsm2_bufferSizeExt`                            |`hipsparseScsrsm2_bufferSizeExt`                 | 9.2              |
-|`cusparseDcsrsm2_bufferSizeExt`                            |`hipsparseDcsrsm2_bufferSizeExt`                 | 9.2              |
-|`cusparseCcsrsm2_bufferSizeExt`                            |`hipsparseCcsrsm2_bufferSizeExt`                 | 9.2              |
-|`cusparseZcsrsm2_bufferSizeExt`                            |`hipsparseZcsrsm2_bufferSizeExt`                 | 9.2              |
-|`cusparseScsrsm2_analysis`                                 |`hipsparseScsrsm2_analysis`                      | 9.2              |
-|`cusparseDcsrsm2_analysis`                                 |`hipsparseDcsrsm2_analysis`                      | 9.2              |
-|`cusparseCcsrsm2_analysis`                                 |`hipsparseCcsrsm2_analysis`                      | 9.2              |
-|`cusparseZcsrsm2_analysis`                                 |`hipsparseZcsrsm2_analysis`                      | 9.2              |
-|`cusparseScsrsm2_solve`                                    |`hipsparseScsrsm2_solve`                         | 9.2              |
-|`cusparseDcsrsm2_solve`                                    |`hipsparseDcsrsm2_solve`                         | 9.2              |
-|`cusparseCcsrsm2_solve`                                    |`hipsparseCcsrsm2_solve`                         | 9.2              |
-|`cusparseZcsrsm2_solve`                                    |`hipsparseZcsrsm2_solve`                         | 9.2              |
-|`cusparseXcsrsm2_zeroPivot`                                |`hipsparseXcsrsm2_zeroPivot`                     | 9.2              |
-|`cusparseSbsrmm`                                           |                                                 |
-|`cusparseDbsrmm`                                           |                                                 |
-|`cusparseCbsrmm`                                           |                                                 |
-|`cusparseZbsrmm`                                           |                                                 |
-|`cusparseSbsrsm2_bufferSize`                               |                                                 |
-|`cusparseSbsrsm2_bufferSizeExt`                            |                                                 |
-|`cusparseDbsrsm2_bufferSize`                               |                                                 |
-|`cusparseDbsrsm2_bufferSizeExt`                            |                                                 |
-|`cusparseCbsrsm2_bufferSize`                               |                                                 |
-|`cusparseCbsrsm2_bufferSizeExt`                            |                                                 |
-|`cusparseZbsrsm2_bufferSize`                               |                                                 |
-|`cusparseZbsrsm2_bufferSizeExt`                            |                                                 |
-|`cusparseSbsrsm2_analysis`                                 |                                                 |
-|`cusparseDbsrsm2_analysis`                                 |                                                 |
-|`cusparseCbsrsm2_analysis`                                 |                                                 |
-|`cusparseZbsrsm2_analysis`                                 |                                                 |
-|`cusparseSbsrsm2_solve`                                    |                                                 |
-|`cusparseDbsrsm2_solve`                                    |                                                 |
-|`cusparseCbsrsm2_solve`                                    |                                                 |
-|`cusparseZbsrsm2_solve`                                    |                                                 |
-|`cusparseXbsrsm2_zeroPivot`                                |                                                 |
-|`cusparseSgemmi`                                           |                                                 | 8.0              |
-|`cusparseDgemmi`                                           |                                                 | 8.0              |
-|`cusparseCgemmi`                                           |                                                 | 8.0              |
-|`cusparseZgemmi`                                           |                                                 | 8.0              |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cusparseCbsrmv`|  |  |  |`hipsparseCbsrmv`|
+|`cusparseCbsrsv2_analysis`|  |  |  ||
+|`cusparseCbsrsv2_bufferSize`|  |  |  ||
+|`cusparseCbsrsv2_bufferSizeExt`|  |  |  ||
+|`cusparseCbsrsv2_solve`|  |  |  ||
+|`cusparseCbsrxmv`|  |  |  ||
+|`cusparseCcsrmv`|  | 10.2 | 11.0 |`hipsparseCcsrmv`|
+|`cusparseCcsrmv_mp`| 8.0 | 10.2 | 11.0 ||
+|`cusparseCcsrsv2_analysis`|  |  |  |`hipsparseCcsrsv2_analysis`|
+|`cusparseCcsrsv2_bufferSize`|  |  |  |`hipsparseCcsrsv2_bufferSize`|
+|`cusparseCcsrsv2_bufferSizeExt`|  |  |  |`hipsparseCcsrsv2_bufferSizeExt`|
+|`cusparseCcsrsv2_solve`|  |  |  |`hipsparseCcsrsv2_solve`|
+|`cusparseCcsrsv_analysis`|  | 10.2 | 11.0 ||
+|`cusparseCcsrsv_solve`|  | 10.2 | 11.0 ||
+|`cusparseCgemvi`| 7.5 |  |  ||
+|`cusparseCgemvi_bufferSize`| 7.5 |  |  ||
+|`cusparseChybmv`|  | 10.2 | 11.0 |`hipsparseChybmv`|
+|`cusparseChybsv_analysis`|  | 10.2 | 11.0 ||
+|`cusparseChybsv_solve`|  | 10.2 | 11.0 ||
+|`cusparseCsrmvEx`| 8.0 |  |  ||
+|`cusparseCsrmvEx_bufferSize`| 8.0 |  |  ||
+|`cusparseCsrsv_analysisEx`| 8.0 | 10.2 | 11.0 ||
+|`cusparseCsrsv_solveEx`| 8.0 | 10.2 | 11.0 ||
+|`cusparseDbsrmv`|  |  |  |`hipsparseDbsrmv`|
+|`cusparseDbsrsv2_analysis`|  |  |  ||
+|`cusparseDbsrsv2_bufferSize`|  |  |  ||
+|`cusparseDbsrsv2_bufferSizeExt`|  |  |  ||
+|`cusparseDbsrsv2_solve`|  |  |  ||
+|`cusparseDbsrxmv`|  |  |  ||
+|`cusparseDcsrmv`|  | 10.2 | 11.0 |`hipsparseDcsrmv`|
+|`cusparseDcsrmv_mp`| 8.0 | 10.2 | 11.0 ||
+|`cusparseDcsrsv2_analysis`|  |  |  |`hipsparseDcsrsv2_analysis`|
+|`cusparseDcsrsv2_bufferSize`|  |  |  |`hipsparseDcsrsv2_bufferSize`|
+|`cusparseDcsrsv2_bufferSizeExt`|  |  |  |`hipsparseDcsrsv2_bufferSizeExt`|
+|`cusparseDcsrsv2_solve`|  |  |  |`hipsparseDcsrsv2_solve`|
+|`cusparseDcsrsv_analysis`|  | 10.2 | 11.0 ||
+|`cusparseDcsrsv_solve`|  | 10.2 | 11.0 ||
+|`cusparseDgemvi`| 7.5 |  |  ||
+|`cusparseDgemvi_bufferSize`| 7.5 |  |  ||
+|`cusparseDhybmv`|  | 10.2 | 11.0 |`hipsparseDhybmv`|
+|`cusparseDhybsv_analysis`|  | 10.2 | 11.0 ||
+|`cusparseDhybsv_solve`|  | 10.2 | 11.0 ||
+|`cusparseSbsrmv`|  |  |  |`hipsparseSbsrmv`|
+|`cusparseSbsrsv2_analysis`|  |  |  ||
+|`cusparseSbsrsv2_bufferSize`|  |  |  ||
+|`cusparseSbsrsv2_bufferSizeExt`|  |  |  ||
+|`cusparseSbsrsv2_solve`|  |  |  ||
+|`cusparseSbsrxmv`|  |  |  ||
+|`cusparseScsrmv`|  | 10.2 | 11.0 |`hipsparseScsrmv`|
+|`cusparseScsrmv_mp`| 8.0 | 10.2 | 11.0 ||
+|`cusparseScsrsv2_analysis`|  |  |  |`hipsparseScsrsv2_analysis`|
+|`cusparseScsrsv2_bufferSize`|  |  |  |`hipsparseScsrsv2_bufferSize`|
+|`cusparseScsrsv2_bufferSizeExt`|  |  |  |`hipsparseScsrsv2_bufferSizeExt`|
+|`cusparseScsrsv2_solve`|  |  |  |`hipsparseScsrsv2_solve`|
+|`cusparseScsrsv_analysis`|  | 10.2 | 11.0 ||
+|`cusparseScsrsv_solve`|  | 10.2 | 11.0 ||
+|`cusparseSgemvi`| 7.5 |  |  ||
+|`cusparseSgemvi_bufferSize`| 7.5 |  |  ||
+|`cusparseShybmv`|  | 10.2 | 11.0 |`hipsparseShybmv`|
+|`cusparseShybsv_analysis`|  | 10.2 | 11.0 ||
+|`cusparseShybsv_solve`|  | 10.2 | 11.0 ||
+|`cusparseXbsrsv2_zeroPivot`|  |  |  ||
+|`cusparseXcsrsv2_zeroPivot`|  |  |  |`hipsparseXcsrsv2_zeroPivot`|
+|`cusparseZbsrmv`|  |  |  |`hipsparseZbsrmv`|
+|`cusparseZbsrsv2_analysis`|  |  |  ||
+|`cusparseZbsrsv2_bufferSize`|  |  |  ||
+|`cusparseZbsrsv2_bufferSizeExt`|  |  |  ||
+|`cusparseZbsrsv2_solve`|  |  |  ||
+|`cusparseZbsrxmv`|  |  |  ||
+|`cusparseZcsrmv`|  | 10.2 | 11.0 |`hipsparseZcsrmv`|
+|`cusparseZcsrmv_mp`| 8.0 | 10.2 | 11.0 ||
+|`cusparseZcsrsv2_analysis`|  |  |  |`hipsparseZcsrsv2_analysis`|
+|`cusparseZcsrsv2_bufferSize`|  |  |  |`hipsparseZcsrsv2_bufferSize`|
+|`cusparseZcsrsv2_bufferSizeExt`|  |  |  |`hipsparseZcsrsv2_bufferSizeExt`|
+|`cusparseZcsrsv2_solve`|  |  |  |`hipsparseZcsrsv2_solve`|
+|`cusparseZcsrsv_analysis`|  | 10.2 | 11.0 ||
+|`cusparseZcsrsv_solve`|  | 10.2 | 11.0 ||
+|`cusparseZgemvi`| 7.5 |  |  ||
+|`cusparseZgemvi_bufferSize`| 7.5 |  |  ||
+|`cusparseZhybmv`|  | 10.2 | 11.0 |`hipsparseZhybmv`|
+|`cusparseZhybsv_analysis`|  | 10.2 | 11.0 ||
+|`cusparseZhybsv_solve`|  | 10.2 | 11.0 ||
 
-## **6. cuSPARSE Extra Function Reference**
+## **9. CUSPARSE Level 3 Function Reference**
 
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseXcsrgeamNnz`                                      |`hipsparseXcsrgeamNnz`                           |
-|`cusparseScsrgeam`                                         |`hipsparseScsrgeam`                              |
-|`cusparseDcsrgeam`                                         |`hipsparseDcsrgeam`                              |
-|`cusparseCcsrgeam`                                         |`hipsparseCcsrgeam`                              |
-|`cusparseZcsrgeam`                                         |`hipsparseZcsrgeam`                              |
-|`cusparseXcsrgeam2Nnz`                                     |`hipsparseXcsrgeam2Nnz`                          | 9.2              |
-|`cusparseScsrgeam2`                                        |`hipsparseScsrgeam2`                             | 9.2              |
-|`cusparseDcsrgeam2`                                        |`hipsparseDcsrgeam2`                             | 9.2              |
-|`cusparseCcsrgeam2`                                        |`hipsparseCcsrgeam2`                             | 9.2              |
-|`cusparseZcsrgeam2`                                        |`hipsparseZcsrgeam2`                             | 9.2              |
-|`cusparseScsrgeam2_bufferSizeExt`                          |`hipsparseScsrgeam2_bufferSizeExt`               | 9.2              |
-|`cusparseDcsrgeam2_bufferSizeExt`                          |`hipsparseDcsrgeam2_bufferSizeExt`               | 9.2              |
-|`cusparseCcsrgeam2_bufferSizeExt`                          |`hipsparseCcsrgeam2_bufferSizeExt`               | 9.2              |
-|`cusparseZcsrgeam2_bufferSizeExt`                          |`hipsparseZcsrgeam2_bufferSizeExt`               | 9.2              |
-|`cusparseXcsrgemmNnz`                                      |`hipsparseXcsrgemmNnz`                           |
-|`cusparseScsrgemm`                                         |`hipsparseScsrgemm`                              |
-|`cusparseDcsrgemm`                                         |`hipsparseDcsrgemm`                              |
-|`cusparseCcsrgemm`                                         |`hipsparseCcsrgemm`                              |
-|`cusparseZcsrgemm`                                         |`hipsparseZcsrgemm`                              |
-|`cusparseXcsrgemm2Nnz`                                     |`hipsparseXcsrgemm2Nnz`                          |
-|`cusparseScsrgemm2`                                        |`hipsparseScsrgemm2`                             |
-|`cusparseDcsrgemm2`                                        |`hipsparseDcsrgemm2`                             |
-|`cusparseCcsrgemm2`                                        |`hipsparseCcsrgemm2`                             |
-|`cusparseZcsrgemm2`                                        |`hipsparseZcsrgemm2`                             |
-|`cusparseScsrgemm2_bufferSizeExt`                          |`hipsparseScsrgemm2_bufferSizeExt`               |
-|`cusparseDcsrgemm2_bufferSizeExt`                          |`hipsparseDcsrgemm2_bufferSizeExt`               |
-|`cusparseCcsrgemm2_bufferSizeExt`                          |`hipsparseCcsrgemm2_bufferSizeExt`               |
-|`cusparseZcsrgemm2_bufferSizeExt`                          |`hipsparseZcsrgemm2_bufferSizeExt`               |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cusparseCbsrmm`|  |  |  ||
+|`cusparseCbsrsm2_analysis`|  |  |  ||
+|`cusparseCbsrsm2_bufferSize`|  |  |  ||
+|`cusparseCbsrsm2_bufferSizeExt`|  |  |  ||
+|`cusparseCbsrsm2_solve`|  |  |  ||
+|`cusparseCcsrmm`|  | 10.2 | 11.0 |`hipsparseCcsrmm`|
+|`cusparseCcsrmm2`|  | 10.2 | 11.0 |`hipsparseCcsrmm2`|
+|`cusparseCcsrsm2_analysis`| 10.0 |  |  |`hipsparseCcsrsm2_analysis`|
+|`cusparseCcsrsm2_bufferSizeExt`| 10.0 |  |  |`hipsparseCcsrsm2_bufferSizeExt`|
+|`cusparseCcsrsm2_solve`| 10.0 |  |  |`hipsparseCcsrsm2_solve`|
+|`cusparseCcsrsm_analysis`|  | 10.2 | 11.0 ||
+|`cusparseCcsrsm_solve`|  | 10.2 | 11.0 |`hipsparseCcsrsm_solve`|
+|`cusparseCgemmi`| 8.0 | 11.0 |  ||
+|`cusparseDbsrmm`|  |  |  ||
+|`cusparseDbsrsm2_analysis`|  |  |  ||
+|`cusparseDbsrsm2_bufferSize`|  |  |  ||
+|`cusparseDbsrsm2_bufferSizeExt`|  |  |  ||
+|`cusparseDbsrsm2_solve`|  |  |  ||
+|`cusparseDcsrmm`|  | 10.2 | 11.0 |`hipsparseDcsrmm`|
+|`cusparseDcsrmm2`|  | 10.2 | 11.0 |`hipsparseDcsrmm2`|
+|`cusparseDcsrsm2_analysis`| 10.0 |  |  |`hipsparseDcsrsm2_analysis`|
+|`cusparseDcsrsm2_bufferSizeExt`| 10.0 |  |  |`hipsparseDcsrsm2_bufferSizeExt`|
+|`cusparseDcsrsm2_solve`| 10.0 |  |  |`hipsparseDcsrsm2_solve`|
+|`cusparseDcsrsm_analysis`|  | 10.2 | 11.0 ||
+|`cusparseDcsrsm_solve`|  | 10.2 | 11.0 |`hipsparseDcsrsm_solve`|
+|`cusparseDgemmi`| 8.0 | 11.0 |  ||
+|`cusparseSbsrmm`|  |  |  ||
+|`cusparseSbsrsm2_analysis`|  |  |  ||
+|`cusparseSbsrsm2_bufferSize`|  |  |  ||
+|`cusparseSbsrsm2_bufferSizeExt`|  |  |  ||
+|`cusparseSbsrsm2_solve`|  |  |  ||
+|`cusparseScsrmm`|  | 10.2 | 11.0 |`hipsparseScsrmm`|
+|`cusparseScsrmm2`|  | 10.2 | 11.0 |`hipsparseScsrmm2`|
+|`cusparseScsrsm2_analysis`| 10.0 |  |  |`hipsparseScsrsm2_analysis`|
+|`cusparseScsrsm2_bufferSizeExt`| 10.0 |  |  |`hipsparseScsrsm2_bufferSizeExt`|
+|`cusparseScsrsm2_solve`| 10.0 |  |  |`hipsparseScsrsm2_solve`|
+|`cusparseScsrsm_analysis`|  | 10.2 | 11.0 ||
+|`cusparseScsrsm_solve`|  | 10.2 | 11.0 |`hipsparseScsrsm_solve`|
+|`cusparseSgemmi`| 8.0 | 11.0 |  ||
+|`cusparseXbsrsm2_zeroPivot`|  |  |  ||
+|`cusparseXcsrsm2_zeroPivot`| 10.0 |  |  |`hipsparseXcsrsm2_zeroPivot`|
+|`cusparseZbsrmm`|  |  |  ||
+|`cusparseZbsrsm2_analysis`|  |  |  ||
+|`cusparseZbsrsm2_bufferSize`|  |  |  ||
+|`cusparseZbsrsm2_bufferSizeExt`|  |  |  ||
+|`cusparseZbsrsm2_solve`|  |  |  ||
+|`cusparseZcsrmm`|  | 10.2 | 11.0 |`hipsparseZcsrmm`|
+|`cusparseZcsrmm2`|  | 10.2 | 11.0 |`hipsparseZcsrmm2`|
+|`cusparseZcsrsm2_analysis`| 10.0 |  |  |`hipsparseZcsrsm2_analysis`|
+|`cusparseZcsrsm2_bufferSizeExt`| 10.0 |  |  |`hipsparseZcsrsm2_bufferSizeExt`|
+|`cusparseZcsrsm2_solve`| 10.0 |  |  |`hipsparseZcsrsm2_solve`|
+|`cusparseZcsrsm_analysis`|  | 10.2 | 11.0 ||
+|`cusparseZcsrsm_solve`|  | 10.2 | 11.0 |`hipsparseZcsrsm_solve`|
+|`cusparseZgemmi`| 8.0 | 11.0 |  ||
 
-## **7. cuSPARSE Preconditioners Reference**
+## **10. CUSPARSE Extra Function Reference**
 
-## ***7.1. Incomplete Cholesky Factorization: level 0***
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cusparseCcsrgeam`|  | 10.2 | 11.0 |`hipsparseCcsrgeam`|
+|`cusparseCcsrgeam2`| 10.0 |  |  |`hipsparseCcsrgeam2`|
+|`cusparseCcsrgeam2_bufferSizeExt`| 10.0 |  |  |`hipsparseCcsrgeam2_bufferSizeExt`|
+|`cusparseCcsrgemm`|  | 10.2 | 11.0 |`hipsparseCcsrgemm`|
+|`cusparseCcsrgemm2`|  | 11.0 |  |`hipsparseCcsrgemm2`|
+|`cusparseCcsrgemm2_bufferSizeExt`|  | 11.0 |  |`hipsparseCcsrgemm2_bufferSizeExt`|
+|`cusparseDcsrgeam`|  | 10.2 | 11.0 |`hipsparseDcsrgeam`|
+|`cusparseDcsrgeam2`| 10.0 |  |  |`hipsparseDcsrgeam2`|
+|`cusparseDcsrgeam2_bufferSizeExt`| 10.0 |  |  |`hipsparseDcsrgeam2_bufferSizeExt`|
+|`cusparseDcsrgemm`|  | 10.2 | 11.0 |`hipsparseDcsrgemm`|
+|`cusparseDcsrgemm2`|  | 11.0 |  |`hipsparseDcsrgemm2`|
+|`cusparseDcsrgemm2_bufferSizeExt`|  | 11.0 |  |`hipsparseDcsrgemm2_bufferSizeExt`|
+|`cusparseScsrgeam`|  | 10.2 | 11.0 |`hipsparseScsrgeam`|
+|`cusparseScsrgeam2`| 10.0 |  |  |`hipsparseScsrgeam2`|
+|`cusparseScsrgeam2_bufferSizeExt`| 10.0 |  |  |`hipsparseScsrgeam2_bufferSizeExt`|
+|`cusparseScsrgemm`|  | 10.2 | 11.0 |`hipsparseScsrgemm`|
+|`cusparseScsrgemm2`|  | 11.0 |  |`hipsparseScsrgemm2`|
+|`cusparseScsrgemm2_bufferSizeExt`|  | 11.0 |  |`hipsparseScsrgemm2_bufferSizeExt`|
+|`cusparseXcsrgeam2Nnz`| 10.0 |  |  |`hipsparseXcsrgeam2Nnz`|
+|`cusparseXcsrgeamNnz`|  | 10.2 | 11.0 |`hipsparseXcsrgeamNnz`|
+|`cusparseXcsrgemm2Nnz`|  | 11.0 |  |`hipsparseXcsrgemm2Nnz`|
+|`cusparseXcsrgemmNnz`|  | 10.2 | 11.0 |`hipsparseXcsrgemmNnz`|
+|`cusparseZcsrgeam`|  | 10.2 | 11.0 |`hipsparseZcsrgeam`|
+|`cusparseZcsrgeam2`| 10.0 |  |  |`hipsparseZcsrgeam2`|
+|`cusparseZcsrgeam2_bufferSizeExt`| 10.0 |  |  |`hipsparseZcsrgeam2_bufferSizeExt`|
+|`cusparseZcsrgemm`|  | 10.2 | 11.0 |`hipsparseZcsrgemm`|
+|`cusparseZcsrgemm2`|  | 11.0 |  |`hipsparseZcsrgemm2`|
+|`cusparseZcsrgemm2_bufferSizeExt`|  | 11.0 |  |`hipsparseZcsrgemm2_bufferSizeExt`|
 
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseScsric0`                                          |                                                 |
-|`cusparseDcsric0`                                          |                                                 |
-|`cusparseCcsric0`                                          |                                                 |
-|`cusparseZcsric0`                                          |                                                 |
-|`cusparseScsric02_bufferSize`                              |`hipsparseScsric02_bufferSize`                   |
-|`cusparseScsric02_bufferSizeExt`                           |`hipsparseScsric02_bufferSizeExt`                |
-|`cusparseDcsric02_bufferSize`                              |`hipsparseDcsric02_bufferSize`                   |
-|`cusparseDcsric02_bufferSizeExt`                           |`hipsparseDcsric02_bufferSizeExt`                |
-|`cusparseCcsric02_bufferSize`                              |`hipsparseCcsric02_bufferSize`                   |
-|`cusparseCcsric02_bufferSizeExt`                           |`hipsparseCcsric02_bufferSizeExt`                |
-|`cusparseZcsric02_bufferSize`                              |`hipsparseZcsric02_bufferSize`                   |
-|`cusparseZcsric02_bufferSizeExt`                           |`hipsparseZcsric02_bufferSizeExt`                |
-|`cusparseScsric02_analysis`                                |`hipsparseScsric02_analysis`                     |
-|`cusparseDcsric02_analysis`                                |`hipsparseDcsric02_analysis`                     |
-|`cusparseCcsric02_analysis`                                |`hipsparseCcsric02_analysis`                     |
-|`cusparseZcsric02_analysis`                                |`hipsparseZcsric02_analysis`                     |
-|`cusparseScsric02`                                         |`hipsparseScsric02`                              |
-|`cusparseDcsric02`                                         |`hipsparseDcsric02`                              |
-|`cusparseCcsric02`                                         |`hipsparseCcsric02`                              |
-|`cusparseZcsric02`                                         |`hipsparseZcsric02`                              |
-|`cusparseXcsric02_zeroPivot`                               |`hipsparseXcsric02_zeroPivot`                    |
-|`cusparseSbsric02_bufferSize`                              |                                                 |
-|`cusparseSbsric02_bufferSizeExt`                           |                                                 |
-|`cusparseDbsric02_bufferSize`                              |                                                 |
-|`cusparseDbsric02_bufferSizeExt`                           |                                                 |
-|`cusparseCbsric02_bufferSize`                              |                                                 |
-|`cusparseCbsric02_bufferSizeExt`                           |                                                 |
-|`cusparseZbsric02_bufferSize`                              |                                                 |
-|`cusparseZbsric02_bufferSizeExt`                           |                                                 |
-|`cusparseSbsric02_analysis`                                |                                                 |
-|`cusparseDbsric02_analysis`                                |                                                 |
-|`cusparseCbsric02_analysis`                                |                                                 |
-|`cusparseZbsric02_analysis`                                |                                                 |
-|`cusparseSbsric02`                                         |                                                 |
-|`cusparseDbsric02`                                         |                                                 |
-|`cusparseCbsric02`                                         |                                                 |
-|`cusparseZbsric02`                                         |                                                 |
-|`cusparseXbsric02_zeroPivot`                               |                                                 |
+## **11. CUSPARSE Preconditioners Reference**
 
-## ***7.2. Incomplete LU Factorization: level 0***
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cusparseCbsric02`|  |  |  ||
+|`cusparseCbsric02_analysis`|  |  |  ||
+|`cusparseCbsric02_bufferSize`|  |  |  ||
+|`cusparseCbsric02_bufferSizeExt`|  |  |  ||
+|`cusparseCbsrilu02`|  |  |  ||
+|`cusparseCbsrilu02_analysis`|  |  |  ||
+|`cusparseCbsrilu02_bufferSize`|  |  |  ||
+|`cusparseCbsrilu02_bufferSizeExt`|  |  |  ||
+|`cusparseCbsrilu02_numericBoost`|  |  |  ||
+|`cusparseCcsric0`|  | 10.2 | 11.0 ||
+|`cusparseCcsric02`|  |  |  |`hipsparseCcsric02`|
+|`cusparseCcsric02_analysis`|  |  |  |`hipsparseCcsric02_analysis`|
+|`cusparseCcsric02_bufferSize`|  |  |  |`hipsparseCcsric02_bufferSize`|
+|`cusparseCcsric02_bufferSizeExt`|  |  |  |`hipsparseCcsric02_bufferSizeExt`|
+|`cusparseCcsrilu0`|  | 10.2 | 11.0 ||
+|`cusparseCcsrilu02`|  |  |  |`hipsparseCcsrilu02`|
+|`cusparseCcsrilu02_analysis`|  |  |  |`hipsparseCcsrilu02_analysis`|
+|`cusparseCcsrilu02_bufferSize`|  |  |  |`hipsparseCcsrilu02_bufferSize`|
+|`cusparseCcsrilu02_bufferSizeExt`|  |  |  |`hipsparseCcsrilu02_bufferSizeExt`|
+|`cusparseCcsrilu02_numericBoost`|  |  |  ||
+|`cusparseCgpsvInterleavedBatch`| 9.2 |  |  ||
+|`cusparseCgpsvInterleavedBatch_bufferSizeExt`| 9.2 |  |  ||
+|`cusparseCgtsv`|  | 10.2 | 11.0 ||
+|`cusparseCgtsv2`| 9.0 |  |  ||
+|`cusparseCgtsv2StridedBatch`|  |  |  ||
+|`cusparseCgtsv2StridedBatch_bufferSizeExt`|  |  |  ||
+|`cusparseCgtsv2_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseCgtsv2_nopivot`| 9.0 |  |  ||
+|`cusparseCgtsv2_nopivot_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseCgtsvInterleavedBatch`| 9.2 |  |  ||
+|`cusparseCgtsvInterleavedBatch_bufferSizeExt`| 9.2 |  |  ||
+|`cusparseCgtsvStridedBatch`|  | 10.2 | 11.0 ||
+|`cusparseCgtsv_nopivot`|  | 10.2 | 11.0 ||
+|`cusparseCsrilu0Ex`| 8.0 | 10.2 | 11.0 ||
+|`cusparseDbsric02`|  |  |  ||
+|`cusparseDbsric02_analysis`|  |  |  ||
+|`cusparseDbsric02_bufferSize`|  |  |  ||
+|`cusparseDbsric02_bufferSizeExt`|  |  |  ||
+|`cusparseDbsrilu02`|  |  |  ||
+|`cusparseDbsrilu02_analysis`|  |  |  ||
+|`cusparseDbsrilu02_bufferSize`|  |  |  ||
+|`cusparseDbsrilu02_bufferSizeExt`|  |  |  ||
+|`cusparseDbsrilu02_numericBoost`|  |  |  ||
+|`cusparseDcsric0`|  | 10.2 | 11.0 ||
+|`cusparseDcsric02`|  |  |  |`hipsparseDcsric02`|
+|`cusparseDcsric02_analysis`|  |  |  |`hipsparseDcsric02_analysis`|
+|`cusparseDcsric02_bufferSize`|  |  |  |`hipsparseDcsric02_bufferSize`|
+|`cusparseDcsric02_bufferSizeExt`|  |  |  |`hipsparseDcsric02_bufferSizeExt`|
+|`cusparseDcsrilu0`|  | 10.2 | 11.0 ||
+|`cusparseDcsrilu02`|  |  |  |`hipsparseDcsrilu02`|
+|`cusparseDcsrilu02_analysis`|  |  |  |`hipsparseDcsrilu02_analysis`|
+|`cusparseDcsrilu02_bufferSize`|  |  |  |`hipsparseDcsrilu02_bufferSize`|
+|`cusparseDcsrilu02_bufferSizeExt`|  |  |  |`hipsparseDcsrilu02_bufferSizeExt`|
+|`cusparseDcsrilu02_numericBoost`|  |  |  ||
+|`cusparseDgpsvInterleavedBatch`| 9.2 |  |  ||
+|`cusparseDgpsvInterleavedBatch_bufferSizeExt`| 9.2 |  |  ||
+|`cusparseDgtsv`|  | 10.2 | 11.0 ||
+|`cusparseDgtsv2`| 9.0 |  |  ||
+|`cusparseDgtsv2StridedBatch`|  |  |  ||
+|`cusparseDgtsv2StridedBatch_bufferSizeExt`|  |  |  ||
+|`cusparseDgtsv2_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseDgtsv2_nopivot`| 9.0 |  |  ||
+|`cusparseDgtsv2_nopivot_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseDgtsvInterleavedBatch`| 9.2 |  |  ||
+|`cusparseDgtsvInterleavedBatch_bufferSizeExt`| 9.2 |  |  ||
+|`cusparseDgtsvStridedBatch`|  | 10.2 | 11.0 ||
+|`cusparseDgtsv_nopivot`|  | 10.2 | 11.0 ||
+|`cusparseSbsric02`|  |  |  ||
+|`cusparseSbsric02_analysis`|  |  |  ||
+|`cusparseSbsric02_bufferSize`|  |  |  ||
+|`cusparseSbsric02_bufferSizeExt`|  |  |  ||
+|`cusparseSbsrilu02`|  |  |  ||
+|`cusparseSbsrilu02_analysis`|  |  |  ||
+|`cusparseSbsrilu02_bufferSize`|  |  |  ||
+|`cusparseSbsrilu02_bufferSizeExt`|  |  |  ||
+|`cusparseSbsrilu02_numericBoost`|  |  |  ||
+|`cusparseScsric0`|  | 10.2 | 11.0 ||
+|`cusparseScsric02`|  |  |  |`hipsparseScsric02`|
+|`cusparseScsric02_analysis`|  |  |  |`hipsparseScsric02_analysis`|
+|`cusparseScsric02_bufferSize`|  |  |  |`hipsparseScsric02_bufferSize`|
+|`cusparseScsric02_bufferSizeExt`|  |  |  |`hipsparseScsric02_bufferSizeExt`|
+|`cusparseScsrilu0`|  | 10.2 | 11.0 ||
+|`cusparseScsrilu02`|  |  |  |`hipsparseScsrilu02`|
+|`cusparseScsrilu02_analysis`|  |  |  |`hipsparseScsrilu02_analysis`|
+|`cusparseScsrilu02_bufferSize`|  |  |  |`hipsparseScsrilu02_bufferSize`|
+|`cusparseScsrilu02_bufferSizeExt`|  |  |  |`hipsparseScsrilu02_bufferSizeExt`|
+|`cusparseScsrilu02_numericBoost`|  |  |  ||
+|`cusparseSgpsvInterleavedBatch`| 9.2 |  |  ||
+|`cusparseSgpsvInterleavedBatch_bufferSizeExt`| 9.2 |  |  ||
+|`cusparseSgtsv`|  | 10.2 | 11.0 ||
+|`cusparseSgtsv2`| 9.0 |  |  ||
+|`cusparseSgtsv2StridedBatch`| 9.0 |  |  ||
+|`cusparseSgtsv2StridedBatch_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseSgtsv2_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseSgtsv2_nopivot`| 9.0 |  |  ||
+|`cusparseSgtsv2_nopivot_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseSgtsvInterleavedBatch`| 9.2 |  |  ||
+|`cusparseSgtsvInterleavedBatch_bufferSizeExt`| 9.2 |  |  ||
+|`cusparseSgtsvStridedBatch`|  | 10.2 | 11.0 ||
+|`cusparseSgtsv_nopivot`|  | 10.2 | 11.0 ||
+|`cusparseXbsric02_zeroPivot`|  |  |  ||
+|`cusparseXbsrilu02_zeroPivot`|  |  |  |`hipsparseXbsrilu02_zeroPivot`|
+|`cusparseXcsric02_zeroPivot`|  |  |  |`hipsparseXcsric02_zeroPivot`|
+|`cusparseXcsrilu02_zeroPivot`|  |  |  |`hipsparseXcsrilu02_zeroPivot`|
+|`cusparseZbsric02`|  |  |  ||
+|`cusparseZbsric02_analysis`|  |  |  ||
+|`cusparseZbsric02_bufferSize`|  |  |  ||
+|`cusparseZbsric02_bufferSizeExt`|  |  |  ||
+|`cusparseZbsrilu02`|  |  |  ||
+|`cusparseZbsrilu02_analysis`|  |  |  ||
+|`cusparseZbsrilu02_bufferSize`|  |  |  ||
+|`cusparseZbsrilu02_bufferSizeExt`|  |  |  ||
+|`cusparseZbsrilu02_numericBoost`|  |  |  ||
+|`cusparseZcsric0`|  | 10.2 | 11.0 ||
+|`cusparseZcsric02`|  |  |  |`hipsparseZcsric02`|
+|`cusparseZcsric02_analysis`|  |  |  |`hipsparseZcsric02_analysis`|
+|`cusparseZcsric02_bufferSize`|  |  |  |`hipsparseZcsric02_bufferSize`|
+|`cusparseZcsric02_bufferSizeExt`|  |  |  |`hipsparseZcsric02_bufferSizeExt`|
+|`cusparseZcsrilu0`|  | 10.2 | 11.0 ||
+|`cusparseZcsrilu02`|  |  |  |`hipsparseZcsrilu02`|
+|`cusparseZcsrilu02_analysis`|  |  |  |`hipsparseZcsrilu02_analysis`|
+|`cusparseZcsrilu02_bufferSize`|  |  |  |`hipsparseZcsrilu02_bufferSize`|
+|`cusparseZcsrilu02_bufferSizeExt`|  |  |  |`hipsparseZcsrilu02_bufferSizeExt`|
+|`cusparseZcsrilu02_numericBoost`|  |  |  ||
+|`cusparseZgpsvInterleavedBatch`| 9.2 |  |  ||
+|`cusparseZgpsvInterleavedBatch_bufferSizeExt`| 9.2 |  |  ||
+|`cusparseZgtsv`|  | 10.2 | 11.0 ||
+|`cusparseZgtsv2`| 9.0 |  |  ||
+|`cusparseZgtsv2StridedBatch`|  |  |  ||
+|`cusparseZgtsv2StridedBatch_bufferSizeExt`|  |  |  ||
+|`cusparseZgtsv2_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseZgtsv2_nopivot`| 9.0 |  |  ||
+|`cusparseZgtsv2_nopivot_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseZgtsvInterleavedBatch`| 9.2 |  |  ||
+|`cusparseZgtsvInterleavedBatch_bufferSizeExt`| 9.2 |  |  ||
+|`cusparseZgtsvStridedBatch`|  | 10.2 | 11.0 ||
+|`cusparseZgtsv_nopivot`|  | 10.2 | 11.0 ||
 
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseScsrilu0`                                         |                                                 |
-|`cusparseDcsrilu0`                                         |                                                 |
-|`cusparseCcsrilu0`                                         |                                                 |
-|`cusparseZcsrilu0`                                         |                                                 |
-|`cusparseCsrilu0Ex`                                        |                                                 | 8.0              |
-|`cusparseScsrilu02_numericBoost`                           |                                                 |
-|`cusparseDcsrilu02_numericBoost`                           |                                                 |
-|`cusparseCcsrilu02_numericBoost`                           |                                                 |
-|`cusparseZcsrilu02_numericBoost`                           |                                                 |
-|`cusparseXcsrilu02_zeroPivot`                              |`hipsparseXcsrilu02_zeroPivot`                   |
-|`cusparseScsrilu02_bufferSize`                             |`hipsparseScsrilu02_bufferSize`                  |
-|`cusparseScsrilu02_bufferSizeExt`                          |`hipsparseScsrilu02_bufferSizeExt`               |
-|`cusparseDcsrilu02_bufferSize`                             |`hipsparseDcsrilu02_bufferSize`                  |
-|`cusparseDcsrilu02_bufferSizeExt`                          |`hipsparseDcsrilu02_bufferSizeExt`               |
-|`cusparseCcsrilu02_bufferSize`                             |`hipsparseCcsrilu02_bufferSize`                  |
-|`cusparseCcsrilu02_bufferSizeExt`                          |`hipsparseCcsrilu02_bufferSizeExt`               |
-|`cusparseZcsrilu02_bufferSize`                             |`hipsparseZcsrilu02_bufferSize`                  |
-|`cusparseZcsrilu02_bufferSizeExt`                          |`hipsparseZcsrilu02_bufferSizeExt`               |
-|`cusparseScsrilu02_analysis`                               |`hipsparseScsrilu02_analysis`                    |
-|`cusparseDcsrilu02_analysis`                               |`hipsparseDcsrilu02_analysis`                    |
-|`cusparseCcsrilu02_analysis`                               |`hipsparseCcsrilu02_analysis`                    |
-|`cusparseZcsrilu02_analysis`                               |`hipsparseZcsrilu02_analysis`                    |
-|`cusparseScsrilu02`                                        |`hipsparseScsrilu02`                             |
-|`cusparseDcsrilu02`                                        |`hipsparseDcsrilu02`                             |
-|`cusparseCcsrilu02`                                        |`hipsparseCcsrilu02`                             |
-|`cusparseZcsrilu02`                                        |`hipsparseZcsrilu02`                             |
-|`cusparseXbsric02_zeroPivot`                               |`hipsparseXcsrilu02_zeroPivot`                   |
-|`cusparseSbsrilu02_numericBoost`                           |                                                 |
-|`cusparseDbsrilu02_numericBoost`                           |                                                 |
-|`cusparseCbsrilu02_numericBoost`                           |                                                 |
-|`cusparseZbsrilu02_numericBoost`                           |                                                 |
-|`cusparseSbsrilu02_bufferSize`                             |                                                 |
-|`cusparseSbsrilu02_bufferSizeExt`                          |                                                 |
-|`cusparseDbsrilu02_bufferSize`                             |                                                 |
-|`cusparseDbsrilu02_bufferSizeExt`                          |                                                 |
-|`cusparseCbsrilu02_bufferSize`                             |                                                 |
-|`cusparseCbsrilu02_bufferSizeExt`                          |                                                 |
-|`cusparseZbsrilu02_bufferSize`                             |                                                 |
-|`cusparseZbsrilu02_bufferSizeExt`                          |                                                 |
-|`cusparseSbsrilu02_analysis`                               |                                                 |
-|`cusparseDbsrilu02_analysis`                               |                                                 |
-|`cusparseCbsrilu02_analysis`                               |                                                 |
-|`cusparseZbsrilu02_analysis`                               |                                                 |
-|`cusparseSbsrilu02`                                        |                                                 |
-|`cusparseDbsrilu02`                                        |                                                 |
-|`cusparseCbsrilu02`                                        |                                                 |
-|`cusparseZbsrilu02`                                        |                                                 |
-|`cusparseXbsrilu02_zeroPivot`                              |                                                 |
+## **12. CUSPARSE Reorderings Reference**
 
-## ***7.3. Tridiagonal Solve***
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cusparseCcsrcolor`|  |  |  ||
+|`cusparseDcsrcolor`|  |  |  ||
+|`cusparseScsrcolor`|  |  |  ||
+|`cusparseZcsrcolor`|  |  |  ||
 
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseSgtsv`                                            |                                                 |
-|`cusparseDgtsv`                                            |                                                 |
-|`cusparseCgtsv`                                            |                                                 |
-|`cusparseZgtsv`                                            |                                                 |
-|`cusparseSgtsv_nopivot`                                    |                                                 |
-|`cusparseDgtsv_nopivot`                                    |                                                 |
-|`cusparseCgtsv_nopivot`                                    |                                                 |
-|`cusparseZgtsv_nopivot`                                    |                                                 |
-|`cusparseSgtsv2_bufferSizeExt`                             |                                                 | 9.0              |
-|`cusparseDgtsv2_bufferSizeExt`                             |                                                 | 9.0              |
-|`cusparseCgtsv2_bufferSizeExt`                             |                                                 | 9.0              |
-|`cusparseZgtsv2_bufferSizeExt`                             |                                                 | 9.0              |
-|`cusparseSgtsv2`                                           |                                                 | 9.0              |
-|`cusparseDgtsv2`                                           |                                                 | 9.0              |
-|`cusparseCgtsv2`                                           |                                                 | 9.0              |
-|`cusparseZgtsv2`                                           |                                                 | 9.0              |
-|`cusparseSgtsv2_nopivot_bufferSizeExt`                     |                                                 | 9.0              |
-|`cusparseDgtsv2_nopivot_bufferSizeExt`                     |                                                 | 9.0              |
-|`cusparseCgtsv2_nopivot_bufferSizeExt`                     |                                                 | 9.0              |
-|`cusparseZgtsv2_nopivot_bufferSizeExt`                     |                                                 | 9.0              |
-|`cusparseSgtsv2_nopivot`                                   |                                                 | 9.0              |
-|`cusparseDgtsv2_nopivot`                                   |                                                 | 9.0              |
-|`cusparseCgtsv2_nopivot`                                   |                                                 | 9.0              |
-|`cusparseZgtsv2_nopivot`                                   |                                                 | 9.0              |
+## **13. CUSPARSE Format Conversion Reference**
 
-## ***7.4. Batched Tridiagonal Solve***
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cusparseCbsr2csr`|  |  |  |`hipsparseCbsr2csr`|
+|`cusparseCcsc2dense`|  |  |  |`hipsparseCcsc2dense`|
+|`cusparseCcsc2hyb`|  | 10.2 | 11.0 ||
+|`cusparseCcsr2bsr`|  |  |  |`hipsparseCcsr2bsr`|
+|`cusparseCcsr2csc`|  | 10.2 | 11.0 |`hipsparseCcsr2csc`|
+|`cusparseCcsr2csr_compress`| 8.0 |  |  |`hipsparseCcsr2csr_compress`|
+|`cusparseCcsr2csru`|  |  |  ||
+|`cusparseCcsr2dense`|  |  |  |`hipsparseCcsr2dense`|
+|`cusparseCcsr2gebsr`|  |  |  ||
+|`cusparseCcsr2gebsr_bufferSize`|  |  |  ||
+|`cusparseCcsr2gebsr_bufferSizeExt`|  |  |  ||
+|`cusparseCcsr2hyb`|  | 10.2 | 11.0 |`hipsparseCcsr2hyb`|
+|`cusparseCcsru2csr_bufferSizeExt`|  |  |  ||
+|`cusparseCdense2csc`|  |  |  |`hipsparseCdense2csc`|
+|`cusparseCdense2csr`|  |  |  |`hipsparseCdense2csr`|
+|`cusparseCdense2hyb`|  | 10.2 | 11.0 ||
+|`cusparseCgebsr2csr`|  |  |  ||
+|`cusparseCgebsr2gebsc`|  |  |  ||
+|`cusparseCgebsr2gebsc_bufferSize`|  |  |  ||
+|`cusparseCgebsr2gebsc_bufferSizeExt`|  |  |  ||
+|`cusparseCgebsr2gebsr`|  |  |  ||
+|`cusparseCgebsr2gebsr_bufferSize`|  |  |  ||
+|`cusparseCgebsr2gebsr_bufferSizeExt`|  |  |  ||
+|`cusparseChyb2csc`|  | 10.2 | 11.0 ||
+|`cusparseChyb2csr`|  | 10.2 | 11.0 |`hipsparseChyb2csr`|
+|`cusparseChyb2dense`|  | 10.2 | 11.0 ||
+|`cusparseCnnz`|  |  |  |`hipsparseCnnz`|
+|`cusparseCnnz_compress`| 8.0 |  |  |`hipsparseCnnz_compress`|
+|`cusparseCreateCsru2csrInfo`|  |  |  ||
+|`cusparseCreateIdentityPermutation`|  |  |  |`hipsparseCreateIdentityPermutation`|
+|`cusparseCsr2cscEx`| 8.0 | 10.2 | 11.0 ||
+|`cusparseCsr2cscEx2`| 10.1 |  |  ||
+|`cusparseCsr2cscEx2_bufferSize`| 10.1 |  |  ||
+|`cusparseDbsr2csr`|  |  |  |`hipsparseDbsr2csr`|
+|`cusparseDcsc2dense`|  |  |  |`hipsparseDcsc2dense`|
+|`cusparseDcsc2hyb`|  | 10.2 | 11.0 ||
+|`cusparseDcsr2bsr`|  |  |  |`hipsparseDcsr2bsr`|
+|`cusparseDcsr2csc`|  | 10.2 | 11.0 |`hipsparseDcsr2csc`|
+|`cusparseDcsr2csr_compress`| 8.0 |  |  |`hipsparseDcsr2csr_compress`|
+|`cusparseDcsr2csru`|  |  |  ||
+|`cusparseDcsr2dense`|  |  |  |`hipsparseDcsr2dense`|
+|`cusparseDcsr2gebsr`|  |  |  ||
+|`cusparseDcsr2gebsr_bufferSize`|  |  |  ||
+|`cusparseDcsr2gebsr_bufferSizeExt`|  |  |  ||
+|`cusparseDcsr2hyb`|  | 10.2 | 11.0 |`hipsparseDcsr2hyb`|
+|`cusparseDcsru2csr_bufferSizeExt`|  |  |  ||
+|`cusparseDdense2csc`|  |  |  |`hipsparseDdense2csc`|
+|`cusparseDdense2csr`|  |  |  |`hipsparseDdense2csr`|
+|`cusparseDdense2hyb`|  | 10.2 | 11.0 ||
+|`cusparseDestroyCsru2csrInfo`|  |  |  ||
+|`cusparseDgebsr2csr`|  |  |  ||
+|`cusparseDgebsr2gebsc`|  |  |  ||
+|`cusparseDgebsr2gebsc_bufferSize`|  |  |  ||
+|`cusparseDgebsr2gebsc_bufferSizeExt`|  |  |  ||
+|`cusparseDgebsr2gebsr`|  |  |  ||
+|`cusparseDgebsr2gebsr_bufferSize`|  |  |  ||
+|`cusparseDgebsr2gebsr_bufferSizeExt`|  |  |  ||
+|`cusparseDhyb2csc`|  | 10.2 | 11.0 ||
+|`cusparseDhyb2csr`|  | 10.2 | 11.0 |`hipsparseDhyb2csr`|
+|`cusparseDhyb2dense`|  | 10.2 | 11.0 ||
+|`cusparseDnnz`|  |  |  |`hipsparseDnnz`|
+|`cusparseDnnz_compress`| 8.0 |  |  |`hipsparseDnnz_compress`|
+|`cusparseDpruneCsr2csr`| 9.0 |  |  ||
+|`cusparseDpruneCsr2csrByPercentage`| 9.0 |  |  ||
+|`cusparseDpruneCsr2csrByPercentage_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseDpruneCsr2csrNnz`| 9.0 |  |  ||
+|`cusparseDpruneCsr2csrNnzByPercentage`| 9.0 |  |  ||
+|`cusparseDpruneCsr2csr_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseDpruneDense2csr`| 9.0 |  |  ||
+|`cusparseDpruneDense2csrByPercentage`| 9.0 |  |  ||
+|`cusparseDpruneDense2csrByPercentage_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseDpruneDense2csrNnz`| 9.0 |  |  ||
+|`cusparseDpruneDense2csrNnzByPercentage`| 9.0 |  |  ||
+|`cusparseDpruneDense2csr_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseHpruneCsr2csr`| 9.0 |  |  ||
+|`cusparseHpruneCsr2csrByPercentage`| 9.0 |  |  ||
+|`cusparseHpruneCsr2csrByPercentage_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseHpruneCsr2csrNnz`| 9.0 |  |  ||
+|`cusparseHpruneCsr2csrNnzByPercentage`| 9.0 |  |  ||
+|`cusparseHpruneCsr2csr_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseHpruneDense2csr`| 9.0 |  |  ||
+|`cusparseHpruneDense2csrByPercentage`| 9.0 |  |  ||
+|`cusparseHpruneDense2csrByPercentage_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseHpruneDense2csrNnz`| 9.0 |  |  ||
+|`cusparseHpruneDense2csrNnzByPercentage`| 9.0 |  |  ||
+|`cusparseHpruneDense2csr_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseSbsr2csr`|  |  |  |`hipsparseSbsr2csr`|
+|`cusparseScsc2dense`|  |  |  |`hipsparseScsc2dense`|
+|`cusparseScsc2hyb`|  | 10.2 | 11.0 ||
+|`cusparseScsr2bsr`|  |  |  |`hipsparseScsr2bsr`|
+|`cusparseScsr2csc`|  | 10.2 | 11.0 |`hipsparseScsr2csc`|
+|`cusparseScsr2csr_compress`| 8.0 |  |  |`hipsparseScsr2csr_compress`|
+|`cusparseScsr2csru`|  |  |  ||
+|`cusparseScsr2dense`|  |  |  |`hipsparseScsr2dense`|
+|`cusparseScsr2gebsr`|  |  |  ||
+|`cusparseScsr2gebsr_bufferSize`|  |  |  ||
+|`cusparseScsr2gebsr_bufferSizeExt`|  |  |  ||
+|`cusparseScsr2hyb`|  | 10.2 | 11.0 |`hipsparseScsr2hyb`|
+|`cusparseScsru2csr_bufferSizeExt`|  |  |  ||
+|`cusparseSdense2csc`|  |  |  |`hipsparseSdense2csc`|
+|`cusparseSdense2csr`|  |  |  |`hipsparseSdense2csr`|
+|`cusparseSdense2hyb`|  | 10.2 | 11.0 ||
+|`cusparseSgebsr2csr`|  |  |  ||
+|`cusparseSgebsr2gebsc`|  |  |  ||
+|`cusparseSgebsr2gebsc_bufferSize`|  |  |  ||
+|`cusparseSgebsr2gebsc_bufferSizeExt`|  |  |  ||
+|`cusparseSgebsr2gebsr`|  |  |  ||
+|`cusparseSgebsr2gebsr_bufferSize`|  |  |  ||
+|`cusparseSgebsr2gebsr_bufferSizeExt`|  |  |  ||
+|`cusparseShyb2csc`|  | 10.2 | 11.0 ||
+|`cusparseShyb2csr`|  | 10.2 | 11.0 |`hipsparseShyb2csr`|
+|`cusparseShyb2dense`|  | 10.2 | 11.0 ||
+|`cusparseSnnz`|  |  |  |`hipsparseSnnz`|
+|`cusparseSnnz_compress`| 8.0 |  |  |`hipsparseSnnz_compress`|
+|`cusparseSpruneCsr2csr`| 9.0 |  |  ||
+|`cusparseSpruneCsr2csrByPercentage`| 9.0 |  |  ||
+|`cusparseSpruneCsr2csrByPercentage_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseSpruneCsr2csrNnz`| 9.0 |  |  ||
+|`cusparseSpruneCsr2csrNnzByPercentage`| 9.0 |  |  ||
+|`cusparseSpruneCsr2csr_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseSpruneDense2csr`| 9.0 |  |  ||
+|`cusparseSpruneDense2csrByPercentage`| 9.0 |  |  ||
+|`cusparseSpruneDense2csrByPercentage_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseSpruneDense2csrNnz`| 9.0 |  |  ||
+|`cusparseSpruneDense2csrNnzByPercentage`| 9.0 |  |  ||
+|`cusparseSpruneDense2csr_bufferSizeExt`| 9.0 |  |  ||
+|`cusparseXcoo2csr`|  |  |  |`hipsparseXcoo2csr`|
+|`cusparseXcoosortByColumn`|  |  |  |`hipsparseXcoosortByColumn`|
+|`cusparseXcoosortByRow`|  |  |  |`hipsparseXcoosortByRow`|
+|`cusparseXcoosort_bufferSizeExt`|  |  |  |`hipsparseXcoosort_bufferSizeExt`|
+|`cusparseXcscsort`|  |  |  |`hipsparseXcscsort`|
+|`cusparseXcscsort_bufferSizeExt`|  |  |  |`hipsparseXcscsort_bufferSizeExt`|
+|`cusparseXcsr2bsrNnz`|  |  |  |`hipsparseXcsr2bsrNnz`|
+|`cusparseXcsr2coo`|  |  |  |`hipsparseXcsr2coo`|
+|`cusparseXcsr2gebsrNnz`|  |  |  ||
+|`cusparseXcsrsort`|  |  |  |`hipsparseXcsrsort`|
+|`cusparseXcsrsort_bufferSizeExt`|  |  |  |`hipsparseXcsrsort_bufferSizeExt`|
+|`cusparseXgebsr2csr`|  |  |  ||
+|`cusparseXgebsr2gebsrNnz`|  |  |  ||
+|`cusparseZbsr2csr`|  |  |  |`hipsparseZbsr2csr`|
+|`cusparseZcsc2dense`|  |  |  |`hipsparseZcsc2dense`|
+|`cusparseZcsc2hyb`|  | 10.2 | 11.0 ||
+|`cusparseZcsr2bsr`|  |  |  |`hipsparseZcsr2bsr`|
+|`cusparseZcsr2csc`|  | 10.2 | 11.0 |`hipsparseZcsr2csc`|
+|`cusparseZcsr2csr_compress`| 8.0 |  |  |`hipsparseZcsr2csr_compress`|
+|`cusparseZcsr2csru`|  |  |  ||
+|`cusparseZcsr2dense`|  |  |  |`hipsparseZcsr2dense`|
+|`cusparseZcsr2gebsr`|  |  |  ||
+|`cusparseZcsr2gebsr_bufferSize`|  |  |  ||
+|`cusparseZcsr2gebsr_bufferSizeExt`|  |  |  ||
+|`cusparseZcsr2hyb`|  | 10.2 | 11.0 |`hipsparseZcsr2hyb`|
+|`cusparseZcsru2csr_bufferSizeExt`|  |  |  ||
+|`cusparseZdense2csc`|  |  |  |`hipsparseZdense2csc`|
+|`cusparseZdense2csr`|  |  |  |`hipsparseZdense2csr`|
+|`cusparseZdense2hyb`|  | 10.2 | 11.0 ||
+|`cusparseZgebsr2csr`|  |  |  ||
+|`cusparseZgebsr2gebsc`|  |  |  ||
+|`cusparseZgebsr2gebsc_bufferSize`|  |  |  ||
+|`cusparseZgebsr2gebsc_bufferSizeExt`|  |  |  ||
+|`cusparseZgebsr2gebsr`|  |  |  ||
+|`cusparseZgebsr2gebsr_bufferSize`|  |  |  ||
+|`cusparseZgebsr2gebsr_bufferSizeExt`|  |  |  ||
+|`cusparseZhyb2csc`|  | 10.2 | 11.0 ||
+|`cusparseZhyb2csr`|  | 10.2 | 11.0 |`hipsparseZhyb2csr`|
+|`cusparseZhyb2dense`|  | 10.2 | 11.0 ||
+|`cusparseZnnz`|  |  |  |`hipsparseZnnz`|
+|`cusparseZnnz_compress`| 8.0 |  |  |`hipsparseZnnz_compress`|
 
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseSgtsvStridedBatch`                                |                                                 |
-|`cusparseDgtsvStridedBatch`                                |                                                 |
-|`cusparseCgtsvStridedBatch`                                |                                                 |
-|`cusparseZgtsvStridedBatch`                                |                                                 |
-|`cusparseSgtsv2StridedBatch_bufferSizeExt`                 |                                                 | 9.0              |
-|`cusparseDgtsv2StridedBatch_bufferSizeExt`                 |                                                 | 9.0              |
-|`cusparseCgtsv2StridedBatch_bufferSizeExt`                 |                                                 | 9.0              |
-|`cusparseZgtsv2StridedBatch_bufferSizeExt`                 |                                                 | 9.0              |
-|`cusparseSgtsv2StridedBatch`                               |                                                 | 9.0              |
-|`cusparseDgtsv2StridedBatch`                               |                                                 | 9.0              |
-|`cusparseCgtsv2StridedBatch`                               |                                                 | 9.0              |
-|`cusparseZgtsv2StridedBatch`                               |                                                 | 9.0              |
-|`cusparseSgtsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
-|`cusparseDgtsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
-|`cusparseCgtsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
-|`cusparseZgtsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
-|`cusparseSgtsvInterleavedBatch`                            |                                                 | 9.2              |
-|`cusparseDgtsvInterleavedBatch`                            |                                                 | 9.2              |
-|`cusparseCgtsvInterleavedBatch`                            |                                                 | 9.2              |
-|`cusparseZgtsvInterleavedBatch`                            |                                                 | 9.2              |
+## **14. CUSPARSE Generic API Reference**
 
-## ***7.5. Batched Pentadiagonal Solve***
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cusparseAxpby`| 11.0 |  |  ||
+|`cusparseConstrainedGeMM`| 10.2 |  |  ||
+|`cusparseConstrainedGeMM_bufferSize`| 10.2 |  |  ||
+|`cusparseCooAoSGet`| 10.2 |  |  ||
+|`cusparseCooGet`| 10.1 |  |  ||
+|`cusparseCooSetStridedBatch`| 11.0 |  |  ||
+|`cusparseCreateCoo`| 10.1 |  |  ||
+|`cusparseCreateCooAoS`| 10.2 |  |  ||
+|`cusparseCreateCsr`| 10.2 |  |  ||
+|`cusparseCreateDnMat`| 10.1 |  |  ||
+|`cusparseCreateDnVec`| 10.2 |  |  ||
+|`cusparseCreateSpVec`| 10.2 |  |  ||
+|`cusparseCsrGet`| 10.2 |  |  ||
+|`cusparseCsrSetStridedBatch`| 11.0 |  |  ||
+|`cusparseDestroyDnMat`| 10.1 |  |  ||
+|`cusparseDestroyDnVec`| 10.2 |  |  ||
+|`cusparseDestroySpMat`| 10.1 |  |  ||
+|`cusparseDestroySpVec`| 10.2 |  |  ||
+|`cusparseDnMatGet`| 10.1 |  |  ||
+|`cusparseDnMatGetStridedBatch`| 10.1 |  |  ||
+|`cusparseDnMatGetValues`| 10.2 |  |  ||
+|`cusparseDnMatSetStridedBatch`| 10.1 |  |  ||
+|`cusparseDnMatSetValues`| 10.2 |  |  ||
+|`cusparseDnVecGet`| 10.2 |  |  ||
+|`cusparseDnVecGetValues`| 10.2 |  |  ||
+|`cusparseDnVecSetValues`| 10.2 |  |  ||
+|`cusparseGather`| 11.0 |  |  ||
+|`cusparseRot`| 11.0 |  |  ||
+|`cusparseScatter`| 11.0 |  |  ||
+|`cusparseSpGEMM_compute`| 11.0 |  |  ||
+|`cusparseSpGEMM_copy`| 11.0 |  |  ||
+|`cusparseSpGEMM_createDescr`| 11.0 |  |  ||
+|`cusparseSpGEMM_destroyDescr`| 11.0 |  |  ||
+|`cusparseSpGEMM_workEstimation`|  |  |  ||
+|`cusparseSpMM`| 10.1 |  |  ||
+|`cusparseSpMM_bufferSize`| 10.1 |  |  ||
+|`cusparseSpMV`| 10.2 |  |  ||
+|`cusparseSpMV_bufferSize`| 10.2 |  |  ||
+|`cusparseSpMatGetFormat`| 10.1 |  |  ||
+|`cusparseSpMatGetIndexBase`| 10.1 |  |  ||
+|`cusparseSpMatGetNumBatches`| 10.1 |  | 10.2 ||
+|`cusparseSpMatGetSize`| 11.0 |  |  ||
+|`cusparseSpMatGetStridedBatch`| 10.2 |  |  ||
+|`cusparseSpMatGetValues`| 10.2 |  |  ||
+|`cusparseSpMatSetNumBatches`| 10.1 |  | 10.2 ||
+|`cusparseSpMatSetStridedBatch`| 10.2 |  |  ||
+|`cusparseSpMatSetValues`| 10.2 |  |  ||
+|`cusparseSpVV`| 10.2 |  |  ||
+|`cusparseSpVV_bufferSize`| 10.2 |  |  ||
+|`cusparseSpVecGet`| 10.2 |  |  ||
+|`cusparseSpVecGetIndexBase`| 10.2 |  |  ||
+|`cusparseSpVecGetValues`| 10.2 |  |  ||
+|`cusparseSpVecSetValues`| 10.2 |  |  ||
 
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseSgpsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
-|`cusparseDgpsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
-|`cusparseCgpsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
-|`cusparseZgpsvInterleavedBatch_bufferSizeExt`              |                                                 | 9.2              |
-|`cusparseSgpsvInterleavedBatch`                            |                                                 | 9.2              |
-|`cusparseDgpsvInterleavedBatch`                            |                                                 | 9.2              |
-|`cusparseCgpsvInterleavedBatch`                            |                                                 | 9.2              |
-|`cusparseZgpsvInterleavedBatch`                            |                                                 | 9.2              |
 
-## **8. cuSPARSE Matrix Reorderings Reference**
-
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseScsrcolor`                                        |                                                 |
-|`cusparseDcsrcolor`                                        |                                                 |
-|`cusparseCcsrcolor`                                        |                                                 |
-|`cusparseZcsrcolor`                                        |                                                 |
-
-## **9. cuSPARSE Format Conversion Reference**
-
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseSbsr2csr`                                         |`hipsparseSbsr2csr`                              |
-|`cusparseDbsr2csr`                                         |`hipsparseDbsr2csr`                              |
-|`cusparseCbsr2csr`                                         |`hipsparseCbsr2csr`                              |
-|`cusparseZbsr2csr`                                         |`hipsparseZbsr2csr`                              |
-|`cusparseSgebsr2gebsc_bufferSize`                          |                                                 |
-|`cusparseSgebsr2gebsc_bufferSizeExt`                       |                                                 |
-|`cusparseDgebsr2gebsc_bufferSize`                          |                                                 |
-|`cusparseDgebsr2gebsc_bufferSizeExt`                       |                                                 |
-|`cusparseCgebsr2gebsc_bufferSize`                          |                                                 |
-|`cusparseCgebsr2gebsc_bufferSizeExt`                       |                                                 |
-|`cusparseZgebsr2gebsc_bufferSize`                          |                                                 |
-|`cusparseZgebsr2gebsc_bufferSizeExt`                       |                                                 |
-|`cusparseSgebsr2gebsc`                                     |                                                 |
-|`cusparseDgebsr2gebsc`                                     |                                                 |
-|`cusparseCgebsr2gebsc`                                     |                                                 |
-|`cusparseZgebsr2gebsc`                                     |                                                 |
-|`cusparseSgebsr2gebsr_bufferSize`                          |                                                 |
-|`cusparseSgebsr2gebsr_bufferSizeExt`                       |                                                 |
-|`cusparseDgebsr2gebsr_bufferSize`                          |                                                 |
-|`cusparseDgebsr2gebsr_bufferSizeExt`                       |                                                 |
-|`cusparseCgebsr2gebsr_bufferSize`                          |                                                 |
-|`cusparseCgebsr2gebsr_bufferSizeExt`                       |                                                 |
-|`cusparseZgebsr2gebsr_bufferSize`                          |                                                 |
-|`cusparseZgebsr2gebsr_bufferSizeExt`                       |                                                 |
-|`cusparseXgebsr2gebsrNnz`                                  |                                                 |
-|`cusparseSgebsr2gebsr`                                     |                                                 |
-|`cusparseDgebsr2gebsr`                                     |                                                 |
-|`cusparseCgebsr2gebsr`                                     |                                                 |
-|`cusparseZgebsr2gebsr`                                     |                                                 |
-|`cusparseXgebsr2csr`                                       |                                                 |
-|`cusparseSgebsr2csr`                                       |                                                 |
-|`cusparseDgebsr2csr`                                       |                                                 |
-|`cusparseCgebsr2csr`                                       |                                                 |
-|`cusparseZgebsr2csr`                                       |                                                 |
-|`cusparseScsr2gebsr_bufferSize`                            |                                                 |
-|`cusparseScsr2gebsr_bufferSizeExt`                         |                                                 |
-|`cusparseDcsr2gebsr_bufferSize`                            |                                                 |
-|`cusparseDcsr2gebsr_bufferSizeExt`                         |                                                 |
-|`cusparseCcsr2gebsr_bufferSize`                            |                                                 |
-|`cusparseCcsr2gebsr_bufferSizeExt`                         |                                                 |
-|`cusparseZcsr2gebsr_bufferSize`                            |                                                 |
-|`cusparseZcsr2gebsr_bufferSizeExt`                         |                                                 |
-|`cusparseXcsr2gebsrNnz`                                    |                                                 |
-|`cusparseScsr2gebsr`                                       |                                                 |
-|`cusparseDcsr2gebsr`                                       |                                                 |
-|`cusparseCcsr2gebsr`                                       |                                                 |
-|`cusparseZcsr2gebsr`                                       |                                                 |
-|`cusparseXcoo2csr`                                         |`hipsparseXcoo2csr`                              |
-|`cusparseScsc2dense`                                       |`hipsparseScsc2dense`                            |
-|`cusparseDcsc2dense`                                       |`hipsparseDcsc2dense`                            |
-|`cusparseCcsc2dense`                                       |`hipsparseCcsc2dense`                            |
-|`cusparseZcsc2dense`                                       |`hipsparseZcsc2dense`                            |
-|`cusparseScsc2hyb`                                         |                                                 |
-|`cusparseDcsc2hyb`                                         |                                                 |
-|`cusparseCcsc2hyb`                                         |                                                 |
-|`cusparseZcsc2hyb`                                         |                                                 |
-|`cusparseXcsr2bsrNnz`                                      |`hipsparseXcsr2bsrNnz`                           |
-|`cusparseScsr2bsr`                                         |`hipsparseScsr2bsr`                              |
-|`cusparseDcsr2bsr`                                         |`hipsparseDcsr2bsr`                              |
-|`cusparseCcsr2bsr`                                         |`hipsparseCcsr2bsr`                              |
-|`cusparseZcsr2bsr`                                         |`hipsparseZcsr2bsr`                              |
-|`cusparseXcsr2coo`                                         |`hipsparseXcsr2coo`                              |
-|`cusparseScsr2csc`                                         |`hipsparseScsr2csc`                              |
-|`cusparseDcsr2csc`                                         |`hipsparseDcsr2csc`                              |
-|`cusparseCcsr2csc`                                         |`hipsparseCcsr2csc`                              |
-|`cusparseZcsr2csc`                                         |`hipsparseZcsr2csc`                              |
-|`cusparseCsr2cscEx`                                        |                                                 | 8.0              |
-|`cusparseCsr2cscEx2`                                       |                                                 | 10.1             |
-|`cusparseCsr2cscEx2_bufferSize`                            |                                                 | 10.1             |
-|`cusparseScsr2dense`                                       |`hipsparseScsr2dense`                            |
-|`cusparseDcsr2dense`                                       |`hipsparseDcsr2dense`                            |
-|`cusparseCcsr2dense`                                       |`hipsparseCcsr2dense`                            |
-|`cusparseZcsr2dense`                                       |`hipsparseZcsr2dense`                            |
-|`cusparseScsr2csr_compress`                                |`hipsparseScsr2csr_compress`                     | 8.0              |
-|`cusparseDcsr2csr_compress`                                |`hipsparseDcsr2csr_compress`                     | 8.0              |
-|`cusparseCcsr2csr_compress`                                |`hipsparseCcsr2csr_compress`                     | 8.0              |
-|`cusparseZcsr2csr_compress`                                |`hipsparseZcsr2csr_compress`                     | 8.0              |
-|`cusparseScsr2hyb`                                         |`hipsparseScsr2hyb`                              |
-|`cusparseDcsr2hyb`                                         |`hipsparseDcsr2hyb`                              |
-|`cusparseCcsr2hyb`                                         |`hipsparseCcsr2hyb`                              |
-|`cusparseZcsr2hyb`                                         |`hipsparseZcsr2hyb`                              |
-|`cusparseSdense2csc`                                       |`hipsparseSdense2csc`                            |
-|`cusparseDdense2csc`                                       |`hipsparseDdense2csc`                            |
-|`cusparseCdense2csc`                                       |`hipsparseCdense2csc`                            |
-|`cusparseZdense2csc`                                       |`hipsparseZdense2csc`                            |
-|`cusparseSdense2csr`                                       |`hipsparseSdense2csr`                            |
-|`cusparseDdense2csr`                                       |`hipsparseDdense2csr`                            |
-|`cusparseCdense2csr`                                       |`hipsparseCdense2csr`                            |
-|`cusparseZdense2csr`                                       |`hipsparseZdense2csr`                            |
-|`cusparseSdense2hyb`                                       |                                                 |
-|`cusparseDdense2hyb`                                       |                                                 |
-|`cusparseCdense2hyb`                                       |                                                 |
-|`cusparseZdense2hyb`                                       |                                                 |
-|`cusparseShyb2csc`                                         |                                                 |
-|`cusparseDhyb2csc`                                         |                                                 |
-|`cusparseChyb2csc`                                         |                                                 |
-|`cusparseZhyb2csc`                                         |                                                 |
-|`cusparseShyb2csr`                                         |`hipsparseShyb2csr`                              |
-|`cusparseDhyb2csr`                                         |`hipsparseDhyb2csr`                              |
-|`cusparseChyb2csr`                                         |`hipsparseChyb2csr`                              |
-|`cusparseZhyb2csr`                                         |`hipsparseZhyb2csr`                              |
-|`cusparseShyb2dense`                                       |                                                 |
-|`cusparseDhyb2dense`                                       |                                                 |
-|`cusparseChyb2dense`                                       |                                                 |
-|`cusparseZhyb2dense`                                       |                                                 |
-|`cusparseSnnz`                                             |`cusparseSnnz`                                   |
-|`cusparseDnnz`                                             |`cusparseDnnz`                                   |
-|`cusparseCnnz`                                             |`cusparseCnnz`                                   |
-|`cusparseZnnz`                                             |`cusparseZnnz`                                   |
-|`cusparseCreateIdentityPermutation`                        |`hipsparseCreateIdentityPermutation`             |
-|`cusparseXcoosort_bufferSizeExt`                           |`hipsparseXcoosort_bufferSizeExt`                |
-|`cusparseXcoosortByRow`                                    |`hipsparseXcoosortByRow`                         |
-|`cusparseXcoosortByColumn`                                 |`hipsparseXcoosortByColumn`                      |
-|`cusparseXcsrsort_bufferSizeExt`                           |`hipsparseXcsrsort_bufferSizeExt`                |
-|`cusparseXcsrsort`                                         |`hipsparseXcsrsort`                              |
-|`cusparseXcscsort_bufferSizeExt`                           |`hipsparseXcscsort_bufferSizeExt`                |
-|`cusparseXcscsort`                                         |`hipsparseXcscsort`                              |
-|`cusparseCreateCsru2csrInfo`                               |                                                 |
-|`cusparseDestroyCsru2csrInfo`                              |                                                 |
-|`cusparseScsru2csr_bufferSizeExt`                          |                                                 |
-|`cusparseDcsru2csr_bufferSizeExt`                          |                                                 |
-|`cusparseCcsru2csr_bufferSizeExt`                          |                                                 |
-|`cusparseZcsru2csr_bufferSizeExt`                          |                                                 |
-|`cusparseScsru2csr`                                        |                                                 |
-|`cusparseDcsru2csr`                                        |                                                 |
-|`cusparseCcsru2csr`                                        |                                                 |
-|`cusparseZcsru2csr`                                        |                                                 |
-|`cusparseScsr2csru`                                        |                                                 |
-|`cusparseDcsr2csru`                                        |                                                 |
-|`cusparseCcsr2csru`                                        |                                                 |
-|`cusparseZcsr2csru`                                        |                                                 |
-|`cusparseHpruneDense2csr`                                  |                                                 | 9.0              |
-|`cusparseSpruneDense2csr`                                  |                                                 | 9.0              |
-|`cusparseDpruneDense2csr`                                  |                                                 | 9.0              |
-|`cusparseHpruneDense2csr_bufferSizeExt`                    |                                                 | 9.0              |
-|`cusparseSpruneDense2csr_bufferSizeExt`                    |                                                 | 9.0              |
-|`cusparseDpruneDense2csr_bufferSizeExt`                    |                                                 | 9.0              |
-|`cusparseHpruneDense2csrNnz`                               |                                                 | 9.0              |
-|`cusparseSpruneDense2csrNnz`                               |                                                 | 9.0              |
-|`cusparseDpruneDense2csrNnz`                               |                                                 | 9.0              |
-|`cusparseHpruneCsr2csr`                                    |                                                 | 9.0              |
-|`cusparseSpruneCsr2csr`                                    |                                                 | 9.0              |
-|`cusparseDpruneCsr2csr`                                    |                                                 | 9.0              |
-|`cusparseHpruneCsr2csr_bufferSizeExt`                      |                                                 | 9.0              |
-|`cusparseSpruneCsr2csr_bufferSizeExt`                      |                                                 | 9.0              |
-|`cusparseDpruneCsr2csr_bufferSizeExt`                      |                                                 | 9.0              |
-|`cusparseHpruneCsr2csrNnz`                                 |                                                 | 9.0              |
-|`cusparseSpruneCsr2csrNnz`                                 |                                                 | 9.0              |
-|`cusparseDpruneCsr2csrNnz`                                 |                                                 | 9.0              |
-|`cusparseHpruneDense2csrByPercentage`                      |                                                 | 9.0              |
-|`cusparseSpruneDense2csrByPercentage`                      |                                                 | 9.0              |
-|`cusparseDpruneDense2csrByPercentage`                      |                                                 | 9.0              |
-|`cusparseHpruneDense2csrByPercentage_bufferSizeExt`        |                                                 | 9.0              |
-|`cusparseSpruneDense2csrByPercentage_bufferSizeExt`        |                                                 | 9.0              |
-|`cusparseDpruneDense2csrByPercentage_bufferSizeExt`        |                                                 | 9.0              |
-|`cusparseHpruneDense2csrNnzByPercentage`                   |                                                 | 9.0              |
-|`cusparseSpruneDense2csrNnzByPercentage`                   |                                                 | 9.0              |
-|`cusparseDpruneDense2csrNnzByPercentage`                   |                                                 | 9.0              |
-|`cusparseHpruneCsr2csrByPercentage`                        |                                                 | 9.0              |
-|`cusparseSpruneCsr2csrByPercentage`                        |                                                 | 9.0              |
-|`cusparseDpruneCsr2csrByPercentage`                        |                                                 | 9.0              |
-|`cusparseHpruneCsr2csrByPercentage_bufferSizeExt`          |                                                 | 9.0              |
-|`cusparseSpruneCsr2csrByPercentage_bufferSizeExt`          |                                                 | 9.0              |
-|`cusparseDpruneCsr2csrByPercentage_bufferSizeExt`          |                                                 | 9.0              |
-|`cusparseHpruneCsr2csrNnzByPercentage`                     |                                                 | 9.0              |
-|`cusparseSpruneCsr2csrNnzByPercentage`                     |                                                 | 9.0              |
-|`cusparseDpruneCsr2csrNnzByPercentage`                     |                                                 | 9.0              |
-|`cusparseSnnz_compress`                                    |`hipsparseSnnz_compress`                         | 8.0              |
-|`cusparseDnnz_compress`                                    |`hipsparseDnnz_compress`                         | 8.0              |
-|`cusparseCnnz_compress`                                    |`hipsparseCnnz_compress`                         | 8.0              |
-|`cusparseZnnz_compress`                                    |`hipsparseZnnz_compress`                         | 8.0              |
-
-## **10. cuSPARSE Generic API Reference**
-
-## ***10.1. Generic Sparse API helper functions***
-
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseCreateCoo`                                        |                                                 | 10.1             |
-|`cusparseCreateCooAoS`                                     |                                                 | 10.1             |
-|`cusparseCreateCsr`                                        |                                                 | 10.1             |
-|`cusparseDestroySpMat`                                     |                                                 | 10.1             |
-|`cusparseCooGet`                                           |                                                 | 10.1             |
-|`cusparseCooAoSGet`                                        |                                                 | 10.1             |
-|`cusparseCsrGet`                                           |                                                 | 10.1             |
-|`cusparseSpMatGetFormat`                                   |                                                 | 10.1             |
-|`cusparseSpMatGetIndexBase`                                |                                                 | 10.1             |
-|`cusparseSpMatGetValues`                                   |                                                 | 10.1             |
-|`cusparseSpMatSetValues`                                   |                                                 | 10.1             |
-|`cusparseSpMatGetStridedBatch`                             |                                                 | 10.1             |
-|`cusparseSpMatSetStridedBatch`                             |                                                 | 10.1             |
-|`cusparseSpMatGetNumBatches`                               |                                                 | 10.1             |
-|`cusparseSpMatSetNumBatches`                               |                                                 | 10.1             |
-|`cusparseCreateSpVec`                                      |                                                 | 10.1             |
-|`cusparseDestroySpVec`                                     |                                                 | 10.1             |
-|`cusparseSpVecGet`                                         |                                                 | 10.1             |
-|`cusparseSpVecGetIndexBase`                                |                                                 | 10.1             |
-|`cusparseSpVecGetValues`                                   |                                                 | 10.1             |
-|`cusparseSpVecSetValues`                                   |                                                 | 10.1             |
-
-## ***10.2. Generic Dense API helper functions***
-
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseCreateDnMat`                                      |                                                 | 10.1             |
-|`cusparseDestroyDnMat`                                     |                                                 | 10.1             |
-|`cusparseDnMatGet`                                         |                                                 | 10.1             |
-|`cusparseDnMatGetValues`                                   |                                                 | 10.1             |
-|`cusparseDnMatSetValues`                                   |                                                 | 10.1             |
-|`cusparseDnMatSetStridedBatch`                             |                                                 | 10.1             |
-|`cusparseDnMatGetStridedBatch`                             |                                                 | 10.1             |
-|`cusparseCreateDnVec`                                      |                                                 | 10.1             |
-|`cusparseDestroyDnVec`                                     |                                                 | 10.1             |
-|`cusparseDnVecGet`                                         |                                                 | 10.1             |
-|`cusparseDnVecGetValues`                                   |                                                 | 10.1             |
-|`cusparseDnVecSetValues`                                   |                                                 | 10.1             |
-
-## ***10.3. Generic SpMM API functions***
-
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseSpMM`                                             |                                                 | 10.1             |
-|`cusparseSpMM_bufferSize`                                  |                                                 | 10.1             |
-
-## ***10.4. Generic SpVV API functions [Undocumented]***
-
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseSpVV`                                             |                                                 | 10.1             |
-|`cusparseSpVV_bufferSize`                                  |                                                 | 10.1             |
-
-## ***10.5. Generic SpMV API functions [Undocumented]***
-
-|   **CUDA**                                                |   **HIP**                                       |**CUDA version\***|
-|-----------------------------------------------------------|-------------------------------------------------|:----------------:|
-|`cusparseSpMV`                                             |                                                 | 10.1             |
-|`cusparseSpMV_bufferSize`                                  |                                                 | 10.1             |
-
-\* CUDA version, in which API has appeared and (optional) last version before abandoning it; no value in case of earlier versions < 7.5.
+\* A - Added, D - Deprecated, R - Removed

--- a/docs/markdown/cuComplex_API_supported_by_HIP.md
+++ b/docs/markdown/cuComplex_API_supported_by_HIP.md
@@ -1,37 +1,40 @@
-# cuComplex API supported by HIP
+# CUCOMPLEX API supported by HIP
 
 ## **1. cuComplex Data types**
 
-| **type**     |   **CUDA**                                                    |   **HIP**                                                  |**HIP value** (if differs) |
-|-------------:|---------------------------------------------------------------|------------------------------------------------------------|---------------------------|
-| float2       |***`cuFloatComplex`***                                         |***`hipFloatComplex`***                                     | struct                    |
-| double2      |***`cuDoubleComplex`***                                        |***`hipDoubleComplex`***                                    | struct                    |
-| float2       |***`cuComplex`***                                              |***`hipComplex`***                                          | struct                    |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuComplex`|  |  |  |`hipComplex`|
+|`cuDoubleComplex`|  |  |  |`hipDoubleComplex`|
+|`cuFloatComplex`|  |  |  |`hipFloatComplex`|
 
 ## **2. cuComplex API functions**
 
-|   **CUDA**                                                |   **HIP**                                       |
-|-----------------------------------------------------------|-------------------------------------------------|
-|`cuCrealf`                                                 |`hipCrealf`                                      |
-|`cuCimagf`                                                 |`hipCimagf`                                      |
-|`make_cuFloatComplex`                                      |`make_hipFloatComplex`                           |
-|`cuConjf`                                                  |`hipConjf`                                       |
-|`cuCaddf`                                                  |`hipCaddf`                                       |
-|`cuCsubf`                                                  |`hipCsubf`                                       |
-|`cuCmulf`                                                  |`hipCmulf`                                       |
-|`cuCdivf`                                                  |`hipCdivf`                                       |
-|`cuCabsf`                                                  |`hipCabsf`                                       |
-|`cuCreal`                                                  |`hipCreal`                                       |
-|`cuCimag`                                                  |`hipCimag`                                       |
-|`make_cuDoubleComplex`                                     |`make_hipDoubleComplex`                          |
-|`cuConj`                                                   |`hipConj`                                        |
-|`cuCadd`                                                   |`hipCadd`                                        |
-|`cuCsub`                                                   |`hipCsub`                                        |
-|`cuCmul`                                                   |`hipCmul`                                        |
-|`cuCdiv`                                                   |`hipCdiv`                                        |
-|`cuCabs`                                                   |`hipCabs`                                        |
-|`make_cuComplex`                                           |`make_hipComplex`                                |
-|`cuComplexFloatToDouble`                                   |`hipComplexFloatToDouble`                        |
-|`cuComplexDoubleToFloat`                                   |`hipComplexDoubleToFloat`                        |
-|`cuCfmaf`                                                  |`hipCfmaf`                                       |
-|`cuCfma`                                                   |`hipCfma`                                        |
+| **CUDA** | **A** | **D** | **R** | **HIP** |
+|:--|:-:|:-:|:-:|:--|
+|`cuCabs`|  |  |  |`hipCabs`|
+|`cuCabsf`|  |  |  |`hipCabsf`|
+|`cuCadd`|  |  |  |`hipCadd`|
+|`cuCaddf`|  |  |  |`hipCaddf`|
+|`cuCdiv`|  |  |  |`hipCdiv`|
+|`cuCdivf`|  |  |  |`hipCdivf`|
+|`cuCfma`|  |  |  |`hipCfma`|
+|`cuCfmaf`|  |  |  |`hipCfmaf`|
+|`cuCimag`|  |  |  |`hipCimag`|
+|`cuCimagf`|  |  |  |`hipCimagf`|
+|`cuCmul`|  |  |  |`hipCmul`|
+|`cuCmulf`|  |  |  |`hipCmulf`|
+|`cuComplexDoubleToFloat`|  |  |  |`hipComplexDoubleToFloat`|
+|`cuComplexFloatToDouble`|  |  |  |`hipComplexFloatToDouble`|
+|`cuConj`|  |  |  |`hipConj`|
+|`cuConjf`|  |  |  |`hipConjf`|
+|`cuCreal`|  |  |  |`hipCreal`|
+|`cuCrealf`|  |  |  |`hipCrealf`|
+|`cuCsub`|  |  |  |`hipCsub`|
+|`cuCsubf`|  |  |  |`hipCsubf`|
+|`make_cuComplex`|  |  |  |`make_hipComplex`|
+|`make_cuDoubleComplex`|  |  |  |`make_hipDoubleComplex`|
+|`make_cuFloatComplex`|  |  |  |`make_hipFloatComplex`|
+
+
+\* A - Added, D - Deprecated, R - Removed


### PR DESCRIPTION
+ All the docs are generated by `hipify-clang --md`

These docs are being called directly from the official ROCm documentation: https://rocmdocs.amd.com/en/latest/Programming_Guides/Programming-Guides.html
