### PR TITLE
SWDEV-273235 - enabling catch2 config file and graph tests

### DIFF
--- a/tests/catch/CMakeLists.txt
+++ b/tests/catch/CMakeLists.txt
@@ -76,6 +76,8 @@ include_directories(
     ${JSON_PARSER}
 )
 
+file(COPY ./hipTestMain/config DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/hipTestMain)
+
 if(HIP_PLATFORM MATCHES "amd" AND HIP_COMPILER MATCHES "clang")
     add_compile_options(-Wall -Wextra -pedantic -Werror)
 endif()

--- a/tests/catch/README.md
+++ b/tests/catch/README.md
@@ -35,7 +35,14 @@ Some useful functions are:
 This information can be accessed in any test via using: `TestContext::get().isAmd()`.
 
 ## Config file schema
-Some tests can be skipped using a config file placed in same directory as the exe.
+Some tests can be skipped using a config file placed in hipTestMain/config folder. Multiple config files can be defined for different configurations.
+The naming convention for the file needs to be "config_platform_os_archname.json"
+Platform and os are mandatory, "all" for os if the tests needs to be skipped for all OS.
+Arch name is optional and takes precedence while loading the json file.
+
+example:
+config_amd_windows.json
+config_nvidia_windows.json
 
 The schema of the json file is as follows:
 ```json

--- a/tests/catch/hipTestMain/config/config_amd_windows.json
+++ b/tests/catch/hipTestMain/config/config_amd_windows.json
@@ -1,0 +1,28 @@
+{
+    "DisabledTests":
+	[
+	   "Unit_hipMemcpy3D_Basic - int",
+	   "Unit_hipMemcpy3D_Basic - unsigned int",
+	   "Unit_hipMemcpy3D_Basic - float",
+	   "Unit_hipMemcpy3DAsync_Basic - int",
+	   "Unit_hipMemcpy3DAsync_Basic - unsigned int",
+	   "Unit_hipMemcpy3DAsync_Basic - float",
+	   "Unit_hipMemcpy3DAsync_multiDevice-Negative",
+	   "Unit_hipMemcpy3DAsync_multiDevice-DiffStream",
+	   "Unit_hipPointerGetAttributes_ClusterAlloc",
+	   "Unit_hipMallocManaged_MultiChunkMultiDevice",
+	   "Unit_hipMallocManaged_TwoPointers - int",
+	   "Unit_hipMallocManaged_TwoPointers - float",
+	   "Unit_hipMallocManaged_TwoPointers - double",
+	   "Unit_hipMallocManaged_DeviceContextChange - unsigned char",
+	   "Unit_hipMallocManaged_DeviceContextChange - int",
+	   "Unit_hipMallocManaged_DeviceContextChange - float",
+	   "Unit_hipMallocManaged_DeviceContextChange - double",
+	   "Unit_hipHostMalloc_CoherentTst",
+	   "Unit_hipMallocManaged_CoherentTst",
+	   "Unit_hipMallocManaged_CoherentTstWthAdvise",
+	   "Unit_hipMalloc_CoherentTst",
+	   "Unit_hipExtMallocWithFlags_CoherentTst"
+	]
+
+}

--- a/tests/catch/hipTestMain/hip_test_context.cc
+++ b/tests/catch/hipTestMain/hip_test_context.cc
@@ -21,7 +21,79 @@ void TestContext::detectPlatform() {
 #endif
 }
 
+std::string TestContext::substringFound(std::vector<std::string> list, std::string filename) {
+  std::string match = "";
+  for(unsigned int i = 0; i < list.size() ; i++) {
+    if (filename.find(list.at(i)) != std::string::npos) {
+        match = list.at(i);
+        break;
+    }
+  }
+  return match;
+}
+
+
+std::string TestContext::getMatchingConfigFile(std::string config_dir) {
+  std::string configFileToUse;
+  for(auto& p: fs::recursive_directory_iterator(config_dir)) {
+    fs::path filename = p.path();
+    std::string cur_arch = "TODO";
+    std::string arch = substringFound(amd_arch_list_,filename.filename().string());
+    std::string platform = substringFound(platform_list_,filename.filename().string());
+    std::string os = substringFound(os_list_,filename.filename().string());
+    // if arch found then use that exit from loop
+    if(arch == cur_arch) {
+      configFileToUse = filename.string();
+      break;
+    // match the platform/os and continue to look
+    } else if((platform == config_.platform) &&
+              (os == config_.os || os == "all")) {
+      configFileToUse  = filename.string();
+    }
+  }
+  return configFileToUse;
+}
+
+
+std::string& TestContext::getJsonFile() {
+  fs::path config_dir = exe_path;
+  config_dir = config_dir.parent_path();
+  int levels = 0;
+  bool configFolderFound = false;
+  std::vector <std::string> configList;
+  std::string configFile;
+  // check a max of 5 levels down the executable path
+  while(levels < 5) {
+    fs::path temp_path = config_dir;
+    temp_path /= "hipTestMain";
+    temp_path /= "config";
+    if (fs::exists(temp_path)) {
+      config_dir = fs::absolute(temp_path);
+      configFolderFound = true;
+      break;
+    } else {
+      config_dir = config_dir.parent_path();
+      levels++;
+    }
+  }
+
+  // get config.json files if config folder.
+  if (configFolderFound) {
+    json_file_ = getMatchingConfigFile(config_dir.string());
+  }
+  return json_file_;
+}
+
+
 void TestContext::fillConfig() {
+  config_.platform = (amd ? "amd" : (nvidia ? "nvidia" : "unknown"));
+  config_.os = (p_windows ? "windows" : (p_linux ? "linux" : "unknown"));
+
+  if (config_.os == "unknown" || config_.platform == "unknown") {
+    LogPrintf("%s", "Either Config or Os is unknown, this wont end well");
+    abort();
+  }
+
   const char* env_config = std::getenv("HT_CONFIG_FILE");
   LogPrintf("Env Config file: %s",
             (env_config != nullptr) ? env_config : "Not found, using default config");
@@ -41,17 +113,9 @@ void TestContext::fillConfig() {
   } else if (config_path.has_parent_path()) {
     config_.json_file = config_path.string() + def_config_json;
   } else {
-    config_.json_file = exe_path + def_config_json;
+    config_.json_file = getJsonFile();
   }
   LogPrintf("Config file path: %s", config_.json_file.c_str());
-
-  config_.platform = (amd ? "amd" : (nvidia ? "nvidia" : "unknown"));
-  config_.os = (p_windows ? "windows" : (p_linux ? "linux" : "unknown"));
-
-  if (config_.os == "unknown" || config_.platform == "unknown") {
-    LogPrintf("%s", "Either Config or Os is unknown, this wont end well");
-    abort();
-  }
 }
 
 TestContext::TestContext(int argc, char** argv) {

--- a/tests/catch/include/hip_test_context.hh
+++ b/tests/catch/include/hip_test_context.hh
@@ -68,15 +68,22 @@ class TestContext {
   std::string exe_path;
   std::string current_test;
   std::set<std::string> skip_test;
+  std::string json_file_;
+  std::vector<std::string>  platform_list_ = {"amd" , "nvidia"};
+  std::vector<std::string>  os_list_ = {"windows", "linux", "all"};
+  std::vector<std::string>  amd_arch_list_ = {};
 
   Config config_;
-
+  std::string& getJsonFile();
+  std::string substringFound( std::vector<std::string> list,
+                              std::string filename);
   void detectOS();
   void detectPlatform();
   void fillConfig();
   void setExePath(int, char**);
   void parseOptions(int, char**);
   bool parseJsonFile();
+  std::string getMatchingConfigFile(std::string config_dir);
   const Config& getConfig() const { return config_; }
 
   TestContext(int argc, char** argv);

--- a/tests/catch/unit/graph/CMakeLists.txt
+++ b/tests/catch/unit/graph/CMakeLists.txt
@@ -27,8 +27,6 @@ set(TEST_SRC
   hipGraphAddMemcpyNode.cc
 )
 
-# Create shared lib of all tests
-add_library(GraphsTest SHARED EXCLUDE_FROM_ALL ${TEST_SRC})
-
-# Add dependency on build_tests to build it on this custom target
-add_dependencies(build_tests GraphsTest)
+hip_add_exe_to_target(NAME GraphsTest
+                      TEST_SRC ${TEST_SRC}
+                      TEST_TARGET_NAME build_tests)


### PR DESCRIPTION
Enabling windows catch config Json file to have a successful jenkins build 

Change-Id: Ia9ce9e4b32aaca0986b86a237ff01a030e8da4d5