### PR TITLE
Docs: Fix verbose paths generated by doxygen

### DIFF
--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -170,7 +170,8 @@ FULL_PATH_NAMES        = YES
 # will be relative from the directory where doxygen is started.
 # This tag requires that the tag FULL_PATH_NAMES is set to YES.
 
-STRIP_FROM_PATH        =
+STRIP_FROM_PATH        = ../../ \
+                         ../../../
 
 # The STRIP_FROM_INC_PATH tag can be used to strip a user-defined part of the
 # path mentioned in the documentation of a class, which tells the reader which


### PR DESCRIPTION
There was an issue in the doxygen generated files where it printed the full path of the build, e.g. `/home/docs/checkouts/readthedocs.org/user_builds/advanced-micro-devices-hip/checkouts/latest/include/hip/[hip_runtime_api.h](https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/hip__runtime__api_8h_source.html)` in https://rocm.docs.amd.com/projects/HIP/en/latest/doxygen/html/structhip_array_map_info.html

This PR rectifies this so only `include/hip/[hip_runtime_api.h]` is shown instead (all other paths in other pages are fixed)