### PR TITLE
Minor documentation fixes

### DIFF
--- a/docs/how-to/cooperative_groups.rst
+++ b/docs/how-to/cooperative_groups.rst
@@ -5,10 +5,10 @@
 .. _cooperative_groups_how-to:
 
 *******************************************************************************
-Cooperative Groups
+Cooperative groups
 *******************************************************************************
 
-Cooperative groups API is an extension to the HIP programming model, which provides developers with a flexible, dynamic grouping mechanism for the communicating threads. Cooperative Groups let you define your own set of thread groups which may fit your user-cases better than those defined by the hardware. This lets you specify the level of granularity for thread communication which can lead to more efficient parallel decompositions.
+Cooperative groups API is an extension to the HIP programming model, which provides developers with a flexible, dynamic grouping mechanism for the communicating threads. Cooperative groups let you define your own set of thread groups which may fit your user-cases better than those defined by the hardware. This lets you specify the level of granularity for thread communication which can lead to more efficient parallel decompositions.
 
 The API is accessible in the ``cooperative_groups`` namespace after the  ``hip_cooperative_groups.h`` is included. The header contains the following  elements:
 
@@ -44,7 +44,7 @@ The **block** is the same as the :ref:`inherent_thread_model` block entity.
 
 .. note::
 
-  Explicit warp-level thread handling is absent from the Cooperative Groups API. In order to exploit the known hardware SIMD width on which built-in functionality translates to simpler logic, you can use the group partitioning part of the API, such as ``tiled_partition``.
+  Explicit warp-level thread handling is absent from the Cooperative groups API. In order to exploit the known hardware SIMD width on which built-in functionality translates to simpler logic, you can use the group partitioning part of the API, such as ``tiled_partition``.
 
 .. _coop_thread_bottom_hierarchy:
 
@@ -216,7 +216,7 @@ The difference to the original block model in the ``reduce_sum`` device function
           // ...
       }
 
-  .. tab-item:: Cooperative Groups
+  .. tab-item:: Cooperative groups
     :sync: cooperative-groups
 
     .. code-block:: cuda
@@ -271,7 +271,7 @@ The ``reduce_sum()`` function call and input data initialization difference to t
           // ...
       }
 
-  .. tab-item:: Cooperative Groups
+  .. tab-item:: Cooperative groups
     :sync: cooperative-groups
 
     .. code-block:: cuda

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ On non-AMD platforms, like NVIDIA, HIP provides header files required to support
 * [Debugging with HIP](./how-to/debugging)
 * {doc}`./how-to/logging`
 * [Unified memory](./how-to/unified_memory)
-* [Cooperative Groups](./how-to/cooperative_groups)
+* [Cooperative groups](./how-to/cooperative_groups)
 * {doc}`./how-to/faq`
 
 :::
@@ -60,7 +60,7 @@ On non-AMD platforms, like NVIDIA, HIP provides header files required to support
 * [Comparing syntax for different APIs](./reference/terms)
 * [HSA runtime API for ROCm](./reference/virtual_rocr)
 * [HIP managed memory allocation API](./reference/unified_memory_reference)
-* [HIP Cooperative Groups API](./reference/cooperative_groups)
+* [HIP Cooperative groups API](./reference/cooperative_groups)
 * [List of deprecated APIs](./reference/deprecated_api_list)
 
 :::

--- a/docs/reference/cooperative_groups_reference.rst
+++ b/docs/reference/cooperative_groups_reference.rst
@@ -5,7 +5,7 @@
 .. _cooperative_groups_reference:
 
 *******************************************************************************
-HIP Cooperative Groups API
+HIP Cooperative groups API
 *******************************************************************************
 
 Cooperative kernel launches

--- a/docs/tutorial/cooperative_groups_tutorial.rst
+++ b/docs/tutorial/cooperative_groups_tutorial.rst
@@ -3,7 +3,7 @@
   :keywords: AMD, ROCm, HIP, cooperative groups, tutorial
 
 *******************************************************************************
-Cooperative Groups
+Cooperative groups
 *******************************************************************************
 
 This tutorial demonstrates the basic concepts of cooperative groups in the HIP (Heterogeneous-computing Interface for Portability) programming model and the most essential tooling supporting it. This topic also reviews the commonalities of heterogeneous APIs. Familiarity with the C/C++ compilation model and the language is assumed.

--- a/docs/tutorial/saxpy.rst
+++ b/docs/tutorial/saxpy.rst
@@ -160,7 +160,7 @@ example follow.
     :sync: linux-amd
 
     While distro maintainers might package ROCm so that it installs to
-    system-default locations, AMD's packages don't install that way. They need
+    system-default locations, AMD's packages aren't installed that way. They need
     to be added to the PATH by the user.
 
     .. code-block:: bash

--- a/docs/tutorial/saxpy.rst
+++ b/docs/tutorial/saxpy.rst
@@ -159,7 +159,9 @@ example follow.
   .. tab-item:: Linux and AMD
     :sync: linux-amd
 
-    While distro maintainers might package ROCm so that it installs to system-default locations, AMD's packages don't install that way. They need to be added to the PATH by the user.
+    While distro maintainers might package ROCm so that it installs to
+    system-default locations, AMD's packages don't install that way. They need
+    to be added to the PATH by the user.
 
     .. code-block:: bash
 

--- a/docs/tutorial/saxpy.rst
+++ b/docs/tutorial/saxpy.rst
@@ -159,9 +159,7 @@ example follow.
   .. tab-item:: Linux and AMD
     :sync: linux-amd
 
-    While distro maintainers might package ROCm so that it installs to
-    system-default locations, AMD's installation packages aren't. They need to
-    be added to the PATH by the user.
+    While distro maintainers might package ROCm so that it installs to system-default locations, AMD's packages don't install that way. They need to be added to the PATH by the user.
 
     .. code-block:: bash
 

--- a/docs/understand/programming_model_reference.rst
+++ b/docs/understand/programming_model_reference.rst
@@ -77,17 +77,17 @@ Grid
   is 3-dimensional, as provided by the API and is queryable by every thread
   within the block.
 
-Cooperative Groups Thread Model
+Cooperative groups Thread Model
 -------------------------------
 
-The Cooperative Groups API introduces new APIs to launch, group, subdivide,
+The Cooperative groups API introduces new APIs to launch, group, subdivide,
 synchronize and identify threads, as well as some predefined group-collective
 algorithms, but most importantly a matching threading model to think in terms
 of. It relaxes some restrictions of the :ref:`inherent_thread_model`
 imposed by the strict 1:1 mapping of architectural details to the programming
 model.
 
-The Cooperative Groups API lets you define your own thread groups which may fit your use-case better than those defined by the default thread model.
+The Cooperative groups API lets you define your own thread groups which may fit your use-case better than those defined by the default thread model.
 
 .. note::
 


### PR DESCRIPTION
- Fix SAXPY tutorial grammar issues
- Replace title case with sentence case