### PR TITLE
Deprecated list update docs 6.2.2

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -125,8 +125,8 @@ Compiler related questions
 hipcc detected my platform incorrectly. What should I do?
 ---------------------------------------------------------
 
-The environment variable `HIP_PLATFORM` can be used to specify the platform for
-which the code is going to be compiled with ``hipcc``. See the
+The environment variable ``HIP_PLATFORM`` can be used to specify the platform
+for which the code is going to be compiled with ``hipcc``. See the
 :doc:`hipcc environment variables<hipcc:env>` for more information.
 
 How to use HIP-Clang to build HIP programs?

--- a/docs/reference/deprecated_api_list.rst
+++ b/docs/reference/deprecated_api_list.rst
@@ -53,7 +53,7 @@ Deprecated texture management functions.
    * - :cpp:func:`hipTexRefSetArray`
    * - :cpp:func:`hipTexRefSetFlags`
    * - :cpp:func:`hipTexRefSetFilterMode`
-   * - :cpp:func:`hipTexRefSetBorderColor`
+   * - :cpp:func:`hipTexRefSetFormat`
    * - :cpp:func:`hipTexRefSetMipmapFilterMode`
    * - :cpp:func:`hipTexRefSetMipmapLevelBias`
    * - :cpp:func:`hipTexRefSetMipmapLevelClamp`
@@ -70,7 +70,6 @@ Deprecated texture management functions.
    :align: left
 
    * - function
-   * - :cpp:func:`hipTexRefSetFormat`
    * - :cpp:func:`hipTexRefGetAddress`
    * - :cpp:func:`hipTexRefGetAddressMode`
    * - :cpp:func:`hipTexRefGetFilterMode`
@@ -83,6 +82,7 @@ Deprecated texture management functions.
    * - :cpp:func:`hipTexRefGetMipMappedArray`
    * - :cpp:func:`hipTexRefSetAddress`
    * - :cpp:func:`hipTexRefSetAddress2D`
+   * - :cpp:func:`hipTexRefSetBorderColor`
    * - :cpp:func:`hipTexRefSetMaxAnisotropy`
 
 Deprecated since ROCm 3.8.0
@@ -117,9 +117,13 @@ Deprecated memory management functions.
    * - function
      -
    * - :cpp:func:`hipMallocHost`
-     - replaced with :cpp:func:`hipHostAlloc`
+     - replaced with :cpp:func:`hipHostMalloc`
    * - :cpp:func:`hipMemAllocHost`
-     - replaced with :cpp:func:`hipHostAlloc`
+     - replaced with :cpp:func:`hipHostMalloc`
+   * - :cpp:func:`hipHostAlloc` 
+     - replaced with :cpp:func:`hipHostMalloc`
+   * - :cpp:func:`hipFreeHost` 
+     - replaced with :cpp:func:`hipHostFree`
 
 Deprecated since ROCm 3.0.0
 ============================================================

--- a/docs/reference/hip_runtime_api/modules.rst
+++ b/docs/reference/hip_runtime_api/modules.rst
@@ -19,6 +19,7 @@ The API is organized into modules based on functionality.
 * :ref:`event_management_reference`
 * :ref:`memory_management_reference`
 
+  * :ref:`memory_management_deprecated_reference`
   * :ref:`external_resource_interoperability_reference`
   * :ref:`stream_ordered_memory_allocator_reference`
   * :ref:`unified_memory_reference`

--- a/docs/reference/hip_runtime_api/modules/memory_management/memory_management_deprecated.rst
+++ b/docs/reference/hip_runtime_api/modules/memory_management/memory_management_deprecated.rst
@@ -1,0 +1,11 @@
+.. meta::
+  :description: The deprecated memory management reference page.
+
+.. _memory_management_deprecated_reference:
+
+*******************************************************************************
+Memory management (deprecated)
+*******************************************************************************
+
+.. doxygengroup:: MemoryD
+   :content-only:

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -66,6 +66,7 @@ subtrees:
           - file: reference/hip_runtime_api/modules/memory_management
             subtrees:
             - entries:
+              - file: reference/hip_runtime_api/modules/memory_management/memory_management_deprecated
               - file: reference/hip_runtime_api/modules/memory_management/external_resource_interoperability
               - file: reference/hip_runtime_api/modules/memory_management/stream_ordered_memory_allocator
               - file: reference/hip_runtime_api/modules/memory_management/unified_memory_reference

--- a/include/hip/hip_runtime_api.h
+++ b/include/hip/hip_runtime_api.h
@@ -3158,6 +3158,18 @@ hipError_t hipMalloc(void** ptr, size_t size);
  * hipHostFree, hipHostMalloc
  */
 hipError_t hipExtMallocWithFlags(void** ptr, size_t sizeBytes, unsigned int flags);
+
+
+/**
+ *-------------------------------------------------------------------------------------------------
+ *-------------------------------------------------------------------------------------------------
+ *  @defgroup MemoryD Memory Management [Deprecated]
+ *  @ingroup Memory
+ *  @{
+ *  This section describes the deprecated memory management functions of HIP runtime API.
+ *
+ */
+
 /**
  *  @brief Allocate pinned host memory [Deprecated]
  *
@@ -3186,6 +3198,11 @@ hipError_t hipMallocHost(void** ptr, size_t size);
  */
 DEPRECATED("use hipHostMalloc instead")
 hipError_t hipMemAllocHost(void** ptr, size_t size);
+// end doxygen deprecated management memory
+/**
+ * @}
+ */
+
 /**
  *  @brief Allocates device accessible page locked (pinned) host memory
  *
@@ -3786,6 +3803,7 @@ hipError_t hipMemPoolImportPointer(
 
 /**
  *  @brief Allocate device accessible page locked host memory [Deprecated]
+ *  @ingroup MemoryD
  *
  *  @param[out] ptr Pointer to the allocated host pinned memory
  *  @param[in]  size Requested memory size in bytes
@@ -3926,6 +3944,7 @@ hipError_t hipMemAllocPitch(hipDeviceptr_t* dptr, size_t* pitch, size_t widthInB
 hipError_t hipFree(void* ptr);
 /**
  *  @brief Free memory allocated by the hcc hip host memory allocation API [Deprecated]
+ *  @ingroup MemoryD
  *
  *  @param[in] ptr Pointer to memory to be freed
  *  @return #hipSuccess,
@@ -4807,6 +4826,7 @@ hipError_t hipMemcpy2DArrayToArray(hipArray_t dst, size_t wOffsetDst, size_t hOf
                                    size_t width, size_t height, hipMemcpyKind kind);
 /**
  *  @brief Copies data between host and device.
+ *  @ingroup MemoryD
  *
  *  @param[in]   dst     Destination memory address
  *  @param[in]   wOffset Destination starting X offset
@@ -4826,6 +4846,7 @@ hipError_t hipMemcpyToArray(hipArray_t dst, size_t wOffset, size_t hOffset, cons
                             size_t count, hipMemcpyKind kind);
 /**
  *  @brief Copies data between host and device.
+ *  @ingroup MemoryD
  *
  *  @param[in]   dst       Destination memory address
  *  @param[in]   srcArray  Source memory address


### PR DESCRIPTION
The deprecated API list reference reorg was also updated on this release.