### PR TITLE
SWDEV-356700 - HIP porting improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Key features include:
 * HIP is very thin and has little or no performance impact over coding directly in CUDA mode.
 * HIP allows coding in a single-source C++ programming language including features such as templates, C++11 lambdas, classes, namespaces, and more.
 * HIP allows developers to use the "best" development environment and tools on each target platform.
-* The [HIPIFY](https://github.com/ROCm-Developer-Tools/HIPIFY/blob/master/README.md) tools automatically convert source from CUDA to HIP.
+* The [HIPIFY](https://github.com/ROCm-Developer-Tools/HIPIFY/blob/amd-staging/README.md) tools automatically convert source from CUDA to HIP.
 * Developers can specialize for the platform (CUDA or AMD) to tune for performance or handle tricky cases.
 
 New projects can be developed directly in the portable HIP C++ language and can run on either NVIDIA or AMD platforms.  Additionally, HIP provides porting tools which make it easy to port existing CUDA codes to the HIP layer, with no loss of performance as compared to the original CUDA application.  HIP is not intended to be a drop-in replacement for CUDA, and developers should expect to do some manual coding and performance tuning work to complete the port.

--- a/docs/.sphinx/_toc.yml.in
+++ b/docs/.sphinx/_toc.yml.in
@@ -5,7 +5,7 @@ subtrees:
     - file: user_guide/programming_manual
     - file: user_guide/hip_rtc
     - file: user_guide/faq
-    - file: user_guide/hip_porting_guide    
+    - file: user_guide/hip_porting_guide
     - file: user_guide/hip_porting_driver_api
 - caption: How to Guides
   entries:

--- a/docs/developer_guide/build.md
+++ b/docs/developer_guide/build.md
@@ -6,13 +6,14 @@ HIP code can be developed either on AMD ROCm platform using HIP-Clang compiler, 
 Before build and run HIP, make sure drivers and pre-build packages are installed properly on the platform.
 
 ### AMD platform
-Install ROCm packages (see ROCm Installation Guide on AMD public documentation site (https://docs.amd.com/)) or install pre-built binary packages using the package manager,
+Install ROCm packages (see ROCm Installation Guide on AMD public documentation site (https://docs.amd.com/) or install pre-built binary packages using the package manager,
 
 ```shell
 sudo apt install mesa-common-dev
 sudo apt install clang
 sudo apt install comgr
 sudo apt-get -y install rocm-dkms
+sudo apt-get install -y libelf-dev
 ```
 
 ### NVIDIA platform
@@ -22,14 +23,14 @@ Install Nvidia driver and pre-build packages (see HIP Installation Guide at http
 ### Branch of repository
 
 Before get HIP source code, set the expected branch of repository at the variable `ROCM_BRANCH`.
-For example, for ROCm5.0 release branch, set
+For example, for ROCm5.6 release branch, set
 ```shell
-export ROCM_BRANCH=rocm-5.0.x
+export ROCM_BRANCH=rocm-5.6.x
 ```
 
-ROCm5.4 release branch, set
+ROCm5.6 release branch, set
 ```shell
-export ROCM_BRANCH=rocm-5.4.x
+export ROCM_BRANCH=rocm-5.6.x
 ```
 Similiar format for future branches.
 
@@ -42,38 +43,47 @@ Similiar format for future branches.
 ### Get HIP source code
 
 ```shell
-git clone -b "$ROCM_BRANCH" https://github.com/ROCm-Developer-Tools/hipamd.git
+git clone -b "$ROCM_BRANCH" https://github.com/ROCm-Developer-Tools/clr.git
 git clone -b "$ROCM_BRANCH" https://github.com/ROCm-Developer-Tools/hip.git
-git clone -b "$ROCM_BRANCH" https://github.com/ROCm-Developer-Tools/ROCclr.git
-git clone -b "$ROCM_BRANCH" https://github.com/RadeonOpenCompute/ROCm-OpenCL-Runtime.git
+git clone -b "$ROCM_BRANCH" https://github.com/ROCm-Developer-Tools/HIPCC.git
 ```
 
 ### Set the environment variables
 
 ```shell
-export HIPAMD_DIR="$(readlink -f hipamd)"
+export CLR_DIR="$(readlink -f clr)"
 export HIP_DIR="$(readlink -f hip)"
+export HIPCC_DIR="$(readlink -f hipcc)"
 ```
 
-ROCclr is defined on AMD platform that HIP use Radeon Open Compute Common Language Runtime (ROCclr), which is a virtual device interface that HIP runtimes interact with different backends.
-See https://github.com/ROCm-Developer-Tools/ROCclr
+Note, starting from ROCM 5.6 release, clr is a new repository including the previous ROCclr, HIPAMD and OpenCl repositories.
+ROCclr is defined on AMD platform that HIP uses Radeon Open Compute Common Language Runtime (ROCclr), which is a virtual device interface that HIP runtimes interact with different backends.
+HIPAMD provides implementation specifically for AMD platform.
+OpenCL provides headers that ROCclr runtime currently depends on.
 
-HIPAMD repository provides implementation specifically for AMD platform.
-See https://github.com/ROCm-Developer-Tools/hipamd
+### Build the HIPCC runtime
+
+```shell
+cd "$HIPCC_DIR"
+mkdir -p build; cd build
+cmake ..
+make -j4
+```
 
 ### Build HIP
 
 ```shell
-cd "$HIPAMD_DIR"
+cd "$CLR_DIR"
 mkdir -p build; cd build
-cmake -DHIP_COMMON_DIR=$HIP_DIR -DCMAKE_PREFIX_PATH="<ROCM_PATH>/" -DCMAKE_INSTALL_PREFIX=$PWD/install ..
+cmake -DHIP_COMMON_DIR=$HIP_DIR -DHIP_PLATFORM=amd -DCMAKE_PREFIX_PATH="/opt/rocm/" -DCMAKE_INSTALL_PREFIX=$PWD/install -DHIPCC_BIN_DIR=$HIPCC_DIR/build -DHIP_CATCH_TEST=0 -DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=OFF ..
+
 make -j$(nproc)
 sudo make install
 ```
-::::{note}
-If you don't specify `CMAKE_INSTALL_PREFIX`, hip runtime will be installed to `<ROCM_PATH>/hip`.
-By default, release version of AMDHIP is built.
-::::
+
+Note, if `CMAKE_INSTALL_PREFIX` is not specified, hip runtime will be installed to `<ROCM_PATH>/hip`.
+By default, release version of HIP is built.
+
 
 ### Default paths and environment variables
 
@@ -120,9 +130,9 @@ Developers can build HIP directed tests right after build HIP commands,
 sudo make install
 make -j$(nproc) build_tests
 ```
-By default, all HIP directed tests will be built and generated under the folder `$HIPAMD_DIR/build/`directed_tests.
+By default, all HIP directed tests will be built and generated under the folder `$CLR_DIR/build/hipamd`directed_tests.
 Take HIP directed device APIs tests, as an example, all available test applications will have executable files generated under,
-`$HIPAMD_DIR/build/directed_tests/runtimeApi/device`.
+`$CLR_DIR/build/hipamd/directed_tests/runtimeApi/device`.
 
 Run all HIP directed_tests, use the command,
 
@@ -138,7 +148,7 @@ Build and run a single directed test, use the follow command as an example,
 
 ```shell
 make directed_tests.texture.hipTexObjPitch
-cd $HIPAMD_DIR/build/directed_tests/texcture
+cd $CLR_DIR/build/hipamd/directed_tests/texcture
 ./hipTexObjPitch
 ```
 Please note, the integrated HIP directed tests, will be deprecated in future release.
@@ -156,20 +166,20 @@ git clone -b "$ROCM_BRANCH" https://github.com/ROCm-Developer-Tools/hip-tests.gi
 ##### Build HIP tests from source
 
 ```shell
-export HIP_TESTS_DIR="$(readlink -f hip-tests)"
-cd "$HIP_TESTS_DIR"
+export HIPTESTS_DIR="$(readlink -f hip-tests)"
+cd "$HIPTESTS_DIR"
 mkdir -p build; cd build
-export HIP_PATH=$HIPAMD_DIR/build/install (or any path where HIP is installed, for example, /opt/rocm)
+export HIP_PATH=$CLR_DIR/build/install (or any path where HIP is installed, for example, /opt/rocm)
 cmake ../catch/ -DHIP_PLATFORM=amd
 make -j$(nproc) build_tests
 ctest # run tests
 ```
-HIP catch tests are built under the folder $HIP_TESTS_DIR/build.
+HIP catch tests are built under the folder $HIPTESTS_DIR/build.
 
 To run any single catch test, the following is an example,
 
 ```shell
-cd $HIP_TESTS_DIR/build/catch_tests/unit/texture
+cd $HIPTESTS_DIR/build/catch_tests/unit/texture
 ./TextureTest
 ```
 
@@ -178,8 +188,8 @@ cd $HIP_TESTS_DIR/build/catch_tests/unit/texture
 HIP Catch2 supports build a standalone test, for example,
 
 ```shell
-cd "$HIP_TESTS_DIR"
-hipcc $HIP_TESTS_DIR/catch/unit/memory/hipPointerGetAttributes.cc -I ./catch/include ./catch/hipTestMain/standalone_main.cc -I ./catch/external/Catch2 -o hipPointerGetAttributes
+cd "$HIPTESTS_DIR"
+hipcc $HIPTESTS_DIR/catch/unit/memory/hipPointerGetAttributes.cc -I ./catch/include ./catch/hipTestMain/standalone_main.cc -I ./catch/external/Catch2 -o hipPointerGetAttributes
 ./hipPointerGetAttributes
 ...
 
@@ -193,22 +203,33 @@ All tests passed
 
 ```shell
 git clone -b "$ROCM_BRANCH" https://github.com/ROCm-Developer-Tools/hip.git
-git clone -b "$ROCM_BRANCH" https://github.com/ROCm-Developer-Tools/hipamd.git
+git clone -b "$ROCM_BRANCH" https://github.com/ROCm-Developer-Tools/clr.git
+git clone -b "$ROCM_BRANCH" https://github.com/ROCm-Developer-Tools/HIPCC.git
 ```
 
 ### Set the environment variables
 
 ```shell
 export HIP_DIR="$(readlink -f hip)"
-export HIPAMD_DIR="$(readlink -f hipamd)"
+export CLR_DIR="$(readlink -f hipamd)"
+export HIPCC_DIR="$(readlink -f hipcc)"
+```
+
+### Build the HIPCC runtime
+
+```shell
+cd "$HIPCC_DIR"
+mkdir -p build; cd build
+cmake ..
+make -j4
 ```
 
 ### Build HIP
 
 ```shell
-cd "$HIPAMD_DIR"
+cd "$CLR_DIR"
 mkdir -p build; cd build
-cmake -DHIP_COMMON_DIR=$HIP_DIR -DHIP_PLATFORM=nvidia -DCMAKE_INSTALL_PREFIX=$PWD/install ..
+cmake -DHIP_COMMON_DIR=$HIP_DIR -DHIP_PLATFORM=nvidia -DCMAKE_INSTALL_PREFIX=$PWD/install -DHIPCC_BIN_DIR=$HIPCC_DIR/build -DHIP_CATCH_TEST=0 -DCLR_BUILD_HIP=ON -DCLR_BUILD_OCL=OFF ..
 make -j$(nproc)
 sudo make install
 ```
@@ -218,5 +239,5 @@ Build HIP tests commands on NVIDIA platform are basically the same as AMD, excep
 
 ## Run HIP
 
-Compile and run the [square sample](https://github.com/ROCm-Developer-Tools/HIP/tree/rocm-5.0.x/samples/0_Intro/square).
+Compile and run the [square sample](https://github.com/ROCm-Developer-Tools/hip-tests/tree/rocm-5.5.x/samples/0_Intro/square).
 

--- a/docs/developer_guide/logging.md
+++ b/docs/developer_guide/logging.md
@@ -85,8 +85,7 @@ ClPrint(amd::LOG_INFO, amd::LOG_INIT, "Initializing HSA stack.");
 
 ## HIP Logging Example:
 
-Below is an example to enable HIP logging and get logging information during
-execution of hipinfo,
+Below is an example to enable HIP logging and get logging information during execution of hipinfo on Linux,
 
 ```console
 user@user-test:~/hip/bin$ export AMD_LOG_LEVEL=4
@@ -136,22 +135,7 @@ concurrentKernels:                1
 cooperativeLaunch:                0
 cooperativeMultiDeviceLaunch:     0
 arch.hasGlobalInt32Atomics:       1
-arch.hasGlobalFloatAtomicExch:    1
-arch.hasSharedInt32Atomics:       1
-arch.hasSharedFloatAtomicExch:    1
-arch.hasFloatAtomicAdd:           1
-arch.hasGlobalInt64Atomics:       1
-arch.hasSharedInt64Atomics:       1
-arch.hasDoubles:                  1
-arch.hasWarpVote:                 1
-arch.hasWarpBallot:               1
-arch.hasWarpShuffle:              1
-arch.hasFunnelShift:              0
-arch.hasThreadFenceSystem:        1
-arch.hasSyncThreadsExt:           0
-arch.hasSurfaceFuncs:             0
-arch.has3dGrid:                   1
-arch.hasDynamicParallelism:       0
+...
 gcnArch:                          1012
 isIntegrated:                     0
 maxTexture1D:                     65536
@@ -176,6 +160,54 @@ non-peers:                        device#0
 :3:hip_memory.cpp           :360 : 23647702243: 5617 : [7fad295dd840] hipMemGetInfo: Returned hipSuccess
 memInfo.total:                    7.98 GB
 memInfo.free:                     7.98 GB (100%)
+```
+
+On Windows, AMD_LOG_LEVEL can be set via environment variable from advanced system setting, or from Command prompt run as administrator, as shown below as an example, which shows some debug log information calling backend runtime on Windows.
+```
+C:\hip\bin>set AMD_LOG_LEVEL=4
+C:\hip\bin>hipinfo
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\vdi\device\comgrctx.cpp:33  : 605413686305 us: 29864: [tid:0x9298] Loading COMGR library.
+:4:C:\constructicon\builds\gfx\two\22.40\drivers\compute\vdi\platform\runtime.cpp:83  : 605413869411 us: 29864: [tid:0x9298] init
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\hipamd\src\hip_context.cpp:47  : 605413869502 us: 29864: [tid:0x9298] Direct Dispatch: 0
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\hipamd\src\hip_device_runtime.cpp:543 : 605413870553 us: 29864: [tid:0x9298] hipGetDeviceCount: Returned hipSuccess :
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\hipamd\src\hip_device_runtime.cpp:556 : 605413870631 us: 29864: [tid:0x9298] ←[32m hipSetDevice ( 0 ) ←[0m
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\hipamd\src\hip_device_runtime.cpp:561 : 605413870848 us: 29864: [tid:0x9298] hipSetDevice: Returned hipSuccess :
+--------------------------------------------------------------------------------
+device#                           0
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\hipamd\src\hip_device.cpp:346 : 605413871623 us: 29864: [tid:0x9298] ←[32m hipGetDeviceProperties ( 0000008AEBEFF8C8, 0 ) ←[0m
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\hipamd\src\hip_device.cpp:348 : 605413871695 us: 29864: [tid:0x9298] hipGetDeviceProperties: Returned hipSuccess :
+Name:                             AMD Radeon(TM) Graphics
+pciBusID:                         3
+pciDeviceID:                      0
+pciDomainID:                      0
+multiProcessorCount:              7
+maxThreadsPerMultiProcessor:      2560
+isMultiGpuBoard:                  0
+clockRate:                        1600 Mhz
+memoryClockRate:                  1333 Mhz
+memoryBusWidth:                   0
+totalGlobalMem:                   12.06 GB
+totalConstMem:                    2147483647
+sharedMemPerBlock:                64.00 KB
+...
+gcnArchName:                      gfx90c:xnack-
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\hipamd\src\hip_device_runtime.cpp:541 : 605413924779 us: 29864: [tid:0x9298] ←[32m hipGetDeviceCount ( 0000008AEBEFF8A4 ) ←[0m
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\hipamd\src\hip_device_runtime.cpp:543 : 605413925075 us: 29864: [tid:0x9298] hipGetDeviceCount: Returned hipSuccess :
+peers:                            :3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\hipamd\src\hip_peer.cpp:176 : 605413928643 us: 29864: [tid:0x9298] ←[32m hipDeviceCanAccessPeer ( 0000008AEBEFF890, 0, 0 ) ←[0m
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\hipamd\src\hip_peer.cpp:177 : 605413928743 us: 29864: [tid:0x9298] hipDeviceCanAccessPeer: Returned hipSuccess :
+non-peers:                        :3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\hipamd\src\hip_peer.cpp:176 : 605413930830 us: 29864: [tid:0x9298] ←[32m hipDeviceCanAccessPeer ( 0000008AEBEFF890, 0, 0 ) ←[0m
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\hipamd\src\hip_peer.cpp:177 : 605413930882 us: 29864: [tid:0x9298] hipDeviceCanAccessPeer: Returned hipSuccess :
+device#0
+...
+:4:C:\constructicon\builds\gfx\two\22.40\drivers\compute\vdi\device\pal\palmemory.cpp:430 : 605414517802 us: 29864: [tid:0x9298] Free-:     8000 bytes, VM[ 3007c8000,  3007d0000]
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\vdi\device\devprogram.cpp:2979: 605414517893 us: 29864: [tid:0x9298] For Init/Fini: Kernel Name: __amd_rocclr_copyBufferToImage
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\vdi\device\devprogram.cpp:2979: 605414518259 us: 29864: [tid:0x9298] For Init/Fini: Kernel Name: __amd_rocclr_copyBuffer
+...
+:4:C:\constructicon\builds\gfx\two\22.40\drivers\compute\vdi\device\pal\palmemory.cpp:206 : 605414523422 us: 29864: [tid:0x9298] Alloc: 100000 bytes, ptr[00000003008D0000-00000003009D0000], obj[00000003007D0000-00000003047D0000]
+:4:C:\constructicon\builds\gfx\two\22.40\drivers\compute\vdi\device\pal\palmemory.cpp:206 : 605414523767 us: 29864: [tid:0x9298] Alloc: 100000 bytes, ptr[00000003009D0000-0000000300AD0000], obj[00000003007D0000-00000003047D0000]
+:3:C:\constructicon\builds\gfx\two\22.40\drivers\compute\hipamd\src\hip_memory.cpp:681 : 605414524092 us: 29864: [tid:0x9298] hipMemGetInfo: Returned hipSuccess :
+memInfo.total:                    12.06 GB
+memInfo.free:                     11.93 GB (99%)
 ```
 
 ## HIP Logging Tips:

--- a/docs/how_to_guides/debugging.md
+++ b/docs/how_to_guides/debugging.md
@@ -204,7 +204,7 @@ So HIP runtime can wait for GPU idle before/after any GPU command depending on t
 
 ### Making Device visible
 For system with multiple devices, it's possible to make only certain device(s) visible to HIP via setting environment variable,
-HIP_VISIBLE_DEVICES, only devices whose index is present in the sequence are visible to HIP.
+HIP_VISIBLE_DEVICES(or CUDA_VISIBLE_DEVICES on Nvidia platform), only devices whose index is present in the sequence are visible to HIP.
 
 For example,
 ```console
@@ -244,7 +244,7 @@ The following is the summary of the most useful environment variables in HIP.
 | ---------------------------------------------------------------------------------------------------------------| ----------------- | --------- |
 | AMD_LOG_LEVEL <br><sub> Enable HIP log on different Level. </sub> |  0  | 0: Disable log. <br> 1: Enable log on error level. <br> 2: Enable log on warning and below levels. <br> 0x3: Enable log on information and below levels. <br> 0x4: Decode and display AQL packets. |
 | AMD_LOG_MASK <br><sub> Enable HIP log on different Level. </sub> |  0x7FFFFFFF  | 0x1: Log API calls. <br> 0x02: Kernel and Copy Commands and Barriers. <br> 0x4: Synchronization and waiting for commands to finish. <br> 0x8: Enable log on information and below levels. <br> 0x20: Queue commands and queue contents. <br> 0x40:Signal creation, allocation, pool. <br> 0x80: Locks and thread-safety code. <br> 0x100: Copy debug. <br> 0x200: Detailed copy debug. <br> 0x400: Resource allocation, performance-impacting events. <br> 0x800: Initialization and shutdown. <br> 0x1000: Misc debug, not yet classified. <br> 0x2000: Show raw bytes of AQL packet. <br> 0x4000: Show code creation debug. <br> 0x8000: More detailed command info, including barrier commands. <br> 0x10000: Log message location. <br> 0xFFFFFFFF: Log always even mask flag is zero. |
-| HIP_VISIBLE_DEVICES <br><sub> Only devices whose index is present in the sequence are visible to HIP. </sub> |   | 0,1,2: Depending on the number of devices on the system.  |
+| HIP_VISIBLE_DEVICES(or CUDA_VISIBLE_DEVICES) <br><sub> Only devices whose index is present in the sequence are visible to HIP. </sub> |   | 0,1,2: Depending on the number of devices on the system.  |
 | GPU_DUMP_CODE_OBJECT <br><sub> Dump code object. </sub> |  0  | 0: Disable. <br> 1: Enable. |
 | AMD_SERIALIZE_KERNEL <br><sub> Serialize kernel enqueue. </sub> |  0  | 1: Wait for completion before enqueue. <br> 2: Wait for completion after enqueue. <br> 3: Both. |
 | AMD_SERIALIZE_COPY <br><sub> Serialize copies. </sub> |  0  | 1: Wait for completion before enqueue. <br> 2: Wait for completion after enqueue. <br> 3: Both. |

--- a/docs/how_to_guides/debugging.md
+++ b/docs/how_to_guides/debugging.md
@@ -100,7 +100,7 @@ Reading symbols from ./hipTexObjPitch...
 (gdb) break main
 Breakpoint 1 at 0x4013d1: file /home/test/hip/tests/src/texture/hipTexObjPitch.cpp, line 98.
 (gdb) run
-Starting program: /home/test/hip/build/directed_tests/texture/hipTexObjPitch 
+Starting program: /home/test/hip/build/directed_tests/texture/hipTexObjPitch
 [Thread debugging using libthread_db enabled]
 Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
 
@@ -112,11 +112,11 @@ Breakpoint 1, main ()
 ```
 
 ### Other Debugging Tools
-There are also other debugging tools available online developers can google and choose the one best suits the debugging requirements.
+There are also other debugging tools available online developers can google and choose the one best suits the debugging requirements. For example, Microsoft Visual Studio and Windgb tools are options on Windows.
 
 ## Debugging HIP Applications
 
-Below is an example to show how to get useful information from the debugger while running a simple memory copy test, which caused an issue of segmentation fault.
+Below is an example on Linux to show how to get useful information from the debugger while running a simple memory copy test, which caused an issue of segmentation fault.
 
 ```console
 test: simpleTest2<?> numElements=4194304 sizeElements=4194304 bytes
@@ -176,11 +176,14 @@ Thread 1 "hipMemcpy_simpl" received signal SIGSEGV, Segmentation fault.
 ...
 ```
 
+On Windows, debugging HIP applications on IDE like Microsoft Visual Studio tools, are more informative and visible to debug codes, inspect  variables, watch multiple details and examine the call stacks.
+
 ## Useful Environment Variables
-HIP provides some environment variables which allow HIP, hip-clang, or HSA driver to disable some feature or optimization.
+
+HIP provides some environment variables which allow HIP, hip-clang, or HSA driver on Linux to disable some feature or optimization.
 These are not intended for production but can be useful diagnose synchronization problems in the application (or driver).
 
-Some of the most useful environment variables are described here. They are supported on the ROCm path.
+Some of the most useful environment variables are described here. They are supported on the ROCm path on Linux and Windows as well.
 
 ### Kernel Enqueue Serialization
 Developers can control kernel command serialization from the host using the environment variable,
@@ -221,8 +224,8 @@ if (totalDeviceNum > 2) {
 Developers can dump code object to analyze compiler related issues via setting environment variable,
 GPU_DUMP_CODE_OBJECT
 
-### HSA related environment variables
-HSA provides some environment variables help to analyze issues in driver or hardware, for example,
+### HSA related environment variables on Linux
+On Linux with open source, HSA provides some environment variables help to analyze issues in driver or hardware, for example,
 
 HSA_ENABLE_SDMA=0
 It causes host-to-device and device-to-host copies to use compute shader blit kernels rather than the dedicated DMA copy engines.
@@ -246,12 +249,12 @@ The following is the summary of the most useful environment variables in HIP.
 | AMD_SERIALIZE_KERNEL <br><sub> Serialize kernel enqueue. </sub> |  0  | 1: Wait for completion before enqueue. <br> 2: Wait for completion after enqueue. <br> 3: Both. |
 | AMD_SERIALIZE_COPY <br><sub> Serialize copies. </sub> |  0  | 1: Wait for completion before enqueue. <br> 2: Wait for completion after enqueue. <br> 3: Both. |
 | HIP_HOST_COHERENT <br><sub> Coherent memory in hipHostMalloc. </sub> |  0  |  0: memory is not coherent between host and GPU. <br> 1: memory is coherent with host. |
-| AMD_DIRECT_DISPATCH <br><sub> Enable direct kernel dispatch. </sub> | 1  | 0: Disable. <br> 1: Enable. |
+| AMD_DIRECT_DISPATCH <br><sub> Enable direct kernel dispatch (Currently for Linux, under development on Windows). </sub> | 1  | 0: Disable. <br> 1: Enable. |
 | GPU_MAX_HW_QUEUES <br><sub> The maximum number of hardware queues allocated per device. </sub> | 4  | The variable controls how many independent hardware queues HIP runtime can create per process, per device. If application allocates more HIP streams than this number, then HIP runtime will reuse the same hardware queues for the new streams in round robin manner. Please note, this maximum number does not apply to either hardware queues that are created for CU masked HIP streams, or cooperative queue for HIP Cooperative Groups (there is only one single queue per device). |
 
 ## General Debugging Tips
 - 'gdb --args' can be used to conveniently pass the executable and arguments to gdb.
-- From inside GDB, you can set environment variables "set env".  Note the command does not use an '=' sign:
+- From inside GDB on Linux, you can set environment variables "set env".  Note the command does not use an '=' sign:
 
 ```
 (gdb) set env AMD_SERIALIZE_KERNEL 3

--- a/docs/reference/kernel_language.md
+++ b/docs/reference/kernel_language.md
@@ -126,15 +126,15 @@ The `__restrict__` keyword tells the compiler that the associated memory pointer
 
 ## Built-In Variables
 
-(coordinate_builtins)=
 ### Coordinate Built-Ins
 Built-ins determine the coordinate of the active work item in the execution grid. They are defined in amd_hip_runtime.h (rather than being implicitly defined by the compiler).
 In HIP, built-ins coordinate variable definitions are the same as in Cuda, for instance:
 threadIdx.x, blockIdx.y, gridDim.y, etc.
 The products gridDim.x * blockDim.x, gridDim.y * blockDim.y and gridDim.z * blockDim.z are always less than 2^32.
+Coordinates builtins are implemented as structures for better performance. When used with printf, they needs to be casted to integer types explicitly.
 
 ### warpSize
-The warpSize variable is of type int and contains the warp size (in threads) for the target device. Note that all current Nvidia devices return 32 for this variable, and all current AMD devices return 64. Device code should use the warpSize built-in to develop portable wave-aware code.
+The warpSize variable is of type int and contains the warp size (in threads) for the target device. Note that all current Nvidia devices return 32 for this variable, and current AMD devices return 64 for gfx9 and 32 for gfx10 and above. The warpSize variable should only be used in device functions. Device code should use the warpSize built-in to develop portable wave-aware code.
 
 
 ## Vector Types

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -148,6 +148,9 @@ ROCclr (Radeon Open Compute Common Language Runtime) is a virtual device interfa
 ## What is HIPAMD?
 HIPAMD is a repository branched out from HIP, mainly the implementation for AMD GPU.
 
+## Can I get HIP open source repository for Windows?
+No, there is no HIP repository open publicly on Windows.
+
 ## Can a HIP binary run on both AMD and Nvidia platforms?
 HIP is a source-portable language that can be compiled to run on either AMD or NVIDIA platform. HIP tools don't create a "fat binary" that can run on either platform, however.
 
@@ -236,6 +239,11 @@ In ROCm, a compilation option should be added in order to compile the translatio
 Once source is compiled with per-thread default stream enabled, all APIs will be executed on per thread default stream, hence there will not be any implicit synchronization with other streams.
 
 Besides, per-thread default stream be enabled per translation unit, users can compile some files with feature enabled and some with feature disabled. Feature enabled translation unit will have default stream as per thread and there will not be any implicit synchronization done but other modules will have legacy default stream which will do implicit synchronization.
+
+## Can I develop applications with HIP APIs on Windows the same on Linux?
+
+Yes, HIP APIs are available to use on both Linux and Windows.
+Due to different working mechanisms on operating systems like Windows vs Linux, HIP APIs call corresponding lower level backend runtime libraries and kernel drivers for the OS, in order to control the executions on GPU hardware accordingly. There might be a few differences on the related backend software and driver support, which might affect usage of HIP APIs. See OS support details in HIP API document.
 
 ## How can I know the version of HIP?
 

--- a/docs/user_guide/faq.md
+++ b/docs/user_guide/faq.md
@@ -226,7 +226,7 @@ If you have compiled the application yourself, make sure you have given the corr
 If you have a precompiled application/library (like rocblas, tensorflow etc) which gives you such error, there are one of two possibilities.
 
  - The application/library does not ship code object bundles for *all* of your device(s): in this case you need to recompile the application/library yourself with correct `--offload-arch`.
- - The application/library does not ship code object bundles for *some* of your device(s), for example you have a system with an APU + GPU and the library does not ship code objects for your APU. For this you can set the environment variable `HIP_VISIBLE_DEVICES` to only enable GPUs for which code object is available. This will limit the GPUs visible to your application and allow it to run.
+ - The application/library does not ship code object bundles for *some* of your device(s), for example you have a system with an APU + GPU and the library does not ship code objects for your APU. For this you can set the environment variable `HIP_VISIBLE_DEVICES` or `CUDA_VISIBLE_DEVICES` on NVdia platform, to only enable GPUs for which code object is available. This will limit the GPUs visible to your application and allow it to run.
 
 ## How to use per-thread default stream in HIP?
 

--- a/docs/user_guide/hip_porting_guide.md
+++ b/docs/user_guide/hip_porting_guide.md
@@ -78,19 +78,26 @@ directory names.
 
 ### Library Equivalents
 
-| CUDA Library | ROCm Library | Comment |
-|------- | ---------   | -----   |
-| cuBLAS        |    rocBLAS     | Basic Linear Algebra Subroutines
-| cuFFT        |    rocFFT     | Fast Fourier Transfer Library
-| cuSPARSE     |    rocSPARSE   | Sparse BLAS  + SPMV
-| cuSolver     |    rocSOLVER   | Lapack library
-| AMG-X    |    rocALUTION   | Sparse iterative solvers and preconditioners with Geometric and Algebraic MultiGrid
-| Thrust    |    rocThrust | C++ parallel algorithms library
-| CUB     |    rocPRIM | Low Level Optimized Parallel Primitives
-| cuDNN    |    MIOpen | Deep learning Solver Library
-| cuRAND    |    rocRAND | Random Number Generator Library
-| EIGEN    |    EIGEN – HIP port | C++ template library for linear algebra: matrices, vectors, numerical solvers,
-| NCCL    |    RCCL  | Communications Primitives Library based on the MPI equivalents
+Most CUDA libraries have a corresponding ROCm library with similar functionality and APIs. However, ROCm also provides HIP marshalling libraries that greatly simplify the porting process because they more precisely reflect their CUDA counterparts and can be used with either the AMD or NVIDIA platforms (see "Identifying HIP Target Platform" below). There are a few notable exceptions:
+  - MIOpen does not have a marshalling library interface to ease porting from cuDNN.
+  - RCCL is a drop-in replacement for NCCL and implements the NCCL APIs.
+  - hipBLASLt does not have a ROCm library but can still target the NVIDIA platform, as needed.
+  - EIGEN's HIP support is part of the library.
+
+| CUDA Library | HIP Library | ROCm Library | Comment |
+|------------- | ----------- | ------------ | ------- |
+| cuBLAS       | hipBLAS     | rocBLAS      | Basic Linear Algebra Subroutines
+| cuBLASLt     | hipBLASLt   | N/A          | Basic Linear Algebra Subroutines, lightweight and new flexible API
+| cuFFT        | hipFFT      | rocFFT       | Fast Fourier Transfer Library
+| cuSPARSE     | hipSPARSE   | rocSPARSE    | Sparse BLAS  + SPMV
+| cuSolver     | hipSOLVER   | rocSOLVER    | Lapack library
+| AMG-X        | N/A         | rocALUTION   | Sparse iterative solvers and preconditioners with Geometric and Algebraic MultiGrid
+| Thrust       | N/A         | rocThrust    | C++ parallel algorithms library
+| CUB          | hipCUB      | rocPRIM      | Low Level Optimized Parallel Primitives
+| cuDNN        | N/A         | MIOpen       | Deep learning Solver Library
+| cuRAND       | hipRAND     | rocRAND      | Random Number Generator Library
+| EIGEN        | EIGEN       | N/A          | C++ template library for linear algebra: matrices, vectors, numerical solvers,
+| NCCL         | N/A         | RCCL         | Communications Primitives Library based on the MPI equivalents
 
 
 
@@ -354,7 +361,7 @@ run hipcc when appropriate.
 ## Workarounds
 
 ### warpSize
-Code should not assume a warp size of 32 or 64.  See [Warp Cross-Lane Functions](hip_kernel_language.md#warp-cross-lane-functions) for information on how to write portable wave-aware code.
+Code should not assume a warp size of 32 or 64.  See [Warp Cross-Lane Functions](/docs/reference/kernel_language.md#warp-cross-lane-functions) for information on how to write portable wave-aware code.
 
 ### Kernel launch with group size > 256
 Kernel code should use ``` __attribute__((amdgpu_flat_work_group_size(<min>,<max>)))```.

--- a/include/hip/hip_runtime_api.h
+++ b/include/hip/hip_runtime_api.h
@@ -2863,7 +2863,7 @@ hipError_t hipHostMalloc(void** ptr, size_t size, unsigned int flags);
 /**
  * @brief Allocates memory that will be automatically managed by HIP.
  *
- * This API is used for managed memory, allows data be shared and accessible to both the CPU and
+ * This API is used for managed memory, allows data be shared and accessible to both CPU and
  * GPU using a single pointer.
  *
  * The API returns the allocation pointer, managed by HMM, can be used further to execute kernels
@@ -2902,11 +2902,17 @@ hipError_t hipMemPrefetchAsync(const void* dev_ptr,
  * @brief Advise about the usage of a given memory range to HIP.
  *
  * @param [in] dev_ptr  pointer to memory to set the advice for
- * @param [in] count    size in bytes of the memory range, it should be 4KB alligned.
+ * @param [in] count    size in bytes of the memory range, it should be CPU page size alligned.
  * @param [in] advice   advice to be applied for the specified memory range
  * @param [in] device   device to apply the advice for
  *
  * @returns #hipSuccess, #hipErrorInvalidValue
+ *
+ * This HIP advises about the usage to be applied on unified memory allocation in the
+ * range starting from the pointer address devPtr, with the size of count bytes.
+ * The memory range must refer to managed memory allocated via the API hipMallocManaged, and the
+ * range will be handled with proper round down and round up respectively in the driver to
+ * be aligned to CPU page size.
  *
  * @note  This API is implemented on Linux, under development on Windows.
  */


### PR DESCRIPTION
- Add HIP libraries to Library Equivalents doc.
- Improve warp cross lane doc, adding sync primitives.
- Fix #3312. Use '/' as an absolute path to the file instead of relative.