### PR TITLE
Fix use of blockDim in 'square' sample

### DIFF
--- a/samples/0_Intro/square/square.hipref.cpp
+++ b/samples/0_Intro/square/square.hipref.cpp
@@ -38,7 +38,7 @@ THE SOFTWARE.
  */
 template <typename T>
 __global__ void vector_square(T* C_d, const T* A_d, size_t N) {
-    size_t offset = (blockIdx.x * blockDim_x + threadIdx.x);
+    size_t offset = (blockIdx.x * blockDim.x + threadIdx.x);
     size_t stride = blockDim.x * gridDim.x;
 
     for (size_t i = offset; i < N; i += stride) {


### PR DESCRIPTION
It looks like a minor typo was made when updating the kernel in `square.hipref.cpp` in https://github.com/ROCm-Developer-Tools/HIP/commit/e6ded458987e53366259dcefcb0c29122b0ac450. This PR fixes the typo so that `square.hipref.cpp` compiles.