### PR TITLE
SWDEV-542333, SWDEV-541096 - add hipEventWaitDefault and hipEventWaitExternal

### DIFF
--- a/include/hip/hip_runtime_api.h
+++ b/include/hip/hip_runtime_api.h
@@ -752,6 +752,13 @@ enum hipLimit_t {
 /** Event is captured in the graph as an external event node when performing stream capture. */
 #define hipEventRecordExternal 0x01
 
+//Flags that can be used with hipStreamWaitEvent.
+/** Default flag. */
+#define hipEventWaitDefault 0x00
+
+/** Wait is captured in the graph as an external event node when performing stream capture. */
+#define hipEventWaitExternal 0x01
+
 /** Disable performing a system scope sequentially consistent memory fence when the event
  * transitions from recording to recorded.  This can be used for events that are only being
  * used to measure timing, and do not require the event inspection operations
@@ -2803,13 +2810,19 @@ hipError_t hipStreamSynchronize(hipStream_t stream);
  *
  * @param[in] stream  Stream to make wait
  * @param[in] event  Event to wait on
- * @param[in] flags  Parameters to control the operation [must be 0]
+ * @param[in] flags  Parameters to control the operation
  *
- * @returns #hipSuccess, #hipErrorInvalidHandle
+ * @returns #hipSuccess, #hipErrorInvalidHandle, #hipErrorInvalidValue,
+ * #hipErrorStreamCaptureIsolation
  *
  * This function inserts a wait operation into the specified stream.
  * All future work submitted to @p stream will wait until @p event reports completion before
  * beginning execution.
+ *
+ * Flags include:
+ *   hipEventWaitDefault: Default event creation flag.
+ *   hipEventWaitExternal: Wait is captured in the graph as an external event node when
+ *                           performing stream capture
  *
  * This function only waits for commands in the current stream to complete.  Notably, this function
  * does not implicitly wait for commands in the default stream to complete, even if the specified


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number
<!-- For example: "Closes #1234" or "Fixes SWDEV-123456" -->
SWDEV-542333 SWDEV-541096

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Continuous Integration

## What were the changes?
add hipEventWaitDefault and hipEventWaitExternal to hip runtime api
<!-- Please give a short summary of the change. -->

## Why are these changes needed?
to match cuda
<!-- Please explain the motivation behind the change and why this solves the given problem. -->

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [x] Yes
- [ ] No, Does not apply to this PR.

## Added/Updated documentation?

- [x] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [x] Any dependent changes have been merged.
