### PR TITLE
Add hint about using `amdgpu-dkms` for IPC API

### DIFF
--- a/docs/how-to/hip_runtime_api/memory_management/stream_ordered_allocator.rst
+++ b/docs/how-to/hip_runtime_api/memory_management/stream_ordered_allocator.rst
@@ -121,6 +121,11 @@ Allocations are initially accessible from the device where they reside.
 Interprocess memory handling
 =============================
 
+.. attention::
+    IPC API calls are only supported on systems with an active ``amdgpu-dkms`` driver. Please refer to the
+    `AMDGPU documentation <https://instinct.docs.amd.com/projects/amdgpu-docs/en/latest/index.html>`__ for information
+    on how to install ``amdgpu-dkms``.
+
 Interprocess capable (IPC) memory pools facilitate efficient and secure sharing of GPU memory between processes.
 
 To achieve interprocess memory sharing, you can use either :ref:`device pointer <device-pointer>` or :ref:`shareable handle <shareable-handle>`. Both provide allocator (export) and consumer (import) interfaces.


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number

None.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update
- [ ] Continuous Integration

## What were the changes?

The SOMA section about IPC calls now features a hint about requiring `amdgpu-dkms` to work.

## Why are these changes needed?

It is not obvious that `amdgpu-dkms` is required for SOMA IPC calls to work.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [X] No, Does not apply to this PR.

## Added/Updated documentation?

- [X] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [X] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [X] Any dependent changes have been merged.
