### PR TITLE
Detect and report empty compiler paths in cmake_linker_helper

### DIFF
--- a/bin/hipcc_cmake_linker_helper
+++ b/bin/hipcc_cmake_linker_helper
@@ -3,6 +3,9 @@
 SOURCE="${BASH_SOURCE[0]}"
 HIP_PATH="$( command cd -P "$( dirname "$SOURCE" )/.." && pwd )"
 HIP_COMPILER=$(eval "$HIP_PATH/bin/hipconfig --compiler")
+if [[ "$HIP_COMPILER" =~ hcc|clang ]] && [[ ! -d "$1" ]]; then
+  echo "$(basename "$0"): error: HIP compiler path is not a directory" >&2 && exit 1
+fi
 if [ "$HIP_COMPILER" =  "hcc" ]; then
   HCC_HOME=$1 $HIP_PATH/bin/hipcc "${@:2}"
 elif [ "$HIP_COMPILER" = "clang" ]; then


### PR DESCRIPTION
This PR is intended to detect and report empty `HCC_HOME` conditions like the one discussed in #631 and similar conditions where `HIP_CLANG_PATH` is empty.

The added check only attempts to confirm that the first command-line argument is a directory and not that the directory is actually the root of a compiler installation.