### PR TITLE
EXSWCPHIPT-139 - Added tests for hipStreamDestroy

### DIFF
--- a/tests/catch/unit/stream/CMakeLists.txt
+++ b/tests/catch/unit/stream/CMakeLists.txt
@@ -7,6 +7,7 @@ set(TEST_SRC
     hipStreamAddCallback.cc
     hipStreamCreateWithFlags.cc
     hipStreamCreateWithPriority.cc
+    hipStreamDestroy.cc
     hipStreamGetCUMask.cc
     hipAPIStreamDisable.cc
     streamCommon.cc
@@ -25,6 +26,7 @@ set(TEST_SRC
     hipStreamAddCallback.cc
     hipStreamCreateWithFlags.cc
     hipStreamCreateWithPriority.cc
+    hipStreamDestroy.cc
     hipAPIStreamDisable.cc
     # hipStreamAttachMemAsync.cc   # Disabling it on nvidia due to issue in function definition of hipStreamAttachMemAsync
                                    # Fixing would break ABI, to be re-enabled when the fix is made.

--- a/tests/catch/unit/stream/hipStreamDestroy.cc
+++ b/tests/catch/unit/stream/hipStreamDestroy.cc
@@ -1,0 +1,97 @@
+/*
+Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#include <chrono>
+#include <hip_test_common.hh>
+
+namespace hipStreamDestroyTests {
+
+TEST_CASE("Unit_hipStreamDestroy_Default") {
+  hipStream_t stream{};
+  HIP_CHECK(hipStreamCreate(&stream));
+  HIP_CHECK(hipStreamDestroy(stream));
+}
+
+TEST_CASE("Unit_hipStreamDestroy_Negative_DoubleDestroy") {
+  hipStream_t stream{};
+  HIP_CHECK(hipStreamCreate(&stream));
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK_ERROR(hipStreamDestroy(stream), hipErrorContextIsDestroyed);
+}
+
+TEST_CASE("Unit_hipStreamDestroy_Negative_NullStream") {
+  HIP_CHECK_ERROR(hipStreamDestroy(nullptr), hipErrorInvalidResourceHandle);
+}
+
+template <size_t numDataPoints> void checkDataSet(int* deviceData) {
+  HIP_CHECK(hipStreamSynchronize(nullptr));
+  std::array<int, numDataPoints> hostData{};
+  HIP_CHECK(
+      hipMemcpy(hostData.data(), deviceData, sizeof(int) * numDataPoints, hipMemcpyDeviceToHost));
+  REQUIRE(std::all_of(std::begin(hostData), std::end(hostData), [](int x) { return x == 1; }));
+}
+
+__global__ void setToOne(int* x, size_t size) {
+  unsigned int idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (idx < size) {
+    x[idx] = 1;
+  }
+}
+
+TEST_CASE("Unit_hipStreamDestroy_WithFinishedWork") {
+  hipStream_t stream{};
+  HIP_CHECK(hipStreamCreate(&stream));
+
+  constexpr int numDataPoints = 10;
+  int* deviceData{};
+  HIP_CHECK(hipMalloc(&deviceData, sizeof(int) * numDataPoints));
+  HIP_CHECK(hipMemset(deviceData, 0, sizeof(int) * numDataPoints));
+
+  setToOne<<<1, numDataPoints, 0, stream>>>(deviceData, numDataPoints);
+  checkDataSet<numDataPoints>(deviceData);
+  HIP_CHECK(hipStreamDestroy(stream));
+  HIP_CHECK(hipFree(deviceData));
+}
+
+// hipStreamDestroy should return immediately then clean up the resources when the stream is empty
+// of work
+#if HT_AMD /* Disabled because frequency based wait is timing out on nvidia platforms */
+TEST_CASE("Unit_hipStreamDestroy_WithPendingWork") {
+#if HT_AMD
+  HipTest::HIP_SKIP_TEST(
+      "EXSWCPHIPT-44 - expected hipStreamDestroy to return immediately then release the resources "
+      "when the queued jobs are finished");
+  return;
+#endif
+  hipStream_t stream{};
+  HIP_CHECK(hipStreamCreate(&stream));
+  constexpr int numDataPoints = 10;
+  int* deviceData{};
+  HIP_CHECK(hipMalloc(&deviceData, sizeof(int) * numDataPoints));
+  HIP_CHECK(hipMemset(deviceData, 0, sizeof(int) * numDataPoints));
+
+  HipTest::runKernelForDuration(std::chrono::milliseconds(500), stream);
+  setToOne<<<1, numDataPoints, 0, stream>>>(deviceData, numDataPoints);
+  HIP_CHECK_ERROR(hipStreamQuery(stream), hipErrorNotReady);
+  HIP_CHECK_ERROR(hipStreamQuery(nullptr), hipErrorNotReady);
+  HIP_CHECK(hipStreamDestroy(stream));
+  checkDataSet<numDataPoints>(deviceData);
+  HIP_CHECK(hipFree(deviceData));
+}
+#endif
+}  // namespace hipStreamDestroyTests


### PR DESCRIPTION
CMakeLists.txt was updated so any changes to config_amd_*.json copied when the project was rebuilt.

Unit_hipStreamDestroy_DoubleDestroy fails, but this could just be undefined behaviour.

Unit_hipStreamDestroy_WithPendingWork was found to hang, I think this is due to hipStreamDestroy not synchronizing before destroying the stream, but I'm not sure what the intended functionality is.

Depends on #2517