### PR TITLE
EXSWHTEC-14 - Implement tests for hipEventCreateWithFlags

### DIFF
--- a/tests/catch/unit/event/CMakeLists.txt
+++ b/tests/catch/unit/event/CMakeLists.txt
@@ -6,6 +6,7 @@ set(TEST_SRC
     Unit_hipEventRecord.cc
     Unit_hipEventIpc.cc
     hipEventDestroy.cc
+    hipEventCreateWithFlags.cc
 )
 
 # The test used wait mechanism and doesnt play well with all arch of nvidia

--- a/tests/catch/unit/event/Unit_hipEvent_Negative.cc
+++ b/tests/catch/unit/event/Unit_hipEvent_Negative.cc
@@ -19,16 +19,25 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
+/*
+Testcase Scenarios :
+Unit_hipEventCreate_NullCheck - Test unsuccessful event creation when event passed as nullptr
+Unit_hipEventCreateWithFlags_NullCheck - Test unsuccessful event creation with flags when event passed as nullptr
+Unit_hipEventSynchronize_NullCheck - Test unsuccessful event synchronization when event passed as nullptr
+Unit_hipEventQuery_NullCheck - Test unsuccessful event query when event passed as nullptr
+Unit_hipEventDestroy_NullCheck - Test unsuccessful event destruction when event passed as nullptr
+Unit_hipEventCreate_IncompatibleFlags - Test unsuccessful event creation when incompatible flags are passed
+*/
 
 #include <hip_test_common.hh>
 
 TEST_CASE("Unit_hipEventCreate_NullCheck") {
-  hipEvent_t start_event;
   auto res = hipEventCreate(nullptr);
   REQUIRE(res != hipSuccess);
-  res = hipEventCreateWithFlags(nullptr, 0);
-  REQUIRE(res != hipSuccess);
-  res = hipEventCreateWithFlags(&start_event, 10);
+}
+
+TEST_CASE("Unit_hipEventCreateWithFlags_NullCheck") {
+  auto res = hipEventCreateWithFlags(nullptr, 0);
   REQUIRE(res != hipSuccess);
 }
 

--- a/tests/catch/unit/event/hipEventCreateWithFlags.cc
+++ b/tests/catch/unit/event/hipEventCreateWithFlags.cc
@@ -26,8 +26,6 @@ Unit_hipEventCreateWithFlags_Positive - Test simple event creation with hipEvent
 
 #include <hip_test_common.hh>
 
-namespace hipEventCreateWithFlagsTests {
-
 TEST_CASE("Unit_hipEventCreateWithFlags_Positive") {
 
 #if HT_AMD
@@ -44,6 +42,3 @@ TEST_CASE("Unit_hipEventCreateWithFlags_Positive") {
 
   HIP_CHECK(hipEventDestroy(event));
 }
-
-}  // namespace hipEventCreateWithFlagsTests
-

--- a/tests/catch/unit/event/hipEventCreateWithFlags.cc
+++ b/tests/catch/unit/event/hipEventCreateWithFlags.cc
@@ -1,0 +1,49 @@
+/*
+Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+/*
+Testcase Scenarios :
+Unit_hipEventCreateWithFlags_Positive - Test simple event creation with hipEventCreateWithFlags api for each flag
+*/
+
+#include <hip_test_common.hh>
+
+namespace hipEventCreateWithFlagsTests {
+
+TEST_CASE("Unit_hipEventCreateWithFlags_Positive") {
+
+#if HT_AMD
+  // On AMD platform, hipEventInterprocess support is under development. Use of this flag will return an error. Omitted
+  const unsigned int flagUnderTest = GENERATE(hipEventDefault, hipEventBlockingSync, hipEventDisableTiming, hipEventReleaseToDevice, hipEventReleaseToSystem);
+#else
+  // On Non-AMD platforms hipEventReleaseToDevice / hipEventReleaseToSystem are not defined
+  const unsigned int flagUnderTest = GENERATE(hipEventDefault, hipEventBlockingSync, hipEventDisableTiming, hipEventInterprocess | hipEventDisableTiming);
+#endif
+
+  hipEvent_t event;
+  HIP_CHECK(hipEventCreateWithFlags(&event, flagUnderTest));
+  REQUIRE(event != nullptr);
+
+  HIP_CHECK(hipEventDestroy(event));
+}
+
+}  // namespace hipEventCreateWithFlagsTests
+


### PR DESCRIPTION
- Add hipEventCreateWithFlags.cc with a simple positive unit test
- Divide Unit_hipEventCreate_NullCheck into two separate tests
- Add newly created file into CMakeLists.txt