### PR TITLE
Fix patch version number when building from tarball

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,16 @@ string(REPLACE "." ";" VERSION_LIST ${HIP_BASE_VERSION})
 list(GET VERSION_LIST 0 HIP_VERSION_MAJOR)
 list(GET VERSION_LIST 1 HIP_VERSION_MINOR)
 
-find_package(Git)
+# only look for git when we have a git repo
+if (IS_DIRECTORY "${PROJECT_SOURCE_DIR}/.git")
+  find_package(Git)
+endif()
+
+# FIXME: Two different version strings used.
+
+set(HIP_PACKAGING_VERSION_PATCH "0")
+set(HIP_VERSION_GITDATE "0")
+set(HIP_VERSION_PATCH "0")
 
 # FIXME: Two different version strings used.
 if(GIT_FOUND)
@@ -98,9 +107,6 @@ if(GIT_FOUND)
   else()
     set(HIP_PACKAGING_VERSION_PATCH ${HIP_VERSION_GITDATE}.${HIP_VERSION_GITCOUNT}-${HIP_VERSION_GITHASH})
   endif()
-else()
-  # FIXME: Some parts depend on this being set.
-  set(HIP_PACKAGING_VERSION_PATCH "0")
 endif()
 
 ## Debian package specific variables
@@ -290,10 +296,6 @@ file(WRITE "${PROJECT_BINARY_DIR}/.hipInfo" ${_buildInfo})
 
 # Generate .hipVersion
 file(WRITE "${PROJECT_BINARY_DIR}/.hipVersion" ${_versionInfo})
-
-if(NOT DEFINED HIP_VERSION_GITDATE)
-    set(HIP_VERSION_GITDATE 0)
-endif()
 
 # Build doxygen documentation
 find_program(DOXYGEN_EXE doxygen)


### PR DESCRIPTION
I have git installed on my system, and I'm using spack to build hip, which downloads tarballs without the git repo.

When building, it somehow ends up with incorrect patch version numbers (tried it on 3.9.0 ... 4.0.0).

This patch ensures that `find_package(Git)` will only ever be run when there is in fact a `.git` folder in the project source directory.

Before this patch, I ended up with shared libs like this:

```
$ ls /home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.3.0/hip-3.9.0-bluiqfy2yt6jobgtn4qkqmdvvrqkghx6/lib/
cmake  hip_prof_str.h  libamdhip64.so  libamdhip64.so.3  libamdhip64.so.3.9.21014-
```

After this patch, things look much better:

```
$ ls /home/harmen/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-9.3.0/hip-3.9.0-4qli74twugr4mbbx7ee5niudq3oiph7x/lib/
cmake  hip_prof_str.h  libamdhip64.so  libamdhip64.so.3  libamdhip64.so.3.9.0
```

In fact previously I coulnd't even use the `hip::amdhip64` target because it would link against `/abs/path/to/libamdhip64.so.3.9.21014-`, which resulted in a linking error in GCC because of the trailing dash.
