### PR TITLE
Docs: Update example references

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,19 +127,9 @@ provides source portability to either platform.   HIP provides the _hipcc_ compi
 
 ## Examples and Getting Started
 
-* A sample and [blog](https://github.com/ROCm/hip-tests/tree/develop/samples/0_Intro/square) that uses any of [HIPIFY](https://github.com/ROCm/HIPIFY/blob/amd-staging/README.md) tools to convert a simple app from CUDA to HIP:
+* The [ROCm-examples](https://github.com/ROCm/rocm-examples) repository includes many examples with explanations that help users getting started with HIP, as well as providing advanced examples for HIP and its libraries.
 
-  ```shell
-  cd samples/01_Intro/square
-  # follow README / blog steps to hipify the application.
-  ```
-
-* Guide to [Porting a New Cuda Project](https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_porting_guide.html#porting-a-new-cuda-project)
-
-## More Examples
-
-The GitHub repository [HIP-Examples](https://github.com/ROCm/HIP-Examples) contains a hipified version of benchmark suite.
-Besides, there are more samples in Github [HIP samples](https://github.com/ROCm/hip-tests/tree/develop/samples), showing how to program with different features, build and run.
+* HIP's documentation includes a guide for [Porting a New Cuda Project](https://rocm.docs.amd.com/projects/HIP/en/latest/how-to/hip_porting_guide.html#porting-a-new-cuda-project).
 
 ## Tour of the HIP Directories
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,8 +55,7 @@ The HIP documentation is organized into the following categories:
 :::{grid-item-card} Tutorial
 
 * [HIP basic examples](https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic)
-* [HIP examples](https://github.com/ROCm/HIP-Examples)
-* [HIP test samples](https://github.com/ROCm/hip-tests/tree/develop/samples)
+* [HIP examples](https://github.com/ROCm/rocm-examples)
 * [SAXPY tutorial](./tutorial/saxpy)
 * [Reduction tutorial](./tutorial/reduction)
 * [Cooperative groups tutorial](./tutorial/cooperative_groups_tutorial)

--- a/docs/install/build.rst
+++ b/docs/install/build.rst
@@ -238,4 +238,4 @@ Run HIP
 =================================================
 
 After installation and building HIP, you can compile your application and run.
-A simple example is `square sample <https://github.com/ROCm/hip-tests/tree/develop/samples/0_Intro/square>`_.
+Simple examples can be found in the `ROCm-examples repository <https://github.com/ROCm/rocm-examples>`_.

--- a/docs/sphinx/_toc.yml.in
+++ b/docs/sphinx/_toc.yml.in
@@ -122,10 +122,8 @@ subtrees:
   entries:
   - url: https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic
     title: HIP basic examples
-  - url: https://github.com/ROCm/HIP-Examples
+  - url: https://github.com/ROCm/rocm-examples
     title: HIP examples
-  - url: https://github.com/ROCm/hip-tests/tree/develop/samples
-    title: HIP test samples
   - file: tutorial/saxpy
   - file: tutorial/reduction
   - file: tutorial/cooperative_groups_tutorial

--- a/docs/understand/compilers.rst
+++ b/docs/understand/compilers.rst
@@ -96,5 +96,6 @@ Static libraries
     ar rcsD libHipDevice.a hipDevice.o
     hipcc libHipDevice.a test.cpp -fgpu-rdc -o test.out
 
-For more information, see `HIP samples host functions <https://github.com/ROCm/hip-tests/tree/develop/samples/2_Cookbook/15_static_library/host_functions>`_
-and `device functions <https://github.com/ROCm/hip-tests/tree/develop/samples/2_Cookbook/15_static_library/device_functions>`_.
+A full example for this can be found in the ROCm-examples, see the examples for
+`static host libraries <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/static_host_library>`_
+or `static device libraries <https://github.com/ROCm/rocm-examples/tree/develop/HIP-Basic/static_device_library>`_.


### PR DESCRIPTION
The ROCm-examples replace the HIP-examples repository and the samples in hip-tests.