### PR TITLE
SWDEV-389829 - Fix hipModule_--tests_0x2 failure on MI100

### DIFF
--- a/tests/src/runtimeApi/module/hipModule.cpp
+++ b/tests/src/runtimeApi/module/hipModule.cpp
@@ -130,6 +130,12 @@ bool testMultiTargArchCodeObj() {
   char command[COMMAND_LEN];
   hipDeviceProp_t props;
   hipGetDeviceProperties(&props, 0);
+  // Extract the base GPU arch name excluding any feature
+  std::string arch = std::string(props.gcnArchName);
+  auto pos = arch.find(":");
+  if (pos != std::string::npos)
+    arch = arch.substr(0, pos);
+
   // Hardcoding the codeobject lines in multiple string to avoid cpplint warning
   std::string CodeObjL1 = "#include \"hip/hip_runtime.h\"\n";
   std::string CodeObjL2 =
@@ -162,7 +168,7 @@ bool testMultiTargArchCodeObj() {
   const char* input_codeobj = "/tmp/vcpy_kernel.cpp";
   snprintf(command, COMMAND_LEN,
   "unset HIP_PATH;%s --genco %s=gfx801,gfx802,gfx803,gfx900,gfx908,%s %s -o %s",
-  hipcc_path, genco_option, props.gcnArchName, input_codeobj,
+  hipcc_path, genco_option, arch.c_str(), input_codeobj,
   CODE_OBJ_MULTIARCH);
 
   printf("command = %s\n", command);


### PR DESCRIPTION
- gfx908 and gfx908:sramecc+:xnack- together cannot be passed as --offload-arch to hipcc
- Strip features from gcnArchName before passing to hipcc