### PR TITLE
SWDEV-327563 - Windows: fix memory tests build failure

### DIFF
--- a/tests/catch/unit/memory/hipMallocArray.cc
+++ b/tests/catch/unit/memory/hipMallocArray.cc
@@ -27,6 +27,9 @@ hipMallocArray API test scenarios
 
 #include <hip_test_common.hh>
 #include <limits>
+#if defined(_WIN32) || defined(_WIN64)
+#include <numeric>
+#endif
 
 static constexpr auto NUM_W{4};
 static constexpr auto BIGNUM_W{100};


### PR DESCRIPTION
SWDEV-327563 - Windows: fix memory tests build failure

enable memory tests on Windows. Fixing the build failure