### PR TITLE
Hip acronym

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # HIP documentation
 
-HIP is a C++ runtime API and kernel language that lets developers create
-portable applications for AMD and NVIDIA GPUs from single source code.
+The Heterogeneous-computing Interface for Portability (HIP) API is a C++ runtime 
+API and kernel language that lets developers create portable applications for AMD and NVIDIA GPUs from single source code. 
 
 ## Overview
 

--- a/docs/install/install.rst
+++ b/docs/install/install.rst
@@ -43,6 +43,9 @@ Installation
 
       By default, HIP is installed into ``/opt/rocm/hip``.
 
+      .. note::
+         There is no autodetection for the HIP installation. If you choose to install it somewhere other than the default location, you must set the ``HIP_PATH`` environment variable as explained in `Build HIP from source <./build.html>`_. 
+
    .. tab-item:: NVIDIA
       :sync: nvidia
 


### PR DESCRIPTION
defined HIP acronym on the index.rst page
added a note about the lack of autodetection for the HIP installation, and the need to use HIP_PATH