### PR TITLE
SWDEV-1 - skip rtc test build on windows

### DIFF
--- a/tests/catch/unit/CMakeLists.txt
+++ b/tests/catch/unit/CMakeLists.txt
@@ -18,10 +18,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-# Currently build fails for these two test sets
+# build fails in windows
 if (UNIX)
   add_subdirectory(memory)
   add_subdirectory(graph)
+  add_subdirectory(rtc)
 endif()
 
 add_subdirectory(deviceLib)
@@ -29,7 +30,6 @@ add_subdirectory(stream)
 add_subdirectory(event)
 add_subdirectory(occupancy)
 add_subdirectory(device)
-add_subdirectory(rtc)
 add_subdirectory(printf)
 add_subdirectory(printfExe)
 add_subdirectory(texture)


### PR DESCRIPTION
Skipping rtc test build on Windows.