### PR TITLE
Drop clang rt builtins linking on hip::host

### DIFF
--- a/hip-config.cmake.in
+++ b/hip-config.cmake.in
@@ -205,10 +205,11 @@ if(HIP_COMPILER STREQUAL "clang")
     endif()
   endif()
 
+  add_library(hip::clang_rt_builtins INTERFACE)
+  target_link_libraries(hip::clang_rt_builtins PUBLIC -L${HIP_CLANG_INCLUDE_PATH}/../lib/linux -lclang_rt.builtins-x86_64)
+
   # Add support for __fp16 and _Float16, explicitly link with compiler-rt
-  set_property(TARGET hip::device APPEND PROPERTY
-    INTERFACE_LINK_LIBRARIES -L${HIP_CLANG_INCLUDE_PATH}/../lib/linux -lclang_rt.builtins-x86_64
-  )
+  target_link_libraries(hip::device PUBLIC hip::clang_rt_builtins)
 endif()
 
 set( hip_LIBRARIES hip::host hip::device)

--- a/hip-config.cmake.in
+++ b/hip-config.cmake.in
@@ -206,9 +206,6 @@ if(HIP_COMPILER STREQUAL "clang")
   endif()
 
   # Add support for __fp16 and _Float16, explicitly link with compiler-rt
-  set_property(TARGET hip::host APPEND PROPERTY
-    INTERFACE_LINK_LIBRARIES -L${HIP_CLANG_INCLUDE_PATH}/../lib/linux -lclang_rt.builtins-x86_64
-  )
   set_property(TARGET hip::device APPEND PROPERTY
     INTERFACE_LINK_LIBRARIES -L${HIP_CLANG_INCLUDE_PATH}/../lib/linux -lclang_rt.builtins-x86_64
   )


### PR DESCRIPTION
Ref this comment
https://github.com/ROCm-Developer-Tools/HIP/pull/2217#discussion_r555402581:

> Yea, this should only be linked on hip::device as I believe its needed
> for __fp16 support on the GPU. If users need this on the host-side,
> then they should explicitly add it.
