### PR TITLE
Fix memcpyToSymbol example

### DIFF
--- a/docs/how-to/hip_porting_guide.md
+++ b/docs/how-to/hip_porting_guide.md
@@ -403,7 +403,7 @@ Device Code:
 
 __constant__ int Value[LEN];
 
-__global__ void Get(hipLaunchParm lp, int *Ad)
+__global__ void Get(int *Ad)
 {
     int tid = threadIdx.x + blockIdx.x * blockDim.x;
     Ad[tid] = Value[tid];


### PR DESCRIPTION
mempcpyToSymbol example was failing to compile, see https://github.com/ROCm/ROCm/issues/3079

Adding another `0` in the parameters of `hipLaunchKernelGGL(Get, dim3(1,1,1), dim3(LEN,1,1), 0, 0, Ad);` resolves this
or 
Removing `hipLaunchParm lp` from `__global__ void Get(hipLaunchParm lp, int *Ad)` 

This PR is based on the latter.
