### PR TITLE
Fix documentation warnings

### DIFF
--- a/docs/doxygen/Doxyfile
+++ b/docs/doxygen/Doxyfile
@@ -2211,7 +2211,8 @@ PREDEFINED             = "__HIP_PLATFORM_AMD__" \
                          "HIP_PUBLIC_API" \
                          "HIP_ENABLE_WARP_SYNC_BUILTINS" \
                          "__HOST_DEVICE__" \
-                         "__forceinline__"
+                         "__forceinline__" \
+                         "__HIP_NODISCARD=[[nodiscard]]"
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/hip/hip_ext.h
+++ b/include/hip/hip_ext.h
@@ -27,7 +27,7 @@ THE SOFTWARE.
 #include <tuple>
 #include <type_traits>
 #endif
-/** @addtogroup Execution Execution Management
+/** @addtogroup Execution Execution Control
  *  @{
  */
 

--- a/include/hip/hip_runtime_api.h
+++ b/include/hip/hip_runtime_api.h
@@ -1473,7 +1473,7 @@ typedef enum hipLaunchAttributeID {
  */
 typedef union hipLaunchAttributeValue {
     char pad[64];                              ///< 64 byte padding
-    hipAccessPolicyWindow accessPolicyWindow;  ///< Value of launch attribute ::hipLaunchAttributePolicyWindow.
+    hipAccessPolicyWindow accessPolicyWindow;  ///< Value of launch attribute ::hipLaunchAttributeAccessPolicyWindow.
     int cooperative;                           ///< Value of launch attribute ::hipLaunchAttributeCooperative. Indicates whether the kernel is cooperative.
     int priority;                              ///< Value of launch attribute :: hipLaunchAttributePriority. Execution priority of kernel
 } hipLaunchAttributeValue;
@@ -6094,7 +6094,7 @@ hipError_t hipLinkComplete(hipLinkState_t state, void** hipBinOut, size_t* sizeO
 /**
  * @brief Creates a linker instance with options.
  * @param [in] numOptions  Number of options
- * @param [in] option  Array of options
+ * @param [in] options  Array of options
  * @param [in] optionValues  Array of option values cast to void*
  * @param [out] stateOut  hip link state created upon success
  *


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number

Partially fixes ROCDOC-1806. For the rest see the JIRA discussion.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update
- [ ] Continuous Integration

## What were the changes?

From a code POV, nothing has changed. All changes only improve the documentation build process and fix a few warnings that are present in the current state of `docs/develop`.

## Updated CHANGELOG?

- [ ] Yes
- [X] No, Does not apply to this PR.

## Added/Updated documentation?

- [X] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [ ] Any dependent changes have been merged.
