### PR TITLE
[WIP] Fix hipcc lib dir

### DIFF
--- a/bin/hipcc.pl
+++ b/bin/hipcc.pl
@@ -168,7 +168,7 @@ if ($HIP_PLATFORM eq "amd") {
     $HIP_CLANG_TARGET = chomp($HIP_CLANG_TARGET);
 
     if (! defined $HIP_CLANG_INCLUDE_PATH) {
-        $HIP_CLANG_INCLUDE_PATH = abs_path("$HIP_CLANG_PATH/../lib/clang/$HIP_CLANG_VERSION/include");
+        $HIP_CLANG_INCLUDE_PATH = abs_path("$HIP_CLANG_PATH/../$LIB/clang/$HIP_CLANG_VERSION/include");
     }
     if (! defined $HIP_INCLUDE_PATH) {
         $HIP_INCLUDE_PATH = "$HIP_PATH/include";
@@ -711,11 +711,11 @@ if ($HIP_PLATFORM eq "amd") {
         $toolArgs = ${toolArgs} . " -Wl,--enable-new-dtags -Wl,-rpath=$HIP_LIB_PATH:$ROCM_PATH/$LIB -lamdhip64 ";
       }
       # To support __fp16 and _Float16, explicitly link with compiler-rt
-      $HIP_CLANG_BUILTIN_LIB="$HIP_CLANG_PATH/../lib/clang/$HIP_CLANG_VERSION/lib/$HIP_CLANG_TARGET/libclang_rt.builtins.a";
+      $HIP_CLANG_BUILTIN_LIB="$HIP_CLANG_PATH/../$LIB/clang/$HIP_CLANG_VERSION/lib/$HIP_CLANG_TARGET/libclang_rt.builtins.a";
       if (-e $HIP_CLANG_BUILTIN_LIB) {
-        $toolArgs .= " -L$HIP_CLANG_PATH/../lib/clang/$HIP_CLANG_VERSION/lib/$HIP_CLANG_TARGET -lclang_rt.builtins "
+        $toolArgs .= " -L$HIP_CLANG_PATH/../$LIB/clang/$HIP_CLANG_VERSION/lib/$HIP_CLANG_TARGET -lclang_rt.builtins "
       } else {
-        $toolArgs .= " -L$HIP_CLANG_PATH/../lib/clang/$HIP_CLANG_VERSION/lib/linux -lclang_rt.builtins-x86_64 "
+        $toolArgs .= " -L$HIP_CLANG_PATH/../$LIB/clang/$HIP_CLANG_VERSION/lib/linux -lclang_rt.builtins-x86_64 "
       }
     }
 }

--- a/bin/hipcc.pl
+++ b/bin/hipcc.pl
@@ -105,6 +105,7 @@ $ROCM_PATH      =   $hipvars::ROCM_PATH;
 $HIP_VERSION    =   $hipvars::HIP_VERSION;
 $HSA_PATH       =   $hipvars::HSA_PATH;
 $HIP_ROCCLR_HOME =   $hipvars::HIP_ROCCLR_HOME;
+$LIB            =   $hipvars::LIB;
 
 if ($HIP_PLATFORM eq "amd") {
   # If using ROCclr runtime, need to find HIP_ROCCLR_HOME
@@ -113,14 +114,15 @@ if ($HIP_PLATFORM eq "amd") {
   }
   $HIP_INCLUDE_PATH = "$HIP_ROCCLR_HOME/include";
   if (!defined $HIP_LIB_PATH) {
-    $HIP_LIB_PATH = "$HIP_ROCCLR_HOME/lib";
+    $HIP_LIB_PATH = "$HIP_ROCCLR_HOME/$LIB";
   }
 
   if (!defined $DEVICE_LIB_PATH) {
     if (-e "$ROCM_PATH/amdgcn/bitcode") {
       $DEVICE_LIB_PATH = "$ROCM_PATH/amdgcn/bitcode";
-    }
-    else {
+    } elsif (-e "$ROCM_PATH/$LIB/amdgcn/bitcode") {
+      $DEVICE_LIB_PATH = "$ROCM_PATH/$LIB/amdgcn/bitcode";
+    } else {
       # This path is to support an older build of the device library
       # TODO: To be removed in the future.
       $DEVICE_LIB_PATH = "$ROCM_PATH/lib";
@@ -172,7 +174,7 @@ if ($HIP_PLATFORM eq "amd") {
         $HIP_INCLUDE_PATH = "$HIP_PATH/include";
     }
     if (! defined $HIP_LIB_PATH) {
-        $HIP_LIB_PATH = "$HIP_PATH/lib";
+        $HIP_LIB_PATH = "$HIP_PATH/$LIB";
     }
     if ($verbose & 0x2) {
         print ("ROCM_PATH=$ROCM_PATH\n");
@@ -706,9 +708,9 @@ if ($HIP_PLATFORM eq "amd") {
 
     if (not $isWindows  and not $compileOnly) {
       if ($linkType eq 0) {
-        $toolArgs = " -L$HIP_LIB_PATH -lamdhip64 -L$ROCM_PATH/lib -lhsa-runtime64 -ldl -lnuma " . ${toolArgs};
+        $toolArgs = " -L$HIP_LIB_PATH -lamdhip64 -L$ROCM_PATH/$LIB -lhsa-runtime64 -ldl -lnuma " . ${toolArgs};
       } else {
-        $toolArgs = ${toolArgs} . " -Wl,--enable-new-dtags -Wl,-rpath=$HIP_LIB_PATH:$ROCM_PATH/lib -lamdhip64 ";
+        $toolArgs = ${toolArgs} . " -Wl,--enable-new-dtags -Wl,-rpath=$HIP_LIB_PATH:$ROCM_PATH/$LIB -lamdhip64 ";
       }
       # To support __fp16 and _Float16, explicitly link with compiler-rt
       $HIP_CLANG_BUILTIN_LIB="$HIP_CLANG_PATH/../lib/clang/$HIP_CLANG_VERSION/lib/$HIP_CLANG_TARGET/libclang_rt.builtins.a";

--- a/bin/hipcc.pl
+++ b/bin/hipcc.pl
@@ -201,13 +201,11 @@ if ($HIP_PLATFORM eq "amd") {
     }
 
     if (not $isWindows) {
-        $HSA_PATH=$ENV{'HSA_PATH'} // "$ROCM_PATH/hsa";
         $HIPCXXFLAGS .= " -isystem $HSA_PATH/include";
         $HIPCFLAGS .= " -isystem $HSA_PATH/include";
     }
 
 } elsif ($HIP_PLATFORM eq "nvidia") {
-    $CUDA_PATH=$ENV{'CUDA_PATH'} // '/usr/local/cuda';
     $HIP_INCLUDE_PATH = "$HIP_PATH/include";
     if ($verbose & 0x2) {
         print ("CUDA_PATH=$CUDA_PATH\n");

--- a/bin/hipvars.pm
+++ b/bin/hipvars.pm
@@ -93,22 +93,19 @@ if ($isWindows) {
 # HIP_ROCCLR_HOME is used by Windows builds
 $HIP_ROCCLR_HOME=$ENV{'HIP_ROCCLR_HOME'};
 
-if (defined $HIP_ROCCLR_HOME) {
-    # Only used for Windows builds
+if ($isWindows) {
     $LIB = "lib";
-    $HIP_INFO_PATH = "$HIP_ROCCLR_HOME/lib/.hipInfo";
 } else {
-    # Detect lib directory (i.e. 'lib64' or 'lib')
-    if (-e "$HIP_PATH/lib64/.hipInfo") {
-        $LIB = "lib64";
-    } else {
-        $LIB = "lib";
-    }
-    $HIP_INFO_PATH = "$HIP_PATH/$LIB/.hipInfo";
+    # Look for the HSA runtime library to determine the lib directory name
+    $LIB = `find $HIP_PATH/lib $HIP_PATH/lib64 -name libhsa-runtime64* | grep -m1 -o '.*/lib.*/'`;
+    chomp($LIB); # Remove trailing newline characters
+    $LIB = basename($LIB); # Get the lib directory name
 }
-if (! -f $HIP_INFO_PATH) {
-    printf ("error: HIP_INFO_PATH does not exist ('$HIP_INFO_PATH')\n");
-    exit (-1);
+
+if (defined $HIP_ROCCLR_HOME) {
+    $HIP_INFO_PATH= "$HIP_ROCCLR_HOME/$LIB/.hipInfo";
+} else {
+    $HIP_INFO_PATH= "$HIP_PATH/$LIB/.hipInfo"; # use actual file
 }
 #---
 #HIP_PLATFORM controls whether to use nvidia or amd platform:

--- a/bin/hipvars.pm
+++ b/bin/hipvars.pm
@@ -97,10 +97,10 @@ if ($isWindows) {
     $LIB = "lib";
 } else {
     # Look for the AMD HIP library to determine the lib directory name
-    if (my @libs = glob("\E$HIP_PATH/lib*/*libamdhip64*.so*")) {
+    if (my @libs = glob("$HIP_PATH/lib*/libamdhip64*.so*")) {
         # Multi-lib layout (Fedora and others: /usr/lib64)
         $LIB = basename(dirname($libs[0]));
-    } elsif (my @libs = glob("\E$HIP_PATH/lib/*/*libamdhip64*.so*")) {
+    } elsif (@libs = glob("$HIP_PATH/lib/*/libamdhip64*.so*")) {
         # Multi-arch layout (Debian: /usr/lib/x86_64-linux-gnu)
         $LIB = "lib/" . basename(dirname($libs[0]));
     } else {

--- a/bin/hipvars.pm
+++ b/bin/hipvars.pm
@@ -96,10 +96,18 @@ $HIP_ROCCLR_HOME=$ENV{'HIP_ROCCLR_HOME'};
 if ($isWindows) {
     $LIB = "lib";
 } else {
-    # Look for the HSA runtime library to determine the lib directory name
-    $LIB = `find $HIP_PATH/lib $HIP_PATH/lib64 -name libhsa-runtime64* | grep -m1 -o '.*/lib.*/'`;
-    chomp($LIB); # Remove trailing newline characters
-    $LIB = basename($LIB); # Get the lib directory name
+    # Look for the AMD HIP library to determine the lib directory name
+    if (my @libs = glob("\E$HIP_PATH/lib*/*libamdhip64*.so*")) {
+        # Multi-lib layout (Fedora and others: /usr/lib64)
+        $LIB = basename(dirname($libs[0]));
+    } elsif (my @libs = glob("\E$HIP_PATH/lib/*/*libamdhip64*.so*")) {
+        # Multi-arch layout (Debian: /usr/lib/x86_64-linux-gnu)
+        $LIB = "lib/" . basename(dirname($libs[0]));
+    } else {
+        # Set to 'lib' for backwards compatibility with cases that are not
+        # caught in the above checks
+        $LIB = "lib";
+    }
 }
 
 if (defined $HIP_ROCCLR_HOME) {

--- a/bin/hipvars.pm
+++ b/bin/hipvars.pm
@@ -94,9 +94,21 @@ if ($isWindows) {
 $HIP_ROCCLR_HOME=$ENV{'HIP_ROCCLR_HOME'};
 
 if (defined $HIP_ROCCLR_HOME) {
-    $HIP_INFO_PATH= "$HIP_ROCCLR_HOME/lib/.hipInfo";
+    # Only used for Windows builds
+    $LIB = "lib";
+    $HIP_INFO_PATH = "$HIP_ROCCLR_HOME/lib/.hipInfo";
 } else {
-    $HIP_INFO_PATH= "$HIP_PATH/lib/.hipInfo"; # use actual file
+    # Detect lib directory (i.e. 'lib64' or 'lib')
+    if (-e "$HIP_PATH/lib64/.hipInfo") {
+        $LIB = "lib64";
+    } else {
+        $LIB = "lib";
+    }
+    $HIP_INFO_PATH = "$HIP_PATH/$LIB/.hipInfo";
+}
+if (! -f $HIP_INFO_PATH) {
+    printf ("error: HIP_INFO_PATH does not exist ('$HIP_INFO_PATH')\n");
+    exit (-1);
 }
 #---
 #HIP_PLATFORM controls whether to use nvidia or amd platform:


### PR DESCRIPTION
This fixes various issues around the lib path in `hipvars.pm` and `hipcc.pl`:
- `hipvars.pm`: Detect the correct lib directory (i.e. 'lib64' or 'lib')
- `hipcc.pl`: Use the correct lib path in the linker arguments
- `hipcc.pl`: Set the `DEVICE_LIB_PATH` correctly for system installation (e.g. in /usr/lib64/amdgcn/bitcode/)

Note that this does not yet fix the issues around the include directories, which requires not only changes in HIP, but also ROCm-CompilerSupport.

@raramakr, this addresses some of the issues mentioned in https://github.com/ROCm-Developer-Tools/hipamd/issues/43#issuecomment-1222959814. Could you please have a look and merge those changes as you have been working on updating HIP to use GNUInstallDirs (https://github.com/ROCm-Developer-Tools/hipamd/commit/c92a12faf39210e24d329cc2c7e94dd124e69fed)?