### PR TITLE
Fixed clang version munging in hipcc

### DIFF
--- a/bin/hipcc
+++ b/bin/hipcc
@@ -154,7 +154,7 @@ if ($HIP_PLATFORM eq "amd") {
     }
 
     $HIP_CLANG_VERSION = `$HIPCC --version`;
-    $HIP_CLANG_VERSION=~/.*clang version (\S+).*/;
+    $HIP_CLANG_VERSION=~/.*clang version ([0-9\.]*).*/;
     $HIP_CLANG_VERSION=$1;
 
     # Figure out the target with which llvm is configured


### PR DESCRIPTION
When using upstream llvm-project is officially supported,
the version can be of the form `Debian clang version 13.0.0-9+b2` and that `-9+b2` needs to be dismissed.

I know that you will switch from Perl to a standalone binary executable, but meanwhile this remains helpful.