### PR TITLE
SWDEV-341955 - hiprtc kernel file path fix.

### DIFF
--- a/tests/catch/CMakeLists.txt
+++ b/tests/catch/CMakeLists.txt
@@ -113,7 +113,7 @@ option(RTC_TESTING "Run tests using HIP RTC to compile the kernels" OFF)
 if (RTC_TESTING)
     add_definitions(-DRTC_TESTING=ON)
 endif()
-add_definitions(-DKERNELS_PATH="${CMAKE_CURRENT_SOURCE_DIR}/kernels/")
+add_definitions(-DKERNELS_PATH="\\"${CMAKE_CURRENT_SOURCE_DIR}/kernels/\\"")
 
 file(COPY ./hipTestMain/config DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/hipTestMain)
 file(COPY ./external/Catch2/cmake/Catch2/CatchAddTests.cmake DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/script)


### PR DESCRIPTION
SWDEV-341955 - hiprtc kernel file path fix.

Issue causes by not handling hipcc args with quotes. 
Also the add_definitions needs to add appropriate escape characters to get it working
Requires hipcc change as well to pass hiprtc build