### PR TITLE
Add spellcheck configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .*
 !.gitignore
+!.spellcheck.local.yaml
 *.o
 *.exe
 *.swp

--- a/.spellcheck.local.yaml
+++ b/.spellcheck.local.yaml
@@ -1,0 +1,10 @@
+matrix:
+- name: Markdown
+  sources:
+  - ['!docs/doxygen/mainpage.md']
+- name: reST
+  sources:
+  - []
+- name: Cpp
+  sources:
+  - ['include/hip/*']

--- a/.wordlist.txt
+++ b/.wordlist.txt
@@ -157,6 +157,7 @@ sinewave
 SOMA
 SPMV
 structs
+struct's
 SYCL
 syntaxes
 texel


### PR DESCRIPTION
This PR depends on https://github.com/ROCm/rocm-docs-core/pull/1100

Once the above is merged in, the `linting.yml` file will be updated to target the proper branch.

This PR adds a local spellcheck file that adds all C++ files from `include/hip` for the C++ spellchecking workflow (for now the spellchecking ignores all block and line comments).