### PR TITLE
Add HIP_CHECK_THREAD and REQUIRE_THREAD macro for multi threaded HIP API tests

### DIFF
--- a/tests/catch/include/hip_test_checkers.hh
+++ b/tests/catch/include/hip_test_checkers.hh
@@ -23,17 +23,17 @@ THE SOFTWARE.
 #pragma once
 #include "hip_test_common.hh"
 #include <iostream>
-#include<fstream>
-#include<regex>
+#include <fstream>
+#include <regex>
 #include <type_traits>
 
-#define guarantee(cond, str)                                                                        \
-   {                                                                                                \
-     if (!(cond)) {                                                                                 \
-       INFO("guarantee failed: " << str);                                                           \
-       abort();                                                                                     \
-     }                                                                                              \
-   }
+#define guarantee(cond, str)                                                                       \
+  {                                                                                                \
+    if (!(cond)) {                                                                                 \
+      INFO("guarantee failed: " << str);                                                           \
+      abort();                                                                                     \
+    }                                                                                              \
+  }
 
 
 namespace HipTest {
@@ -73,15 +73,15 @@ size_t checkVectors(T* A, T* B, T* Out, size_t N, T (*F)(T a, T b), bool expectM
 
   return mismatchCount;
 }
-template<typename T> // pointer type
-bool checkArray(T* hData, T* hOutputData, size_t width, size_t height,size_t depth = 1) {
+template <typename T>  // pointer type
+bool checkArray(T* hData, T* hOutputData, size_t width, size_t height, size_t depth = 1) {
   for (size_t i = 0; i < depth; i++) {
     for (size_t j = 0; j < height; j++) {
       for (size_t k = 0; k < width; k++) {
-        int offset = i*width*height + j*width + k;
+        int offset = i * width * height + j * width + k;
         if (hData[offset] != hOutputData[offset]) {
-          INFO("Mismatch at ["  << i << "," << j << "," << k << "]:"
-               << hData[offset] << "----" << hOutputData[offset]);
+          INFO("Mismatch at [" << i << "," << j << "," << k << "]:" << hData[offset] << "----"
+                               << hOutputData[offset]);
           CHECK(false);
           return false;
         }
@@ -120,7 +120,7 @@ template <typename T> void setDefaultData(size_t numElements, T* A_h, T* B_h, T*
       if (A_h) A_h[i] = 3;
       if (B_h) B_h[i] = 4;
       if (C_h) C_h[i] = 5;
-    } else if(std::is_same<T, char>::value || std::is_same<T, unsigned char>::value) {
+    } else if (std::is_same<T, char>::value || std::is_same<T, unsigned char>::value) {
       if (A_h) A_h[i] = 'a';
       if (B_h) B_h[i] = 'b';
       if (C_h) C_h[i] = 'c';
@@ -185,6 +185,110 @@ bool initArrays(T** A_d, T** B_d, T** C_d, T** A_h, T** B_h, T** C_h, size_t N,
   return initArraysForHost(A_h, B_h, C_h, N, usePinnedHost);
 }
 
+// Threaded version of setDefaultData to be called from multi thread tests
+// Call HIP_CHECK_THREAD_FINALIZE after joining
+template <typename T> void setDefaultDataT(size_t numElements, T* A_h, T* B_h, T* C_h) {
+  // Initialize the host data:
+
+  for (size_t i = 0; i < numElements; i++) {
+    if (std::is_same<T, int>::value || std::is_same<T, unsigned int>::value) {
+      if (A_h) A_h[i] = 3;
+      if (B_h) B_h[i] = 4;
+      if (C_h) C_h[i] = 5;
+    } else if (std::is_same<T, char>::value || std::is_same<T, unsigned char>::value) {
+      if (A_h) A_h[i] = 'a';
+      if (B_h) B_h[i] = 'b';
+      if (C_h) C_h[i] = 'c';
+    } else {
+      if (A_h) A_h[i] = 3.146f + i;
+      if (B_h) B_h[i] = 1.618f + i;
+      if (C_h) C_h[i] = 1.4f + i;
+    }
+  }
+}
+
+// Threaded version of initArraysForHost to be called from multi thread tests
+// Call HIP_CHECK_THREAD_FINALIZE after joining
+template <typename T>
+void initArraysForHostT(T** A_h, T** B_h, T** C_h, size_t N, bool usePinnedHost = false) {
+  size_t Nbytes = N * sizeof(T);
+
+  if (usePinnedHost) {
+    if (A_h) {
+      HIP_CHECK_THREAD(hipHostMalloc((void**)A_h, Nbytes));
+    }
+    if (B_h) {
+      HIP_CHECK_THREAD(hipHostMalloc((void**)B_h, Nbytes));
+    }
+    if (C_h) {
+      HIP_CHECK_THREAD(hipHostMalloc((void**)C_h, Nbytes));
+    }
+  } else {
+    if (A_h) {
+      *A_h = (T*)malloc(Nbytes);
+      REQUIRE_THREAD(*A_h != nullptr);
+    }
+
+    if (B_h) {
+      *B_h = (T*)malloc(Nbytes);
+      REQUIRE_THREAD(*B_h != nullptr);
+    }
+
+    if (C_h) {
+      *C_h = (T*)malloc(Nbytes);
+      REQUIRE_THREAD(*C_h != nullptr);
+    }
+  }
+
+  setDefaultDataT(N, A_h ? *A_h : nullptr, B_h ? *B_h : nullptr, C_h ? *C_h : nullptr);
+}
+
+// Threaded version of initArrays to be called from multi thread tests
+// Call HIP_CHECK_THREAD_FINALIZE after joining
+template <typename T>
+void initArraysT(T** A_d, T** B_d, T** C_d, T** A_h, T** B_h, T** C_h, size_t N,
+                 bool usePinnedHost = false) {
+  size_t Nbytes = N * sizeof(T);
+
+  if (A_d) {
+    HIP_CHECK_THREAD(hipMalloc(A_d, Nbytes));
+  }
+  if (B_d) {
+    HIP_CHECK_THREAD(hipMalloc(B_d, Nbytes));
+  }
+  if (C_d) {
+    HIP_CHECK_THREAD(hipMalloc(C_d, Nbytes));
+  }
+
+  initArraysForHostT(A_h, B_h, C_h, N, usePinnedHost);
+}
+
+// Threaded version of freeArraysForHost to be called from multi thread tests
+// Call HIP_CHECK_THREAD_FINALIZE after joining
+template <typename T> void freeArraysForHostT(T* A_h, T* B_h, T* C_h, bool usePinnedHost) {
+  if (usePinnedHost) {
+    if (A_h) {
+      HIP_CHECK_THREAD(hipHostFree(A_h));
+    }
+    if (B_h) {
+      HIP_CHECK_THREAD(hipHostFree(B_h));
+    }
+    if (C_h) {
+      HIP_CHECK_THREAD(hipHostFree(C_h));
+    }
+  } else {
+    if (A_h) {
+      free(A_h);
+    }
+    if (B_h) {
+      free(B_h);
+    }
+    if (C_h) {
+      free(C_h);
+    }
+  }
+}
+
 template <typename T> bool freeArraysForHost(T* A_h, T* B_h, T* C_h, bool usePinnedHost) {
   if (usePinnedHost) {
     if (A_h) {
@@ -211,6 +315,21 @@ template <typename T> bool freeArraysForHost(T* A_h, T* B_h, T* C_h, bool usePin
 }
 
 template <typename T>
+void freeArraysT(T* A_d, T* B_d, T* C_d, T* A_h, T* B_h, T* C_h, bool usePinnedHost) {
+  if (A_d) {
+    HIP_CHECK_THREAD(hipFree(A_d));
+  }
+  if (B_d) {
+    HIP_CHECK_THREAD(hipFree(B_d));
+  }
+  if (C_d) {
+    HIP_CHECK_THREAD(hipFree(C_d));
+  }
+
+  freeArraysForHostT(A_h, B_h, C_h, usePinnedHost);
+}
+
+template <typename T>
 bool freeArrays(T* A_d, T* B_d, T* C_d, T* A_h, T* B_h, T* C_h, bool usePinnedHost) {
   if (A_d) {
     HIP_CHECK(hipFree(A_d));
@@ -226,20 +345,6 @@ bool freeArrays(T* A_d, T* B_d, T* C_d, T* A_h, T* B_h, T* C_h, bool usePinnedHo
 }
 
 template <typename T>
-unsigned setNumBlocks(T blocksPerCU, T threadsPerBlock,
-    size_t N) {
-  int device;
-  HIP_CHECK(hipGetDevice(&device));
-  hipDeviceProp_t props;
-  HIP_CHECK(hipGetDeviceProperties(&props, device));
-
-  unsigned blocks = props.multiProcessorCount * blocksPerCU;
-  if (blocks * threadsPerBlock > N) {
-    blocks = (N + threadsPerBlock - 1) / threadsPerBlock;
-  }
-  return blocks;
-}
-template<typename T>
 static bool assemblyFile_Verification(std::string assemfilename, std::string inst) {
   std::string filePath = "./catch/unit/deviceLib/";
   bool result = false;
@@ -254,34 +359,27 @@ static bool assemblyFile_Verification(std::string assemfilename, std::string ins
     while (getline(file, line)) {
       line_pos++;
       if ((std::is_same<T, float>::value)) {
-        if (!start_pos &&
-            std::regex_search(line,
-              std::regex("Begin function (.*)AtomicCheck"))) {
+        if (!start_pos && std::regex_search(line, std::regex("Begin function (.*)AtomicCheck"))) {
           start_pos = line_pos;
         }
-        if (!last_pos &&
-            std::regex_search(line,
-              std::regex(".Lfunc_end0-(.*)AtomicCheck"))) {
+        if (!last_pos && std::regex_search(line, std::regex(".Lfunc_end0-(.*)AtomicCheck"))) {
           last_pos = line_pos;
           break;
         }
       } else {
-        if ((start_match != 2) && std::regex_search(line,
-              std::regex("Begin function (.*)AtomicCheck"))) {
+        if ((start_match != 2) &&
+            std::regex_search(line, std::regex("Begin function (.*)AtomicCheck"))) {
           start_match++;
-          if (start_match == 2)
-            start_pos = line_pos;
+          if (start_match == 2) start_pos = line_pos;
         }
-        if (!last_pos && std::regex_search(line,
-              std::regex("func_end1-(.*)AtomicCheck"))) {
+        if (!last_pos && std::regex_search(line, std::regex("func_end1-(.*)AtomicCheck"))) {
           last_pos = line_pos;
           break;
         }
       }
       if (start_pos) {
         result = std::regex_search(line, std::regex(inst));
-        if (result)
-          break;
+        if (result) break;
       }
     }
   } else {

--- a/tests/catch/unit/stream/streamCommon.cc
+++ b/tests/catch/unit/stream/streamCommon.cc
@@ -95,11 +95,11 @@ __global__ void waiting_kernel(int* semaphore) {
 std::thread startSignalingThread(int* semaphore) {
   std::thread signalingThread([semaphore]() {
     hipStream_t signalingStream;
-    HIP_CHECK(hipStreamCreateWithFlags(&signalingStream, hipStreamNonBlocking));
+    HIP_CHECK_THREAD(hipStreamCreateWithFlags(&signalingStream, hipStreamNonBlocking));
 
     signaling_kernel<<<1, 1, 0, signalingStream>>>(semaphore);
-    HIP_CHECK(hipStreamSynchronize(signalingStream));
-    HIP_CHECK(hipStreamDestroy(signalingStream));
+    HIP_CHECK_THREAD(hipStreamSynchronize(signalingStream));
+    HIP_CHECK_THREAD(hipStreamDestroy(signalingStream));
   });
 
   return signalingThread;

--- a/tests/catch/unit/stream/streamCommon.hh
+++ b/tests/catch/unit/stream/streamCommon.hh
@@ -44,6 +44,7 @@ __global__ void waiting_kernel(int* semaphore = nullptr);
 /**
  * @brief Creates a thread that runs a signaling_kernel on a non-blocking stream.
  * hipStreamNonBlocking is used here to avoid interfering with tests for the Null Stream.
+ * You must call HIP_CHECK_THREAD_FINALIZE after joining this thread.
  *
  * @param semaphore memory location to signal
  * @return std::thread thread that has to be joined after the testing is done.


### PR DESCRIPTION
- Adds ```HIP_CHECK_THREAD```, which is similar to ```HIP_CHECK``` but is only to be called in multi threaded tests
- Adds ```REQUIRE_THREAD``` which is similar to ```REQUIRE``` but is to be called in multi threaded tests
- Adds documentation of usage of these macros
- ~~Fix current multi threaded tests to use this macro~~ - To be done in later PRs
- Fixes some breaking tests