### PR TITLE
SWDEV-1 - hipcc/hipconfig path detection in bat file

### DIFF
--- a/bin/hipcc.bat
+++ b/bin/hipcc.bat
@@ -1,2 +1,2 @@
-@IF DEFINED HIP_PATH (set HIPCC="%HIP_PATH%/bin/hipcc") ELSE (set HIPCC="%~dp0/hipcc")
+set HIPCC="%~dp0/hipcc"
 @perl %HIPCC% %*

--- a/bin/hipconfig.bat
+++ b/bin/hipconfig.bat
@@ -1,2 +1,2 @@
-@IF DEFINED HIP_PATH (set HIPCONFIG="%HIP_PATH%/bin/hipconfig") ELSE (set HIPCONFIG="%~dp0/hipconfig")
+set HIPCONFIG="%~dp0/hipconfig"
 @perl %HIPCONFIG% %*


### PR DESCRIPTION
hipcc/hipconfig perl path currently depends on env HIP_PATH which is confusing. 
perl script from the same folder as the bat file should be used for building.

This change removes the env HIP_PATH usage from HIPCC_PATH.

Change-Id: I075148087bc07b5044a3360f1636d07372b16a1d