### PR TITLE
Clarifying that hipExtLaunch timing does not include cache flush time

### DIFF
--- a/include/hip/hip_ext.h
+++ b/include/hip/hip_ext.h
@@ -56,6 +56,8 @@ THE SOFTWARE.
  * @warning kernellParams argument is not yet implemented in HIP. Please use extra instead. Please
  refer to hip_porting_driver_api.md for sample usage.
  * HIP/ROCm actually updates the start event when the associated kernel completes.
+ * Currently, timing between startEvent and stopEvent does not include the time it takes to perform
+ * a system scope release / cache flush - only the time it takes to issues writes to cache.
  */
 HIP_PUBLIC_API
 hipError_t hipExtModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,


### PR DESCRIPTION
- Providing some clarity on what is omitted from being timed by hipExtLaunch
- Please double-check for correct wording

This arose from misinterpreting that timing differences were due to lower overhead, due to a combined call (instead of sandwiching the kernel launch between hipRecordEvent()),  instead of not actually timing cache flushes.
