### PR TITLE
SWDEV-302654 - Fix cooperative_streams_half_capacity

### DIFF
--- a/tests/src/runtimeApi/cooperativeGrps/cooperative_streams.cpp
+++ b/tests/src/runtimeApi/cooperativeGrps/cooperative_streams.cpp
@@ -238,6 +238,7 @@ int main(int argc, char** argv) {
   HIPCHECK(hipGetDeviceCount(&device_num));
   for (int dev = 0; dev < device_num; ++dev) {
     /*************************************************************************/
+    HIPCHECK(hipSetDevice(dev));
     hipDeviceProp_t device_properties;
     HIPCHECK(hipGetDeviceProperties(&device_properties, dev));
 


### PR DESCRIPTION
Fix random failure of cooperative_streams_half_capacity by
adding HIPCHECK(hipSetDevice(dev))

Change-Id: Ic4baf10a2c69f981aa7134a999c4779642852f53