### PR TITLE
Fix perl and python shebang lines

### DIFF
--- a/bin/extractkernel
+++ b/bin/extractkernel
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 use strict;
 use File::Copy;
 use File::Spec;

--- a/bin/hipcc
+++ b/bin/hipcc
@@ -1,8 +1,9 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 
 # Need perl > 5.10 to use logic-defined or
 use 5.006; use v5.10.1;
+use warnings;
 use File::Basename;
 use File::Temp qw/ :mktemp  /;
 use Cwd;

--- a/bin/hipconfig
+++ b/bin/hipconfig
@@ -1,10 +1,11 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 $HIP_BASE_VERSION_MAJOR = "3";
 $HIP_BASE_VERSION_MINOR = "10";
 
 # Need perl > 5.10 to use logic-defined or
 use 5.006; use v5.10.1;
+use warnings;
 use Getopt::Long;
 use Cwd;
 

--- a/bin/hipify-cmakefile
+++ b/bin/hipify-cmakefile
@@ -1,4 +1,4 @@
-#!/usr/bin/perl  -w
+#!/usr/bin/env perl
 ##
 # Copyright (c) 2015-2016 Advanced Micro Devices, Inc. All rights reserved.
 #
@@ -21,6 +21,7 @@
 # THE SOFTWARE.
 ##
 #usage hipify-cmakefile [OPTIONS] INPUT_FILE
+use warnings;
 use Getopt::Long;
 
 GetOptions(

--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 ##
 # Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.
@@ -26,6 +26,7 @@
 
 #usage hipify-perl [OPTIONS] INPUT_FILE
 
+use warnings;
 use Getopt::Long;
 my $whitelist = "";
 my $fileName = "";

--- a/bin/hipify-perl
+++ b/bin/hipify-perl
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!/usr/bin/perl -w
 
 ##
 # Copyright (c) 2015-present Advanced Micro Devices, Inc. All rights reserved.
@@ -26,7 +26,6 @@
 
 #usage hipify-perl [OPTIONS] INPUT_FILE
 
-use warnings;
 use Getopt::Long;
 my $whitelist = "";
 my $fileName = "";

--- a/hip_prof_gen.py
+++ b/hip_prof_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 import os, sys, re
 
 PROF_HEADER = "hip_prof_str.h"

--- a/rocclr/hip_prof_gen.py
+++ b/rocclr/hip_prof_gen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # Copyright (c) 2019-present Advanced Micro Devices, Inc. All rights reserved.
 #

--- a/tests/hit/parser
+++ b/tests/hit/parser
@@ -1,6 +1,7 @@
-#!/usr/bin/perl -w
+#!/usr/bin/env perl
 
 use 5.006; use v5.10.1;
+use warnings;
 use File::Basename;
 use File::Spec;
 


### PR DESCRIPTION
- Do not expect perl to be bin /usr/bin/perl, but use perl in $PATH
- Don't expect python to be in /usr/bin/python but use what is in $PATH
