### PR TITLE
Disable newly added failing tests

### DIFF
--- a/tests/catch/hipTestMain/config/config_amd_windows.json
+++ b/tests/catch/hipTestMain/config/config_amd_windows.json
@@ -30,6 +30,8 @@
 	   "Unit_hipGraphMemcpyNodeSetParamsFromSymbol_Functional",
 	   "Unit_hipGraphExecEventWaitNodeSetEvent_Negative",
 	   "Unit_hipGraphExecEventWaitNodeSetEvent_SetAndVerifyMemory",
-	   "Unit_hipGraphMemcpyNodeSetParams_Functional"
+	   "Unit_hipGraphMemcpyNodeSetParams_Functional",
+	   "Unit_hipMalloc3D_ValidatePitch",
+	   "Unit_hipArrayCreate_happy"
 	]
 }

--- a/tests/catch/unit/memory/hipHostUnregister.cc
+++ b/tests/catch/unit/memory/hipHostUnregister.cc
@@ -73,11 +73,19 @@ TEST_CASE("Unit_hipHostUnregister_NullPtr") {
 }
 
 TEST_CASE("Unit_hipHostUnregister_NotRegisteredPointer") {
+#if HT_AMD
+  HipTest::HIP_SKIP_TEST("TODO-MATCH-ERRORCODE");
+  return;
+#endif
   auto x = std::unique_ptr<int>(new int);
   HIP_CHECK_ERROR(hipHostUnregister(x.get()), hipErrorHostMemoryNotRegistered);
 }
 
 TEST_CASE("Unit_hipHostUnregister_AlreadyUnregisteredPointer") {
+#if HT_AMD
+  HipTest::HIP_SKIP_TEST("TODO-MATCH-ERRORCODE");
+  return;
+#endif
   if (!hipHostRegisterSupported()) {
     return;
   }

--- a/tests/catch/unit/memory/hipMallocPitch.cc
+++ b/tests/catch/unit/memory/hipMallocPitch.cc
@@ -173,6 +173,10 @@ TEST_CASE("Unit_hipMemAllocPitch_ValidatePitch") {
 }
 
 TEST_CASE("Unit_hipMallocPitch_ValidatePitch") {
+#if HT_AMD
+  HipTest::HIP_SKIP_TEST("TODO-FIX-EXTENT-GENERATOR");
+  return;
+#endif
   size_t pitch;
   void* ptr;
   hipExtent validExtent{generateExtent(AllocationApi::hipMemAllocPitch)};
@@ -191,10 +195,13 @@ TEST_CASE("Unit_hipMalloc3D_Negative") {
   hipPitchedPtr ptr;
   constexpr size_t maxSizeT = std::numeric_limits<size_t>::max();
 
+#if HT_NVIDIA
+  //TODO-MATCH-ERRORCODE
   SECTION("Max size_t width") {
     hipExtent validExtent{maxSizeT, 1, 1};
     HIP_CHECK_ERROR(hipMalloc3D(&ptr, validExtent), hipErrorInvalidValue);
   }
+#endif
 
   SECTION("Max size_t height") {
     hipExtent validExtent{1, maxSizeT, 1};
@@ -206,10 +213,13 @@ TEST_CASE("Unit_hipMalloc3D_Negative") {
     HIP_CHECK_ERROR(hipMalloc3D(&ptr, validExtent), hipErrorOutOfMemory);
   }
 
+#if HT_NVIDIA
+  //TODO-MATCH-ERRORCODE
   SECTION("Max size_t all dimensions") {
     hipExtent validExtent{maxSizeT, maxSizeT, maxSizeT};
     HIP_CHECK_ERROR(hipMalloc3D(&ptr, validExtent), hipErrorInvalidValue);
   }
+#endif
 }
 
 TEST_CASE("Unit_hipMallocPitch_Negative") {
@@ -225,9 +235,12 @@ TEST_CASE("Unit_hipMallocPitch_Negative") {
     HIP_CHECK_ERROR(hipMallocPitch(&ptr, nullptr, 1, 1), hipErrorInvalidValue);
   }
 
+#if HT_NVIDIA
+  //TODO-MATCH-ERRORCODE
   SECTION("Max size_t width") {
     HIP_CHECK_ERROR(hipMallocPitch(&ptr, &pitch, maxSizeT, 1), hipErrorInvalidValue);
   }
+#endif
 
   SECTION("Max size_t height") {
     HIP_CHECK_ERROR(hipMallocPitch(&ptr, &pitch, 1, maxSizeT), hipErrorOutOfMemory);
@@ -272,10 +285,13 @@ TEST_CASE("Unit_hipMemAllocPitch_Negative") {
                     hipErrorInvalidValue);
   }
 
+#if HT_NVIDIA
+  //TODO-MATCH-ERRORCODE
   SECTION("Max size_t width") {
     HIP_CHECK_ERROR(hipMemAllocPitch(&ptr, &pitch, maxSizeT, 1, validElementSizeBytes),
                     hipErrorInvalidValue);
   }
+#endif
 
   SECTION("Max size_t height") {
     HIP_CHECK_ERROR(hipMemAllocPitch(&ptr, &pitch, 1, maxSizeT, validElementSizeBytes),


### PR DESCRIPTION
Linux
- Disable Unit_hipHostUnregister_NotRegisteredPointer
- Disable Unit_hipHostUnregister_AlreadyUnregisteredPointer
- Disable Unit_hipMallocPitch_ValidatePitch
- Disable failing sections of Unit_hipMalloc3D_Negative
- Disable failing sections of Unit_hipMallocPitch_Negative
- Disable failing sections of Unit_hipMemAllocPitch_Negative
Windows
- Disabled Unit_hipMalloc3D_ValidatePitch
- Disabled Unit_hipArrayCreate_happy