### PR TITLE
Hipconfig fixes on windows

### DIFF
--- a/bin/hipcc.pl
+++ b/bin/hipcc.pl
@@ -160,6 +160,9 @@ if ($HIP_PLATFORM eq "amd") {
 
         # escape possible spaces in path name
         $HIPCC =~ s/\s/\\$&/g;
+        
+        # put hipcc path in quotes on windows
+        $HIPCC = "\"$HIPCC\""
     }
 
     # get Clang RT Builtin path 
@@ -196,6 +199,12 @@ if ($HIP_PLATFORM eq "amd") {
     }
 
     $HIPCC="$CUDA_PATH/bin/nvcc";
+    
+    if($isWindows) {
+        # put hipcc path in quotes on windows
+        $HIPCC = "\"$HIPCC\""
+    }
+
     $HIPCXXFLAGS .= " -Wno-deprecated-gpu-targets ";
     $HIPCXXFLAGS .= " -isystem $CUDA_PATH/include";
     $HIPCFLAGS .= " -isystem $CUDA_PATH/include";

--- a/bin/hipcc.pl
+++ b/bin/hipcc.pl
@@ -157,9 +157,6 @@ if ($HIP_PLATFORM eq "amd") {
     if($isWindows) {
         $HIPLDFLAGS .= " -fuse-ld=lld";
         $HIPLDFLAGS .= " --ld-path=$HIP_CLANG_PATH/lld-link.exe";
-
-        # escape possible spaces in path name
-        $HIPCC =~ s/\s/\\$&/g;
         
         # put hipcc path in quotes on windows
         $HIPCC = "\"$HIPCC\""

--- a/bin/hipconfig.pl
+++ b/bin/hipconfig.pl
@@ -188,8 +188,9 @@ if (!$printed or $p_full) {
     if ($HIP_PLATFORM eq "nvidia")  {
         print "\n" ;
         print "== nvcc\n";
+        $NVCC = $isWindows ? "\"$CUDA_PATH/bin/nvcc\"" : "$CUDA_PATH/bin/nvcc";
         print "CUDA_PATH   : ", $CUDA_PATH, "\n";
-        system("$CUDA_PATH/bin/nvcc --version");
+        system("$NVCC --version");
 
     }
     print "\n" ;
@@ -197,7 +198,7 @@ if (!$printed or $p_full) {
     print "=== Environment Variables\n";
     if ($isWindows) {
         print ("PATH=$ENV{PATH}\n");
-        system("set | findstr //B //C:\"HIP\" //C:\"CUDA\" //C:\"LD_LIBRARY_PATH\"");
+        system("set | findstr //B //C:\"HIP\" //C:\"CUDA\" //C:\"LD_LIBRARY_PATH\" 2> null");
     } else {
         system("echo PATH=\$PATH");
         system("env | egrep '^HIP|^CUDA|^LD_LIBRARY_PATH'");
@@ -208,7 +209,7 @@ if (!$printed or $p_full) {
     if ($isWindows) {
         print "== Windows Display Drivers\n";
         print "Hostname     : "; system ("hostname");
-        system ("wmic path win32_VideoController get AdapterCompatibility,InstalledDisplayDrivers,Name | findstr //B //C:\"Advanced Micro Devices\"");
+        system ("wmic path win32_VideoController get AdapterCompatibility,InstalledDisplayDrivers,Name | findstr //B //C:\"Advanced Micro Devices\" //C:\"NVIDIA\" 2> null");
     } else {
         print "== Linux Kernel\n";
         print "Hostname     : "; system ("hostname");


### PR DESCRIPTION
Fixed some calls to executables not being wrapped in quotes in hipcc.pl and hipconfig.pl.
Added Nvidia to Windows Display Drivers listing in hipconfig.pl.
Piped findstr errors to null in findstr calls on windows to remove `FINDSTR: // ignored` messages.

Changes the output from:
```
D:\AMD\Tools\HIP\bin>hipconfig
HIP version  : 5.4.22970-cf12a8e4

== hipconfig
HIP_PATH     : C:\Program Files\AMD\ROCm\5.3\
ROCM_PATH    : /opt/rocm
HIP_COMPILER : clang
HIP_PLATFORM : nvidia
HIP_RUNTIME  : rocclr
CPP_CONFIG   :  -D__HIP_PLATFORM_NVCC__= -D__HIP_PLATFORM_NVIDIA__= -IC:\Program Files\AMD\ROCm\5.3\/include -IC:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8/include

== nvcc
CUDA_PATH   : C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8
'C:\Program' is not recognized as an internal or external command,
operable program or batch file.

=== Environment Variables
PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\libnvvp;;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\Git\cmd;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\ProgramData\chocolatey\bin;C:\Program Files\LLVM\bin;C:\Tools;C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\bin\Hostx64\x64;;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Program Files\NVIDIA Corporation\Nsight Compute 2022.3.0\;C:\Program Files\CMake\bin;C:\Users\Nara\AppData\Local\Microsoft\WindowsApps;;C:\Users\Nara\AppData\Local\Programs\Microsoft VS Code\bin;C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin;
FINDSTR: // ignored
FINDSTR: // ignored
FINDSTR: // ignored
FINDSTR: // ignored
CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8
CUDA_PATH_V11_8=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8
CUDA_PATH_V12_0=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0
HIPCONFIG="D:\AMD\Tools\HIP\bin\hipconfig"
HIP_PATH=C:\Program Files\AMD\ROCm\5.3\
HIP_PATH_53=C:\Program Files\AMD\ROCm\5.3\
HIP_PLATFORM=nvidia

== Windows Display Drivers
Hostname     : DESKTOP-98I6EF1
FINDSTR: // ignored
FINDSTR: // ignored
```

To the fixed version:
```
D:\AMD\Tools\HIP\bin>hipconfig
HIP version  : 5.4.22970-cf12a8e4

== hipconfig
HIP_PATH     : C:\Program Files\AMD\ROCm\5.3\
ROCM_PATH    : /opt/rocm
HIP_COMPILER : clang
HIP_PLATFORM : nvidia
HIP_RUNTIME  : rocclr
CPP_CONFIG   :  -D__HIP_PLATFORM_NVCC__= -D__HIP_PLATFORM_NVIDIA__= -IC:\Program Files\AMD\ROCm\5.3\/include -IC:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8/include

== nvcc
CUDA_PATH   : C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8
nvcc: NVIDIA (R) Cuda compiler driver
Copyright (c) 2005-2022 NVIDIA Corporation
Built on Wed_Sep_21_10:41:10_Pacific_Daylight_Time_2022
Cuda compilation tools, release 11.8, V11.8.89
Build cuda_11.8.r11.8/compiler.31833905_0

=== Environment Variables
PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8\libnvvp;;C:\WINDOWS\system32;C:\WINDOWS;C:\WINDOWS\System32\Wbem;C:\WINDOWS\System32\WindowsPowerShell\v1.0\;C:\WINDOWS\System32\OpenSSH\;C:\Program Files\Git\cmd;C:\Program Files (x86)\NVIDIA Corporation\PhysX\Common;C:\ProgramData\chocolatey\bin;C:\Program Files\LLVM\bin;C:\Tools;C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Tools\MSVC\14.29.30133\bin\Hostx64\x64;;C:\Strawberry\c\bin;C:\Strawberry\perl\site\bin;C:\Strawberry\perl\bin;C:\Program Files\NVIDIA Corporation\Nsight Compute 2022.3.0\;C:\Program Files\CMake\bin;C:\Users\Nara\AppData\Local\Microsoft\WindowsApps;;C:\Users\Nara\AppData\Local\Programs\Microsoft VS Code\bin;C:\ProgramData\chocolatey\lib\mingw\tools\install\mingw64\bin;
CUDA_PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8
CUDA_PATH_V11_8=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v11.8
CUDA_PATH_V12_0=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.0
HIPCONFIG="D:\AMD\Tools\HIP\bin\hipconfig"
HIP_PATH=C:\Program Files\AMD\ROCm\5.3\
HIP_PATH_53=C:\Program Files\AMD\ROCm\5.3\
HIP_PLATFORM=nvidia

== Windows Display Drivers
Hostname     : DESKTOP-98I6EF1
NVIDIA                C:\WINDOWS\System32\DriverStore\FileRepository\nvmiui.inf_amd64_53ed5af51a55f0c4\nvldumdx.dll,C:\WINDOWS\System32\DriverStore\FileRepository\nvmiui.inf_amd64_53ed5af51a55f0c4\nvldumdx.dll,C:\WINDOWS\System32\DriverStore\FileRepository\nvmiui.inf_amd64_53ed5af51a55f0c4\nvldumdx.dll,C:\WINDOWS\System32\DriverStore\FileRepository\nvmiui.inf_amd64_53ed5af51a55f0c4\nvldumdx.dll                    NVIDIA GeForce GTX 1060
```