### PR TITLE
SWDEV-238517 - [dtest] New Catch2 Tests for texture object apis.

### DIFF
--- a/tests/catch/hipTestMain/CMakeLists.txt
+++ b/tests/catch/hipTestMain/CMakeLists.txt
@@ -1,3 +1,23 @@
+# Copyright (c) 2021 Advanced Micro Devices, Inc. All Rights Reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
 if(CMAKE_BUILD_TYPE MATCHES "^Debug$")
     add_definitions(-DHT_LOG_ENABLE)
 endif()
@@ -16,6 +36,7 @@ target_link_libraries(UnitTests PRIVATE UnitDeviceTests
                                         OccupancyTest
                                         DeviceTest
                                         RTC
+                                        TextureTest
                                         stdc++fs)
 
 if(HIP_PLATFORM MATCHES "nvidia")

--- a/tests/catch/unit/texture/CMakeLists.txt
+++ b/tests/catch/unit/texture/CMakeLists.txt
@@ -18,11 +18,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-add_subdirectory(memory)
-add_subdirectory(deviceLib)
-add_subdirectory(stream)
-add_subdirectory(event)
-add_subdirectory(occupancy)
-add_subdirectory(device)
-add_subdirectory(rtc)
-add_subdirectory(texture)
+# Common Tests - Test independent of all platforms
+set(TEST_SRC
+    hipCreateTextureObject_ArgValidation.cc
+    hipCreateTextureObject_Linear.cc
+    hipCreateTextureObject_Pitch2D.cc
+    hipCreateTextureObject_Array.cc
+)
+
+# Create shared lib of all tests
+add_library(TextureTest SHARED EXCLUDE_FROM_ALL ${TEST_SRC})
+
+# Add dependency on build_tests to build it on this custom target
+add_dependencies(build_tests TextureTest)

--- a/tests/catch/unit/texture/hipCreateTextureObject_ArgValidation.cc
+++ b/tests/catch/unit/texture/hipCreateTextureObject_ArgValidation.cc
@@ -1,0 +1,81 @@
+/*
+Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip_test_common.hh>
+
+#define N 512
+
+/*
+ * Validate argument list of texture object api.
+ */
+TEST_CASE("Unit_hipCreateTextureObject_ArgValidation") {
+  float *texBuf;
+  hipError_t ret;
+  constexpr int xsize = 32;
+  hipResourceDesc resDesc;
+  hipTextureDesc texDesc;
+  hipTextureObject_t texObj;
+
+  /** Initialization */
+  HIP_CHECK(hipMalloc(&texBuf, N * sizeof(float)));
+  // Populate resource descriptor
+  memset(&resDesc, 0, sizeof(resDesc));
+  resDesc.resType = hipResourceTypeLinear;
+  resDesc.res.linear.devPtr = texBuf;
+  resDesc.res.linear.desc = hipCreateChannelDesc(xsize, 0, 0, 0,
+                       hipChannelFormatKindFloat);
+  resDesc.res.linear.sizeInBytes = N * sizeof(float);
+
+  // Populate texture descriptor
+  memset(&texDesc, 0, sizeof(texDesc));
+  texDesc.readMode = hipReadModeElementType;
+
+
+  /** Sections */
+  SECTION("TextureObject as nullptr") {
+    ret = hipCreateTextureObject(nullptr, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret != hipSuccess);
+  }
+
+  SECTION("Resouce Descriptor as nullptr") {
+    ret = hipCreateTextureObject(&texObj, nullptr, &texDesc, nullptr);
+    REQUIRE(ret != hipSuccess);
+  }
+
+  SECTION("Texture Descriptor as nullptr") {
+    if ((TestContext::get()).isAmd()) {
+      ret = hipCreateTextureObject(&texObj, &resDesc, nullptr, nullptr);
+      REQUIRE(ret != hipSuccess);
+    } else {
+      // API expected to return failure. Test skipped
+      // on nvidia as api returns success and would lead
+      // to unexpected behavior with app.
+      WARN("Texture Desc(nullptr) skipped on nvidia");
+    }
+  }
+
+  SECTION("Destroy TextureObject with nullptr") {
+    ret = hipDestroyTextureObject((hipTextureObject_t)nullptr);
+    // api to return success and no crash seen.
+    REQUIRE(ret == hipSuccess);
+  }
+
+  /** De-Initialization */
+  HIP_CHECK(hipFree(texBuf));
+}

--- a/tests/catch/unit/texture/hipCreateTextureObject_Array.cc
+++ b/tests/catch/unit/texture/hipCreateTextureObject_Array.cc
@@ -1,0 +1,67 @@
+/*
+Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip_test_common.hh>
+
+/*
+ * Validates Array Resource texture object with negative/functional tests.
+ */
+TEST_CASE("Unit_hipCreateTextureObject_ArrayResource") {
+  hipError_t ret;
+  hipResourceDesc resDesc;
+  hipTextureDesc texDesc;
+  hipTextureObject_t texObj;
+
+  /* set resource type as hipResourceTypeArray and array(nullptr) */
+  // Populate resource descriptor
+  memset(&resDesc, 0, sizeof(resDesc));
+  resDesc.resType = hipResourceTypeArray;
+  resDesc.res.array.array = nullptr;
+
+  // Populate texture descriptor
+  memset(&texDesc, 0, sizeof(texDesc));
+  texDesc.readMode = hipReadModeElementType;
+
+  ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+  REQUIRE(ret != hipSuccess);
+}
+
+/*
+ * Validates MipMappedArray Resource texture object
+ * with negative/functional tests.
+ */
+TEST_CASE("Unit_hipCreateTextureObject_MmArrayResource") {
+  hipError_t ret;
+  hipResourceDesc resDesc;
+  hipTextureDesc texDesc;
+  hipTextureObject_t texObj;
+
+  /* set resource type as hipResourceTypeMipmappedArray and mipmap(nullptr) */
+  // Populate resource descriptor
+  memset(&resDesc, 0, sizeof(resDesc));
+  resDesc.resType = hipResourceTypeMipmappedArray;
+  resDesc.res.mipmap.mipmap = nullptr;
+
+  // Populate texture descriptor
+  memset(&texDesc, 0, sizeof(texDesc));
+  texDesc.readMode = hipReadModeElementType;
+
+  ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+  REQUIRE(ret != hipSuccess);
+}

--- a/tests/catch/unit/texture/hipCreateTextureObject_Linear.cc
+++ b/tests/catch/unit/texture/hipCreateTextureObject_Linear.cc
@@ -1,0 +1,133 @@
+/*
+Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip_test_common.hh>
+
+#define UNALIGN_OFFSET 1
+#define N 512
+
+/*
+ * Validates Linear Resource texture object with negative/functional tests.
+ */
+TEST_CASE("Unit_hipCreateTextureObject_LinearResource") {
+  float *texBuf;
+  hipError_t ret;
+  constexpr int xsize = 32;
+  hipResourceDesc resDesc;
+  hipTextureDesc texDesc;
+  hipResourceViewDesc resViewDesc;
+  hipTextureObject_t texObj;
+  hipDeviceProp_t devProp;
+
+  /** Initialization */
+  HIP_CHECK(hipMalloc(&texBuf, N * sizeof(float)));
+  HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
+  memset(&resDesc, 0, sizeof(resDesc));
+  memset(&texDesc, 0, sizeof(texDesc));
+  resDesc.resType = hipResourceTypeLinear;
+
+  /** Sections */
+  SECTION("hipResourceTypeLinear and devPtr(nullptr)") {
+    // Populate resource descriptor
+    resDesc.res.linear.devPtr = nullptr;
+    resDesc.res.linear.desc = hipCreateChannelDesc(xsize, 0, 0, 0,
+                           hipChannelFormatKindFloat);
+    resDesc.res.linear.sizeInBytes = N * sizeof(float);
+
+    // Populate texture descriptor
+    texDesc.readMode = hipReadModeElementType;
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret != hipSuccess);
+  }
+
+  SECTION("hipResourceTypeLinear and sizeInBytes(0)") {
+    if ((TestContext::get()).isAmd()) {
+      // Populate resource descriptor
+      resDesc.res.linear.devPtr = texBuf;
+      resDesc.res.linear.desc = hipCreateChannelDesc(xsize, 0, 0, 0,
+                                              hipChannelFormatKindFloat);
+      resDesc.res.linear.sizeInBytes = 0;
+
+      // Populate texture descriptor
+      texDesc.readMode = hipReadModeElementType;
+      ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+      REQUIRE(ret != hipSuccess);
+    } else {
+      // API expected to return failure. Test skipped
+      // on nvidia as api returns success and would lead
+      // to unexpected behavior with app.
+      WARN("Resource type Linear/sizeInBytes(0) skipped on nvidia");
+    }
+  }
+
+  SECTION("hipResourceTypeLinear and sizeInBytes(max(size_t))") {
+    // Populate resource descriptor
+    resDesc.res.linear.devPtr = texBuf;
+    resDesc.res.linear.desc = hipCreateChannelDesc(xsize, 0, 0, 0,
+                           hipChannelFormatKindFloat);
+    resDesc.res.linear.sizeInBytes = std::numeric_limits<std::size_t>::max();
+
+    // Populate texture descriptor
+    texDesc.readMode = hipReadModeElementType;
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret != hipSuccess);
+  }
+
+  SECTION("hipResourceTypeLinear and valid resource view descriptor") {
+#if HT_AMD
+    // Populate resource descriptor
+    resDesc.res.linear.devPtr = texBuf;
+    resDesc.res.linear.desc = hipCreateChannelDesc(xsize, 0, 0, 0,
+                           hipChannelFormatKindFloat);
+    resDesc.res.linear.sizeInBytes = N * sizeof(float);
+
+    // Populate texture descriptor
+    texDesc.readMode = hipReadModeElementType;
+
+    // Populate resourceview descriptor
+    memset(&resViewDesc, 0, sizeof(resViewDesc));
+    resViewDesc.format = hipResViewFormatFloat1;
+    resViewDesc.width = N * sizeof(float);
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, &resViewDesc);
+    REQUIRE(ret != hipSuccess);
+#else
+    // API expected to return error according to cuda documentation.
+    WARN("Resource view descriptor test skipped on nvidia");
+#endif
+  }
+
+  SECTION("hipResourceTypeLinear and devicePtr un-aligned") {
+    if (devProp.textureAlignment > UNALIGN_OFFSET) {
+    // Populate resource descriptor
+    resDesc.res.linear.devPtr = reinterpret_cast<char *>(texBuf)
+                                                      + UNALIGN_OFFSET;
+    resDesc.res.linear.desc = hipCreateChannelDesc(xsize, 0, 0, 0,
+                                               hipChannelFormatKindFloat);
+    resDesc.res.linear.sizeInBytes = N * sizeof(float);
+
+    // Populate texture descriptor
+    texDesc.readMode = hipReadModeElementType;
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret != hipSuccess);
+    }
+  }
+
+  /** De-Initialization */
+  HIP_CHECK(hipFree(texBuf));
+}

--- a/tests/catch/unit/texture/hipCreateTextureObject_Pitch2D.cc
+++ b/tests/catch/unit/texture/hipCreateTextureObject_Pitch2D.cc
@@ -1,0 +1,216 @@
+/*
+Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+#include <hip_test_common.hh>
+
+#define UNALIGN_OFFSET 1
+#define SIZE_H 20
+#define SIZE_W 30
+#define N 512
+
+
+/*
+ * Validates Pitch2D Resource texture object with negative and functional tests
+ */
+TEST_CASE("Unit_hipCreateTextureObject_Pitch2DResource") {
+  hipError_t ret;
+  hipResourceDesc resDesc;
+  hipTextureDesc texDesc;
+  hipTextureObject_t texObj;
+  hipDeviceProp_t devProp;
+  size_t devPitchA;
+  float *devPtrA;
+
+  /** Initialization */
+  HIP_CHECK(hipMallocPitch(reinterpret_cast<void**>(&devPtrA), &devPitchA,
+                                             SIZE_W*sizeof(float), SIZE_H));
+  HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
+  memset(&resDesc, 0, sizeof(resDesc));
+  memset(&texDesc, 0, sizeof(texDesc));
+  resDesc.resType = hipResourceTypePitch2D;
+
+  /** Sections */
+  SECTION("hipResourceTypePitch2D and devPtr(nullptr)") {
+    // Populate resource descriptor
+    resDesc.res.pitch2D.devPtr = nullptr;
+    resDesc.res.pitch2D.height = SIZE_H;
+    resDesc.res.pitch2D.width = SIZE_W;
+    resDesc.res.pitch2D.pitchInBytes = devPitchA;
+    resDesc.res.pitch2D.desc = hipCreateChannelDesc<float>();
+
+    // Populate texture descriptor
+    texDesc.readMode = hipReadModeElementType;
+
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret != hipSuccess);
+  }
+
+  SECTION("hipResourceTypePitch2D and devicePtr un-aligned") {
+    if (devProp.textureAlignment > UNALIGN_OFFSET) {
+      // Populate resource descriptor
+      resDesc.res.pitch2D.devPtr = reinterpret_cast<char *>(devPtrA)
+                                                        + UNALIGN_OFFSET;
+      resDesc.res.pitch2D.height = SIZE_H;
+      resDesc.res.pitch2D.width = SIZE_W;
+      resDesc.res.pitch2D.pitchInBytes = devPitchA;
+      resDesc.res.pitch2D.desc = hipCreateChannelDesc<float>();
+
+      // Populate texture descriptor
+      memset(&texDesc, 0, sizeof(texDesc));
+      texDesc.readMode = hipReadModeElementType;
+      ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+      REQUIRE(ret != hipSuccess);
+    }
+  }
+
+  SECTION("hipResourceTypePitch2D and pitch(un-aligned)") {
+    // Populate resource descriptor
+    resDesc.res.pitch2D.devPtr = devPtrA;
+    resDesc.res.pitch2D.height = SIZE_H;
+    resDesc.res.pitch2D.width = SIZE_W;
+    resDesc.res.pitch2D.pitchInBytes = UNALIGN_OFFSET;
+    resDesc.res.pitch2D.desc = hipCreateChannelDesc<float>();
+
+    // Populate texture descriptor
+    texDesc.readMode = hipReadModeElementType;
+
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret != hipSuccess);
+  }
+
+  SECTION("hipResourceTypePitch2D and height(0)") {
+    if ((TestContext::get()).isAmd()) {
+      // Populate resource descriptor
+      resDesc.res.pitch2D.devPtr = devPtrA;
+      resDesc.res.pitch2D.height = 0;
+      resDesc.res.pitch2D.width = SIZE_W;
+      resDesc.res.pitch2D.pitchInBytes = devPitchA;
+      resDesc.res.pitch2D.desc = hipCreateChannelDesc<float>();
+
+      // Populate texture descriptor
+      texDesc.readMode = hipReadModeElementType;
+
+      ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+      REQUIRE(ret != hipSuccess);
+    } else {
+      // Test expected to return error with height(0).
+      WARN("Resourcetype Pitch2D/height(0) skipped on nvidia");
+    }
+  }
+
+  SECTION("hipResourceTypePitch2D and height(0)/devptr(nullptr)") {
+    // Populate resource descriptor
+    resDesc.res.pitch2D.devPtr = nullptr;
+    resDesc.res.pitch2D.height = 0;
+    resDesc.res.pitch2D.width = SIZE_W;
+    resDesc.res.pitch2D.pitchInBytes = devPitchA;
+    resDesc.res.pitch2D.desc = hipCreateChannelDesc<float>();
+
+    // Populate texture descriptor
+    texDesc.readMode = hipReadModeElementType;
+
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret != hipSuccess);
+  }
+
+  SECTION("hipResourceTypePitch2D and height(max(size_t))") {
+    // Populate resource descriptor
+    resDesc.res.pitch2D.devPtr = devPtrA;
+    resDesc.res.pitch2D.height = std::numeric_limits<std::size_t>::max();
+    resDesc.res.pitch2D.width = SIZE_W;
+    resDesc.res.pitch2D.pitchInBytes = devPitchA;
+    resDesc.res.pitch2D.desc = hipCreateChannelDesc<float>();
+
+    // Populate texture descriptor
+    texDesc.readMode = hipReadModeElementType;
+
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret != hipSuccess);
+  }
+
+  SECTION("hipResourceTypePitch2D and width(0)") {
+    if ((TestContext::get()).isAmd()) {
+      // Populate resource descriptor
+      resDesc.resType = hipResourceTypePitch2D;
+      resDesc.res.pitch2D.devPtr = devPtrA;
+      resDesc.res.pitch2D.height = SIZE_H;
+      resDesc.res.pitch2D.width = 0;
+      resDesc.res.pitch2D.pitchInBytes = devPitchA;
+      resDesc.res.pitch2D.desc = hipCreateChannelDesc<float>();
+
+      // Populate texture descriptor
+      texDesc.readMode = hipReadModeElementType;
+
+      ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+      REQUIRE(ret != hipSuccess);
+    } else {
+      // api expected to return failure when width(0) is passed.
+      WARN("ResourceType Pitch2D/width(0) skipped on nvidia");
+    }
+  }
+
+  SECTION("hipResourceTypePitch2D and width(0)/devPtr(nullptr)") {
+    // Populate resource descriptor
+    resDesc.res.pitch2D.devPtr = nullptr;
+    resDesc.res.pitch2D.height = SIZE_H;
+    resDesc.res.pitch2D.width = 0;
+    resDesc.res.pitch2D.pitchInBytes = devPitchA;
+    resDesc.res.pitch2D.desc = hipCreateChannelDesc<float>();
+
+    // Populate texture descriptor
+    texDesc.readMode = hipReadModeElementType;
+
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret != hipSuccess);
+  }
+
+  SECTION("hipResourceTypePitch2D and width(max(size_t))") {
+    // Populate resource descriptor
+    resDesc.res.pitch2D.devPtr = devPtrA;
+    resDesc.res.pitch2D.height = SIZE_H;
+    resDesc.res.pitch2D.width = std::numeric_limits<std::size_t>::max();
+    resDesc.res.pitch2D.pitchInBytes = devPitchA;
+    resDesc.res.pitch2D.desc = hipCreateChannelDesc<float>();
+
+    // Populate texture descriptor
+    texDesc.readMode = hipReadModeElementType;
+
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret != hipSuccess);
+  }
+
+  SECTION("hipResourceTypePitch2D and pitch(max(size_t))") {
+    // Populate resource descriptor
+    resDesc.res.pitch2D.devPtr = devPtrA;
+    resDesc.res.pitch2D.height = SIZE_H;
+    resDesc.res.pitch2D.width = SIZE_W;
+    resDesc.res.pitch2D.pitchInBytes = std::numeric_limits<std::size_t>::max();
+    resDesc.res.pitch2D.desc = hipCreateChannelDesc<float>();
+
+    // Populate texture descriptor
+    texDesc.readMode = hipReadModeElementType;
+
+    ret = hipCreateTextureObject(&texObj, &resDesc, &texDesc, nullptr);
+    REQUIRE(ret != hipSuccess);
+  }
+
+  /** De-Initialization */
+  HIP_CHECK(hipFree(devPtrA));
+}
+


### PR DESCRIPTION
New Catch2 Tests for texture object apis.
Seperate Catch2 files are created for each resource type. Future test additions of respective resource type will be added to resource type specific files.

Change-Id: I7ba09f5bd31605bb670ec70ed7f12904e34cf40d