### PR TITLE
HIPCC: allow hipcc to recognize .C files the same as .cpp/cxx/cc

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -674,7 +674,7 @@ foreach $arg (@ARGV)
                 $hasC = 1;
                 $needCFLAGS = 1;
                 $toolArgs .= " -x c"
-            } elsif (($arg =~ /\.cpp$/) or ($arg =~ /\.cxx$/) or ($arg =~ /\.cc$/) ) {
+            } elsif (($arg =~ /\.cpp$/) or ($arg =~ /\.cxx$/) or ($arg =~ /\.cc$/) or ($arg =~ /\.C$/)) {
                 $needCXXFLAGS = 1;
                 if ($HIP_COMPILE_CXX_AS_HIP eq '0' or $HIP_COMPILER ne "clang") {
                     $hasCXX = 1;


### PR DESCRIPTION
.C is another fairly common extension for C++ files. Note the capital C not lower case c. A number of our projects use .C for C++ extensions. 