### PR TITLE
SWDEV-314867 - Fix clang missing issue in cuda docker

### DIFF
--- a/tests/catch/CMakeLists.txt
+++ b/tests/catch/CMakeLists.txt
@@ -129,11 +129,6 @@ if(DEFINED OFFLOAD_ARCH_STR)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OFFLOAD_ARCH_STR} ")
 endif()
 
-# Use clang as host compiler with nvcc
-if(HIP_COMPILER MATCHES "nvcc")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ccbin clang")
-endif()
-
 # Disable CXX extensions (gnu++11 etc)
 set(CMAKE_CXX_EXTENSIONS OFF)
 


### PR DESCRIPTION
Cuda dockers doesn't contain clang. The dependence on clang
will fail catch2 building. Catch2 building actually doesn't
need clang. Remove clang dependence from catch2 cmake file.

Change-Id: I8fd76e99d27ce4f5769baffae0608dd1cf0f4188