### PR TITLE
Correct Porting Guide Macros

### DIFF
--- a/docs/how-to/hip_porting_guide.md
+++ b/docs/how-to/hip_porting_guide.md
@@ -111,10 +111,10 @@ Most CUDA libraries have a corresponding ROCm library with similar functionality
 
 All HIP projects target either AMD or NVIDIA platform. The platform affects which headers are included and which libraries are used for linking.
 
-* `HIP_PLATFORM_AMD` is defined if the HIP platform targets AMD.
-Note, `HIP_PLATFORM_HCC` was previously defined if the HIP platform targeted AMD, it is deprecated.
-* `HIP_PLATFORM_NVDIA` is defined if the HIP platform targets NVIDIA.
-Note, `HIP_PLATFORM_NVCC` was previously defined if the HIP platform targeted NVIDIA, it is deprecated.
+* `__HIP_PLATFORM_AMD__` is defined if the HIP platform targets AMD.
+Note, `__HIP_PLATFORM_HCC__` was previously defined if the HIP platform targeted AMD, it is deprecated.
+* `__HIP_PLATFORM_NVDIA__` is defined if the HIP platform targets NVIDIA.
+Note, `__HIP_PLATFORM_NVCC__` was previously defined if the HIP platform targeted NVIDIA, it is deprecated.
 
 ### Identifying the Compiler: hip-clang or NVCC
 


### PR DESCRIPTION
Fix for https://github.com/ROCm/HIP/issues/3199. 

Change were previously made in https://github.com/rocm-ci/HIP/commit/918214ecabd2608058d615471249150b0a549fc4#diff-c993d11f2ff9e3314f88524d14116463a55ccd2bbccd453d33783eec28a3ca46R154 but was overridden.

Preprocessor macros include double underscores which are missing in the porting guide.