### PR TITLE
EXSWHTEC-15 - Implement additional HipEventElapsedTime tests

### DIFF
--- a/tests/catch/unit/event/Unit_hipEvent.cc
+++ b/tests/catch/unit/event/Unit_hipEvent.cc
@@ -114,7 +114,8 @@ void test(unsigned testMask, int* C_d, int* C_h, int64_t numElements, hipStream_
     if (e == hipSuccess) assert(t == 0.0f);
 
     // stop usually ready unless we skipped the synchronization (syncNone)
-    HIP_ASSERT(hipEventElapsedTime(&t, stop, stop) == expectedStopError);
+    e = hipEventElapsedTime(&t, stop, stop);
+    HIP_ASSERT(e == expectedStopError);
     if (e == hipSuccess) assert(t == 0.0f);
 
     e = hipEventElapsedTime(&t, start, stop);

--- a/tests/catch/unit/event/Unit_hipEventElapsedTime.cc
+++ b/tests/catch/unit/event/Unit_hipEventElapsedTime.cc
@@ -19,8 +19,16 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
+/*
+Testcase Scenarios :
+Unit_hipEventElapsedTime_NullCheck - Test unsuccessful hipEventElapsedTime when either event passed as nullptr
+Unit_hipEventElapsedTime_DisableTiming - Test unsuccessful hipEventElapsedTime when events are created with hipEventDisableTiming flag
+Unit_hipEventElapsedTime_DifferentDevices - Test unsuccessful hipEventElapsedTime when events are recorded on different devices
+Unit_hipEventElapsedTime - Test time elapsed between two recorded events with hipEventElapsedTime api
+*/
 
 #include <hip_test_common.hh>
+
 #include <iostream>
 
 TEST_CASE("Unit_hipEventElapsedTime_NullCheck") {
@@ -51,9 +59,7 @@ TEST_CASE("Unit_hipEventElapsedTime_DifferentDevices") {
     // create event on dev=0
     HIP_CHECK(hipSetDevice(0));
     hipEvent_t start;
-    hipEvent_t start1;
     HIP_CHECK(hipEventCreate(&start));
-    HIP_CHECK(hipEventCreate(&start1));
 
     HIP_CHECK(hipEventRecord(start, nullptr));
     HIP_CHECK(hipEventSynchronize(start));
@@ -63,9 +69,6 @@ TEST_CASE("Unit_hipEventElapsedTime_DifferentDevices") {
     hipEvent_t stop;
     HIP_CHECK(hipEventCreate(&stop));
 
-    // start1 on device 0 but null stream on device 1
-    HIP_ASSERT(hipEventRecord(start1, nullptr) == hipErrorInvalidHandle);
-
     HIP_CHECK(hipEventRecord(stop, nullptr));
     HIP_CHECK(hipEventSynchronize(stop));
 
@@ -74,7 +77,6 @@ TEST_CASE("Unit_hipEventElapsedTime_DifferentDevices") {
     HIP_ASSERT(hipEventElapsedTime(&tElapsed,start,stop) == hipErrorInvalidHandle);
 
     HIP_CHECK(hipEventDestroy(start));
-    HIP_CHECK(hipEventDestroy(start1));
     HIP_CHECK(hipEventDestroy(stop));
   }
 }

--- a/tests/catch/unit/event/Unit_hipEventRecord.cc
+++ b/tests/catch/unit/event/Unit_hipEventRecord.cc
@@ -19,8 +19,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-
-// Test hipEventRecord serialization behavior.
+/*
+Testcase Scenarios :
+Unit_hipEventRecord- Test hipEventRecord serialization behavior
+Unit_hipEventRecord_Negative - Test unsuccessful hipEventRecord when event is passed as nullptr
+                             - Test unsuccessful hipEventRecord when event is created/recorded on different devices
+*/
 
 #include <hip_test_common.hh>
 
@@ -116,5 +120,20 @@ TEST_CASE("Unit_hipEventRecord") {
 TEST_CASE("Unit_hipEventRecord_Negative") {
   SECTION("Nullptr event") {
     HIP_CHECK_ERROR(hipEventRecord(nullptr, nullptr), hipErrorInvalidResourceHandle);
+  }
+
+  SECTION("Different devices") {
+    int devCount = 0;
+    HIP_CHECK(hipGetDeviceCount(&devCount));
+    if (devCount > 1) {
+      // create event on dev=0
+      HIP_CHECK(hipSetDevice(0));
+      hipEvent_t start;
+      HIP_CHECK(hipEventCreate(&start));
+
+      // start on device 0 but null stream on device 1
+      HIP_CHECK(hipSetDevice(1));
+      HIP_CHECK_ERROR(hipEventRecord(start, nullptr), hipErrorInvalidHandle)
+    }
   }
 }

--- a/tests/catch/unit/event/Unit_hipEventRecord.cc
+++ b/tests/catch/unit/event/Unit_hipEventRecord.cc
@@ -134,6 +134,8 @@ TEST_CASE("Unit_hipEventRecord_Negative") {
       // start on device 0 but null stream on device 1
       HIP_CHECK(hipSetDevice(1));
       HIP_CHECK_ERROR(hipEventRecord(start, nullptr), hipErrorInvalidHandle)
+	  
+	  HIP_CHECK(hipEventDestroy(start));
     }
   }
 }

--- a/tests/catch/unit/event/Unit_hipEventRecord.cc
+++ b/tests/catch/unit/event/Unit_hipEventRecord.cc
@@ -135,7 +135,7 @@ TEST_CASE("Unit_hipEventRecord_Negative") {
       HIP_CHECK(hipSetDevice(1));
       HIP_CHECK_ERROR(hipEventRecord(start, nullptr), hipErrorInvalidHandle)
 	  
-	  HIP_CHECK(hipEventDestroy(start));
+      HIP_CHECK(hipEventDestroy(start));
     }
   }
 }


### PR DESCRIPTION
- Fix minor bug in helper test function in Unit_hipEvent.cc
- Move negative test from Unit_hipEventElapsedTime_DifferentDevices to Unit_hipEventRecord_Negative
- Add Unit_hipEventElapsedTime_NotReady_Negative test when function is called on event that has not been completed