### PR TITLE
Cosmetic fixes for HIP Graph API tutorial

### DIFF
--- a/docs/how-to/hip_runtime_api/hipgraph.rst
+++ b/docs/how-to/hip_runtime_api/hipgraph.rst
@@ -14,6 +14,10 @@ method via streams. A HIP graph is made up of nodes and edges. The nodes of a
 HIP graph represent the operations performed, while the edges mark dependencies
 between those operations.
 
+.. hint::
+    The :ref:`HIP Graph API tutorial <hip_graph_api_tutorial>` demonstrates how
+    to use HIP graphs in a real-world application.
+
 The nodes can be one of the following:
 
 - empty nodes

--- a/docs/tools/example_codes/graph_api_tutorial_main_graph_capture.hip
+++ b/docs/tools/example_codes/graph_api_tutorial_main_graph_capture.hip
@@ -144,7 +144,7 @@ auto main() -> int
                                            << volGeom.dim.z << std::endl;
 
         // Initialize per-stream data
-        for(auto streamIdx = 0; streamIdx < streams.size(); ++streamIdx)
+        for(auto streamIdx = 0u; streamIdx < streams.size(); ++streamIdx)
         {
             std::cout << "Initializing stream " << streamIdx << "... " << std::flush;
             auto stream = streams.at(streamIdx);
@@ -265,7 +265,7 @@ auto main() -> int
 
         auto start = std::chrono::steady_clock::now();
             
-        auto projIdx = 0;
+        auto projIdx = 0u;
         while(projIdx < projGeom.numProj)
         {
             // [sphinx-begin-capture-start]
@@ -283,7 +283,7 @@ auto main() -> int
                 auto forkEvent = hipEvent_t{};
                 hip_check(hipEventCreate(&forkEvent));
                 hip_check(hipEventRecord(forkEvent, streams.at(0)));
-                hip_check(hipStreamWaitEvent(streams.at(streamIdx), forkEvent));
+                hip_check(hipStreamWaitEvent(streams.at(streamIdx), forkEvent, 0));
                 hip_check(hipEventDestroy(forkEvent)); // Can destroy after wait is recorded
             }
             // [sphinx-fork-end]
@@ -438,7 +438,7 @@ auto main() -> int
                 auto joinEvent = hipEvent_t{};
                 hip_check(hipEventCreate(&joinEvent));
                 hip_check(hipEventRecord(joinEvent, streams.at(streamIdx)));
-                hip_check(hipStreamWaitEvent(streams.at(0), joinEvent));
+                hip_check(hipStreamWaitEvent(streams.at(0), joinEvent, 0));
                 hip_check(hipEventDestroy(joinEvent)); // Can destroy after wait is recorded
             }
             // [sphinx-join-end]
@@ -554,7 +554,7 @@ auto main() -> int
         std::cout << "Done!" << std::endl;
         
         auto const elapsed = std::chrono::duration<double>{stop - start};
-        std::cout << "Reconstruction time: " << elapsed << std::endl;
+        std::cout << "Reconstruction time: " << elapsed.count() << 's' << std::endl;
 
         // Cleanup
         if(graphFinalCreated)

--- a/docs/tools/example_codes/graph_api_tutorial_main_graph_creation.hip
+++ b/docs/tools/example_codes/graph_api_tutorial_main_graph_creation.hip
@@ -265,7 +265,7 @@ auto main() -> int
 
         auto start = std::chrono::steady_clock::now();
 
-        auto projIdx = 0;
+        auto projIdx = 0u;
         while(projIdx < projGeom.numProj)
         {
             auto batchSize = std::min(numBranches, static_cast<int>(projGeom.numProj - projIdx));
@@ -752,7 +752,7 @@ auto main() -> int
         std::cout << "Done!" << std::endl;
 
         auto const elapsed = std::chrono::duration<double>{stop - start};
-        std::cout << "Reconstruction time: " << elapsed << std::endl;
+        std::cout << "Reconstruction time: " << elapsed.count() << 's' << std::endl;
 
         // Cleanup
         if(graphFinalCreated)

--- a/docs/tools/example_codes/graph_api_tutorial_main_streams.hip
+++ b/docs/tools/example_codes/graph_api_tutorial_main_streams.hip
@@ -146,7 +146,7 @@ auto main() -> int
                                            << volGeom.dim.z << std::endl;
 
         // Initialize per-stream data
-        for(auto streamIdx = 0; streamIdx < streams.size(); ++streamIdx)
+        for(auto streamIdx = 0u; streamIdx < streams.size(); ++streamIdx)
         {
             std::cout << "Initializing stream " << streamIdx << "... " << std::flush;
             auto stream = streams.at(streamIdx);
@@ -259,7 +259,7 @@ auto main() -> int
         auto start = std::chrono::steady_clock::now();
 
         // [sphinx-batch-start]
-        auto projIdx = 0;
+        auto projIdx = 0u;
         while(projIdx < projGeom.numProj)
         {
             auto batchSize = std::min(numStreams, static_cast<int>(projGeom.numProj - projIdx));
@@ -427,7 +427,7 @@ auto main() -> int
         // [sphinx-sync-start]
         // First stream waits for other streams to complete
         auto completionEvents = std::vector<hipEvent_t>{};
-        for(auto streamIdx = 1; streamIdx < streams.size(); ++streamIdx)
+        for(auto streamIdx = 1u; streamIdx < streams.size(); ++streamIdx)
         {
             auto event = hipEvent_t{};
             hip_check(hipEventCreate(&event));
@@ -436,7 +436,7 @@ auto main() -> int
         }
 
         for(auto&& event : completionEvents)
-            hip_check(hipStreamWaitEvent(streams.at(0), event));
+            hip_check(hipStreamWaitEvent(streams.at(0), event, 0));
         // [sphinx-sync-end]
 
         // Obtain reconstruction time before copying back the result
@@ -472,7 +472,7 @@ auto main() -> int
         std::cout << "Done!" << std::endl;
 
         auto const elapsed = std::chrono::duration<double>{stop - start};
-        std::cout << "Reconstruction time: " << elapsed << std::endl;
+        std::cout << "Reconstruction time: " << elapsed.count() << 's' << std::endl;
 
         for(auto&& event : completionEvents)
             hip_check(hipEventDestroy(event));

--- a/docs/tools/update_example_codes.py
+++ b/docs/tools/update_example_codes.py
@@ -323,14 +323,14 @@ urllib.request.urlretrieve(
 
 # graph_api
 urllib.request.urlretrieve(
-    "https://raw.githubusercontent.com/ROCm/rocm-examples/amd-staging/HIP-Doc/Tutorials/graph_api/src/main_streams.hip"
+    "https://raw.githubusercontent.com/ROCm/rocm-examples/amd-staging/HIP-Doc/Tutorials/graph_api/src/main_streams.hip",
     "docs/tools/example_codes/graph_api_tutorial_main_streams.hip"
 )
 urllib.request.urlretrieve(
-    "https://raw.githubusercontent.com/ROCm/rocm-examples/amd-staging/HIP-Doc/Tutorials/graph_api/src/main_graph_capture.hip"
+    "https://raw.githubusercontent.com/ROCm/rocm-examples/amd-staging/HIP-Doc/Tutorials/graph_api/src/main_graph_capture.hip",
     "docs/tools/example_codes/graph_api_tutorial_main_graph_capture.hip"
 )
 urllib.request.urlretrieve(
-    "https://raw.githubusercontent.com/ROCm/rocm-examples/amd-staging/HIP-Doc/Tutorials/graph_api/src/main_graph_creation.hip"
+    "https://raw.githubusercontent.com/ROCm/rocm-examples/amd-staging/HIP-Doc/Tutorials/graph_api/src/main_graph_creation.hip",
     "docs/tools/example_codes/graph_api_tutorial_main_graph_creation.hip"
 )

--- a/docs/tutorial/graph_api.rst
+++ b/docs/tutorial/graph_api.rst
@@ -2,6 +2,8 @@
   :description: HIP graph API tutorial
   :keywords: AMD, ROCm, HIP, graph API, tutorial
 
+.. _hip_graph_api_tutorial:
+
 *******************************************************************************
 HIP Graph API Tutorial
 *******************************************************************************
@@ -108,12 +110,14 @@ The reconstruction pipeline consists of:
 
 1. **Load** projection data into GPU memory
 2. **Preprocess** the projection through six stages:
+
   a. Logarithmic transformation (convert X-ray intensities)
   b. Pixel weighting (correct for cone-beam geometry)
   c. Forward FFT (transform to frequency domain)
   d. Shepp-Logan filtering (enhance edges and improve contrast)
   e. Inverse FFT (return to spatial domain)
   f. Normalization (account for unnormalized FFT)
+
 3. **Reconstruct** the 3D volume using the Feldkamp-Davis-Kress (FDK) algorithm [FeDK84]_
 
 **Why HIP graphs?** CT scanners process hundreds of projections per scan. By capturing this fixed workflow as a graph,
@@ -175,7 +179,7 @@ concepts.
   prefixed with ``main_``.
 
 Step 1: Build the tutorial code
-==========================
+===============================
 
 The full code for this tutorial is part of the `ROCm examples repository <https://github.com/ROCm/rocm-examples>`__.
 Check out the repository:
@@ -332,7 +336,7 @@ Inside the ``build`` directory you will now generate a trace:
 
 .. note::
   For more information on the ``rocprofv3`` tool, please refer to its
-  :ref:`documentation <rocprofiler-sdk:using-rocprov3>`.
+  :ref:`documentation <rocprofiler-sdk:using-rocprofv3>`.
 
 Analyzing the trace
 ^^^^^^^^^^^^^^^^^^^
@@ -381,6 +385,7 @@ Inside the main loop, activate capture mode on the first stream:
   :dedent:
 
 .. admonition:: What happens during capture?
+
   When :cpp:func:`hipStreamBeginCapture` is called, the stream stops executing operations immediately. Instead, it
   records operations into a graph template (``graph`` in the code shown here).
 
@@ -658,5 +663,5 @@ Resources
 
 .. rubric:: References
 
-.. [FeDK84] L. A. Feldkamp, L. C. Davis and J. W. Kress: "Practical cone-beam algorithm". In *Journal of the Optical Society of America A*, vol. 1, no. 6, pp. 612-619, June 1984, DOI `10.1364/JOSAA.1.000612 <https://dx.doi.org/10.1364/JOSAA.1.000612>`__.
-.. [ShLo74] L. A. Shepp and B. F. Logan: "The Fourier reconstruction of a head section". In *IEEE Transactions on Nuclear Science*, vol. 21, no. 3, pp. 21-43, June 1974, DOI `10.1109/TNS.1974.6499235 <https://dx.doi.org/10.1109/TNS.1974.6499235>`__.
+.. [FeDK84] L.A. Feldkamp, L.C. Davis and J.W. Kress: "Practical cone-beam algorithm". In *Journal of the Optical Society of America A*, vol. 1, no. 6, pp. 612-619, June 1984, DOI `10.1364/JOSAA.1.000612 <https://dx.doi.org/10.1364/JOSAA.1.000612>`__.
+.. [ShLo74] L.A. Shepp and B.F. Logan: "The Fourier reconstruction of a head section". In *IEEE Transactions on Nuclear Science*, vol. 21, no. 3, pp. 21-43, June 1974, DOI `10.1109/TNS.1974.6499235 <https://dx.doi.org/10.1109/TNS.1974.6499235>`__.


### PR DESCRIPTION
## Associated JIRA ticket number/Github issue number

ROCDOC-2175

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] Optimization
- [X] Documentation Update
- [ ] Continuous Integration

## What were the changes?

* Fixed a few formatting issues and warnings that appeared in the HIP Graph API tutorial.
* The presented codes are updated to their newest version.
* The how-to guide on HIP graphs now includes a reference to the tutorial.

## Why are these changes needed?

An admonition in the tutorial was not appearing in the resulting HTML file, a reference to rocprofv3 had a typo and the literature section was badly formatted.

## Updated CHANGELOG?

<!-- Needed for Release updates for a ROCm release. -->

- [ ] Yes
- [X] No, Does not apply to this PR.

## Added/Updated documentation?

- [X] Yes
- [ ] No, Does not apply to this PR.

## Additional Checks

- [ ] I have added tests relevant to the introduced functionality, and the unit tests are passing locally.
- [X] Any dependent changes have been merged.
