### PR TITLE
fix logic for finding nvcc even if clang exists

### DIFF
--- a/bin/hipvars.pm
+++ b/bin/hipvars.pm
@@ -121,7 +121,7 @@ if (defined $HIP_RUNTIME and $HIP_RUNTIME eq "rocclr" and !defined $HIP_ROCCLR_H
 }
 
 if (not defined $HIP_PLATFORM) {
-    if (can_run("$HIP_CLANG_PATH/clang++") or can_run("clang++")) {
+    if (can_run("$HIP_CLANG_PATH/clang++") or can_run("amdclang++")) {
         $HIP_PLATFORM = "amd";
     } elsif (can_run("$CUDA_PATH/bin/nvcc") or can_run("nvcc")) {
         $HIP_PLATFORM = "nvidia";


### PR DESCRIPTION
Issue: if a system has both `nvcc` and `clang++` (compiled w/o amd) then the HIP-PLATFORM autodetects to `amd`, instead of `nvidia`.

this PR fixes it by only checking for `clang++` compiled with amd with the provided alias of `amdclang++`.

Follow up of https://github.com/ROCm-Developer-Tools/HIP/pull/2623

Fixes: https://github.com/ROCm-Developer-Tools/HIP/issues/1650

Fixes comment: https://github.com/ROCm-Developer-Tools/HIP/issues/2256#issuecomment-818801109

cc: @mangupta 