### PR TITLE
SWDEV-320902 - disable two failing tests on Windows

### DIFF
--- a/tests/catch/hipTestMain/config/config_amd_windows.json
+++ b/tests/catch/hipTestMain/config/config_amd_windows.json
@@ -59,7 +59,9 @@
 	   "Unit_hipGraphExecEventRecordNodeSetEvent_Negative",
 	   "Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Negative",
 	   "Unit_hipGraphExecMemcpyNodeSetParamsFromSymbol_Functional",
-	   "Unit_hipPtrGetAttribute_Simple"
+	   "Unit_hipPtrGetAttribute_Simple",
+	   "Unit_hipStreamCreateWithPriority_ValidateWithEvents",
+	   "Unit_hipEvent"
 	]
 
 }


### PR DESCRIPTION
SWDEV-320902 - disable two failing tests on Windows
Unit_hipStreamCreateWithPriority_ValidateWithEvents 
Unit_hipEvent 