### PR TITLE
SWDEV-357690 - Prevent chomp return from overriding HIP_CLANG_TARGET triple information

### DIFF
--- a/bin/hipcc.pl
+++ b/bin/hipcc.pl
@@ -163,7 +163,7 @@ if ($HIP_PLATFORM eq "amd") {
 
     # Figure out the target with which llvm is configured
     $HIP_CLANG_TARGET = `$HIPCC -print-target-triple`;
-    $HIP_CLANG_TARGET = chomp($HIP_CLANG_TARGET);
+    chomp($HIP_CLANG_TARGET);
 
     if (! defined $HIP_CLANG_INCLUDE_PATH) {
         $HIP_CLANG_INCLUDE_PATH = abs_path("$HIP_CLANG_PATH/../lib/clang/$HIP_CLANG_VERSION/include");


### PR DESCRIPTION
HIP_CLANG_TARGET should contain the target triple for library path generation.