### PR TITLE
Fix use of HIP_CLANG_INSTALL_DIR

### DIFF
--- a/cmake/FindHIP.cmake
+++ b/cmake/FindHIP.cmake
@@ -266,7 +266,7 @@ elseif("${HIP_COMPILER}" STREQUAL "clang")
     if("x${HIP_CLANG_PATH}" STREQUAL "x")
       # IF HIP_CLANG_INSTALL_DIR is Found
       if( HIP_CLANG_INSTALL_DIR )
-        set(HIP_CLANG_PATH ${HIP_CLANG_INSTALL_DIR})
+        set(HIP_CLANG_PATH ${HIP_CLANG_INSTALL_DIR}/bin)
       else() # IF HIP_CLANG_INSTALL_DIR is not found
         if(DEFINED ENV{HIP_CLANG_PATH})
             set(HIP_CLANG_PATH $ENV{HIP_CLANG_PATH})


### PR DESCRIPTION
The HIP_CLANG_PATH needs a /bin