### PR TITLE
EXSWHTEC-106 - Reimplement tests for hipOccupancyMaxActiveBlocksPerMultiprocessor and hipOccupancyMaxPotentialBlockSize APIs

### DIFF
--- a/tests/catch/unit/occupancy/CMakeLists.txt
+++ b/tests/catch/unit/occupancy/CMakeLists.txt
@@ -1,7 +1,9 @@
 # Common Tests - Test independent of all platforms
 set(TEST_SRC
   hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
+  hipOccupancyMaxActiveBlocksPerMultiprocessor_old.cc
   hipOccupancyMaxPotentialBlockSize.cc
+  hipOccupancyMaxPotentialBlockSize_old.cc
 )
 
 hip_add_exe_to_target(NAME OccupancyTest

--- a/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
@@ -16,6 +16,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
+/*
+Testcase Scenarios :
+Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation - Test correct execution of hipOccupancyMaxActiveBlocksPerMultiprocessor for diffrent parameter values
+Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateInvocation - Test correct execution of hipOccupancyMaxActiveBlocksPerMultiprocessor template for diffrent parameter values
+Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters - Test unsuccessful execution of hipOccupancyMaxActiveBlocksPerMultiprocessor api when parameters are invalid
+*/
 #include "occupancy_common.hh"
 
 static __global__ void f1(float *a) { *a = 1.0; }

--- a/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
@@ -32,9 +32,11 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters
   HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, 0, 0));
 
   // Common negative tests
-  MaxActiveBlocksPerMultiprocessorNegative([](int* numBlocks, int blockSize, size_t dynSharedMemPerBlk) {
-    return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize, dynSharedMemPerBlk);
-  }, blockSize);
+  MaxActiveBlocksPerMultiprocessorNegative(
+    [](int* numBlocks, int blockSize, size_t dynSharedMemPerBlk) {
+      return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize, dynSharedMemPerBlk);
+    },
+    blockSize);
 
   SECTION("Kernel function is NULL") {
     HIP_CHECK_ERROR(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocks, NULL, blockSize, 0), hipErrorInvalidDeviceFunction);
@@ -52,17 +54,21 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValid
     // Get potential blocksize
     HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, 0, 0));
 
-    MaxActiveBlocksPerMultiprocessor([blockSize](int* numBlocks) {
-      return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize, 0);
-    }, blockSize, devProp.maxThreadsPerMultiProcessor);
+    MaxActiveBlocksPerMultiprocessor(
+      [blockSize](int* numBlocks) {
+        return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize, 0);
+      },
+      blockSize, devProp.maxThreadsPerMultiProcessor);
   }
   SECTION("dynSharedMemPerBlk = sharedMemPerBlock") {
     // Get potential blocksize
     HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, devProp.sharedMemPerBlock, 0));
 
-    MaxActiveBlocksPerMultiprocessor([blockSize, devProp](int* numBlocks) {
-      return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize, devProp.sharedMemPerBlock);
-    }, blockSize, devProp.maxThreadsPerMultiProcessor);
+    MaxActiveBlocksPerMultiprocessor(
+      [blockSize, devProp](int* numBlocks) {
+        return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize, devProp.sharedMemPerBlock);
+      },
+      blockSize, devProp.maxThreadsPerMultiProcessor);
   }
 }
 
@@ -77,17 +83,21 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateIn
     // Get potential blocksize
     HIP_CHECK(hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(&gridSize, &blockSize, f2, 0, 0));
 
-    MaxActiveBlocksPerMultiprocessor([blockSize](int* numBlocks) {
-      return hipOccupancyMaxActiveBlocksPerMultiprocessor<void(*)(int *)>(numBlocks, f2, blockSize, 0);
-    }, blockSize, devProp.maxThreadsPerMultiProcessor);
+    MaxActiveBlocksPerMultiprocessor(
+      [blockSize](int* numBlocks) {
+        return hipOccupancyMaxActiveBlocksPerMultiprocessor<void(*)(int *)>(numBlocks, f2, blockSize, 0);
+      },
+      blockSize, devProp.maxThreadsPerMultiProcessor);
   }
 
   SECTION("dynSharedMemPerBlk = sharedMemPerBlock") {
     // Get potential blocksize
     HIP_CHECK(hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(&gridSize, &blockSize, f2, devProp.sharedMemPerBlock, 0));
 
-    MaxActiveBlocksPerMultiprocessor([blockSize, devProp](int* numBlocks) {
-      return hipOccupancyMaxActiveBlocksPerMultiprocessor<void(*)(int *)>(numBlocks, f2, blockSize, devProp.sharedMemPerBlock);
-    }, blockSize, devProp.maxThreadsPerMultiProcessor);
+    MaxActiveBlocksPerMultiprocessor(
+      [blockSize, devProp](int* numBlocks) {
+        return hipOccupancyMaxActiveBlocksPerMultiprocessor<void(*)(int *)>(numBlocks, f2, blockSize, devProp.sharedMemPerBlock);
+      },
+      blockSize, devProp.maxThreadsPerMultiProcessor);
   }
 }

--- a/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
@@ -23,7 +23,7 @@ static __global__ void f1(float *a) { *a = 1.0; }
 template <typename T>
 static __global__ void f2(T *a) { *a = 1; }
 
-TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative") {
+TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters") {
   int numBlocks = 0;
   int blockSize = 0;
   int gridSize = 0;
@@ -37,11 +37,11 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative") {
   }, blockSize);
 
   SECTION("Kernel function is NULL") {
-    HIP_CHECK_ERROR(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocks, NULL, blockSize, 0), hipErrorInvalidValue);
+    HIP_CHECK_ERROR(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocks, NULL, blockSize, 0), hipErrorInvalidDeviceFunction);
   }
 }
 
-TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_rangeValidation") {
+TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation") {
   hipDeviceProp_t devProp;
   int blockSize = 0;
   int gridSize = 0;
@@ -66,7 +66,7 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_rangeValidation") {
   }
 }
 
-TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_templateInvocation") {
+TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateInvocation") {
   hipDeviceProp_t devProp;
   int blockSize = 0;
   int gridSize = 0;

--- a/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
@@ -18,16 +18,18 @@ THE SOFTWARE.
 */
 /*
 Testcase Scenarios :
-Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation - Test correct execution of hipOccupancyMaxActiveBlocksPerMultiprocessor for diffrent parameter values
-Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateInvocation - Test correct execution of hipOccupancyMaxActiveBlocksPerMultiprocessor template for diffrent parameter values
-Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters - Test unsuccessful execution of hipOccupancyMaxActiveBlocksPerMultiprocessor api when parameters are invalid
+Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation - Test correct execution
+of hipOccupancyMaxActiveBlocksPerMultiprocessor for diffrent parameter values
+Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateInvocation - Test correct
+execution of hipOccupancyMaxActiveBlocksPerMultiprocessor template for diffrent parameter values
+Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters - Test unsuccessful execution
+of hipOccupancyMaxActiveBlocksPerMultiprocessor api when parameters are invalid
 */
 #include "occupancy_common.hh"
 
-static __global__ void f1(float *a) { *a = 1.0; }
+static __global__ void f1(float* a) { *a = 1.0; }
 
-template <typename T>
-static __global__ void f2(T *a) { *a = 1; }
+template <typename T> static __global__ void f2(T* a) { *a = 1; }
 
 TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters") {
   int numBlocks = 0;
@@ -39,14 +41,18 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative_Parameters
 
   // Common negative tests
   MaxActiveBlocksPerMultiprocessorNegative(
-    [](int* numBlocks, int blockSize, size_t dynSharedMemPerBlk) {
-      return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize, dynSharedMemPerBlk);
-    },
-    blockSize);
+      [](int* numBlocks, int blockSize, size_t dynSharedMemPerBlk) {
+        return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize,
+                                                            dynSharedMemPerBlk);
+      },
+      blockSize);
 
+#ifdef __HIP_PLATFORM_NVIDIA__
   SECTION("Kernel function is NULL") {
-    HIP_CHECK_ERROR(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocks, NULL, blockSize, 0), hipErrorInvalidDeviceFunction);
+    HIP_CHECK_ERROR(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocks, NULL, blockSize, 0),
+                    hipErrorInvalidDeviceFunction);
   }
+#endif
 }
 
 TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValidation") {
@@ -61,20 +67,22 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_RangeValid
     HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, 0, 0));
 
     MaxActiveBlocksPerMultiprocessor(
-      [blockSize](int* numBlocks) {
-        return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize, 0);
-      },
-      blockSize, devProp.maxThreadsPerMultiProcessor);
+        [blockSize](int* numBlocks) {
+          return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize, 0);
+        },
+        blockSize, devProp.maxThreadsPerMultiProcessor);
   }
   SECTION("dynSharedMemPerBlk = sharedMemPerBlock") {
     // Get potential blocksize
-    HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, devProp.sharedMemPerBlock, 0));
+    HIP_CHECK(
+        hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, devProp.sharedMemPerBlock, 0));
 
     MaxActiveBlocksPerMultiprocessor(
-      [blockSize, devProp](int* numBlocks) {
-        return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize, devProp.sharedMemPerBlock);
-      },
-      blockSize, devProp.maxThreadsPerMultiProcessor);
+        [blockSize, devProp](int* numBlocks) {
+          return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize,
+                                                              devProp.sharedMemPerBlock);
+        },
+        blockSize, devProp.maxThreadsPerMultiProcessor);
   }
 }
 
@@ -87,23 +95,26 @@ TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Positive_TemplateIn
 
   SECTION("dynSharedMemPerBlk = 0") {
     // Get potential blocksize
-    HIP_CHECK(hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(&gridSize, &blockSize, f2, 0, 0));
+    HIP_CHECK(hipOccupancyMaxPotentialBlockSize<void (*)(int*)>(&gridSize, &blockSize, f2, 0, 0));
 
     MaxActiveBlocksPerMultiprocessor(
-      [blockSize](int* numBlocks) {
-        return hipOccupancyMaxActiveBlocksPerMultiprocessor<void(*)(int *)>(numBlocks, f2, blockSize, 0);
-      },
-      blockSize, devProp.maxThreadsPerMultiProcessor);
+        [blockSize](int* numBlocks) {
+          return hipOccupancyMaxActiveBlocksPerMultiprocessor<void (*)(int*)>(numBlocks, f2,
+                                                                              blockSize, 0);
+        },
+        blockSize, devProp.maxThreadsPerMultiProcessor);
   }
 
   SECTION("dynSharedMemPerBlk = sharedMemPerBlock") {
     // Get potential blocksize
-    HIP_CHECK(hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(&gridSize, &blockSize, f2, devProp.sharedMemPerBlock, 0));
+    HIP_CHECK(hipOccupancyMaxPotentialBlockSize<void (*)(int*)>(&gridSize, &blockSize, f2,
+                                                                devProp.sharedMemPerBlock, 0));
 
     MaxActiveBlocksPerMultiprocessor(
-      [blockSize, devProp](int* numBlocks) {
-        return hipOccupancyMaxActiveBlocksPerMultiprocessor<void(*)(int *)>(numBlocks, f2, blockSize, devProp.sharedMemPerBlock);
-      },
-      blockSize, devProp.maxThreadsPerMultiProcessor);
+        [blockSize, devProp](int* numBlocks) {
+          return hipOccupancyMaxActiveBlocksPerMultiprocessor<void (*)(int*)>(
+              numBlocks, f2, blockSize, devProp.sharedMemPerBlock);
+        },
+        blockSize, devProp.maxThreadsPerMultiProcessor);
   }
 }

--- a/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor.cc
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
@@ -16,76 +16,78 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-#include <hip_test_common.hh>
+#include "occupancy_common.hh"
 
 static __global__ void f1(float *a) { *a = 1.0; }
 
 template <typename T>
 static __global__ void f2(T *a) { *a = 1; }
 
-/**
- * Defines
- */
-#define OccupancyDisableCachingOverride 0x01
-
 TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative") {
-  hipError_t ret;
-  int numBlock = 0, blockSize = 0;
-  int gridSize = 0, defBlkSize = 32;
-
-  // Get potential blocksize
-  HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, 0, 0));
-
-  // Validate each argument
-  ret = hipOccupancyMaxActiveBlocksPerMultiprocessor(NULL, f1, blockSize, 0);
-  REQUIRE(ret != hipSuccess);
-
-  ret = hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, NULL, blockSize, 0);
-  REQUIRE(ret != hipSuccess);
-
-  ret = hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, f1, 0, 0);
-  REQUIRE(ret != hipSuccess);
-
-  ret = hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, f1, 0,
-                                         std::numeric_limits<std::size_t>::max());
-  REQUIRE(ret != hipSuccess);
-
-  ret = hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(&numBlock, f1,
-                                  defBlkSize, 0, OccupancyDisableCachingOverride);
-  REQUIRE(ret == hipSuccess);
-}
-
-TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_rangeValidation") {
-  hipDeviceProp_t devProp;
-  int numBlock = 0, blockSize = 0;
+  int numBlocks = 0;
+  int blockSize = 0;
   int gridSize = 0;
 
   // Get potential blocksize
   HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, 0, 0));
 
+  // Common negative tests
+  MaxActiveBlocksPerMultiprocessorNegative([](int* numBlocks, int blockSize, size_t dynSharedMemPerBlk) {
+    return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize, dynSharedMemPerBlk);
+  }, blockSize);
+
+  SECTION("Kernel function is NULL") {
+    HIP_CHECK_ERROR(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlocks, NULL, blockSize, 0), hipErrorInvalidValue);
+  }
+}
+
+TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_rangeValidation") {
+  hipDeviceProp_t devProp;
+  int blockSize = 0;
+  int gridSize = 0;
+
   HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
 
-  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, f1, blockSize, 0));
+  SECTION("dynSharedMemPerBlk = 0") {
+    // Get potential blocksize
+    HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, 0, 0));
 
-  // Check if numBlocks and blockSize are within limits
-  REQUIRE(numBlock > 0);
-  REQUIRE((numBlock * blockSize) <= devProp.maxThreadsPerMultiProcessor);
+    MaxActiveBlocksPerMultiprocessor([blockSize](int* numBlocks) {
+      return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize, 0);
+    }, blockSize, devProp.maxThreadsPerMultiProcessor);
+  }
+  SECTION("dynSharedMemPerBlk = sharedMemPerBlock") {
+    // Get potential blocksize
+    HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, devProp.sharedMemPerBlock, 0));
 
-  // Validate numBlock after passing dynSharedMemPerBlk
-  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, f1, blockSize,
-                                                           devProp.sharedMemPerBlock));
-
-  // Check if numBlocks and blockSize are within limits
-  REQUIRE(numBlock > 0);
-  REQUIRE((numBlock * blockSize) <= devProp.maxThreadsPerMultiProcessor);
+    MaxActiveBlocksPerMultiprocessor([blockSize, devProp](int* numBlocks) {
+      return hipOccupancyMaxActiveBlocksPerMultiprocessor(numBlocks, f1, blockSize, devProp.sharedMemPerBlock);
+    }, blockSize, devProp.maxThreadsPerMultiProcessor);
+  }
 }
 
 TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_templateInvocation") {
-  int blockSize = 32;
-  int numBlock = 0;
+  hipDeviceProp_t devProp;
+  int blockSize = 0;
+  int gridSize = 0;
 
-  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor<void(*)(int *)>
-                                                  (&numBlock, f2, blockSize, 0));
-  REQUIRE(numBlock > 0);
+  HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
+
+  SECTION("dynSharedMemPerBlk = 0") {
+    // Get potential blocksize
+    HIP_CHECK(hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(&gridSize, &blockSize, f2, 0, 0));
+
+    MaxActiveBlocksPerMultiprocessor([blockSize](int* numBlocks) {
+      return hipOccupancyMaxActiveBlocksPerMultiprocessor<void(*)(int *)>(numBlocks, f2, blockSize, 0);
+    }, blockSize, devProp.maxThreadsPerMultiProcessor);
+  }
+
+  SECTION("dynSharedMemPerBlk = sharedMemPerBlock") {
+    // Get potential blocksize
+    HIP_CHECK(hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(&gridSize, &blockSize, f2, devProp.sharedMemPerBlock, 0));
+
+    MaxActiveBlocksPerMultiprocessor([blockSize, devProp](int* numBlocks) {
+      return hipOccupancyMaxActiveBlocksPerMultiprocessor<void(*)(int *)>(numBlocks, f2, blockSize, devProp.sharedMemPerBlock);
+    }, blockSize, devProp.maxThreadsPerMultiProcessor);
+  }
 }
-

--- a/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor_old.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxActiveBlocksPerMultiprocessor_old.cc
@@ -1,0 +1,91 @@
+/*
+Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#include <hip_test_common.hh>
+
+static __global__ void f1(float *a) { *a = 1.0; }
+
+template <typename T>
+static __global__ void f2(T *a) { *a = 1; }
+
+/**
+ * Defines
+ */
+#define OccupancyDisableCachingOverride 0x01
+
+TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_Negative") {
+  hipError_t ret;
+  int numBlock = 0, blockSize = 0;
+  int gridSize = 0, defBlkSize = 32;
+
+  // Get potential blocksize
+  HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, 0, 0));
+
+  // Validate each argument
+  ret = hipOccupancyMaxActiveBlocksPerMultiprocessor(NULL, f1, blockSize, 0);
+  REQUIRE(ret != hipSuccess);
+
+  ret = hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, NULL, blockSize, 0);
+  REQUIRE(ret != hipSuccess);
+
+  ret = hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, f1, 0, 0);
+  REQUIRE(ret != hipSuccess);
+
+  ret = hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, f1, 0,
+                                         std::numeric_limits<std::size_t>::max());
+  REQUIRE(ret != hipSuccess);
+
+  ret = hipOccupancyMaxActiveBlocksPerMultiprocessorWithFlags(&numBlock, f1,
+                                  defBlkSize, 0, OccupancyDisableCachingOverride);
+  REQUIRE(ret == hipSuccess);
+}
+
+TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_rangeValidation") {
+  hipDeviceProp_t devProp;
+  int numBlock = 0, blockSize = 0;
+  int gridSize = 0;
+
+  // Get potential blocksize
+  HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, 0, 0));
+
+  HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
+
+  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, f1, blockSize, 0));
+
+  // Check if numBlocks and blockSize are within limits
+  REQUIRE(numBlock > 0);
+  REQUIRE((numBlock * blockSize) <= devProp.maxThreadsPerMultiProcessor);
+
+  // Validate numBlock after passing dynSharedMemPerBlk
+  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor(&numBlock, f1, blockSize,
+                                                           devProp.sharedMemPerBlock));
+
+  // Check if numBlocks and blockSize are within limits
+  REQUIRE(numBlock > 0);
+  REQUIRE((numBlock * blockSize) <= devProp.maxThreadsPerMultiProcessor);
+}
+
+TEST_CASE("Unit_hipOccupancyMaxActiveBlocksPerMultiprocessor_templateInvocation") {
+  int blockSize = 32;
+  int numBlock = 0;
+
+  HIP_CHECK(hipOccupancyMaxActiveBlocksPerMultiprocessor<void(*)(int *)>
+                                                  (&numBlock, f2, blockSize, 0));
+  REQUIRE(numBlock > 0);
+}
+

--- a/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
@@ -24,9 +24,6 @@ template <typename T>
 static __global__ void f2(T *a) { *a = 1; }
 
 TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters") {
-  int blockSize = 0;
-  int gridSize = 0;
-
   // Common negative tests
   MaxPotentialBlockSizeNegative([](int* gridSize, int* blockSize) {
     return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, f1, 0, 0);
@@ -34,6 +31,8 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters") {
 
 #ifndef __HIP_PLATFORM_NVIDIA__
   SECTION("Kernel function is NULL") {
+    int blockSize = 0;
+    int gridSize = 0;
     // nvcc doesnt support kernelfunc(NULL) for api
     HIP_CHECK_ERROR(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, NULL, 0, 0), hipErrorInvalidValue);
   }
@@ -46,15 +45,19 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation") {
   HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
 
   SECTION("dynSharedMemPerBlk = 0, blockSizeLimit = 0") {
-    MaxPotentialBlockSize([](int* gridSize, int* blockSize) {
-      return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, f1, 0, 0);
-    }, devProp.maxThreadsPerBlock);
+    MaxPotentialBlockSize(
+      [](int* gridSize, int* blockSize) {
+        return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, f1, 0, 0);
+      },
+      devProp.maxThreadsPerBlock);
   }
 
   SECTION("dynSharedMemPerBlk = sharedMemPerBlock, blockSizeLimit = maxThreadsPerBlock") {
-    MaxPotentialBlockSize([devProp](int* gridSize, int* blockSize) {
-      return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, f1, devProp.sharedMemPerBlock, devProp.maxThreadsPerBlock);
-    }, devProp.maxThreadsPerBlock);
+    MaxPotentialBlockSize(
+      [devProp](int* gridSize, int* blockSize) {
+        return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, f1, devProp.sharedMemPerBlock, devProp.maxThreadsPerBlock);
+      },
+      devProp.maxThreadsPerBlock);
   }
 }
 
@@ -64,14 +67,18 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Positive_TemplateInvocation") 
   HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
 
   SECTION("dynSharedMemPerBlk = 0, blockSizeLimit = 0") {
-    MaxPotentialBlockSize([](int* gridSize, int* blockSize) {
-      return hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(gridSize, blockSize, f2, 0, 0);
-    }, devProp.maxThreadsPerBlock);
+    MaxPotentialBlockSize(
+      [](int* gridSize, int* blockSize) {
+        return hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(gridSize, blockSize, f2, 0, 0);
+      },
+      devProp.maxThreadsPerBlock);
   }
 
   SECTION("dynSharedMemPerBlk = sharedMemPerBlock, blockSizeLimit = maxThreadsPerBlock") {
-    MaxPotentialBlockSize([devProp](int* gridSize, int* blockSize) {
-      return hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(gridSize, blockSize, f2, devProp.sharedMemPerBlock, devProp.maxThreadsPerBlock);
-    }, devProp.maxThreadsPerBlock);
+    MaxPotentialBlockSize(
+      [devProp](int* gridSize, int* blockSize) {
+        return hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(gridSize, blockSize, f2, devProp.sharedMemPerBlock, devProp.maxThreadsPerBlock);
+      },
+      devProp.maxThreadsPerBlock);
   }
 }

--- a/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
@@ -18,16 +18,18 @@ THE SOFTWARE.
 */
 /*
 Testcase Scenarios :
-Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation - Test correct execution of hipOccupancyMaxPotentialBlockSize for diffrent parameter values
-Unit_hipOccupancyMaxPotentialBlockSize_Positive_TemplateInvocation - Test correct execution of hipOccupancyMaxPotentialBlockSize template for diffrent parameter values
-Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters - Test unsuccessful execution of hipOccupancyMaxPotentialBlockSize api when parameters are invalid
+Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation - Test correct execution of
+hipOccupancyMaxPotentialBlockSize for diffrent parameter values
+Unit_hipOccupancyMaxPotentialBlockSize_Positive_TemplateInvocation - Test correct execution of
+hipOccupancyMaxPotentialBlockSize template for diffrent parameter values
+Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters - Test unsuccessful execution of
+hipOccupancyMaxPotentialBlockSize api when parameters are invalid
 */
 #include "occupancy_common.hh"
 
-static __global__ void f1(float *a) { *a = 1.0; }
+static __global__ void f1(float* a) { *a = 1.0; }
 
-template <typename T>
-static __global__ void f2(T *a) { *a = 1; }
+template <typename T> static __global__ void f2(T* a) { *a = 1; }
 
 TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters") {
   // Common negative tests
@@ -40,7 +42,8 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters") {
     int blockSize = 0;
     int gridSize = 0;
     // nvcc doesnt support kernelfunc(NULL) for api
-    HIP_CHECK_ERROR(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, NULL, 0, 0), hipErrorInvalidValue);
+    HIP_CHECK_ERROR(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, NULL, 0, 0),
+                    hipErrorInvalidValue);
   }
 #endif
 }
@@ -52,18 +55,19 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation") {
 
   SECTION("dynSharedMemPerBlk = 0, blockSizeLimit = 0") {
     MaxPotentialBlockSize(
-      [](int* gridSize, int* blockSize) {
-        return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, f1, 0, 0);
-      },
-      devProp.maxThreadsPerBlock);
+        [](int* gridSize, int* blockSize) {
+          return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, f1, 0, 0);
+        },
+        devProp.maxThreadsPerBlock);
   }
 
   SECTION("dynSharedMemPerBlk = sharedMemPerBlock, blockSizeLimit = maxThreadsPerBlock") {
     MaxPotentialBlockSize(
-      [devProp](int* gridSize, int* blockSize) {
-        return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, f1, devProp.sharedMemPerBlock, devProp.maxThreadsPerBlock);
-      },
-      devProp.maxThreadsPerBlock);
+        [devProp](int* gridSize, int* blockSize) {
+          return hipOccupancyMaxPotentialBlockSize(
+              gridSize, blockSize, f1, devProp.sharedMemPerBlock, devProp.maxThreadsPerBlock);
+        },
+        devProp.maxThreadsPerBlock);
   }
 }
 
@@ -74,17 +78,18 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Positive_TemplateInvocation") 
 
   SECTION("dynSharedMemPerBlk = 0, blockSizeLimit = 0") {
     MaxPotentialBlockSize(
-      [](int* gridSize, int* blockSize) {
-        return hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(gridSize, blockSize, f2, 0, 0);
-      },
-      devProp.maxThreadsPerBlock);
+        [](int* gridSize, int* blockSize) {
+          return hipOccupancyMaxPotentialBlockSize<void (*)(int*)>(gridSize, blockSize, f2, 0, 0);
+        },
+        devProp.maxThreadsPerBlock);
   }
 
   SECTION("dynSharedMemPerBlk = sharedMemPerBlock, blockSizeLimit = maxThreadsPerBlock") {
     MaxPotentialBlockSize(
-      [devProp](int* gridSize, int* blockSize) {
-        return hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(gridSize, blockSize, f2, devProp.sharedMemPerBlock, devProp.maxThreadsPerBlock);
-      },
-      devProp.maxThreadsPerBlock);
+        [devProp](int* gridSize, int* blockSize) {
+          return hipOccupancyMaxPotentialBlockSize<void (*)(int*)>(
+              gridSize, blockSize, f2, devProp.sharedMemPerBlock, devProp.maxThreadsPerBlock);
+        },
+        devProp.maxThreadsPerBlock);
   }
 }

--- a/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
@@ -16,6 +16,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
+/*
+Testcase Scenarios :
+Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation - Test correct execution of hipOccupancyMaxPotentialBlockSize for diffrent parameter values
+Unit_hipOccupancyMaxPotentialBlockSize_Positive_TemplateInvocation - Test correct execution of hipOccupancyMaxPotentialBlockSize template for diffrent parameter values
+Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters - Test unsuccessful execution of hipOccupancyMaxPotentialBlockSize api when parameters are invalid
+*/
 #include "occupancy_common.hh"
 
 static __global__ void f1(float *a) { *a = 1.0; }

--- a/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
@@ -23,7 +23,7 @@ static __global__ void f1(float *a) { *a = 1.0; }
 template <typename T>
 static __global__ void f2(T *a) { *a = 1; }
 
-TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Negative") {
+TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Negative_Parameters") {
   int blockSize = 0;
   int gridSize = 0;
 
@@ -40,7 +40,7 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Negative") {
 #endif
 }
 
-TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_rangeValidation") {
+TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Positive_RangeValidation") {
   hipDeviceProp_t devProp;
 
   HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
@@ -58,7 +58,7 @@ TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_rangeValidation") {
   }
 }
 
-TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_templateInvocation") {
+TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Positive_TemplateInvocation") {
   hipDeviceProp_t devProp;
 
   HIP_CHECK(hipGetDeviceProperties(&devProp, 0));

--- a/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize.cc
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
@@ -16,7 +16,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
-#include <hip_test_common.hh>
+#include "occupancy_common.hh"
 
 static __global__ void f1(float *a) { *a = 1.0; }
 
@@ -24,57 +24,54 @@ template <typename T>
 static __global__ void f2(T *a) { *a = 1; }
 
 TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Negative") {
-  hipError_t ret;
   int blockSize = 0;
   int gridSize = 0;
 
-  // Validate each argument
-  ret = hipOccupancyMaxPotentialBlockSize(NULL, &blockSize, f1, 0, 0);
-  REQUIRE(ret != hipSuccess);
-
-  ret = hipOccupancyMaxPotentialBlockSize(&gridSize, NULL, f1, 0, 0);
-  REQUIRE(ret != hipSuccess);
+  // Common negative tests
+  MaxPotentialBlockSizeNegative([](int* gridSize, int* blockSize) {
+    return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, f1, 0, 0);
+  });
 
 #ifndef __HIP_PLATFORM_NVIDIA__
-  // nvcc doesnt support kernelfunc(NULL) for api
-  ret = hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, NULL, 0, 0);
-  REQUIRE(ret != hipSuccess);
+  SECTION("Kernel function is NULL") {
+    // nvcc doesnt support kernelfunc(NULL) for api
+    HIP_CHECK_ERROR(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, NULL, 0, 0), hipErrorInvalidValue);
+  }
 #endif
 }
 
 TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_rangeValidation") {
   hipDeviceProp_t devProp;
-  int blockSize = 0;
-  int gridSize = 0;
-
-  // Get potential blocksize
-  HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, 0, 0));
 
   HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
 
-  // Check if blockSize doen't exceed maxThreadsPerBlock
-  REQUIRE(gridSize > 0); REQUIRE(blockSize > 0);
-  REQUIRE(blockSize <= devProp.maxThreadsPerBlock);
+  SECTION("dynSharedMemPerBlk = 0, blockSizeLimit = 0") {
+    MaxPotentialBlockSize([](int* gridSize, int* blockSize) {
+      return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, f1, 0, 0);
+    }, devProp.maxThreadsPerBlock);
+  }
 
-  // Pass dynSharedMemPerBlk, blockSizeLimit and check out param
-  blockSize = 0;
-  gridSize = 0;
-
-  HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1,
-           devProp.sharedMemPerBlock, devProp.maxThreadsPerBlock));
-
-  // Check if blockSize doen't exceed maxThreadsPerBlock
-  REQUIRE(gridSize > 0); REQUIRE(blockSize > 0);
-  REQUIRE(blockSize <= devProp.maxThreadsPerBlock);
-
+  SECTION("dynSharedMemPerBlk = sharedMemPerBlock, blockSizeLimit = maxThreadsPerBlock") {
+    MaxPotentialBlockSize([devProp](int* gridSize, int* blockSize) {
+      return hipOccupancyMaxPotentialBlockSize(gridSize, blockSize, f1, devProp.sharedMemPerBlock, devProp.maxThreadsPerBlock);
+    }, devProp.maxThreadsPerBlock);
+  }
 }
 
 TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_templateInvocation") {
-  int gridSize = 0, blockSize = 0;
+  hipDeviceProp_t devProp;
 
-  HIP_CHECK(hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(&gridSize,
-                       &blockSize, f2, 0, 0));
-  REQUIRE(gridSize > 0);
-  REQUIRE(blockSize > 0);
+  HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
+
+  SECTION("dynSharedMemPerBlk = 0, blockSizeLimit = 0") {
+    MaxPotentialBlockSize([](int* gridSize, int* blockSize) {
+      return hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(gridSize, blockSize, f2, 0, 0);
+    }, devProp.maxThreadsPerBlock);
+  }
+
+  SECTION("dynSharedMemPerBlk = sharedMemPerBlock, blockSizeLimit = maxThreadsPerBlock") {
+    MaxPotentialBlockSize([devProp](int* gridSize, int* blockSize) {
+      return hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(gridSize, blockSize, f2, devProp.sharedMemPerBlock, devProp.maxThreadsPerBlock);
+    }, devProp.maxThreadsPerBlock);
+  }
 }
-

--- a/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize_old.cc
+++ b/tests/catch/unit/occupancy/hipOccupancyMaxPotentialBlockSize_old.cc
@@ -1,0 +1,80 @@
+/*
+Copyright (c) 2021 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#include <hip_test_common.hh>
+
+static __global__ void f1(float *a) { *a = 1.0; }
+
+template <typename T>
+static __global__ void f2(T *a) { *a = 1; }
+
+TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_Negative") {
+  hipError_t ret;
+  int blockSize = 0;
+  int gridSize = 0;
+
+  // Validate each argument
+  ret = hipOccupancyMaxPotentialBlockSize(NULL, &blockSize, f1, 0, 0);
+  REQUIRE(ret != hipSuccess);
+
+  ret = hipOccupancyMaxPotentialBlockSize(&gridSize, NULL, f1, 0, 0);
+  REQUIRE(ret != hipSuccess);
+
+#ifndef __HIP_PLATFORM_NVIDIA__
+  // nvcc doesnt support kernelfunc(NULL) for api
+  ret = hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, NULL, 0, 0);
+  REQUIRE(ret != hipSuccess);
+#endif
+}
+
+TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_rangeValidation") {
+  hipDeviceProp_t devProp;
+  int blockSize = 0;
+  int gridSize = 0;
+
+  // Get potential blocksize
+  HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1, 0, 0));
+
+  HIP_CHECK(hipGetDeviceProperties(&devProp, 0));
+
+  // Check if blockSize doen't exceed maxThreadsPerBlock
+  REQUIRE(gridSize > 0); REQUIRE(blockSize > 0);
+  REQUIRE(blockSize <= devProp.maxThreadsPerBlock);
+
+  // Pass dynSharedMemPerBlk, blockSizeLimit and check out param
+  blockSize = 0;
+  gridSize = 0;
+
+  HIP_CHECK(hipOccupancyMaxPotentialBlockSize(&gridSize, &blockSize, f1,
+           devProp.sharedMemPerBlock, devProp.maxThreadsPerBlock));
+
+  // Check if blockSize doen't exceed maxThreadsPerBlock
+  REQUIRE(gridSize > 0); REQUIRE(blockSize > 0);
+  REQUIRE(blockSize <= devProp.maxThreadsPerBlock);
+
+}
+
+TEST_CASE("Unit_hipOccupancyMaxPotentialBlockSize_templateInvocation") {
+  int gridSize = 0, blockSize = 0;
+
+  HIP_CHECK(hipOccupancyMaxPotentialBlockSize<void(*)(int *)>(&gridSize,
+                       &blockSize, f2, 0, 0));
+  REQUIRE(gridSize > 0);
+  REQUIRE(blockSize > 0);
+}
+

--- a/tests/catch/unit/occupancy/occupancy_common.hh
+++ b/tests/catch/unit/occupancy/occupancy_common.hh
@@ -1,0 +1,74 @@
+/*
+Copyright (c) 2022 Advanced Micro Devices, Inc. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#pragma once
+
+#include <hip_test_common.hh>
+
+template <typename F>
+void MaxPotentialBlockSize(F func, int maxThreadsPerBlock) {
+  int gridSize = 0;
+  int blockSize = 0;
+
+  // Get potential blocksize
+  HIP_CHECK(func(&gridSize, &blockSize));
+
+  // Check if blockSize doesn't exceed maxThreadsPerBlock
+  REQUIRE(gridSize > 0); REQUIRE(blockSize > 0);
+  REQUIRE(blockSize <= maxThreadsPerBlock);
+  REQUIRE(gridSize * blockSize <  static_cast<int64_t>(std::pow(2, 32)));
+}
+
+template <typename F>
+void MaxPotentialBlockSizeNegative(F func) {
+  int blockSize = 0;
+  int gridSize = 0;
+
+  // Validate common arguments
+  SECTION("gridSize is nullptr") {
+    HIP_CHECK_ERROR(func(nullptr, &blockSize, 0, 0), hipErrorInvalidValue);
+  }
+  SECTION("blockSize is nullptr") {
+    HIP_CHECK_ERROR(func(&gridSize, nullptr, 0, 0), hipErrorInvalidValue);
+  }
+}
+
+template <typename F>
+void MaxActiveBlocksPerMultiprocessor(F func, int blockSize, int maxThreadsPerMultiProcessor) {
+  int numBlocks = 0;
+
+  // Validate maximum active block pre multiprocessor
+  HIP_CHECK(func(&numBlocks));
+
+  // Check if numBlocks and blockSize are within limits
+  REQUIRE(numBlocks > 0);
+  REQUIRE((numBlocks * blockSize) <= maxThreadsPerMultiProcessor);
+}
+
+template <typename F>
+void MaxActiveBlocksPerMultiprocessorNegative(F func, int blockSize) {
+  int numBlocks = 0;
+
+  // Validate common arguments
+  SECTION("numBlocks is nullptr") {
+    HIP_CHECK_ERROR(func(nullptr, blockSize, 0), hipErrorInvalidValue);
+  }
+  SECTION("Block size is 0") {
+    HIP_CHECK_ERROR(func(&numBlocks, 0, 0), hipErrorInvalidValue);
+  }
+}

--- a/tests/catch/unit/occupancy/occupancy_common.hh
+++ b/tests/catch/unit/occupancy/occupancy_common.hh
@@ -41,10 +41,10 @@ void MaxPotentialBlockSizeNegative(F func) {
 
   // Validate common arguments
   SECTION("gridSize is nullptr") {
-    HIP_CHECK_ERROR(func(nullptr, &blockSize, 0, 0), hipErrorInvalidValue);
+    HIP_CHECK_ERROR(func(nullptr, &blockSize), hipErrorInvalidValue);
   }
   SECTION("blockSize is nullptr") {
-    HIP_CHECK_ERROR(func(&gridSize, nullptr, 0, 0), hipErrorInvalidValue);
+    HIP_CHECK_ERROR(func(&gridSize, nullptr), hipErrorInvalidValue);
   }
 }
 


### PR DESCRIPTION
- Add helper file occupancy_common.hh with parameterized templates
- Expand all positive and negative tests to use the templates