### PR TITLE
fix logic for finding nvcc even if clang exists

### DIFF
--- a/bin/hipvars.pm
+++ b/bin/hipvars.pm
@@ -121,9 +121,7 @@ if (defined $HIP_RUNTIME and $HIP_RUNTIME eq "rocclr" and !defined $HIP_ROCCLR_H
 }
 
 if (not defined $HIP_PLATFORM) {
-    if (can_run("$HIP_CLANG_PATH/clang++") or can_run("clang++")) {
-        $HIP_PLATFORM = "amd";
-    } elsif (can_run("$CUDA_PATH/bin/nvcc") or can_run("nvcc")) {
+    if (can_run("$CUDA_PATH/bin/nvcc") or can_run("nvcc")) {
         $HIP_PLATFORM = "nvidia";
         $HIP_COMPILER = "nvcc";
         $HIP_RUNTIME = "cuda";


### PR DESCRIPTION
Issue: if a system has both `nvcc` and `clang++` then the HIP-PLATFORM autodetects to `amd`, instead of `nvidia`.

this PR fixes it by checking for nvcc first and then defaulting to amd if nvcc is not found.

Follow up of https://github.com/ROCm-Developer-Tools/HIP/pull/2113

Fixes: https://github.com/ROCm-Developer-Tools/HIP/issues/1650

Fixes comment: https://github.com/ROCm-Developer-Tools/HIP/issues/2256#issuecomment-818801109