### PR TITLE
fix documentation for `popcll`

### DIFF
--- a/docs/markdown/hip_kernel_language.md
+++ b/docs/markdown/hip_kernel_language.md
@@ -467,7 +467,7 @@ Following is the list of supported integer intrinsics. Note that intrinsics are 
 | unsigned int __ffsll(unsigned long long int x) <br><sub>Find the position of least signigicant bit set to 1 in a 64 bit unsigned integer.<sup>[1](#f3)</sup></sub> |
 | unsigned int __ffsll(long long int x) <br><sub>Find the position of least signigicant bit set to 1 in a 64 bit signed integer.</sub> |
 | unsigned int __popc ( unsigned int x ) <br><sub>Count the number of bits that are set to 1 in a 32 bit integer.</sub> |
-| int __popcll ( unsigned long long int x )<br><sub>Count the number of bits that are set to 1 in a 64 bit integer.</sub> |
+| unsigned int __popcll ( unsigned long long int x )<br><sub>Count the number of bits that are set to 1 in a 64 bit integer.</sub> |
 | int __mul24 ( int x, int y )<br><sub>Multiply two 24bit integers.</sub> |
 | unsigned int __umul24 ( unsigned int x, unsigned int y )<br><sub>Multiply two 24bit unsigned integers.</sub> |
 <sub><b id="f3"><sup>[1]</sup></b> 


### PR DESCRIPTION
Change return type from `int` to `unsigned int`.

It is correctly documented in [hip-math-api.md](https://github.com/ROCm-Developer-Tools/HIP/blob/586165ebc281eb9461898a5b2abbc74595f5d97d/docs/markdown/hip-math-api.md#__popcll) but not at the place where this PR is updating the documentation.

This PR is equal to #2290 which was closed because of the new develop branch.