### PR TITLE
Docs: Add a few more env variables

### DIFF
--- a/docs/reference/env_variables/debug_hip_env.rst
+++ b/docs/reference/env_variables/debug_hip_env.rst
@@ -51,6 +51,13 @@ and :doc:`GPU isolation <rocm:conceptual/gpu-isolation>`.
         | 0x80000: Timestamp details.
         | 0xFFFFFFFF: Log always even mask flag is zero.
 
+    * - | ``HIP_FORCE_DEV_KERNARG``
+        | Forces kernel arguments to be stored in device memory to reduce latency.
+        | Can improve performance by 2-3 µs for some kernels.
+      - ``1``
+      - | 0: Disable
+        | 1: Enable
+
     * - | ``HIP_LAUNCH_BLOCKING``
         | Used for serialization on kernel execution.
       - ``0``

--- a/docs/reference/env_variables/gpu_isolation_hip_env.rst
+++ b/docs/reference/env_variables/gpu_isolation_hip_env.rst
@@ -14,7 +14,7 @@ environment variables in HIP are collected in the following table.
     * - | ``ROCR_VISIBLE_DEVICES``
         | A list of device indices or UUIDs that will be exposed to applications.
       - :doc:`GPU isolation <rocm:conceptual/gpu-isolation>`, :doc:`Setting the number of compute units <rocm:how-to/setting-cus>`
-      - Example: ``0,GPU-DEADBEEFDEADBEEF``
+      - Example: ``0,GPU-4b2c1a9f-8d3e-6f7a-b5c9-2e4d8a1f6c3b`
 
     * - | ``GPU_DEVICE_ORDINAL``
         | Devices indices exposed to OpenCL and HIP applications.
@@ -25,3 +25,11 @@ environment variables in HIP are collected in the following table.
         | Device indices exposed to HIP applications.
       - :doc:`GPU isolation <rocm:conceptual/gpu-isolation>`, :doc:`HIP debugging <hip:how-to/debugging>`
       - Example: ``0,2``
+
+.. admonition:: Recommendation
+
+  * On Linux, use ``ROCR_VISIBLE_DEVICES``.
+
+  * On Windows, use ``HIP_VISIBLE_DEVICES``.
+
+  * For portability across different vendors, use ``CUDA_VISIBLE_DEVICES``.

--- a/docs/reference/env_variables/memory_management_hip_env.rst
+++ b/docs/reference/env_variables/memory_management_hip_env.rst
@@ -55,6 +55,12 @@ pages:
       - | 0: Disable
         | 1: Enable
 
+    * - | ``GPU_SINGLE_ALLOC_PERCENT``
+        | Limits the maximum size of a single memory allocation as a percentage of GPU memory.
+      - ``100``
+      - | Unit: Percentage
+        | Prevents single allocations from consuming all available GPU memory.
+
     * - | ``GPU_MAX_HEAP_SIZE``
         | Set maximum size of the GPU heap to % of board memory.
       - ``100``


### PR DESCRIPTION
Adding a few more environment variables that were found in the main ROCm docs.