### PR TITLE
Fix memory leak caused by undestroyed hip::Device and hip::Stream.

### DIFF
--- a/rocclr/hip_context.cpp
+++ b/rocclr/hip_context.cpp
@@ -70,6 +70,15 @@ void init() {
   PlatformState::instance().init();
 }
 
+void tearDown() {
+  for (auto it = g_devices.begin(); it != g_devices.end(); ++it) {
+    delete *it;
+  }
+  g_devices.clear();
+
+  delete host_device;
+}
+
 Device* getCurrentDevice() {
   return g_device;
 }

--- a/rocclr/hip_device.cpp
+++ b/rocclr/hip_device.cpp
@@ -26,7 +26,7 @@ namespace hip {
 
 // ================================================================================================
 amd::HostQueue* Device::NullStream(bool skip_alloc) {
-  amd::HostQueue* null_queue = null_stream_.asHostQueue(skip_alloc);
+  amd::HostQueue* null_queue = null_stream_->asHostQueue(skip_alloc);
   if (null_queue == nullptr) {
     return nullptr;
   }

--- a/rocclr/hip_stream.cpp
+++ b/rocclr/hip_stream.cpp
@@ -49,7 +49,10 @@ namespace hip {
 Stream::Stream(hip::Device* dev, Priority p,
     unsigned int f, bool null_stream, const std::vector<uint32_t>& cuMask)
   : queue_(nullptr), lock_("Stream Callback lock"), device_(dev),
-    priority_(p), flags_(f), null_(null_stream), cuMask_(cuMask) {}
+    priority_(p), flags_(f), null_(null_stream), cuMask_(cuMask)
+{
+  dev->addStream(this);
+}
 
 // ================================================================================================
 bool Stream::Create() {
@@ -297,7 +300,10 @@ hipError_t hipStreamDestroy(hipStream_t stream) {
     HIP_RETURN(hipErrorInvalidHandle);
   }
 
-  reinterpret_cast<hip::Stream*>(stream)->Destroy();
+  hip::Stream* hipStream = reinterpret_cast<hip::Stream*>(stream);
+
+  hipStream->Destroy();
+  hipStream->GetDevice()->removeStream(hipStream);
 
   HIP_RETURN(hipSuccess);
 }


### PR DESCRIPTION
1. introduce hip::tearDown() to deallocate hip::Device instances in
g_devices and host_device, which should be issued inside
amd::Runtime::tearDown() in ROCclr;
2. add std::list<Stream*> streams_ to class hip::Device() to record
created hip::Stream instances and deallocate them in the destructor
of hip::Device;
3. define hip::Device::null_stream_ as Stream* type instread of Stream
type to prevent double free in the destructor of hip::Devcie.