### PR TITLE
EXSWHTEC-40 - Implement additional Stream Management negative tests

### DIFF
--- a/tests/catch/unit/stream/hipStreamSynchronize.cc
+++ b/tests/catch/unit/stream/hipStreamSynchronize.cc
@@ -33,6 +33,19 @@ TEST_CASE("Unit_hipStreamSynchronize_EmptyStream") {
   HIP_CHECK(hipStreamDestroy(stream));
 }
 
+#if !HT_NVIDIA
+/**
+ * @brief Check that synchronization of uninitialized stream sets its status to
+ * hipErrorContextIsDestroyed
+ *
+ * Test removed for Nvidia devices because it returns unexpected error
+ */
+TEST_CASE("Unit_hipStreamSynchronize_UninitializedStream") {
+  hipStream_t stream{reinterpret_cast<hipStream_t>(0xFFFF)};
+  HIP_CHECK_ERROR(hipStreamSynchronize(stream), hipErrorContextIsDestroyed);
+}
+#endif
+
 #if HT_AMD /* Disabled because frequency based wait is timing out on nvidia platforms */
 
 /**

--- a/tests/catch/unit/stream/hipStreamValue.cc
+++ b/tests/catch/unit/stream/hipStreamValue.cc
@@ -499,7 +499,40 @@ TEST_CASE("Unit_hipStreamValue_Negative_InvalidMemory") {
   HIP_CHECK(hipStreamDestroy(stream));
 }
 
-TEMPLATE_TEST_CASE("Unit_hipStreamWaitValue_Negative_InvalidFlag", "", uint32_t, uint64_t) {
+TEMPLATE_TEST_CASE("Unit_hipStreamValue_Negative_UninitializedStream", "", uint32_t, uint64_t) {
+  if (!streamWaitValueSupported()) {
+    HipTest::HIP_SKIP_TEST("hipStreamWaitValue not supported on this device.");
+    return;
+  }
+
+  hipStream_t stream{reinterpret_cast<hipStream_t>(0xFFFF)};
+
+  // Allocate Host Memory
+  auto hostPtr = std::make_unique<TestType>();
+
+  // Register Host Memory
+  HIP_CHECK(hipHostRegister(hostPtr.get(), sizeof(TestType), 0));
+
+  // Set dummy data
+  *hostPtr = 0x0;
+
+  const auto compareOp = hipStreamWaitValueGte;
+  const auto expectedError = hipErrorContextIsDestroyed;
+
+  // Stream handle negative tests
+  SECTION("Invalid Stream handle for hipStreamWriteValue") {
+    HIP_CHECK_ERROR(writeFunc<TestType>(stream, hostPtr.get(), 0, writeFlag), expectedError);
+  }
+
+  SECTION("Invalid Stream handle for hipStreamWaitValue") {
+    HIP_CHECK_ERROR(waitFunc<TestType>(stream, hostPtr.get(), 0, compareOp), expectedError);
+  }
+
+  // Cleanup
+  HIP_CHECK(hipHostUnregister(hostPtr.get()));
+}
+
+TEMPLATE_TEST_CASE("Unit_hipStreamValue_Negative_InvalidFlag", "", uint32_t, uint64_t) {
   if (!streamWaitValueSupported()) {
     HipTest::HIP_SKIP_TEST("hipStreamWaitValue not supported on this device.");
     return;
@@ -518,8 +551,13 @@ TEMPLATE_TEST_CASE("Unit_hipStreamWaitValue_Negative_InvalidFlag", "", uint32_t,
   // Set dummy data
   *hostPtr = 0x0;
 
-  /* EXSWCPHIPT-96 */
-  HIP_CHECK_ERROR(waitFunc<TestType>(stream, hostPtr.get(), 0, -1), hipErrorInvalidValue);
+  SECTION("Invalid flag for hipStreamWriteValue") {
+    HIP_CHECK_ERROR(writeFunc<TestType>(stream, hostPtr.get(), 0, -1), hipErrorInvalidValue);
+  }
+
+  SECTION("Invalid flag for hipStreamWaitValue") {
+    HIP_CHECK_ERROR(waitFunc<TestType>(stream, hostPtr.get(), 0, -1), hipErrorInvalidValue);
+  }
 
   // Cleanup
   HIP_CHECK(hipHostUnregister(hostPtr.get()));

--- a/tests/catch/unit/stream/hipStreamValue.cc
+++ b/tests/catch/unit/stream/hipStreamValue.cc
@@ -551,13 +551,7 @@ TEMPLATE_TEST_CASE("Unit_hipStreamValue_Negative_InvalidFlag", "", uint32_t, uin
   // Set dummy data
   *hostPtr = 0x0;
 
-  SECTION("Invalid flag for hipStreamWriteValue") {
-    HIP_CHECK_ERROR(writeFunc<TestType>(stream, hostPtr.get(), 0, -1), hipErrorInvalidValue);
-  }
-
-  SECTION("Invalid flag for hipStreamWaitValue") {
-    HIP_CHECK_ERROR(waitFunc<TestType>(stream, hostPtr.get(), 0, -1), hipErrorInvalidValue);
-  }
+  HIP_CHECK_ERROR(waitFunc<TestType>(stream, hostPtr.get(), 0, -1), hipErrorInvalidValue);
 
   // Cleanup
   HIP_CHECK(hipHostUnregister(hostPtr.get()));


### PR DESCRIPTION
- Implement negative test for hipStream<Write/Wait>Value when stream is uninitialized
- Implement negative test for hipStreamSynchronize when stream is uninitialized