### PR TITLE
Update DOCS/6.1.2 based on Geritt changes

### DIFF
--- a/docs/reference/deprecated_api_list.rst
+++ b/docs/reference/deprecated_api_list.rst
@@ -45,7 +45,6 @@ Memory management
 
 * ``hipMallocHost`` (replaced with ``hipHostMalloc``)
 * ``hipMemAllocHost`` (replaced with ``hipHostMalloc``)
-* ``hipHostAlloc`` (replaced with ``hipHostMalloc``)
 * ``hipFreeHost`` (replaced with ``hipHostFree``)
 * ``hipMemcpyToArray``
 * ``hipMemcpyFromArray``

--- a/include/hip/hip_ext.h
+++ b/include/hip/hip_ext.h
@@ -64,6 +64,8 @@ THE SOFTWARE.
  * Currently, timing between startEvent and stopEvent does not include the time it takes to perform
  * a system scope release/cache flush - only the time it takes to issues writes to cache.
  *
+ * @note  For this HIP API, the flag 'hipExtAnyOrderLaunch' is not supported on AMD GFX9xx boards.
+ *
  */
 HIP_PUBLIC_API
  extern "C" hipError_t hipExtModuleLaunchKernel(hipFunction_t f, uint32_t globalWorkSizeX,

--- a/include/hip/hip_runtime_api.h
+++ b/include/hip/hip_runtime_api.h
@@ -3760,10 +3760,7 @@ hipError_t hipMemPoolImportPointer(
  *  If size is 0, no memory is allocated, *ptr returns nullptr, and hipSuccess is returned.
  *
  *  @return #hipSuccess, #hipErrorOutOfMemory
- *
- *  @warning This API is deprecated, use hipHostMalloc() instead
  */
-DEPRECATED("use hipHostMalloc instead")
 hipError_t hipHostAlloc(void** ptr, size_t size, unsigned int flags);
 /**
  *  @brief Get Device pointer from Host Pointer allocated through hipHostMalloc


### PR DESCRIPTION
- Adding a note in hipExtModuleLaunchKernel
- Un-deprecate hipHostAlloc()