### PR TITLE
Fix nvcc hipconfig

### DIFF
--- a/bin/hipconfig
+++ b/bin/hipconfig
@@ -246,7 +246,7 @@ if (!$printed or $p_full) {
     if ($HIP_PLATFORM eq "nvcc")  {
         print "\n" ;
         print "== nvcc\n";
-        #print "CUDA_PATH   :", $CUDA_PATH";
+        print "CUDA_PATH   : ", $CUDA_PATH, "\n";
         system("nvcc --version");
 
     }

--- a/bin/hipconfig
+++ b/bin/hipconfig
@@ -247,7 +247,7 @@ if (!$printed or $p_full) {
         print "\n" ;
         print "== nvcc\n";
         print "CUDA_PATH   : ", $CUDA_PATH, "\n";
-        system("nvcc --version");
+        system("$CUDA_PATH/bin/nvcc --version");
 
     }
     print "\n" ;


### PR DESCRIPTION
`hipconfig` tries printing the version of nvcc assumed to be on the PATH, not the one that actually gets picked up.