### PR TITLE
Update Kernel Launch Example

### DIFF
--- a/docs/reference/cpp_language_extensions.rst
+++ b/docs/reference/cpp_language_extensions.rst
@@ -104,7 +104,7 @@ You can include your kernel arguments after these parameters.
 .. code-block:: cpp
 
   // Example hipLaunchKernelGGL pseudocode:
-  __global__ MyKernel(float *A, float *B, float *C, size_t N)
+  __global__ void MyKernel(float *A, float *B, float *C, size_t N)
   {
   ...
   }

--- a/docs/reference/cpp_language_extensions.rst
+++ b/docs/reference/cpp_language_extensions.rst
@@ -131,30 +131,31 @@ Kernel launch example
 
   // Example showing device function, __device__ __host__
   // <- compile for both device and host
-  float PlusOne(float x)
+  #include <hip/hip_runtime.h>
+  // Example showing device function, __device__ __host__
+  __host__ __device__ float PlusOne(float x) // <- compile for both device and host
   {
     return x + 1.0;
   }
 
-  __global__
-  void
-  MyKernel (hipLaunchParm lp, /*lp parm for execution configuration */
-            const float *a, const float *b, float *c, unsigned N)
+  __global__ void MyKernel (const float *a, const float *b, float *c, unsigned N)
   {
-    unsigned gid = threadIdx.x; // <- coordinate index function
+    const int gid = threadIdx.x + blockIdx.x * blockDim.x; // <- coordinate index function
     if (gid < N) {
       c[gid] = a[gid] + PlusOne(b[gid]);
     }
   }
+
   void callMyKernel()
   {
     float *a, *b, *c; // initialization not shown...
     unsigned N = 1000000;
     const unsigned blockSize = 256;
+    const int gridSize = (N + blockSize - 1)/blockSize;
 
-    MyKernel<<<dim3(gridDim), dim3(groupDim), 0, 0>>> (a,b,c,n);
+    MyKernel<<<dim3(gridSize), dim3(blockSize), 0, 0>>> (a,b,c,N);
     // Alternatively, kernel can be launched by
-    // hipLaunchKernelGGL(MyKernel, dim3(N/blockSize), dim3(blockSize), 0, 0, a,b,c,N);
+    // hipLaunchKernelGGL(MyKernel, dim3(gridSize), dim3(blockSize), 0, 0, a,b,c,N);
   }
 
 Variable type qualifiers


### PR DESCRIPTION
Updated the kernel launch example to fix the issues highlighted in https://github.com/ROCm/HIP/issues/3428.

Example is essentially pseudo-code and isn't expected to compile but had a few obvious errors that are corrected.

1. hipLaunchParm was causing parameter mismatch on kernel launch 
2. `__host__ ` and `__device__ ` annotations were missing on PlusOne 
3. gid indexing updated
4. Inconsistent use of gridDim and groupDim fixed
5. wrong variable names (N vs n)