### PR TITLE
SWDEV-296926 - warning message for hipcc/hipconfig pl deprecation

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -759,6 +759,11 @@ if ($printCXXFlags) {
 if ($printLDFlags) {
     print $HIPLDFLAGS;
 }
+
+$warn = "\nPlease note that hipcc/hipconfig perl binaries are deprecated and will be removed in a future release.
+hipcc/hipconfig as C++ binaries are available for use as hipcc.bin and hipconfig.bin. \n";
+print "$warn";
+
 if ($runCmd) {
     system ("$CMD");
     if ($? == -1) {

--- a/bin/hipconfig
+++ b/bin/hipconfig
@@ -48,6 +48,7 @@ $ROCM_PATH      =   $hipvars::ROCM_PATH;
 $HIP_VERSION    =   $hipvars::HIP_VERSION;
 $HSA_PATH       =   $hipvars::HSA_PATH;
 
+
 Getopt::Long::Configure ( qw{bundling no_ignore_case});
 GetOptions(
      "help|h" => \$p_help
@@ -148,6 +149,9 @@ if ($p_version) {
 }
 
 if (!$printed or $p_full) {
+    $warn = "Please note that hipcc/hipconfig perl binaries are deprecated and will be removed in a future release.
+hipcc/hipconfig as C++ binaries are available for use as hipcc.bin and hipconfig.bin. \n";
+    print "$warn";
     print "HIP version  : ", $HIP_VERSION, "\n\n";
     print "== hipconfig\n";
     print "HIP_PATH     : ", $HIP_PATH, "\n";


### PR DESCRIPTION
hipcc/hipconfig deprecation warning and to use cpp executables

Change-Id: Ia9ce9e4b32aaca0986b86a237ff01a030e8da4d5