### PR TITLE
Pass HIP version via a commandline argument if .hipVersion is missing

### DIFF
--- a/bin/hipvars.pm
+++ b/bin/hipvars.pm
@@ -151,7 +151,8 @@ if ($HIP_COMPILER eq "clang") {
 #---
 # Read .hipVersion
 my %hipVersion = ();
-parse_config_file("$hipvars::HIP_PATH/bin/.hipVersion", \%hipVersion);
+$HIP_VERSION_PATH = "$HIP_PATH/bin/.hipVersion";
+parse_config_file("$HIP_VERSION_PATH", \%hipVersion);
 $HIP_VERSION_MAJOR = $hipVersion{'HIP_VERSION_MAJOR'} // $HIP_BASE_VERSION_MAJOR;
 $HIP_VERSION_MINOR = $hipVersion{'HIP_VERSION_MINOR'} // $HIP_BASE_VERSION_MINOR;
 $HIP_VERSION_PATCH = $hipVersion{'HIP_VERSION_PATCH'} // $HIP_BASE_VERSION_PATCH;


### PR DESCRIPTION
Clang requires the HIP version information, passed either via a commandline argument or by reading it from the .hipVersion file (see `clang/lib/Driver/ToolChains/AMDGPU.cpp`).  Since there is no FHS compliant location for .hipVersion where clang will still be able to find it, .hipVersion has been omitted in the downstream distribution packages (Debian/Fedora) and subsequently the hip version needs to be passed explicitly.

The issue and fix have been discussed on the Debian mailing list (https://lists.debian.org/debian-ai/2022/05/msg00020.html) and the patch in Debian is here: https://salsa.debian.org/rocm-team/rocm-hipamd/-/blob/0b11747d64820050b48c63cf6424529205ea932e/debian/patches/0013-hipcc-hip-version.patch

For a detailed discussion on the various options and their implications, see also this message from @cgmb on the Debian mailing list:
https://lists.debian.org/debian-ai/2022/07/msg00014.html

@cgmb and @Mystro256 could you please have a look at this and forward it to the right people?