### PR TITLE
    SWDEV-284883 QMCPACK hangs when using rocprof –trace-period

### DIFF
--- a/rocclr/hip_prof_api.h
+++ b/rocclr/hip_prof_api.h
@@ -190,9 +190,9 @@ template <int cid_>
 class api_callbacks_spawner_t {
  public:
   api_callbacks_spawner_t() :
-    api_data_(NULL)
+    api_data_(NULL), was_enabled_on_construction_(is_enabled())
   {
-    if (!is_enabled()) return;
+    if (!was_enabled_on_construction_) return;
 
     if (cid_ >= HIP_API_ID_NUMBER) {
       fprintf(stderr, "HIP %s bad id %d\n", __FUNCTION__, cid_);
@@ -214,7 +214,7 @@ class api_callbacks_spawner_t {
   }
 
   ~api_callbacks_spawner_t() {
-    if (!is_enabled()) return;
+    if (!was_enabled_on_construction_) return;
 
     if (api_data_ != NULL) {
       hip_api_callback_t fun = entry(cid_).fun;
@@ -242,6 +242,7 @@ class api_callbacks_spawner_t {
   }
 
   hip_api_data_t* api_data_;
+  bool was_enabled_on_construction_ = false;
 };
 
 template <>


### PR DESCRIPTION
Workaraund fix race condition in [216](https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.2.x/rocclr/hip_prof_api.h#L216 ) 
Both constructor and desctructor have early return on condition is_enabled(): [217](https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.2.x/rocclr/hip_prof_api.h#L217), [195](https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.2.x/rocclr/hip_prof_api.h#195)

Constructor acquires semaphore hip_cb_table_entry_t.sem and destrcutor releases it.
Whether is_enabled() returns true or not depends on the sequence of calls to [set_callback](https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.2.x/rocclr/hip_prof_api.h#L113) and [set_activity](https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.2.x/rocclr/hip_prof_api.h#L75) from another thread of execution, roctracer control thread.

So, sometimes happens sequence:
1) Initial state: table is empty, is_enabled() -> false, value of [semaphore](https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.2.x/rocclr/hip_prof_api.h#L60)  is 0.
2) T1 creates api_callbacks_spawner_t and early returns in constructor,  [sem_sync](https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.2.x/rocclr/hip_prof_api.h#L137) is not called, value of [semaphore](https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.2.x/rocclr/hip_prof_api.h#L60) is 0.
3) T2 calls [set_callback](https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.2.x/rocclr/hip_prof_api.h#L113).  
4) T2  calls [set_activity](https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.2.x/rocclr/hip_prof_api.h#L75).
5) T1 calls [call](https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.2.x/rocclr/hip_prof_api.h#L207).
6) T1 destroys object and [217](https://github.com/ROCm-Developer-Tools/HIP/blob/rocm-4.2.x/rocclr/hip_prof_api.h#L217) does not return from the destructor.
7) T1 calls [sem_release](https://github.com/kikimych/HIP/blob/fix-race-in-hip_prof_api.h/rocclr/hip_prof_api.h#L228) and aborts.

To fix this sem_sync() and sem_release() need to be called under the same predicates. 