### PR TITLE
[Documentation]: Add information that building on Windows is not supported

### DIFF
--- a/docs/developer_guide/build.md
+++ b/docs/developer_guide/build.md
@@ -5,6 +5,8 @@
 HIP code can be developed on Linux, either on AMD ROCm platform using HIP-Clang compiler, or a CUDA platform with nvcc installed.
 Before building and running HIP, make sure drivers and pre-built packages are installed properly on the platform.
 
+Building on Windows is not supported, since not all source code required to build for Windows from source is available under a permissive open source license. AMD only provides Windows build instructions for projects that can be built from source on Windows using a toolchain that has closed source build prerequisites. The ROCm manifest file is not valid for Windows. AMD does not release a manifest or tag our components in Windows. Corresponding Linux tags can be used to build on Windows. See https://rocm.docs.amd.com/projects/install-on-windows/en/develop/conceptual/release-versioning.html#windows-builds-from-source
+
 ### AMD platform
 Install ROCm packages or pre-built binary packages using the package manager. Refer to the ROCm Installation Guide at https://rocm.docs.amd.com for more information on installing ROCm.
 

--- a/docs/developer_guide/build.md
+++ b/docs/developer_guide/build.md
@@ -2,8 +2,8 @@
 
 ## Prerequisites
 
-HIP code can be developed either on AMD ROCm platform using HIP-Clang compiler, or a CUDA platform with nvcc installed.
-Before build and run HIP, make sure drivers and pre-build packages are installed properly on the platform.
+HIP code can be developed on Linux, either on AMD ROCm platform using HIP-Clang compiler, or a CUDA platform with nvcc installed.
+Before building and running HIP, make sure drivers and pre-built packages are installed properly on the platform.
 
 ### AMD platform
 Install ROCm packages or pre-built binary packages using the package manager. Refer to the ROCm Installation Guide at https://rocm.docs.amd.com for more information on installing ROCm.
@@ -18,11 +18,11 @@ sudo apt-get install -y libelf-dev
 
 ### NVIDIA platform
 
-Install Nvidia driver and pre-build packages (see HIP Installation Guide at https://docs.amd.com/ for the release)
+Install Nvidia driver and pre-built packages (see HIP Installation Guide at https://docs.amd.com/ for the release)
 
 ### Branch of repository
 
-Before get HIP source code, set the expected branch of repository at the variable `ROCM_BRANCH`.
+Before getting HIP source code, set the expected branch of repository at the variable `ROCM_BRANCH`.
 For example, for ROCm 6.1 release branch, set
 ```shell
 export ROCM_BRANCH=rocm-6.1.x
@@ -129,7 +129,7 @@ hip_prof_gen.py -v -p -t --priv <hip>/include/hip/hip_runtime_api.h \
 
 #### Build HIP tests
 
-HIP catch tests, with the newly architectured Catch2, are officially separated from the HIP project. The HIP catch tests are moved to the HIP tests repository and can be built using the  instructions in the following sections.
+HIP catch tests, with the newly architectured Catch2, are officially separated from the HIP project. The HIP catch tests are moved to the HIP tests repository and can be built using the instructions in the following sections.
 
 ##### Get HIP tests source code
 
@@ -151,7 +151,7 @@ Note that when using ctest, you can use different ctest options, for example, to
 ```
 ctest -R hipMemset
 ```
-Use the below option will print test failures for failed tests,
+Using the below option will print test failures for failed tests,
 ```
 ctest --output-on-failure
 ```


### PR DESCRIPTION
As per https://rocm.docs.amd.com/projects/install-on-windows/en/develop/conceptual/release-versioning.html#windows-builds-from-source building on Windows is not supported.
This PR adds this information to the build docs, improving this information's visibility.

Fixes https://github.com/ROCm/HIP/issues/3414#issue-2137693385

### References:

"The windows release cycle differs from the linux release cycle. For more information, see https://rocm.docs.amd.com/projects/install-on-windows/en/develop/conceptual/release-versioning.html The list is not up to date with the linux releases, but currently 5.7 is the latest windows release, so rocm 6.0 is not officially supported on windows. @Sabrewarrior it is sadly not possible to build rocm for windows from source, as it is not completely open source"

Originally posted by @MKKnorr in https://github.com/ROCm/ROCm/discussions/2729#discussioncomment-8451553

"@ColorfulShire I agree, that this information is not very visible. As for adding a note to the build documents, I can't really do much about that, but feel free to open an issue at https://github.com/ROCm/HIP or even a PR to its documentation"

Originally posted by @MKKnorr in https://github.com/ROCm/ROCm/discussions/2729#discussioncomment-8480423