### PR TITLE
Fix conversion of texture addressing mode

### DIFF
--- a/rocclr/hip_conversions.hpp
+++ b/rocclr/hip_conversions.hpp
@@ -126,11 +126,11 @@ cl_addressing_mode getCLAddressingMode(const hipTextureAddressMode hipAddressMod
     case hipAddressModeWrap:
       return CL_ADDRESS_REPEAT;
     case hipAddressModeClamp:
-      return CL_ADDRESS_CLAMP;
+      return CL_ADDRESS_CLAMP_TO_EDGE;
     case hipAddressModeMirror:
       return CL_ADDRESS_MIRRORED_REPEAT;
     case hipAddressModeBorder:
-      return CL_ADDRESS_CLAMP_TO_EDGE;
+      return CL_ADDRESS_CLAMP;
   }
 
   ShouldNotReachHere();


### PR DESCRIPTION
`hipAddressModeClamp` corresponds to `CL_ADDRESS_CLAMP_TO_EDGE`.
This change fixes incorrect sampling near texture edges.

https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/sampler_t.html
> CLK_ADDRESS_CLAMP_TO_EDGE - out-of-range image coordinates are clamped to the extent. 
> CLK_ADDRESS_CLAMP - out-of-range image coordinates will return a border color. This is similar to the GL_ADDRESS_CLAMP_TO_BORDER addressing mode. 

https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html#group__CUDART__TYPES_1g03e1bbd2c491d809279c7a47e2cd0351
> cudaAddressModeClamp = 1
    Clamp to edge address mode 
> cudaAddressModeBorder = 3
    Border address mode 