### PR TITLE
Revert "SWDEV-312141 - Renaming of enum to avoid shadow variable compilation warning"

### DIFF
--- a/include/hip/hip_bfloat16.h
+++ b/include/hip/hip_bfloat16.h
@@ -56,7 +56,7 @@ struct hip_bfloat16
 
     enum truncate_t
     {
-        truncate_0
+        truncate
     };
 
     __host__ __device__ hip_bfloat16() = default;


### PR DESCRIPTION
Reverts ROCm-Developer-Tools/HIP#2487